### PR TITLE
Feature/127 find land

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 }
 
 dependencies {
+    implementation group: 'org.json', name: 'json', version: '20231013'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.land.dto.LandListItemResponse;
+import in.koreatech.koin.domain.land.dto.LandResponse;
 import in.koreatech.koin.domain.land.service.LandService;
 import lombok.RequiredArgsConstructor;
 
@@ -20,5 +22,11 @@ public class LandController {
     public ResponseEntity<List<LandListItemResponse>> getLands() {
         List<LandListItemResponse> responses = landService.getLands();
         return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/lands/{id}")
+    public ResponseEntity<LandResponse> getLand(@PathVariable Long id) {
+        LandResponse response = landService.getLand(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandListItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandListItemResponse.java
@@ -10,11 +10,11 @@ import in.koreatech.koin.domain.land.model.Land;
 public record LandListItemResponse(
     String internalName,
     String monthlyFee,
-    String latitude,
+    Double latitude,
     String charterFee,
     String name,
     Long id,
-    String longitude,
+    Double longitude,
     String roomType) {
 
     public static LandListItemResponse from(Land land) {

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
@@ -1,15 +1,16 @@
 package in.koreatech.koin.domain.land.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.land.model.Land;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record LandResponse(
     Boolean optElectronicDoorLocks,
     Boolean optTv,

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
@@ -1,2 +1,92 @@
-package in.koreatech.koin.domain.land.dto;public class LandResponse {
+package in.koreatech.koin.domain.land.dto;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.land.model.Land;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record LandResponse(
+    Boolean optElectronicDoorLocks,
+    Boolean optTv,
+    String monthlyFee,
+    Boolean optElevator,
+    Boolean optWaterPurifier,
+    Boolean optWasher,
+    String latitude,
+    String charterFee,
+    Boolean optVeranda,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+    String description,
+    String imageUrls,
+    Boolean optGasRange,
+    Boolean optInduction,
+    String internalName,
+    Boolean isDeleted,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt,
+    Boolean optBidet,
+    Boolean optShoeCloset,
+    Boolean optRefrigerator,
+    Long id,
+    Long floor,
+    String managementFee,
+    Boolean optDesk,
+    Boolean optCloset,
+    String longitude,
+    String address,
+    Boolean optBed,
+    String size,
+    String phone,
+    Boolean optAirConditioner,
+    String name,
+    String deposit,
+    Boolean optMicrowave,
+    String permalink,
+    String roomType) {
+
+    public static LandResponse from(Land land) {
+        return new LandResponse(
+            land.getOptElectronicDoorLocks(),
+            land.getOptTv(),
+            land.getMonthlyFee(),
+            land.getOptElevator(),
+            land.getOptWaterPurifier(),
+            land.getOptWasher(),
+            land.getLatitude(),
+            land.getCharterFee(),
+            land.getOptVeranda(),
+            land.getCreatedAt(),
+            land.getDescription(),
+            land.getImageUrls(),
+            land.getOptGasRange(),
+            land.getOptInduction(),
+            land.getInternalName(),
+            land.getIsDeleted(),
+            land.getUpdatedAt(),
+            land.getOptBidet(),
+            land.getOptShoeCloset(),
+            land.getOptRefrigerator(),
+            land.getId(),
+            land.getFloor(),
+            land.getManagementFee(),
+            land.getOptDesk(),
+            land.getOptCloset(),
+            land.getLongitude(),
+            land.getAddress(),
+            land.getOptBed(),
+            land.getSize(),
+            land.getPhone(),
+            land.getOptAirConditioner(),
+            land.getName(),
+            land.getDeposit(),
+            land.getOptMicrowave(),
+            URLEncoder.encode(land.getInternalName(), StandardCharsets.UTF_8),
+            land.getRoomType()
+        );
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
@@ -1,0 +1,2 @@
+package in.koreatech.koin.domain.land.dto;public class LandResponse {
+}

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
@@ -1,8 +1,7 @@
 package in.koreatech.koin.domain.land.dto;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -18,12 +17,12 @@ public record LandResponse(
     Boolean optElevator,
     Boolean optWaterPurifier,
     Boolean optWasher,
-    String latitude,
+    Double latitude,
     String charterFee,
     Boolean optVeranda,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
     String description,
-    String imageUrls,
+    List<String> imageUrls,
     Boolean optGasRange,
     Boolean optInduction,
     String internalName,
@@ -37,10 +36,10 @@ public record LandResponse(
     String managementFee,
     Boolean optDesk,
     Boolean optCloset,
-    String longitude,
+    Double longitude,
     String address,
     Boolean optBed,
-    String size,
+    Double size,
     String phone,
     Boolean optAirConditioner,
     String name,
@@ -49,7 +48,7 @@ public record LandResponse(
     String permalink,
     String roomType) {
 
-    public static LandResponse from(Land land) {
+    public static LandResponse of(Land land, List<String> imageUrls, String permalink) {
         return new LandResponse(
             land.getOptElectronicDoorLocks(),
             land.getOptTv(),
@@ -62,7 +61,7 @@ public record LandResponse(
             land.getOptVeranda(),
             land.getCreatedAt(),
             land.getDescription(),
-            land.getImageUrls(),
+            imageUrls,
             land.getOptGasRange(),
             land.getOptInduction(),
             land.getInternalName(),
@@ -85,7 +84,7 @@ public record LandResponse(
             land.getName(),
             land.getDeposit(),
             land.getOptMicrowave(),
-            URLEncoder.encode(land.getInternalName(), StandardCharsets.UTF_8),
+            permalink,
             land.getRoomType()
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/land/model/Land.java
+++ b/src/main/java/in/koreatech/koin/domain/land/model/Land.java
@@ -36,21 +36,18 @@ public class Land extends BaseEntity {
     @Column(name = "internal_name", nullable = false, length = 50)
     private String internalName;
 
-    @Size(max = 20)
     @Column(name = "size", length = 20)
-    private String size;
+    private Double size;
 
     @Size(max = 20)
     @Column(name = "room_type", length = 20)
     private String roomType;
 
-    @Size(max = 20)
     @Column(name = "latitude", length = 20)
-    private String latitude;
+    private Double latitude;
 
-    @Size(max = 20)
     @Column(name = "longitude", length = 20)
-    private String longitude;
+    private Double longitude;
 
     @Size(max = 20)
     @Column(name = "phone", length = 20)
@@ -156,7 +153,7 @@ public class Land extends BaseEntity {
     private Boolean isDeleted = false;
 
     @Builder
-    private Land(String internalName, String name, String size, String roomType, String latitude, String longitude,
+    private Land(String internalName, String name, Double size, String roomType, Double latitude, Double longitude,
         String phone, String imageUrls, String address, String description, Long floor, String deposit,
         String monthlyFee, String charterFee, String managementFee) {
         this.internalName = internalName;

--- a/src/main/java/in/koreatech/koin/domain/land/model/Land.java
+++ b/src/main/java/in/koreatech/koin/domain/land/model/Land.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.land.model;
 
+import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "lands")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Land {
+public class Land extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/in/koreatech/koin/domain/land/repository/LandRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/land/repository/LandRepository.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.land.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
@@ -9,6 +10,8 @@ import in.koreatech.koin.domain.land.model.Land;
 public interface LandRepository extends Repository<Land, Long> {
 
     List<Land> findAll();
+
+    Optional<Land> findById(Long id);
 
     Land save(Land request);
 }

--- a/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
+++ b/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
@@ -36,7 +36,11 @@ public class LandService {
         List<String> imageUrls = null;
 
         if (image != null) {
-            imageUrls = new JSONArray(image).toList().stream().map(Object::toString).toList();
+            imageUrls = new JSONArray(image)
+                .toList()
+                .stream()
+                .map(Object::toString)
+                .toList();
         }
 
         return LandResponse.of(land, imageUrls, URLEncoder.encode(land.getInternalName(), StandardCharsets.UTF_8));

--- a/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
+++ b/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.land.dto.LandListItemResponse;
+import in.koreatech.koin.domain.land.dto.LandResponse;
+import in.koreatech.koin.domain.land.model.Land;
 import in.koreatech.koin.domain.land.repository.LandRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -21,5 +23,12 @@ public class LandService {
             .stream()
             .map(LandListItemResponse::from)
             .toList();
+    }
+
+    public LandResponse getLand(Long id) {
+        Land land = landRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 복덕방입니다."));
+
+        return LandResponse.from(land);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
+++ b/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
@@ -1,7 +1,10 @@
 package in.koreatech.koin.domain.land.service;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import org.json.JSONArray;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +32,13 @@ public class LandService {
         Land land = landRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 복덕방입니다."));
 
-        return LandResponse.from(land);
+        String image = land.getImageUrls();
+        List<String> imageUrls = null;
+
+        if (image != null) {
+            imageUrls = new JSONArray(image).toList().stream().map(Object::toString).toList();
+        }
+
+        return LandResponse.of(land, imageUrls, URLEncoder.encode(land.getInternalName(), StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #127 

# 🚀 작업 내용

1. 복덕방 단일 조회 API를 구현하였습니다.

2. `id`에 해당하는 복덕방이 없을 경우 `IllegalArgumentException`이 발생하도록 하였습니다.

3. 스웨거에서 반환되는 타입에 맞게 필드의 반환 타입을 수정하였습니다.
   - `List<String>` : image_urls 
   - `Double` : latitude, longitude, size

# 💬 리뷰 중점사항

- comments
  - 스웨거는 comments 객체를 함께 반환하고 있는데, koin과 api를 찾아보니 comments 관련된 기능을 사용하지 않는 것 같아서 반환하지 않았습니다. 빼도 괜찮을까요?
  
    ![image](https://github.com/BCSDLab/KOIN_API_V2/assets/106418303/0a4cca3f-5763-4b22-96a0-6a506d787c42)

- size
  - 스웨거에서 size가 반환되는 것을 보면 11.0처럼 0이 있으면 없애고 11로 반환하고 있습니다. 그러나 저는 11.0이면 그대로 11.0으로 반환하고 있습니다. 
  
      ![image](https://github.com/BCSDLab/KOIN_API_V2/assets/106418303/11eaee5d-3860-4790-8343-8cf62d5068f8)

  - 7.5인 것은 7.5로 반환하기도 하고, Domain에서 size의 타입이 Double인 것을 보면 Double로 반환되는 것 같습니다. 
  
      ![image](https://github.com/BCSDLab/KOIN_API_V2/assets/106418303/88f738c4-192c-4a28-a6ca-9e3fce5e543d)


   1. 같은 Double이어도  뒤의 0으로 문제가 될 수 있을까요?
 
      ![image](https://github.com/BCSDLab/KOIN_API_V2/assets/106418303/58a6020e-a99c-41d2-acc6-40ae6758153d)

   


