### PR TITLE
feat: logout 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/auth/UserAuth.java
+++ b/src/main/java/in/koreatech/koin/domain/auth/UserAuth.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.auth;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({PARAMETER, FIELD})
+@Retention(RUNTIME)
+public @interface UserAuth {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/auth/resolver/UserArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/domain/auth/resolver/UserArgumentResolver.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.domain.auth.resolver;
+
+import in.koreatech.koin.domain.auth.JwtProvider;
+import in.koreatech.koin.domain.auth.UserAuth;
+import in.koreatech.koin.domain.auth.exception.AuthException;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest nativeRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (nativeRequest == null) {
+            throw new AuthException("요청 값이 비어있습니다.");
+        }
+
+        String authorizationHeader = nativeRequest.getHeader(AUTHORIZATION);
+        if (authorizationHeader == null) {
+            throw new AuthException("인증 헤더값이 비어있습니다. authorizationHeader: " + nativeRequest);
+        }
+        Long userId = jwtProvider.getUserId(authorizationHeader);
+        return userRepository.findById(userId)
+            .orElseThrow(() -> UserNotFoundException.withDetail("authorizationHeader: " + authorizationHeader));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -1,17 +1,17 @@
 package in.koreatech.koin.domain.user.controller;
 
+import in.koreatech.koin.domain.auth.UserAuth;
+import in.koreatech.koin.domain.user.dto.UserLoginRequest;
+import in.koreatech.koin.domain.user.dto.UserLoginResponse;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import java.net.URI;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import in.koreatech.koin.domain.user.dto.UserLoginRequest;
-import in.koreatech.koin.domain.user.dto.UserLoginResponse;
-import in.koreatech.koin.domain.user.service.UserService;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +24,11 @@ public class UserController {
         UserLoginResponse response = userService.login(request);
         return ResponseEntity.created(URI.create("/"))
             .body(response);
+    }
+
+    @PostMapping("/user/logout")
+    public ResponseEntity<Void> logout(@UserAuth User user) {
+        userService.logout(user);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserTokenRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserTokenRepository.java
@@ -1,14 +1,14 @@
 package in.koreatech.koin.domain.user.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.repository.Repository;
-
 import in.koreatech.koin.domain.user.model.UserToken;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
 public interface UserTokenRepository extends Repository<UserToken, Long> {
 
     UserToken save(UserToken userToken);
 
     Optional<UserToken> findById(Long userId);
+
+    void deleteById(Long id);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -1,20 +1,18 @@
 package in.koreatech.koin.domain.user.service;
 
-import in.koreatech.koin.domain.user.exception.UserNotFoundException;
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import in.koreatech.koin.domain.auth.JwtProvider;
-import in.koreatech.koin.domain.user.model.User;
-import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -41,5 +39,10 @@ public class UserService {
         User saved = userRepository.save(user);
 
         return UserLoginResponse.of(accessToken, savedToken.getRefreshToken(), saved.getUserType().getValue());
+    }
+
+    @Transactional
+    public void logout(User user) {
+        userTokenRepository.deleteById(user.getId());
     }
 }

--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.global.config;
 
 import in.koreatech.koin.domain.auth.resolver.StudentArgumentResolver;
+import in.koreatech.koin.domain.auth.resolver.UserArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -11,10 +12,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    private final UserArgumentResolver userArgumentResolver;
     private final StudentArgumentResolver studentArgumentResolver;
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userArgumentResolver);
         resolvers.add(studentArgumentResolver);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #20 

# 🚀 작업 내용

1. 로그아웃 호출 시 refreshToken을 제거합니다.

# 💬 리뷰 중점사항

현재 User, Student 두가지 권한이 존재하는데 권한 분리작업은 추후 Owner 권한을 작업하는 과정에서 진행하겠습니다.

- https://github.com/BCSDLab/KOIN_API_V2/issues/1