### PR TITLE
feat: 메뉴 카테고리 목록 조회

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.service.ShopService;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,11 @@ public class ShopController {
     public ResponseEntity<ShopMenuResponse> findMenu(@PathVariable Long shopId, @PathVariable Long menuId) {
         ShopMenuResponse shopMenu = shopService.findMenu(menuId);
         return ResponseEntity.ok(shopMenu);
+    }
+
+    @GetMapping("/shops/{shopId}/menus/categories")
+    public ResponseEntity<MenuCategoriesResponse> findMenuCategories(@PathVariable Long shopId) {
+        MenuCategoriesResponse menuCategories = shopService.getMenuCategories(shopId);
+        return ResponseEntity.ok(menuCategories);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/MenuCategoriesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/MenuCategoriesResponse.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.MenuCategory;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record MenuCategoriesResponse(Long count, List<MenuCategoryResponse> menuCategories) {
+    public static MenuCategoriesResponse of(Long count, List<MenuCategory> menuCategories) {
+        List<MenuCategoryResponse> categories = menuCategories.stream()
+            .map(menuCategory -> MenuCategoryResponse.of(menuCategory.getId(), menuCategory.getName()))
+            .toList();
+
+        return new MenuCategoriesResponse(count, categories);
+    }
+
+    private record MenuCategoryResponse(Long id, String name) {
+        public static MenuCategoryResponse of(Long id, String name) {
+            return new MenuCategoryResponse(id, name);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/MenuCategoriesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/MenuCategoriesResponse.java
@@ -9,12 +9,12 @@ import in.koreatech.koin.domain.shop.model.MenuCategory;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record MenuCategoriesResponse(Long count, List<MenuCategoryResponse> menuCategories) {
-    public static MenuCategoriesResponse of(Long count, List<MenuCategory> menuCategories) {
+    public static MenuCategoriesResponse from(List<MenuCategory> menuCategories) {
         List<MenuCategoryResponse> categories = menuCategories.stream()
             .map(menuCategory -> MenuCategoryResponse.of(menuCategory.getId(), menuCategory.getName()))
             .toList();
 
-        return new MenuCategoriesResponse(count, categories);
+        return new MenuCategoriesResponse((long)categories.size(), categories);
     }
 
     private record MenuCategoryResponse(Long id, String name) {

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategoryMap.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategoryMap.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.domain.shop.model;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,7 +28,7 @@ public class MenuCategoryMap {
     @JoinColumn(name = "shop_menu_id")
     private Menu menu;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_menu_category_id")
     private MenuCategory menuCategory;
 

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/MenuCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/MenuCategoryRepository.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.domain.shop.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.shop.model.MenuCategory;
+
+public interface MenuCategoryRepository extends Repository<MenuCategory, Long> {
+    List<MenuCategory> findAllByShopId(Long shopId);
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/MenuCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/MenuCategoryRepository.java
@@ -8,4 +8,6 @@ import in.koreatech.koin.domain.shop.model.MenuCategory;
 
 public interface MenuCategoryRepository extends Repository<MenuCategory, Long> {
     List<MenuCategory> findAllByShopId(Long shopId);
+
+    MenuCategory save(MenuCategory menuCategory);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -44,6 +44,6 @@ public class ShopService {
     public MenuCategoriesResponse getMenuCategories(Long shopId) {
         //TODO 존재하는 상점인지 검증하고, 없다면 401를 반환하여야 한다. 작업시점: 상점 도메인 조회 기능 추가시
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shopId);
-        return MenuCategoriesResponse.of((long)menuCategories.size(), menuCategories);
+        return MenuCategoriesResponse.from(menuCategories);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -5,10 +5,12 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
+import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.MenuCategoryMap;
-import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
+import in.koreatech.koin.domain.shop.repository.MenuCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class ShopService {
 
     private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
 
     public ShopMenuResponse findMenu(Long menuId) {
         Menu menu = menuRepository.findById(menuId)
@@ -36,5 +39,11 @@ public class ShopService {
             return ShopMenuResponse.createForMultipleOption(menu, menuCategories);
         }
         return ShopMenuResponse.createForSingleOption(menu, menuCategories);
+    }
+
+    public MenuCategoriesResponse getMenuCategories(Long shopId) {
+        //TODO 존재하는 상점인지 검증하고, 없다면 401를 반환하여야 한다. 작업시점: 상점 도메인 조회 기능 추가시
+        List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shopId);
+        return MenuCategoriesResponse.of((long)menuCategories.size(), menuCategories);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -12,6 +12,7 @@ import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.MenuCategoryMap;
 import in.koreatech.koin.domain.shop.model.MenuImage;
 import in.koreatech.koin.domain.shop.model.MenuOption;
+import in.koreatech.koin.domain.shop.repository.MenuCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.MenuRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -21,6 +22,9 @@ class ShopApiTest extends AcceptanceTest {
 
     @Autowired
     private MenuRepository menuRepository;
+
+    @Autowired
+    private MenuCategoryRepository menuCategoryRepository;
 
     @Test
     @DisplayName("옵션이 하나 있는 상점의 메뉴를 조회한다.")
@@ -54,6 +58,7 @@ class ShopApiTest extends AcceptanceTest {
 
         menuCategoryMap.map(menu, menuCategory);
 
+        menuCategoryRepository.save(menuCategory);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured
@@ -133,6 +138,7 @@ class ShopApiTest extends AcceptanceTest {
 
         menuCategoryMap.map(menu, menuCategory);
 
+        menuCategoryRepository.save(menuCategory);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured
@@ -207,6 +213,8 @@ class ShopApiTest extends AcceptanceTest {
         menuCategoryMap1.map(menu, menuCategory1);
         menuCategoryMap2.map(menu, menuCategory2);
 
+        menuCategoryRepository.save(menuCategory1);
+        menuCategoryRepository.save(menuCategory2);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -49,16 +49,15 @@ class ShopApiTest extends AcceptanceTest {
             .shopId(1L)
             .name("중식")
             .build();
+        menuCategoryRepository.save(menuCategory);
 
         MenuCategoryMap menuCategoryMap = MenuCategoryMap.create();
 
-        // when then
         menuOption.setMenu(menu);
         menuImage.setMenu(menu);
 
+        // when then
         menuCategoryMap.map(menu, menuCategory);
-
-        menuCategoryRepository.save(menuCategory);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured
@@ -129,6 +128,7 @@ class ShopApiTest extends AcceptanceTest {
             .build();
 
         MenuCategoryMap menuCategoryMap = MenuCategoryMap.create();
+        menuCategoryRepository.save(menuCategory);
 
         // when then
         menuOption1.setMenu(menu);
@@ -138,7 +138,6 @@ class ShopApiTest extends AcceptanceTest {
 
         menuCategoryMap.map(menu, menuCategory);
 
-        menuCategoryRepository.save(menuCategory);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured
@@ -205,6 +204,9 @@ class ShopApiTest extends AcceptanceTest {
             .shopId(SHOP_ID)
             .name("메인 메뉴")
             .build();
+        
+        menuCategoryRepository.save(menuCategory1);
+        menuCategoryRepository.save(menuCategory2);
 
         MenuCategoryMap menuCategoryMap1 = MenuCategoryMap.create();
         MenuCategoryMap menuCategoryMap2 = MenuCategoryMap.create();
@@ -213,8 +215,6 @@ class ShopApiTest extends AcceptanceTest {
         menuCategoryMap1.map(menu, menuCategory1);
         menuCategoryMap2.map(menu, menuCategory2);
 
-        menuCategoryRepository.save(menuCategory1);
-        menuCategoryRepository.save(menuCategory2);
         menuRepository.save(menu);
 
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -177,4 +177,66 @@ class ShopApiTest extends AcceptanceTest {
             }
         );
     }
+
+    @Test
+    @DisplayName("상점의 메뉴 카테고리들을 조회한다.")
+    void findShopMenuCategories() {
+        // given
+        final long SHOP_ID = 1L;
+
+        Menu menu = Menu.builder()
+            .shopId(SHOP_ID)
+            .name("짜장면")
+            .description("맛있는 짜장면")
+            .build();
+
+        MenuCategory menuCategory1 = MenuCategory.builder()
+            .shopId(SHOP_ID)
+            .name("이벤트 메뉴")
+            .build();
+
+        MenuCategory menuCategory2 = MenuCategory.builder()
+            .shopId(SHOP_ID)
+            .name("메인 메뉴")
+            .build();
+
+        MenuCategoryMap menuCategoryMap1 = MenuCategoryMap.create();
+        MenuCategoryMap menuCategoryMap2 = MenuCategoryMap.create();
+
+        // when then
+        menuCategoryMap1.map(menu, menuCategory1);
+        menuCategoryMap2.map(menu, menuCategory2);
+
+        menuRepository.save(menu);
+
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .log().all()
+            .when()
+            .log().all()
+            .get("/shops/{shopId}/menus/categories", menu.getShopId())
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.body().jsonPath().getLong("count")).isEqualTo(2);
+
+                softly.assertThat(response.body().jsonPath().getList("menu_categories"))
+                    .hasSize(2);
+
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[0].id"))
+                    .isEqualTo(menuCategory1.getId());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].name"))
+                    .isEqualTo(menuCategory1.getName());
+
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[1].id"))
+                    .isEqualTo(menuCategory2.getId());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].name"))
+                    .isEqualTo(menuCategory2.getName());
+            }
+        );
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈
- close #40

# 🚀 작업 내용

1. 메뉴 카테고리 조회 기능 추가했습니다.
  -  MenuCategoryRepository 생성했습니다.
2. 상점 유효성 검증 부분은 상점 조회 로직 만들 때 추가하는 게 맞는 것 같아 `TODO` 에 남겼습니다. (머지시 이슈 댓글에 남길 예정입니다.)

# 💬 리뷰 중점사항

- 도메인 설계가 없고, 단순한 로직이라 크게 리뷰 중점사항이 없어 보입니다..
- 상점/메뉴/메뉴카테고리 등 분리는 추후 상점 로직 다룰 때 하는 게 맞는 것 같아 진행하지 않았습니다.