### PR TITLE
feat: 게시글 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'com.mysql:mysql-connector-j'
+    implementation 'org.jsoup:jsoup:1.15.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -16,8 +16,8 @@ public class CommunityController {
     private final CommunityService communityService;
 
     @GetMapping("/articles")
-    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false, defaultValue = "1") Long page,
-        @RequestParam(required = false, defaultValue = "10") Long limit) {
+    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false) Long page,
+        @RequestParam(required = false) Long limit) {
         ArticlesResponse foundArticles = communityService.getArticles(boardId, page, limit);
         return ResponseEntity.ok().body(foundArticles);
     }

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -1,23 +1,23 @@
 package in.koreatech.koin.domain.community.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.service.CommunityService;
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class CommunityController {
 
     private final CommunityService communityService;
 
     @GetMapping("/articles")
-    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false) Long page,
-        @RequestParam(required = false) Long limit) {
+    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false, defaultValue = "1") Long page,
+        @RequestParam(required = false, defaultValue = "10") Long limit) {
         ArticlesResponse foundArticles = communityService.getArticles(boardId, page, limit);
         return ResponseEntity.ok().body(foundArticles);
     }

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.domain.community.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.domain.community.dto.ArticlesResponse;
+import in.koreatech.koin.domain.community.service.CommunityService;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+    @GetMapping("/articles")
+    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false) Long page,
+        @RequestParam(required = false) Long limit) {
+        return ResponseEntity.ok().body(null);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -18,6 +18,7 @@ public class CommunityController {
     @GetMapping("/articles")
     public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false) Long page,
         @RequestParam(required = false) Long limit) {
-        return ResponseEntity.ok().body(null);
+        ArticlesResponse foundArticles = communityService.getArticles(boardId, page, limit);
+        return ResponseEntity.ok().body(foundArticles);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -16,8 +16,11 @@ public class CommunityController {
     private final CommunityService communityService;
 
     @GetMapping("/articles")
-    public ResponseEntity<ArticlesResponse> getArticles(@RequestParam Long boardId, @RequestParam(required = false) Long page,
-        @RequestParam(required = false) Long limit) {
+    public ResponseEntity<ArticlesResponse> getArticles(
+        @RequestParam Long boardId,
+        @RequestParam(required = false) Long page,
+        @RequestParam(required = false) Long limit
+    ) {
         ArticlesResponse foundArticles = communityService.getArticles(boardId, page, limit);
         return ResponseEntity.ok().body(foundArticles);
     }

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -1,4 +1,97 @@
 package in.koreatech.koin.domain.community.dto;
 
-public class ArticlesResponse {
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.community.model.Article;
+import in.koreatech.koin.domain.community.model.Board;
+
+public record ArticlesResponse(
+    List<InnerArticleResponse> articles,
+    InnerBoardResponse board,
+    Long totalPage
+) {
+
+    public static ArticlesResponse of(List<Article> articles, Board board, Long totalPage) {
+        return new ArticlesResponse(
+            articles.stream()
+                .map(InnerArticleResponse::from)
+                .toList(),
+            InnerBoardResponse.from(board),
+            totalPage
+        );
+    }
+
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    private record InnerArticleResponse(
+        Long id,
+        Long boardId,
+        String title,
+        String content,
+        Long userId,
+        String nickname,
+        Long hit, String ip,
+        Boolean isSolved,
+        Boolean isDeleted,
+        Byte commentCount,
+        String meta,
+        Long noticeArticleId,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
+    ) {
+
+        public static InnerArticleResponse from(Article article) {
+            return new InnerArticleResponse(
+                article.getId(),
+                article.getBoardId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getUserId(),
+                article.getNickname(),
+                article.getHit(),
+                article.getIp(),
+                article.getIsSolved(),
+                article.getIsDeleted(),
+                article.getCommentCount(),
+                article.getMeta(),
+                article.getNoticeArticleId(),
+                article.getCreatedAt(),
+                article.getUpdatedAt()
+            );
+        }
+    }
+
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static record InnerBoardResponse(
+        Long id,
+        String tag,
+        String name,
+        Boolean isAnonymous,
+        Long articleCount,
+        Boolean isDeleted,
+        Long parentId,
+        Long seq,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
+    ) {
+
+        public static InnerBoardResponse from(Board board) {
+            return new InnerBoardResponse(
+                board.getId(),
+                board.getTag(),
+                board.getName(),
+                board.getIsAnonymous(),
+                board.getArticleCount(),
+                board.getIsDeleted(),
+                board.getParentId(),
+                board.getSeq(),
+                board.getCreatedAt(),
+                board.getUpdatedAt()
+            );
+        }
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -42,6 +42,7 @@ public record ArticlesResponse(
         String meta,
         Boolean isNotice,
         Long noticeArticleId,
+        String summary,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt,
         @JsonProperty("contentSummary") String contentSummary
@@ -63,6 +64,7 @@ public record ArticlesResponse(
                 article.getMeta(),
                 article.getIsNotice(),
                 article.getNoticeArticleId(),
+                article.getSummary(),
                 article.getCreatedAt(),
                 article.getUpdatedAt(),
                 article.getContentSummary()

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -39,9 +40,11 @@ public record ArticlesResponse(
         Boolean isDeleted,
         Byte commentCount,
         String meta,
+        Boolean isNotice,
         Long noticeArticleId,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt,
+        @JsonProperty("contentSummary") String contentSummary
     ) {
 
         public static InnerArticleResponse from(Article article) {
@@ -58,23 +61,27 @@ public record ArticlesResponse(
                 article.getIsDeleted(),
                 article.getCommentCount(),
                 article.getMeta(),
+                article.getIsNotice(),
                 article.getNoticeArticleId(),
                 article.getCreatedAt(),
-                article.getUpdatedAt()
+                article.getUpdatedAt(),
+                article.getContentSummary()
             );
         }
     }
 
     @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static record InnerBoardResponse(
+    public record InnerBoardResponse(
         Long id,
         String tag,
         String name,
         Boolean isAnonymous,
         Long articleCount,
         Boolean isDeleted,
+        Boolean isNotice,
         Long parentId,
         Long seq,
+        List<InnerBoardResponse> children,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
     ) {
@@ -87,8 +94,11 @@ public record ArticlesResponse(
                 board.getIsAnonymous(),
                 board.getArticleCount(),
                 board.getIsDeleted(),
+                board.getIsNotice(),
                 board.getParentId(),
                 board.getSeq(),
+                board.getChildren().isEmpty() ?
+                    null : board.getChildren().stream().map(InnerBoardResponse::from).toList(),
                 board.getCreatedAt(),
                 board.getUpdatedAt()
             );

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -99,8 +99,8 @@ public record ArticlesResponse(
                 board.getIsNotice(),
                 board.getParentId(),
                 board.getSeq(),
-                board.getChildren().isEmpty() ?
-                    null : board.getChildren().stream().map(InnerBoardResponse::from).toList(),
+                board.getChildren().isEmpty()
+                    ? null : board.getChildren().stream().map(InnerBoardResponse::from).toList(),
                 board.getCreatedAt(),
                 board.getUpdatedAt()
             );

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -1,0 +1,4 @@
+package in.koreatech.koin.domain.community.dto;
+
+public class ArticlesResponse {
+}

--- a/src/main/java/in/koreatech/koin/domain/community/exception/ArticleNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/community/exception/ArticleNotFoundException.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.community.exception;
+
+public class ArticleNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "게시글이 존재하지 않습니다.";
+
+    public ArticleNotFoundException(String message) {
+        super(message);
+    }
+
+    public static ArticleNotFoundException withDetail(String detail) {
+        String message = String.format("%s %s", DEFAULT_MESSAGE, detail);
+        return new ArticleNotFoundException(message);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.model;
 
+import org.hibernate.annotations.Where;
 import org.jsoup.Jsoup;
 
 import in.koreatech.koin.global.common.BaseEntity;
@@ -22,6 +23,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "articles")
+@Where(clause = "is_deleted=0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends BaseEntity {
 

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -99,10 +99,11 @@ public class Article extends BaseEntity {
             return "";
         }
         String contentSummary = Jsoup.parse(content).text();
-        contentSummary = contentSummary.replace("&nbsp", "").trim();
-        contentSummary = (contentSummary.length() > SUMMARY_MAX_LENGTH)
-            ? contentSummary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH) : contentSummary;
-        return contentSummary;
+        contentSummary = contentSummary.replace("&nbsp", "").strip();
+        if (contentSummary.length() < SUMMARY_MAX_LENGTH) {
+            return contentSummary;
+        }
+        return contentSummary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH);
     }
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -95,13 +95,14 @@ public class Article extends BaseEntity {
     private String summary;
 
     public String getContentSummary() {
-        if (content == null)
+        if (content == null) {
             return "";
-        String summary = Jsoup.parse(content).text();
-        summary = summary.replace("&nbsp", "").trim();
-        summary = (summary.length() > SUMMARY_MAX_LENGTH) ?
-            summary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH) : summary;
-        return summary;
+        }
+        String contentSummary = Jsoup.parse(content).text();
+        contentSummary = contentSummary.replace("&nbsp", "").trim();
+        contentSummary = (contentSummary.length() > SUMMARY_MAX_LENGTH)
+            ? contentSummary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH) : contentSummary;
+        return contentSummary;
     }
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -89,6 +90,9 @@ public class Article extends BaseEntity {
 
     @Column(name = "notice_article_id")
     private Long noticeArticleId;
+
+    @Transient
+    private String summary;
 
     public String getContentSummary() {
         if (content == null)

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -1,0 +1,104 @@
+package in.koreatech.koin.domain.community.model;
+
+import in.koreatech.koin.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "articles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @Column(name = "board_id", nullable = false)
+    private Long boardId;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @NotNull
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @NotNull
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @NotNull
+    @Column(name = "hit", nullable = false)
+    private Long hit;
+
+    @Size(max = 45)
+    @NotNull
+    @Column(name = "ip", nullable = false, length = 45)
+    private String ip;
+
+    @NotNull
+    @Column(name = "is_solved", nullable = false)
+    private Boolean isSolved = false;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @NotNull
+    @Column(name = "comment_count", nullable = false)
+    private Byte commentCount;
+
+    @Lob
+    @Column(name = "meta")
+    private String meta;
+
+    @NotNull
+    @Column(name = "is_notice", nullable = false)
+    private Boolean isNotice = false;
+
+    @Column(name = "notice_article_id")
+    private Long noticeArticleId;
+
+    @Builder
+    private Article(Long boardId, String title, String content, Long userId, String nickname, Long hit,
+        String ip, Boolean isSolved, Boolean isDeleted, Byte commentCount, String meta, Boolean isNotice,
+        Long noticeArticleId) {
+        this.boardId = boardId;
+        this.title = title;
+        this.content = content;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.hit = hit;
+        this.ip = ip;
+        this.isSolved = isSolved;
+        this.isDeleted = isDeleted;
+        this.commentCount = commentCount;
+        this.meta = meta;
+        this.isNotice = isNotice;
+        this.noticeArticleId = noticeArticleId;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.community.model;
 
+import org.jsoup.Jsoup;
+
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +24,9 @@ import lombok.Setter;
 @Table(name = "articles")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends BaseEntity {
+
+    private static final int SUMMARY_MIN_LENGTH = 0;
+    private static final int SUMMARY_MAX_LENGTH = 100;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -82,6 +87,16 @@ public class Article extends BaseEntity {
 
     @Column(name = "notice_article_id")
     private Long noticeArticleId;
+
+    public String getContentSummary() {
+        if (content == null)
+            return "";
+        String summary = Jsoup.parse(content).text();
+        summary = summary.replace("&nbsp", "").trim();
+        summary = (summary.length() > SUMMARY_MAX_LENGTH) ?
+            summary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH) : summary;
+        return summary;
+    }
 
     @Builder
     private Article(Long boardId, String title, String content, Long userId, String nickname, Long hit,

--- a/src/main/java/in/koreatech/koin/domain/community/model/Board.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Board.java
@@ -1,0 +1,74 @@
+package in.koreatech.koin.domain.community.model;
+
+import in.koreatech.koin.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "boards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(max = 10)
+    @NotNull
+    @Column(name = "tag", nullable = false, length = 10)
+    private String tag;
+
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @NotNull
+    @Column(name = "is_anonymous", nullable = false)
+    private Boolean isAnonymous = false;
+
+    @NotNull
+    @Column(name = "article_count", nullable = false)
+    private Long articleCount;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @NotNull
+    @Column(name = "is_notice", nullable = false)
+    private Boolean isNotice = false;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @NotNull
+    @Column(name = "seq", nullable = false)
+    private Long seq;
+
+    @Builder
+    private Board(String tag, String name, Boolean isAnonymous, Long articleCount, Boolean isDeleted,
+        Boolean isNotice, Long parentId, Long seq) {
+        this.tag = tag;
+        this.name = name;
+        this.isAnonymous = isAnonymous;
+        this.articleCount = articleCount;
+        this.isDeleted = isDeleted;
+        this.isNotice = isNotice;
+        this.parentId = parentId;
+        this.seq = seq;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/Board.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Board.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.domain.community.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.Where;
+
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +24,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "boards")
+@Where(clause = "is_deleted=0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board extends BaseEntity {
     @Id

--- a/src/main/java/in/koreatech/koin/domain/community/model/Board.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Board.java
@@ -1,5 +1,8 @@
 package in.koreatech.koin.domain.community.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -58,6 +61,10 @@ public class Board extends BaseEntity {
     @NotNull
     @Column(name = "seq", nullable = false)
     private Long seq;
+
+    public List<Board> getChildren() {
+        return new ArrayList<>();
+    }
 
     @Builder
     private Board(String tag, String name, Boolean isAnonymous, Long articleCount, Boolean isDeleted,

--- a/src/main/java/in/koreatech/koin/domain/community/model/Criteria.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Criteria.java
@@ -24,10 +24,10 @@ public class Criteria {
         if (page == null) {
             page = DEFAULT_PAGE;
         }
-        page -= 1; // start from 0
         if (page < MIN_PAGE) {
             page = MIN_PAGE;
         }
+        page -= 1; // start from 0
         return page.intValue();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/model/Criteria.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Criteria.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.community.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Criteria {
+    private static final Long DEFAULT_PAGE = 1L;
+    private static final Long MIN_PAGE = 1L;
+
+    private static final Long DEFAULT_LIMIT = 10L;
+    private static final Long MIN_LIMIT = 1L;
+    private static final Long MAX_LIMIT = 50L;
+
+    private final int page;
+    private final int limit;
+
+    public static Criteria of(Long page, Long limit) {
+        return new Criteria(validatePage(page), validateLimit(limit));
+    }
+
+    private static int validatePage(Long page) {
+        if (page == null) {
+            page = DEFAULT_PAGE;
+        }
+        page -= 1; // start from 0
+        if (page < MIN_PAGE) {
+            page = MIN_PAGE;
+        }
+        return page.intValue();
+    }
+
+    private static int validateLimit(Long limit) {
+        if (limit == null) {
+            limit = DEFAULT_LIMIT;
+        }
+        if (limit < MIN_LIMIT) {
+            limit = MIN_LIMIT;
+        }
+        if (limit > MAX_LIMIT) {
+            limit = MAX_LIMIT;
+        }
+        return limit.intValue();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -1,12 +1,12 @@
 package in.koreatech.koin.domain.community.repository;
 
-import java.util.Optional;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.community.model.Article;
 
 public interface ArticleRepository extends Repository<Article, Long> {
 
-    Optional<Article> findByBoardId(Long boardId);
+    Page<Article> findByBoardId(Long boardId, Pageable pageable);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -9,4 +9,6 @@ import in.koreatech.koin.domain.community.model.Article;
 public interface ArticleRepository extends Repository<Article, Long> {
 
     Page<Article> findByBoardId(Long boardId, Pageable pageable);
+
+    Article save(Article article);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.community.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.model.Article;
+
+public interface ArticleRepository extends Repository<Article, Long> {
+
+    Optional<Article> findByBoardId(Long boardId);
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -1,11 +1,9 @@
 package in.koreatech.koin.domain.community.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.community.model.Board;
 
 public interface BoardRepository extends Repository<Board, Long> {
-    Optional<Board> findById(Long id);
+    Board findById(Long id);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.domain.community.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.model.Board;
+
+public interface BoardRepository extends Repository<Board, Long> {
+    Optional<Board> findById(Long id);
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -1,9 +1,11 @@
 package in.koreatech.koin.domain.community.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.community.model.Board;
 
 public interface BoardRepository extends Repository<Board, Long> {
-    Board findById(Long id);
+    Optional<Board> findById(Long id);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -8,4 +8,6 @@ import in.koreatech.koin.domain.community.model.Board;
 
 public interface BoardRepository extends Repository<Board, Long> {
     Optional<Board> findById(Long id);
+
+    Board save(Board board);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -9,6 +9,7 @@ import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +23,12 @@ public class CommunityService {
     private final BoardRepository boardRepository;
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
+        Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.findById(boardId);
-
-        PageRequest pageRequest = PageRequest.of(page.intValue() - 1, limit.intValue());
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit());
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
         if (articles.getContent().isEmpty()) {
-            throw ArticleNotFoundException.withDetail("boardId: " + boardId + ", page: " + page + ", limit: " + limit);
+            throw ArticleNotFoundException.withDetail("boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit());
         }
 
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -24,11 +24,14 @@ public class CommunityService {
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
         Criteria criteria = Criteria.of(page, limit);
-        Board board = boardRepository.findById(boardId);
+        Board board = boardRepository.findById(boardId)
+            .orElseThrow(() -> ArticleNotFoundException.withDetail(
+                "boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit()));
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit());
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
         if (articles.getContent().isEmpty()) {
-            throw ArticleNotFoundException.withDetail("boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit());
+            throw ArticleNotFoundException.withDetail(
+                "boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit());
         }
 
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -1,0 +1,7 @@
+package in.koreatech.koin.domain.community.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommunityService {
+}

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -2,6 +2,26 @@ package in.koreatech.koin.domain.community.service;
 
 import org.springframework.stereotype.Service;
 
+import in.koreatech.koin.domain.community.dto.ArticlesResponse;
+import in.koreatech.koin.domain.community.model.Article;
+import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.repository.ArticleRepository;
+import in.koreatech.koin.domain.community.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class CommunityService {
+
+    private final ArticleRepository articleRepository;
+    private final BoardRepository boardRepository;
+
+    public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
+        Board board = boardRepository.findById(boardId)
+            .orElseThrow(); //TODO: 404 Not Found Handling
+        Article article = articleRepository.findByBoardId(boardId)
+            .orElse(null);
+
+        return null;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -6,14 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
+import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.Board;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,14 +22,13 @@ public class CommunityService {
     private final BoardRepository boardRepository;
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
-        page -= 1;
-        Board board = boardRepository.findById(boardId)
-            .orElseThrow(); //TODO: 404 Not Found Handling
+        Board board = boardRepository.findById(boardId);
 
-        PageRequest pageRequest = PageRequest.of(page.intValue(), limit.intValue());
+        PageRequest pageRequest = PageRequest.of(page.intValue() - 1, limit.intValue());
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
-        // Article article = articleRepository.findAllByBoardId(boardId)
-        //     .orElseThrow(); //TODO: 404 Not Found Handling - errorResponse, "There is no article"
+        if (articles.getContent().isEmpty()) {
+            throw ArticleNotFoundException.withDetail("boardId: " + boardId + ", page: " + page + ", limit: " + limit);
+        }
 
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -1,6 +1,9 @@
 package in.koreatech.koin.domain.community.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.model.Article;
@@ -8,20 +11,27 @@ import in.koreatech.koin.domain.community.model.Board;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CommunityService {
 
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
+        page -= 1;
         Board board = boardRepository.findById(boardId)
             .orElseThrow(); //TODO: 404 Not Found Handling
-        Article article = articleRepository.findByBoardId(boardId)
-            .orElseThrow(); //TODO: 404 Not Found Handling - errorResponse, "There is no article"
 
-        return null;
+        PageRequest pageRequest = PageRequest.of(page.intValue(), limit.intValue());
+        Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
+        // Article article = articleRepository.findAllByBoardId(boardId)
+        //     .orElseThrow(); //TODO: 404 Not Found Handling - errorResponse, "There is no article"
+
+        return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.community.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +23,14 @@ public class CommunityService {
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
 
+    public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
+
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
         Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> ArticleNotFoundException.withDetail(
                 "boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit()));
-        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit());
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), SORT_ORDER_BY);
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
         if (articles.getContent().isEmpty()) {
             throw ArticleNotFoundException.withDetail(

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -20,7 +20,7 @@ public class CommunityService {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(); //TODO: 404 Not Found Handling
         Article article = articleRepository.findByBoardId(boardId)
-            .orElse(null);
+            .orElseThrow(); //TODO: 404 Not Found Handling - errorResponse, "There is no article"
 
         return null;
     }

--- a/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
@@ -20,4 +20,11 @@ public class ErrorResponse {
     public static ErrorResponse from(String message) {
         return new ErrorResponse(0, message);
     }
+
+    public record ErrorResponseWrapper(ErrorResponse error) {
+
+        public static ErrorResponseWrapper from(ErrorResponse error) {
+            return new ErrorResponseWrapper(error);
+        }
+    }
 }

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,15 @@
 package in.koreatech.koin.global.exception;
 
-import in.koreatech.koin.domain.auth.exception.AuthException;
-import in.koreatech.koin.domain.user.exception.UserNotFoundException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import in.koreatech.koin.domain.auth.exception.AuthException;
+import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -37,5 +39,19 @@ public class GlobalExceptionHandler {
         log.warn(e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(ErrorResponse.from("잘못된 인증정보입니다."));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponseWrapper> handleArticleNotFoundException(ArticleNotFoundException e) {
+        log.warn(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponseWrapper.from(ErrorResponse.from("There is no article")));
+    }
+
+    public record ErrorResponseWrapper(ErrorResponse error) {
+
+        public static ErrorResponseWrapper from(ErrorResponse error) {
+            return new ErrorResponseWrapper(error);
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import in.koreatech.koin.domain.auth.exception.AuthException;
 import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.global.exception.ErrorResponse.ErrorResponseWrapper;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -46,12 +47,5 @@ public class GlobalExceptionHandler {
         log.warn(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(ErrorResponseWrapper.from(ErrorResponse.from("There is no article")));
-    }
-
-    public record ErrorResponseWrapper(ErrorResponse error) {
-
-        public static ErrorResponseWrapper from(ErrorResponse error) {
-            return new ErrorResponseWrapper(error);
-        }
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -1,0 +1,130 @@
+package in.koreatech.koin.acceptance;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.community.model.Article;
+import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.repository.ArticleRepository;
+import in.koreatech.koin.domain.community.repository.BoardRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+class CommunityApiTest extends AcceptanceTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("게시글들을 페이지네이션하여 조회한다.")
+    void getArticlesByPagination() {
+        // given
+        final long PAGE_NUMBER = 1L;
+        final long PAGE_LIMIT = 1L;
+        final long ARTICLE_COUNT = 2L;
+
+        Board board = Board.builder()
+            .tag("FA001")
+            .name("자유게시판")
+            .isAnonymous(false)
+            .articleCount(338L)
+            .isDeleted(false)
+            .isNotice(false)
+            .parentId(null)
+            .seq(1L)
+            .build();
+
+        Article article1 = Article.builder()
+            .boardId(1L)
+            .title("제목")
+            .content("<p>내용</p>")
+            .userId(1L)
+            .nickname("BCSD")
+            .hit(14L)
+            .ip("123.21.234.321")
+            .isSolved(false)
+            .isDeleted(false)
+            .commentCount((byte)2)
+            .meta(null)
+            .isNotice(false)
+            .noticeArticleId(null)
+            .build();
+
+        Article article2 = Article.builder()
+            .boardId(1L)
+            .title("TITLE")
+            .content("<p> CONTENT</p>")
+            .userId(1L)
+            .nickname("BCSD")
+            .hit(14L)
+            .ip("123.14.321.213")
+            .isSolved(false)
+            .isDeleted(false)
+            .commentCount((byte)2)
+            .meta(null)
+            .isNotice(false)
+            .noticeArticleId(null)
+            .build();
+
+        boardRepository.save(board);
+        articleRepository.save(article1);
+        articleRepository.save(article2);
+
+        // when then
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .log().all()
+            .when()
+            .log().all()
+            .param("boardId", board.getId())
+            .param("page", PAGE_NUMBER)
+            .param("limit", PAGE_LIMIT)
+            .get("/articles")
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.jsonPath().getLong("board.id")).isEqualTo(board.getId());
+                softly.assertThat(response.jsonPath().getString("board.tag")).isEqualTo(board.getTag());
+                softly.assertThat(response.jsonPath().getString("board.name")).isEqualTo(board.getName());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_anonymous")).isEqualTo(board.getIsAnonymous());
+                softly.assertThat(response.jsonPath().getLong("board.article_count")).isEqualTo(board.getArticleCount());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_deleted")).isEqualTo(board.getIsDeleted());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_notice")).isEqualTo(board.getIsNotice());
+                softly.assertThat(response.jsonPath().getString("board.parent_id")).isEqualTo(board.getParentId());
+                softly.assertThat(response.jsonPath().getLong("board.seq")).isEqualTo(board.getSeq());
+                softly.assertThat(response.jsonPath().getString("board.children")).isEqualTo(board.getChildren().isEmpty() ? null : board.getChildren());
+
+                softly.assertThat(response.jsonPath().getLong("articles[0].id")).isEqualTo(article2.getId());
+                softly.assertThat(response.jsonPath().getLong("articles[0].board_id")).isEqualTo(article2.getBoardId());
+                softly.assertThat(response.jsonPath().getString("articles[0].title")).isEqualTo(article2.getTitle());
+                softly.assertThat(response.jsonPath().getString("articles[0].content")).isEqualTo(article2.getContent());
+                softly.assertThat(response.jsonPath().getLong("articles[0].user_id")).isEqualTo(article2.getUserId());
+                softly.assertThat(response.jsonPath().getString("articles[0].nickname")).isEqualTo(article2.getNickname());
+                softly.assertThat(response.jsonPath().getLong("articles[0].hit")).isEqualTo(article2.getHit());
+                softly.assertThat(response.jsonPath().getString("articles[0].ip")).isEqualTo(article2.getIp());
+                softly.assertThat(response.jsonPath().getBoolean("articles[0].is_solved")).isEqualTo(article2.getIsSolved());
+                softly.assertThat(response.jsonPath().getBoolean("articles[0].is_deleted")).isEqualTo(article2.getIsDeleted());
+                softly.assertThat(response.jsonPath().getByte("articles[0].comment_count")).isEqualTo(article2.getCommentCount());
+                softly.assertThat(response.jsonPath().getString("articles[0].meta")).isEqualTo(article2.getMeta());
+                softly.assertThat(response.jsonPath().getBoolean("articles[0].is_notice")).isEqualTo(article2.getIsNotice());
+                softly.assertThat(response.jsonPath().getString("articles[0].notice_article_id")).isEqualTo(article2.getNoticeArticleId());
+                softly.assertThat(response.jsonPath().getString("articles[0].summary")).isEqualTo(article2.getSummary());
+                softly.assertThat(response.jsonPath().getString("articles[0].contentSummary")).isEqualTo(article2.getContentSummary());
+
+                softly.assertThat(response.jsonPath().getLong("totalPage")).isEqualTo(ARTICLE_COUNT / PAGE_LIMIT);
+            }
+        );
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #104 


# 🚀 작업 내용

1. 비즈니스 로직 및 테스트 작성
  - 공지사항 조회 방법: boardId를 4로 검색
  -  참고 
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/fa5eea16-fd03-4099-92eb-9bb845e0ec63)

2. `ErrorResponseWrapper` 추가
  - 타 API와 달리 에러 발생 시 응답 객체가 "error"로 한 번 더 감싸져 있어 해당 응답에 대응하기 위해 추가했습니다.
  - 타 API 에러 응답
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/74de4de4-d34c-47d7-8a4f-eae205c8b0d8)
  - GET /articles 에러 응답
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/fcb051a1-de9d-42b3-abc0-106344b7bfa1)

3. Jsoup 의존성 추가
  - html 태그 제거를 위해 Jsoup 라이브러리 의존성을 추가했습니다.
 

# 💬 리뷰 중점사항

1. 응답 객체에서 articles.summary와 board.children이 항상 null인 것 같아서 그렇게 응답하도록 작성했는데 이렇게 진행해도 괜찮은 것인지 궁금합니다.
2. articles의 board_id가 FK로 잡혀있지 않아서 의존관계는 매핑하지 않았습니다.
3. Response가 조금 복잡하다 보니 실수가 있을 수도 있을 것 같습니다. 한 번씩만 확인해주시면 감사하겠습니다!
