### PR TITLE
feat: 게시글 단일 조회

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -2,9 +2,12 @@ package in.koreatech.koin.domain.community.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.community.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.service.CommunityService;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +16,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommunityController {
 
+    private static final String AUTHORIZATION = "Authorization";
+
     private final CommunityService communityService;
+
+    @GetMapping("/articles/{id}")
+    public ResponseEntity<ArticleResponse> getArticle(@PathVariable Long id, @RequestHeader(AUTHORIZATION) String token) {
+        ArticleResponse foundArticle = communityService.getArticle(id, token);
+        return ResponseEntity.ok().body(foundArticle);
+    }
 
     @GetMapping("/articles")
     public ResponseEntity<ArticlesResponse> getArticles(

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.domain.community.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,14 +15,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommunityController {
 
-    private static final String AUTHORIZATION = "Authorization";
-
     private final CommunityService communityService;
 
     @GetMapping("/articles/{id}")
-    public ResponseEntity<ArticleResponse> getArticle(@PathVariable Long id,
-        @RequestHeader(name = AUTHORIZATION, required = false) String loginToken) {
-        ArticleResponse foundArticle = communityService.getArticle(id, loginToken);
+    public ResponseEntity<ArticleResponse> getArticle(@PathVariable Long id) {
+        ArticleResponse foundArticle = communityService.getArticle(id);
         return ResponseEntity.ok().body(foundArticle);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -21,8 +21,9 @@ public class CommunityController {
     private final CommunityService communityService;
 
     @GetMapping("/articles/{id}")
-    public ResponseEntity<ArticleResponse> getArticle(@PathVariable Long id, @RequestHeader(AUTHORIZATION) String token) {
-        ArticleResponse foundArticle = communityService.getArticle(id, token);
+    public ResponseEntity<ArticleResponse> getArticle(@PathVariable Long id,
+        @RequestHeader(name = AUTHORIZATION, required = false) String loginToken) {
+        ArticleResponse foundArticle = communityService.getArticle(id, loginToken);
         return ResponseEntity.ok().body(foundArticle);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -1,0 +1,93 @@
+package in.koreatech.koin.domain.community.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.model.Comment;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ArticleResponse(
+    Long id,
+    Long board_id,
+    String title,
+    String content,
+    String nickname,
+    Boolean is_solved,
+    Boolean is_notice,
+    String contentSummary,
+    Long hit,
+    Long comment_count,
+    InnerBoardResponse board,
+    List<InnerCommentResponse> comments,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+) {
+
+    private record InnerBoardResponse(
+        Long id,
+        String tag,
+        String name,
+        Boolean is_anonymous,
+        Long article_count,
+        Boolean is_deleted,
+        Boolean is_notice,
+        Long parent_id,
+        Long seq,
+        List<InnerBoardResponse> children,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+        ) {
+
+        public static InnerBoardResponse from(Board board) {
+            return new InnerBoardResponse(
+                board.getId(),
+                board.getTag(),
+                board.getName(),
+                board.getIsAnonymous(),
+                board.getArticleCount(),
+                board.getIsDeleted(),
+                board.getIsNotice(),
+                board.getParentId(),
+                board.getSeq(),
+                board.getChildren().isEmpty()
+                    ? null : board.getChildren().stream().map(InnerBoardResponse::from).toList(),
+                board.getCreatedAt(),
+                board.getUpdatedAt()
+            );
+        }
+    }
+
+    private record InnerCommentResponse(
+        Long id,
+        Long article_id,
+        String content,
+        Long user_id,
+        String nickname,
+        Boolean is_deleted,
+        Boolean grantEdit,
+        Boolean grantDelete,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+    ) {
+
+        public static InnerCommentResponse from(Comment comment) {
+            return new InnerCommentResponse(
+                comment.getId(),
+                comment.getArticleId(),
+                comment.getContent(),
+                comment.getUserId(),
+                comment.getNickname(),
+                comment.getIsDeleted(),
+                comment.getGrantEdit(),
+                comment.getGrantDelete(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.Board;
 import in.koreatech.koin.domain.community.model.Comment;
 
@@ -21,12 +22,32 @@ public record ArticleResponse(
     Boolean is_notice,
     String contentSummary,
     Long hit,
-    Long comment_count,
+    Byte comment_count,
     InnerBoardResponse board,
     List<InnerCommentResponse> comments,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
 ) {
+
+    public static ArticleResponse of(Article article, Board board, List<Comment> comments) {
+        return new ArticleResponse(
+            article.getId(),
+            article.getBoardId(),
+            article.getTitle(),
+            article.getContent(),
+            article.getNickname(),
+            article.getIsSolved(),
+            article.getIsNotice(),
+            article.getContentSummary(),
+            article.getHit(),
+            article.getCommentCount(),
+            InnerBoardResponse.from(board),
+            comments.stream().map(InnerCommentResponse::from).toList(),
+            article.getCreatedAt(),
+            article.getUpdatedAt()
+        );
+    }
+
 
     private record InnerBoardResponse(
         Long id,

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -14,19 +15,19 @@ import in.koreatech.koin.domain.community.model.Comment;
 @JsonNaming(SnakeCaseStrategy.class)
 public record ArticleResponse(
     Long id,
-    Long board_id,
+    Long boardId,
     String title,
     String content,
     String nickname,
-    Boolean is_solved,
-    Boolean is_notice,
-    String contentSummary,
+    Boolean isSolved,
+    Boolean isNotice,
+    @JsonProperty("contentSummary") String contentSummary,
     Long hit,
-    Byte comment_count,
+    Byte commentCount,
     InnerBoardResponse board,
     List<InnerCommentResponse> comments,
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
 ) {
 
     public static ArticleResponse of(Article article, Board board, List<Comment> comments) {
@@ -48,20 +49,20 @@ public record ArticleResponse(
         );
     }
 
-
+    @JsonNaming(value = SnakeCaseStrategy.class)
     private record InnerBoardResponse(
         Long id,
         String tag,
         String name,
-        Boolean is_anonymous,
-        Long article_count,
-        Boolean is_deleted,
-        Boolean is_notice,
-        Long parent_id,
+        Boolean isAnonymous,
+        Long articleCount,
+        Boolean isDeleted,
+        Boolean isNotice,
+        Long parentId,
         Long seq,
         List<InnerBoardResponse> children,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
         ) {
 
         public static InnerBoardResponse from(Board board) {
@@ -83,17 +84,18 @@ public record ArticleResponse(
         }
     }
 
+    @JsonNaming(value = SnakeCaseStrategy.class)
     private record InnerCommentResponse(
         Long id,
-        Long article_id,
+        Long articleId,
         String content,
-        Long user_id,
+        Long userId,
         String nickname,
-        Boolean is_deleted,
-        Boolean grantEdit,
-        Boolean grantDelete,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime created_at,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updated_at
+        Boolean isDeleted,
+        @JsonProperty("grantEdit") Boolean grantEdit,
+        @JsonProperty("grantDelete") Boolean grantDelete,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
     ) {
 
         public static InnerCommentResponse from(Comment comment) {

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -30,10 +30,10 @@ public record ArticleResponse(
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
 ) {
 
-    public static ArticleResponse of(Article article, Board board, List<Comment> comments) {
+    public static ArticleResponse of(Article article) {
         return new ArticleResponse(
             article.getId(),
-            article.getBoardId(),
+            article.getBoard().getId(),
             article.getTitle(),
             article.getContent(),
             article.getNickname(),
@@ -42,8 +42,8 @@ public record ArticleResponse(
             article.getContentSummary(),
             article.getHit(),
             article.getCommentCount(),
-            InnerBoardResponse.from(board),
-            comments.stream().map(InnerCommentResponse::from).toList(),
+            InnerBoardResponse.from(article.getBoard()),
+            article.getComment().stream().map(InnerCommentResponse::from).toList(),
             article.getCreatedAt(),
             article.getUpdatedAt()
         );
@@ -63,7 +63,7 @@ public record ArticleResponse(
         List<InnerBoardResponse> children,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
-        ) {
+    ) {
 
         public static InnerBoardResponse from(Board board) {
             return new InnerBoardResponse(
@@ -101,7 +101,7 @@ public record ArticleResponse(
         public static InnerCommentResponse from(Comment comment) {
             return new InnerCommentResponse(
                 comment.getId(),
-                comment.getArticleId(),
+                comment.getArticle().getId(),
                 comment.getContent(),
                 comment.getUserId(),
                 comment.getNickname(),

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -51,10 +51,10 @@ public record ArticlesResponse(
         public static InnerArticleResponse from(Article article) {
             return new InnerArticleResponse(
                 article.getId(),
-                article.getBoardId(),
+                article.getBoard().getId(),
                 article.getTitle(),
                 article.getContent(),
-                article.getUserId(),
+                article.getUser().getId(),
                 article.getNickname(),
                 article.getHit(),
                 article.getIp(),

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.community.model.Article;
@@ -27,7 +27,7 @@ public record ArticlesResponse(
         );
     }
 
-    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonNaming(value = SnakeCaseStrategy.class)
     private record InnerArticleResponse(
         Long id,
         Long boardId,
@@ -72,7 +72,7 @@ public record ArticlesResponse(
         }
     }
 
-    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerBoardResponse(
         Long id,
         String tag,

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -1,15 +1,22 @@
 package in.koreatech.koin.domain.community.model;
 
+import java.util.List;
+
 import org.hibernate.annotations.Where;
 import org.jsoup.Jsoup;
 
+import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -37,9 +44,9 @@ public class Article extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @NotNull
-    @Column(name = "board_id", nullable = false)
-    private Long boardId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
 
     @Size(max = 255)
     @NotNull
@@ -51,9 +58,9 @@ public class Article extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @NotNull
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Size(max = 50)
     @NotNull
@@ -76,6 +83,9 @@ public class Article extends BaseEntity {
     @NotNull
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
+
+    @OneToMany(mappedBy = "article", fetch = FetchType.LAZY)
+    private List<Comment> comment;
 
     @NotNull
     @Column(name = "comment_count", nullable = false)
@@ -117,13 +127,13 @@ public class Article extends BaseEntity {
     }
 
     @Builder
-    private Article(Long boardId, String title, String content, Long userId, String nickname, Long hit,
+    private Article(Board board, String title, String content, User user, String nickname, Long hit,
         String ip, Boolean isSolved, Boolean isDeleted, Byte commentCount, String meta, Boolean isNotice,
         Long noticeArticleId) {
-        this.boardId = boardId;
+        this.board = board;
         this.title = title;
         this.content = content;
-        this.userId = userId;
+        this.user = user;
         this.nickname = nickname;
         this.hit = hit;
         this.ip = ip;

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -104,8 +104,7 @@ public class Article extends BaseEntity {
             contentSummary = "";
             return;
         }
-        String parseResult = Jsoup.parse(content).text();
-        parseResult = parseResult.replace("&nbsp", "").strip();
+        String parseResult = Jsoup.parse(content).text().replace("&nbsp", "").strip();
         if (parseResult.length() < SUMMARY_MAX_LENGTH) {
             contentSummary = parseResult;
             return;

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -113,6 +113,10 @@ public class Article extends BaseEntity {
         contentSummary = parseResult.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH);
     }
 
+    public void increaseHit() {
+        hit++;
+    }
+
     @Builder
     private Article(Long boardId, String title, String content, Long userId, String nickname, Long hit,
         String ip, Boolean isSolved, Boolean isDeleted, Byte commentCount, String meta, Boolean isNotice,

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
@@ -94,16 +95,22 @@ public class Article extends BaseEntity {
     @Transient
     private String summary;
 
-    public String getContentSummary() {
+    @Transient
+    private String contentSummary;
+
+    @PostLoad
+    public void updateContentSummary() {
         if (content == null) {
-            return "";
+            contentSummary = "";
+            return;
         }
-        String contentSummary = Jsoup.parse(content).text();
-        contentSummary = contentSummary.replace("&nbsp", "").strip();
-        if (contentSummary.length() < SUMMARY_MAX_LENGTH) {
-            return contentSummary;
+        String parseResult = Jsoup.parse(content).text();
+        parseResult = parseResult.replace("&nbsp", "").strip();
+        if (parseResult.length() < SUMMARY_MAX_LENGTH) {
+            contentSummary = parseResult;
+            return;
         }
-        return contentSummary.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH);
+        contentSummary = parseResult.substring(SUMMARY_MIN_LENGTH, SUMMARY_MAX_LENGTH);
     }
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
@@ -1,0 +1,52 @@
+package in.koreatech.koin.domain.community.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "article_view_logs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleViewLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @Column(name = "article_id", nullable = false)
+    private Long articleId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @NotNull
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Size(max = 45)
+    @NotNull
+    @Column(name = "ip", nullable = false, length = 45)
+    private String ip;
+
+    @Builder
+    public ArticleViewLog(Long articleId, Long userId, LocalDateTime expiredAt, String ip) {
+        this.articleId = articleId;
+        this.userId = userId;
+        this.expiredAt = expiredAt;
+        this.ip = ip;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
@@ -2,11 +2,14 @@ package in.koreatech.koin.domain.community.model;
 
 import java.time.LocalDateTime;
 
+import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -28,12 +31,13 @@ public class ArticleViewLog {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @NotNull
-    @Column(name = "article_id", nullable = false)
-    private Long articleId;
+    @OneToOne
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @NotNull
     @Column(name = "expired_at", nullable = false)
@@ -49,9 +53,9 @@ public class ArticleViewLog {
     }
 
     @Builder
-    public ArticleViewLog(Long articleId, Long userId, String ip) {
-        this.articleId = articleId;
-        this.userId = userId;
+    public ArticleViewLog(Article article, User user, String ip) {
+        this.article = article;
+        this.user = user;
         this.ip = ip;
         updateExpiredTime();
     }

--- a/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
@@ -21,6 +21,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleViewLog {
 
+    private static final Long EXPIRED_HOUR = 1L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
@@ -35,12 +37,16 @@ public class ArticleViewLog {
 
     @NotNull
     @Column(name = "expired_at", nullable = false)
-    private LocalDateTime expiredAt;
+    private LocalDateTime expiredAt = LocalDateTime.now().plusHours(EXPIRED_HOUR);
 
     @Size(max = 45)
     @NotNull
     @Column(name = "ip", nullable = false, length = 45)
     private String ip;
+
+    public void updateExpiredTime() {
+        expiredAt = LocalDateTime.now().plusHours(EXPIRED_HOUR);
+    }
 
     @Builder
     public ArticleViewLog(Long articleId, Long userId, LocalDateTime expiredAt, String ip) {

--- a/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/ArticleViewLog.java
@@ -49,10 +49,10 @@ public class ArticleViewLog {
     }
 
     @Builder
-    public ArticleViewLog(Long articleId, Long userId, LocalDateTime expiredAt, String ip) {
+    public ArticleViewLog(Long articleId, Long userId, String ip) {
         this.articleId = articleId;
         this.userId = userId;
-        this.expiredAt = expiredAt;
         this.ip = ip;
+        updateExpiredTime();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.community.model;
 
+import org.hibernate.annotations.Where;
+
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "comments")
+@Where(clause = "is_deleted=0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
@@ -62,16 +65,9 @@ public class Comment extends BaseEntity {
         }
     }
 
-    public Boolean getGrantEdit() {
-        return grantEdit;
-    }
-
-    public Boolean getGrantDelete() {
-        return grantDelete;
-    }
-
     @Builder
-    public Comment(Long id, Long articleId, String content, Long userId, String nickname, Boolean isDeleted) {
+    public Comment(Long id, Long articleId, String content, Long userId,
+        String nickname, Boolean isDeleted) {
         this.id = id;
         this.articleId = articleId;
         this.content = content;

--- a/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
@@ -1,0 +1,82 @@
+package in.koreatech.koin.domain.community.model;
+
+import in.koreatech.koin.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @Column(name = "article_id", nullable = false)
+    private Long articleId;
+
+    @NotNull
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @NotNull
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Size(max = 50)
+    @NotNull
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @Transient
+    private Boolean grantEdit = false;
+
+    @Transient
+    private Boolean grantDelete = false;
+
+    public void updateAuthority(Long userId) {
+        if (this.userId.equals(userId)) {
+            this.grantEdit = true;
+            this.grantDelete = true;
+        }
+    }
+
+    public Boolean getGrantEdit() {
+        return grantEdit;
+    }
+
+    public Boolean getGrantDelete() {
+        return grantDelete;
+    }
+
+    @Builder
+    public Comment(Long id, Long articleId, String content, Long userId, String nickname, Boolean isDeleted) {
+        this.id = id;
+        this.articleId = articleId;
+        this.content = content;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Comment.java
@@ -5,10 +5,13 @@ import org.hibernate.annotations.Where;
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
@@ -30,9 +33,9 @@ public class Comment extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @NotNull
-    @Column(name = "article_id", nullable = false)
-    private Long articleId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
 
     @NotNull
     @Lob
@@ -66,10 +69,9 @@ public class Comment extends BaseEntity {
     }
 
     @Builder
-    public Comment(Long id, Long articleId, String content, Long userId,
+    public Comment(Article article, String content, Long userId,
         String nickname, Boolean isDeleted) {
-        this.id = id;
-        this.articleId = articleId;
+        this.article = article;
         this.content = content;
         this.userId = userId;
         this.nickname = nickname;

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -16,14 +16,7 @@ public interface ArticleRepository extends Repository<Article, Long> {
     Page<Article> findByBoardId(Long boardId, Pageable pageable);
 
     default Page<Article> getByBoardId(Long boardId, Pageable pageable) {
-        Page<Article> articles = findByBoardId(boardId, pageable);
-        if (articles.getContent().isEmpty()) {
-            throw ArticleNotFoundException.withDetail(
-                "boardId: " + boardId
-                    + ", pageNumber: " + pageable.getPageNumber() + ","
-                    + " pageSize: " + pageable.getPageSize());
-        }
-        return articles;
+        return findByBoardId(boardId, pageable);
     }
 
     Optional<Article> findById(Long articleId);

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -11,13 +11,26 @@ import in.koreatech.koin.domain.community.model.Article;
 
 public interface ArticleRepository extends Repository<Article, Long> {
 
+    Article save(Article article);
+
     Page<Article> findByBoardId(Long boardId, Pageable pageable);
 
-    Article save(Article article);
+    default Page<Article> getByBoardId(Long boardId, Pageable pageable) {
+        Page<Article> articles = findByBoardId(boardId, pageable);
+        if (articles.getContent().isEmpty()) {
+            throw ArticleNotFoundException.withDetail(
+                "boardId: " + boardId
+                    + ", pageNumber: " + pageable.getPageNumber() + ","
+                    + " pageSize: " + pageable.getPageSize());
+        }
+        return articles;
+    }
 
     Optional<Article> findById(Long articleId);
 
     default Article getById(Long articleId) {
-        return findById(articleId).orElseThrow(() -> ArticleNotFoundException.withDetail("articleId: " + articleId));
+        return findById(articleId).orElseThrow(
+            () -> ArticleNotFoundException.withDetail(
+                "articleId: " + articleId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -1,9 +1,12 @@
 package in.koreatech.koin.domain.community.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Article;
 
 public interface ArticleRepository extends Repository<Article, Long> {
@@ -11,4 +14,10 @@ public interface ArticleRepository extends Repository<Article, Long> {
     Page<Article> findByBoardId(Long boardId, Pageable pageable);
 
     Article save(Article article);
+
+    Optional<Article> findById(Long articleId);
+
+    default Article getById(Long articleId) {
+        return findById(articleId).orElseThrow(() -> ArticleNotFoundException.withDetail("articleId: " + articleId));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleViewLogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleViewLogRepository.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.community.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.model.ArticleViewLog;
+
+public interface ArticleViewLogRepository extends Repository<ArticleViewLog, Long> {
+
+    Optional<ArticleViewLog> findByArticleIdAndUserId(Long articleId, Long userId);
+
+    ArticleViewLog save(ArticleViewLog articleViewLog);
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -4,10 +4,16 @@ import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Board;
 
 public interface BoardRepository extends Repository<Board, Long> {
     Optional<Board> findById(Long id);
 
     Board save(Board board);
+
+    default Board getById(Long boardId) {
+        return findById(boardId).orElseThrow(
+            () -> ArticleNotFoundException.withDetail("boardId: " + boardId));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/CommentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.community.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.model.Comment;
+
+public interface CommentRepository extends Repository<Comment, Long> {
+
+    List<Comment> findAllByArticleId(Long articleId);
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/CommentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/CommentRepository.java
@@ -9,4 +9,6 @@ import in.koreatech.koin.domain.community.model.Comment;
 public interface CommentRepository extends Repository<Comment, Long> {
 
     List<Comment> findAllByArticleId(Long articleId);
+
+    Comment save(Comment comment);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -93,11 +93,7 @@ public class CommunityService {
     private String getIpAddress() {
         HttpServletRequest request =
             ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
-        String ipAddress = request.getHeader("X-FORWARDED-FOR");
-        if (ipAddress == null) {
-            ipAddress = request.getRemoteAddr();
-        }
-        return ipAddress;
+        return ClientUtil.getClientIP(request);
     }
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -22,6 +22,7 @@ import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.ArticleViewLogRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
+import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.util.ClientUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class CommunityService {
     private final ArticleRepository articleRepository;
     private final ArticleViewLogRepository articleViewLogRepository;
     private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public ArticleResponse getArticle(Long articleId) {
@@ -60,8 +62,8 @@ public class CommunityService {
         if (foundLog.isEmpty()) {
             articleViewLogRepository.save(
                 ArticleViewLog.builder()
-                    .articleId(articleId)
-                    .userId(userId)
+                    .article(articleRepository.getById(articleId))
+                    .user(userRepository.getById(userId))
                     .ip(ipAddress)
                     .build()
             );

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -103,7 +103,7 @@ public class CommunityService {
         Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), SORT_ORDER_BY);
-        Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
+        Page<Article> articles = articleRepository.getByBoardId(boardId, pageRequest);
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.community.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Article;
@@ -24,6 +25,13 @@ public class CommunityService {
     private final BoardRepository boardRepository;
 
     public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
+
+    public ArticleResponse getArticle(Long id, String token) {
+        Article article = articleRepository.findById(id)
+            .orElseThrow(() -> ArticleNotFoundException.withDetail("id: " + id));
+
+        return null;
+    }
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
         Criteria criteria = Criteria.of(page, limit);

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.ArticleViewLogRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
 import in.koreatech.koin.domain.community.repository.CommentRepository;
+import in.koreatech.koin.global.util.ClientUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -48,7 +49,7 @@ public class CommunityService {
         Board board = boardRepository.getById(article.getBoardId());
         Long userId = getUserId();
         String ipAddress = getIpAddress();
-        if (canIncreaseArticleHit(articleId, userId, ipAddress)) {
+        if (isHittable(articleId, userId, ipAddress)) {
             article.increaseHit();
         }
         List<Comment> comments = commentRepository.findAllByArticleId(articleId);
@@ -56,7 +57,7 @@ public class CommunityService {
         return ArticleResponse.of(article, board, comments);
     }
 
-    private boolean canIncreaseArticleHit(Long articleId, Long userId, String ipAddress) {
+    private boolean isHittable(Long articleId, Long userId, String ipAddress) {
         if (userId == null) {
             return false;
         }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import in.koreatech.koin.domain.auth.JwtProvider;
 import in.koreatech.koin.domain.auth.exception.AuthException;
@@ -19,6 +21,7 @@ import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
 import in.koreatech.koin.domain.community.repository.CommentRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -26,24 +29,30 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class CommunityService {
 
+    private static final String AUTHORIZATION = "Authorization";
+    public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
+
     private final JwtProvider jwtProvider;
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
     private final CommentRepository commentRepository;
 
-    public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
 
-    public ArticleResponse getArticle(Long articleId, String loginToken) {
+    public ArticleResponse getArticle(Long articleId) {
         Article article = articleRepository.getById(articleId);
         Board board = boardRepository.getById(article.getBoardId());
+        // board.increaseHit();
         List<Comment> comments = commentRepository.findAllByArticleId(articleId);
-        comments.forEach(comment -> comment.updateAuthority(getUserId(loginToken)));
+        Long userId = getUserId();
+        comments.forEach(comment -> comment.updateAuthority(userId));
         return ArticleResponse.of(article, board, comments);
     }
 
-    private Long getUserId(String loginToken) {
+    private Long getUserId() {
         try {
-            return jwtProvider.getUserId(loginToken);
+            HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            return jwtProvider.getUserId(request.getHeader(AUTHORIZATION));
         } catch (AuthException e) {
             return null;
         }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -1,19 +1,23 @@
 package in.koreatech.koin.domain.community.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.auth.JwtProvider;
 import in.koreatech.koin.domain.community.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
-import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.model.Comment;
 import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
+import in.koreatech.koin.domain.community.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,29 +25,26 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class CommunityService {
 
+    private final JwtProvider jwtProvider;
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
 
     public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
 
     public ArticleResponse getArticle(Long articleId, String token) {
         Article article = articleRepository.getById(articleId);
-
-        return null;
+        Board board = boardRepository.getById(article.getBoardId());
+        List<Comment> comments = commentRepository.findAllByArticleId(articleId);
+        comments.forEach(comment -> comment.updateAuthority(jwtProvider.getUserId(token)));
+        return ArticleResponse.of(article, board, comments);
     }
 
     public ArticlesResponse getArticles(Long boardId, Long page, Long limit) {
         Criteria criteria = Criteria.of(page, limit);
-        Board board = boardRepository.findById(boardId)
-            .orElseThrow(() -> ArticleNotFoundException.withDetail(
-                "boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit()));
+        Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), SORT_ORDER_BY);
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
-        if (articles.getContent().isEmpty()) {
-            throw ArticleNotFoundException.withDetail(
-                "boardId: " + boardId + ", page: " + criteria.getPage() + ", limit: " + criteria.getLimit());
-        }
-
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -19,12 +18,10 @@ import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.ArticleViewLog;
 import in.koreatech.koin.domain.community.model.Board;
-import in.koreatech.koin.domain.community.model.Comment;
 import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.ArticleViewLogRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
-import in.koreatech.koin.domain.community.repository.CommentRepository;
 import in.koreatech.koin.global.util.ClientUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -41,20 +38,17 @@ public class CommunityService {
     private final ArticleRepository articleRepository;
     private final ArticleViewLogRepository articleViewLogRepository;
     private final BoardRepository boardRepository;
-    private final CommentRepository commentRepository;
 
     @Transactional
     public ArticleResponse getArticle(Long articleId) {
         Article article = articleRepository.getById(articleId);
-        Board board = boardRepository.getById(article.getBoardId());
         Long userId = getUserId();
         String ipAddress = getIpAddress();
         if (isHittable(articleId, userId, ipAddress)) {
             article.increaseHit();
         }
-        List<Comment> comments = commentRepository.findAllByArticleId(articleId);
-        comments.forEach(comment -> comment.updateAuthority(userId));
-        return ArticleResponse.of(article, board, comments);
+        article.getComment().forEach(comment -> comment.updateAuthority(userId));
+        return ArticleResponse.of(article);
     }
 
     private boolean isHittable(Long articleId, Long userId, String ipAddress) {

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -26,9 +26,8 @@ public class CommunityService {
 
     public static final Sort SORT_ORDER_BY = Sort.by(Sort.Direction.DESC, "id");
 
-    public ArticleResponse getArticle(Long id, String token) {
-        Article article = articleRepository.findById(id)
-            .orElseThrow(() -> ArticleNotFoundException.withDetail("id: " + id));
+    public ArticleResponse getArticle(Long articleId, String token) {
+        Article article = articleRepository.getById(articleId);
 
         return null;
     }

--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
@@ -19,7 +19,7 @@ public class DeptController {
     private final DeptService deptService;
 
     @GetMapping("/dept")
-    public ResponseEntity<DeptResponse> getDept(@RequestParam(value = "dept_num") Long deptNumber) {
+    public ResponseEntity<DeptResponse> getDept(@RequestParam(value = "dept_num") String deptNumber) {
         DeptResponse foundDepartment = deptService.getById(deptNumber);
         if (foundDepartment == null) {
             return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptListItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptListItemResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record DeptListItemResponse(String name, String curriculumLink, List<Long> deptNums) {
+public record DeptListItemResponse(String name, String curriculumLink, List<String> deptNums) {
 
     public static DeptListItemResponse from(Dept dept) {
         return new DeptListItemResponse(

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptResponse.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record DeptResponse(Long deptNum, String name) {
+public record DeptResponse(String deptNum, String name) {
 
-    public static DeptResponse from(Long findNumber, Dept dept) {
+    public static DeptResponse from(String findNumber, Dept dept) {
         return new DeptResponse(findNumber, dept.getName());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
@@ -9,45 +9,45 @@ import lombok.Getter;
 @Getter
 public enum Dept {
     ARCHITECTURAL_ENGINEERING(
-        "건축공학부", List.of(72L),
+        "건축공학부", List.of("72"),
         "https://cms3.koreatech.ac.kr/arch/1083/subview.do"),
     EMPLOYMENT_SERVICE_POLICY_DEPARTMENT(
-        "고용서비스정책학과", List.of(85L),
+        "고용서비스정책학과", List.of("85"),
         "https://www.koreatech.ac.kr/kor/CMS/UnivOrganMgr/subMain.do?mCode=MN451"),
     MECHANICAL_ENGINEERING(
-        "기계공학부", List.of(20L),
+        "기계공학부", List.of("20"),
         "https://cms3.koreatech.ac.kr/me/795/subview.do"),
     DESIGN_ENGINEERING(
-        "디자인공학부", List.of(51L),
+        "디자인공학부", List.of("51"),
         "https://cms3.koreatech.ac.kr/ide/1047/subview.do"),
     MECHATRONICS_ENGINEERING(
-        "메카트로닉스공학부", List.of(40L),
+        "메카트로닉스공학부", List.of("40"),
         "https://www.koreatech.ac.kr/kor/CMS/UnivOrganMgr/subMain.do?mCode=MN076"),
     INDUSTRIAL_MANAGEMENT(
-        "산업경영학부", List.of(80L),
+        "산업경영학부", List.of("80"),
         "https://cms3.koreatech.ac.kr/sim/1167/subview.do"),
     NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING(
-        "에너지신소재화학공학부", List.of(74L),
+        "에너지신소재화학공학부", List.of("74"),
         "https://cms3.koreatech.ac.kr/ace/992/subview.do"),
     ELECTRICAL_AND_ELECTRONIC_COMMUNICATION_ENGINEERING(
-        "전기전자통신공학부", List.of(61L),
+        "전기전자통신공학부", List.of("61"),
         "https://cms3.koreatech.ac.kr/ite/842/subview.do"),
     COMPUTER_SCIENCE(
-        "컴퓨터공학부", List.of(35L, 36L),
+        "컴퓨터공학부", List.of("35", "36"),
         "https://cse.koreatech.ac.kr/page_izgw21"),
     ;
 
     private final String name;
-    private final List<Long> numbers;
+    private final List<String> numbers;
     private final String curriculumLink;
 
-    Dept(String name, List<Long> numbers, String curriculumLink) {
+    Dept(String name, List<String> numbers, String curriculumLink) {
         this.name = name;
         this.numbers = numbers;
         this.curriculumLink = curriculumLink;
     }
 
-    public static Optional<Dept> findByNumber(Long number) {
+    public static Optional<Dept> findByNumber(String number) {
         for (Dept dept : Dept.values()) {
             if (dept.numbers.contains(number)) {
                 return Optional.of(dept);

--- a/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
@@ -12,7 +12,7 @@ import in.koreatech.koin.domain.dept.model.Dept;
 @Service
 public class DeptService {
 
-    public DeptResponse getById(Long id) {
+    public DeptResponse getById(String id) {
         Optional<Dept> dept = Dept.findByNumber(id);
 
         return dept.map(value -> DeptResponse.from(id, value)).orElse(null);

--- a/src/main/java/in/koreatech/koin/global/util/ClientUtil.java
+++ b/src/main/java/in/koreatech/koin/global/util/ClientUtil.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ClientUtil {
+
+    public static String getClientIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -489,7 +489,7 @@ class CommunityApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("게시글들을 페이지네이션하여 조회한다. - 페이지가 최대 페이지 수를 넘어가면 404")
+    @DisplayName("게시글들을 페이지네이션하여 조회한다. - 요청된 페이지에 게시글이 존재하지 않으면 빈 게시글 배열을 반환한다.")
     void getArticlesByPagination_overMaxPageNotFound() {
         // given
         final long PAGE_NUMBER = 10000L;
@@ -506,7 +506,13 @@ class CommunityApiTest extends AcceptanceTest {
             .get("/articles")
             .then()
             .log().all()
-            .statusCode(HttpStatus.NOT_FOUND.value())
+            .statusCode(HttpStatus.OK.value())
             .extract();
+
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.jsonPath().getList("articles")).hasSize(0);
+            }
+        );
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -8,10 +8,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.auth.JwtProvider;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.model.Comment;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.BoardRepository;
+import in.koreatech.koin.domain.community.repository.CommentRepository;
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.domain.user.model.UserIdentity;
+import in.koreatech.koin.domain.user.model.UserType;
+import in.koreatech.koin.domain.user.repository.StudentRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -24,6 +33,15 @@ class CommunityApiTest extends AcceptanceTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
     private final long PAGE_NUMBER = 1L;
     private final long PAGE_LIMIT = 1L;
     private final long ARTICLE_COUNT = 2L;
@@ -33,7 +51,7 @@ class CommunityApiTest extends AcceptanceTest {
 
     @BeforeEach
     void givenBeforeEach() {
-        board = Board.builder()
+        Board boardRequest = Board.builder()
             .tag("FA001")
             .name("자유게시판")
             .isAnonymous(false)
@@ -44,7 +62,7 @@ class CommunityApiTest extends AcceptanceTest {
             .seq(1L)
             .build();
 
-        article1 = Article.builder()
+        Article article1Request = Article.builder()
             .boardId(1L)
             .title("제목")
             .content("<p>내용</p>")
@@ -60,7 +78,7 @@ class CommunityApiTest extends AcceptanceTest {
             .noticeArticleId(null)
             .build();
 
-        article2 = Article.builder()
+        Article article2Request = Article.builder()
             .boardId(1L)
             .title("TITLE")
             .content("<p> CONTENT</p>")
@@ -76,9 +94,134 @@ class CommunityApiTest extends AcceptanceTest {
             .noticeArticleId(null)
             .build();
 
-        boardRepository.save(board);
-        articleRepository.save(article1);
-        articleRepository.save(article2);
+        board = boardRepository.save(boardRequest);
+        article1 = articleRepository.save(article1Request);
+        article2 = articleRepository.save(article2Request);
+        System.out.println("article2 = " + article2);
+    }
+
+    @Test
+    @DisplayName("특정 게시글을 단일 조회한다.")
+    void getArticle() {
+        // given
+        Comment request = Comment.builder()
+            .articleId(article1.getId())
+            .content("댓글")
+            .userId(1L)
+            .nickname("BCSD")
+            .isDeleted(false)
+            .build();
+
+        Comment comment = commentRepository.save(request);
+
+        // when then
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .log().all()
+            .when()
+            .log().all()
+            .get("/articles/{articleId}", article1.getId())
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        article1.updateContentSummary();
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.jsonPath().getLong("id")).isEqualTo(article1.getId());
+                softly.assertThat(response.jsonPath().getLong("board_id")).isEqualTo(article1.getBoardId());
+                softly.assertThat(response.jsonPath().getString("title")).isEqualTo(article1.getTitle());
+                softly.assertThat(response.jsonPath().getString("content")).isEqualTo(article1.getContent());
+                softly.assertThat(response.jsonPath().getString("nickname")).isEqualTo(article1.getNickname());
+                softly.assertThat(response.jsonPath().getLong("hit")).isEqualTo(article1.getHit());
+                softly.assertThat(response.jsonPath().getBoolean("is_solved")).isEqualTo(article1.getIsSolved());
+                softly.assertThat(response.jsonPath().getByte("comment_count")).isEqualTo(article1.getCommentCount());
+                softly.assertThat(response.jsonPath().getBoolean("is_notice")).isEqualTo(article1.getIsNotice());
+                softly.assertThat(response.jsonPath().getString("contentSummary")).isEqualTo(article1.getContentSummary());
+
+                softly.assertThat(response.jsonPath().getLong("board.id")).isEqualTo(board.getId());
+                softly.assertThat(response.jsonPath().getString("board.tag")).isEqualTo(board.getTag());
+                softly.assertThat(response.jsonPath().getString("board.name")).isEqualTo(board.getName());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_anonymous")).isEqualTo(board.getIsAnonymous());
+                softly.assertThat(response.jsonPath().getLong("board.article_count")).isEqualTo(board.getArticleCount());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_deleted")).isEqualTo(board.getIsDeleted());
+                softly.assertThat(response.jsonPath().getBoolean("board.is_notice")).isEqualTo(board.getIsNotice());
+                softly.assertThat(response.jsonPath().getString("board.parent_id")).isEqualTo(board.getParentId());
+                softly.assertThat(response.jsonPath().getLong("board.seq")).isEqualTo(board.getSeq());
+                softly.assertThat(response.jsonPath().getString("board.children")).isEqualTo(board.getChildren().isEmpty() ? null : board.getChildren());
+
+                softly.assertThat(response.jsonPath().getLong("comments[0].id")).isEqualTo(comment.getId());
+                softly.assertThat(response.jsonPath().getLong("comments[0].article_id")).isEqualTo(comment.getArticleId());
+                softly.assertThat(response.jsonPath().getString("comments[0].content")).isEqualTo(comment.getContent());
+                softly.assertThat(response.jsonPath().getLong("comments[0].user_id")).isEqualTo(comment.getUserId());
+                softly.assertThat(response.jsonPath().getString("comments[0].nickname")).isEqualTo(comment.getNickname());
+                softly.assertThat(response.jsonPath().getBoolean("comments[0].is_deleted")).isEqualTo(comment.getIsDeleted());
+                softly.assertThat(response.jsonPath().getBoolean("comments[0].grantEdit")).isEqualTo(comment.getGrantEdit());
+                softly.assertThat(response.jsonPath().getBoolean("comments[0].grantDelete")).isEqualTo(comment.getGrantDelete());
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("특정 게시글을 단일 조회한다. - 댓글 작성자가 본인이면 수정 및 제거 권한이 부여된다.")
+    void getArticleAuthorizationComment() {
+        // given
+        Student student = Student.builder()
+            .studentNumber("202020136070")
+            .anonymousNickname("익명")
+            .department("컴퓨터공학부")
+            .userIdentity(UserIdentity.UNDERGRADUATE)
+            .isGraduated(false)
+            .user(
+                User.builder()
+                    .password("0000")
+                    .nickname("BCSD")
+                    .name("송선권")
+                    .phoneNumber("010-1234-5678")
+                    .userType(UserType.STUDENT)
+                    .gender(UserGender.MAN)
+                    .email("test@koreatech.ac.kr")
+                    .isAuthed(true)
+                    .isDeleted(false)
+                    .build()
+            )
+            .build();
+
+        student = studentRepository.save(student);
+        String token = jwtProvider.createToken(student.getUser());
+
+        Comment request = Comment.builder()
+            .articleId(article1.getId())
+            .content("댓글")
+            .userId(1L)
+            .nickname("BCSD")
+            .isDeleted(false)
+            .build();
+
+        Comment comment = commentRepository.save(request);
+        comment.updateAuthority(student.getUser().getId());
+
+        // when then
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .log().all()
+            .header("Authorization", "BEARER " + token)
+            .when()
+            .log().all()
+            .get("/articles/{articleId}", article1.getId())
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        article1.updateContentSummary();
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.jsonPath().getBoolean("comments[0].grantEdit")).isEqualTo(comment.getGrantEdit());
+                softly.assertThat(response.jsonPath().getBoolean("comments[0].grantDelete")).isEqualTo(comment.getGrantDelete());
+            }
+        );
     }
 
     @Test
@@ -101,6 +244,7 @@ class CommunityApiTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract();
 
+        article2.updateContentSummary();
         SoftAssertions.assertSoftly(
             softly -> {
                 softly.assertThat(response.jsonPath().getLong("board.id")).isEqualTo(board.getId());
@@ -219,7 +363,6 @@ class CommunityApiTest extends AcceptanceTest {
             }
         );
     }
-
     @Test
     @DisplayName("게시글들을 페이지네이션하여 조회한다. - limit가 음수이면 한 번에 1 게시글 조회")
     void getArticlesByPagination_lessThan0Limit() {
@@ -247,6 +390,7 @@ class CommunityApiTest extends AcceptanceTest {
             }
         );
     }
+
     @Test
     @DisplayName("게시글들을 페이지네이션하여 조회한다. - limit가 50 이상이면 한 번에 50 게시글 조회")
     void getArticlesByPagination_over50Limit() {
@@ -272,7 +416,7 @@ class CommunityApiTest extends AcceptanceTest {
                 .noticeArticleId(null)
                 .build();
             articleRepository.save(article);
-        };
+        }
 
         // when then
         ExtractableResponse<Response> response = RestAssured
@@ -321,7 +465,7 @@ class CommunityApiTest extends AcceptanceTest {
                 .noticeArticleId(null)
                 .build();
             articleRepository.save(article);
-        };
+        }
 
         // when then
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
@@ -35,7 +35,7 @@ class DeptApiTest extends AcceptanceTest {
 
         assertSoftly(
             softly -> {
-                softly.assertThat(response.body().jsonPath().getLong("dept_num")).isEqualTo(dept.getNumbers().get(0));
+                softly.assertThat(response.body().jsonPath().getString("dept_num")).isEqualTo(dept.getNumbers().get(0));
                 softly.assertThat(response.body().jsonPath().getString("name")).isEqualTo(dept.getName());
             }
         );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #106 

# 🚀 작업 내용

"가장 많이 본 게시글" API를 작업하기에 앞서 본 API 개발이 선행되어야 하기에 이번 작업을 진행했습니다.

1. 게시글 단일 조회 시 게시판 정보와 댓글 목록을 함께 반환합니다.
2. (댓글 작성자와 로그인된 사용자의 일치 여부를 기반으로) 댓글 정보 반환 시 댓글 수정 권한(`grantEdit`)과 댓글 제거 권한(`grantEdit`) 정보를 함께 반환합니다.
3. 게시글 조회 시 로그인된 유저 id와 게시글 id, 로그인 ip 정보를 `article_view_logs` 테이블에 저장합니다.
    1. ![image](https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/2ab6e831-b7d3-447e-a6ab-83cc0aaa5bbe)
    2. 이 때 1시간 뒤를 만료시간으로 함께 저장합니다.
    3. 위 사진에서 `0:0:0:0:0:0:0:1`는 IPv6 기준 localhost(IPv4는 127.0.0.1)을 의미합니다. 로컬 환경에서 테스트해서 저렇게 기입되었습니다.
4. 게시글 조회 시
    1. 조회 기록이 없다면
        1. 조회 기록을 저장합니다. (조회수 UP)
    3. 조회 기록이 있다면
        1. 만료 시간이 지나지 않았다면
            1. 아무 것도 하지 않습니다.
        3. 만료 시간이 지났다면
            1. 조회 기록의 만료 시간을 1시간 뒤로 수정합니다. (조회수 UP)
5. `HttpServletRequest`을 통해 로그인 정보와 접속 IP를 조회합니다.
6. 이번 PR 주제와 다른 내용이 포함되어 있습니다. (이전 PR에서 누락된 커밋 반영)
    - 학과 코드 자료형을 Long에서 String으로 수정했습니다.
    - cc. #147 

# 💬 리뷰 중점사항

조회수 증가 로직은 기존 코인을 따라갔습니다. 비로그인 사용자의 경우 조회수가 오르지 않는 문제가 있습니다. 추후에 업데이트가 필요해 보입니다.