### PR TITLE
feat: 회원 탈퇴 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
@@ -19,7 +19,9 @@ public class DeptController implements DeptApi {
     private final DeptService deptService;
 
     @GetMapping("/dept")
-    public ResponseEntity<DeptResponse> getDept(@RequestParam(value = "dept_num") String deptNumber) {
+    public ResponseEntity<DeptResponse> getDept(
+        @RequestParam(value = "dept_num") String deptNumber
+    ) {
         DeptResponse foundDepartment = deptService.getById(deptNumber);
         if (foundDepartment == null) {
             return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
@@ -25,7 +25,9 @@ public class LandController implements LandApi {
     }
 
     @GetMapping("/lands/{id}")
-    public ResponseEntity<LandResponse> getLand(@PathVariable Long id) {
+    public ResponseEntity<LandResponse> getLand(
+        @PathVariable Long id
+    ) {
         LandResponse response = landService.getLand(id);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -17,13 +17,18 @@ public class ShopController implements ShopApi {
     private final ShopService shopService;
 
     @GetMapping("/shops/{shopId}/menus/{menuId}")
-    public ResponseEntity<ShopMenuResponse> findMenu(@PathVariable Long shopId, @PathVariable Long menuId) {
+    public ResponseEntity<ShopMenuResponse> findMenu(
+        @PathVariable Long shopId,
+        @PathVariable Long menuId
+    ) {
         ShopMenuResponse shopMenu = shopService.findMenu(menuId);
         return ResponseEntity.ok(shopMenu);
     }
 
     @GetMapping("/shops/{shopId}/menus/categories")
-    public ResponseEntity<MenuCategoriesResponse> findMenuCategories(@PathVariable Long shopId) {
+    public ResponseEntity<MenuCategoriesResponse> findMenuCategories(
+        @PathVariable Long shopId
+    ) {
         MenuCategoriesResponse menuCategories = shopService.getMenuCategories(shopId);
         return ResponseEntity.ok(menuCategories);
     }

--- a/src/main/java/in/koreatech/koin/domain/track/controller/TrackController.java
+++ b/src/main/java/in/koreatech/koin/domain/track/controller/TrackController.java
@@ -25,7 +25,9 @@ public class TrackController implements TrackApi {
     }
 
     @GetMapping("/tracks/{id}")
-    public ResponseEntity<TrackSingleResponse> getTrack(@PathVariable Long id) {
+    public ResponseEntity<TrackSingleResponse> getTrack(
+        @PathVariable Long id
+    ) {
         TrackSingleResponse response = trackService.getTrack(id);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,5 +81,20 @@ public interface UserApi {
     @PostMapping("/user/refresh")
     ResponseEntity<UserTokenRefreshResponse> refresh(
         @RequestBody @Valid UserTokenRefreshRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "회원 탈퇴")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @DeleteMapping("/user")
+    ResponseEntity<UserTokenRefreshResponse> withdraw(
+        @Auth(permit = {STUDENT}) Long userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.user.controller;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,20 +29,25 @@ public class UserController implements UserApi {
     private final StudentService studentService;
 
     @GetMapping("/user/student/me")
-    public ResponseEntity<StudentResponse> getStudent(@Auth(permit = STUDENT) Long userId) {
+    public ResponseEntity<StudentResponse> getStudent(
+        @Auth(permit = STUDENT) Long userId
+    ) {
         StudentResponse studentResponse = studentService.getStudent(userId);
         return ResponseEntity.ok().body(studentResponse);
     }
 
     @PostMapping("/user/login")
-    public ResponseEntity<UserLoginResponse> login(@RequestBody @Valid UserLoginRequest request) {
+    public ResponseEntity<UserLoginResponse> login(
+        @RequestBody @Valid UserLoginRequest request
+    ) {
         UserLoginResponse response = userService.login(request);
         return ResponseEntity.created(URI.create("/"))
             .body(response);
     }
 
     @PostMapping("/user/logout")
-    public ResponseEntity<Void> logout(@Auth(permit = {STUDENT}) Long userId) {
+    public ResponseEntity<Void> logout(
+        @Auth(permit = {STUDENT}) Long userId) {
         userService.logout(userId);
         return ResponseEntity.ok().build();
     }
@@ -52,5 +58,13 @@ public class UserController implements UserApi {
     ) {
         UserTokenRefreshResponse tokenGroupResponse = userService.refresh(request);
         return ResponseEntity.ok().body(tokenGroupResponse);
+    }
+
+    @DeleteMapping("/user")
+    public ResponseEntity<UserTokenRefreshResponse> withdraw(
+        @Auth(permit = {STUDENT}) Long userId
+    ) {
+        userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -2,6 +2,9 @@ package in.koreatech.koin.domain.user.model;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import in.koreatech.koin.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +25,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "users")
+@Where(clause = "is_deleted=0")
+@SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -24,4 +24,6 @@ public interface UserRepository extends Repository<User, Long> {
         return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
+
+    void delete(User user);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -7,8 +7,6 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.global.auth.JwtProvider;
-import in.koreatech.koin.global.auth.exception.AuthException;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
@@ -17,6 +15,8 @@ import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
+import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -62,11 +62,17 @@ public class UserService {
         return UserTokenRefreshResponse.of(accessToken, userToken.getRefreshToken());
     }
 
-    private static String getUserId(String refreshToken) {
+    private String getUserId(String refreshToken) {
         String[] split = refreshToken.split("-");
         if (split.length == 0) {
             throw new AuthException("올바르지 않은 인증 토큰입니다. refreshToken: " + refreshToken);
         }
         return split[split.length - 1];
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.getById(userId);
+        userRepository.delete(user);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/AuthApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/AuthApiTest.java
@@ -47,7 +47,6 @@ class AuthApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .body("""
                 {
                   "email": "test@koreatech.ac.kr",
@@ -56,10 +55,8 @@ class AuthApiTest extends AcceptanceTest {
                 """)
             .contentType(ContentType.JSON)
             .when()
-            .log().all()
             .post("/user/login")
             .then()
-            .log().all()
             .statusCode(HttpStatus.CREATED.value())
             .extract();
 
@@ -96,7 +93,6 @@ class AuthApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .body("""
                 {
                   "email": "test@koreatech.ac.kr",
@@ -105,22 +101,17 @@ class AuthApiTest extends AcceptanceTest {
                 """)
             .contentType(ContentType.JSON)
             .when()
-            .log().all()
             .post("/user/login")
             .then()
-            .log().all()
             .statusCode(HttpStatus.CREATED.value())
             .extract();
 
         RestAssured
             .given()
-            .log().all()
             .header("Authorization", "Bearer " + response.jsonPath().getString("token"))
             .when()
-            .log().all()
             .post("/user/logout")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -147,7 +138,6 @@ class AuthApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .body("""
                 {
                   "email": "test@koreatech.ac.kr",
@@ -156,25 +146,20 @@ class AuthApiTest extends AcceptanceTest {
                 """)
             .contentType(ContentType.JSON)
             .when()
-            .log().all()
             .post("/user/login")
             .then()
-            .log().all()
             .statusCode(HttpStatus.CREATED.value())
             .extract();
 
         RestAssured
             .given()
-            .log().all()
             .body(
                 Map.of("refresh_token", response.jsonPath().getString("refresh_token"))
             )
             .contentType(ContentType.JSON)
             .when()
-            .log().all()
             .post("/user/refresh")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -139,12 +139,9 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/articles/{articleId}", article1.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -214,13 +211,10 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .header("Authorization", "Bearer " + token)
             .when()
-            .log().all()
             .get("/articles/{articleId}", article1.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -243,15 +237,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER)
             .param("limit", PAGE_LIMIT)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -314,15 +305,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER_ZERO)
             .param("limit", PAGE_LIMIT)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -342,15 +330,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER_MINUS)
             .param("limit", PAGE_LIMIT)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -370,15 +355,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER)
             .param("limit", PAGE_LIMIT_ZERO)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -398,15 +380,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER)
             .param("limit", PAGE_LIMIT_ZERO)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -447,15 +426,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER)
             .param("limit", PAGE_LIMIT_ZERO)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -497,13 +473,10 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -525,15 +498,12 @@ class CommunityApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("boardId", board.getId())
             .param("page", PAGE_NUMBER)
             .param("limit", PAGE_LIMIT)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
@@ -1,7 +1,5 @@
 package in.koreatech.koin.acceptance;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -11,6 +9,7 @@ import in.koreatech.koin.domain.dept.model.Dept;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class DeptApiTest extends AcceptanceTest {
 
@@ -23,13 +22,10 @@ class DeptApiTest extends AcceptanceTest {
         // when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .param("dept_num", dept.getNumbers().get(0))
             .get("/dept")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -50,12 +46,9 @@ class DeptApiTest extends AcceptanceTest {
         //when then
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/depts")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -65,8 +58,10 @@ class DeptApiTest extends AcceptanceTest {
                     .isEqualTo(DEPT_SIZE);
                 for (int i = 0; i < DEPT_SIZE; i++) {
                     softly.assertThat(response.body().jsonPath().getString(String.format("[%d].name", i))).isNotEmpty();
-                    softly.assertThat(response.body().jsonPath().getString(String.format("[%d].curriculum_link", i))).isNotEmpty();
-                    softly.assertThat(response.body().jsonPath().getString(String.format("[%d].dept_nums[0]", i))).isNotEmpty();
+                    softly.assertThat(response.body().jsonPath().getString(String.format("[%d].curriculum_link", i)))
+                        .isNotEmpty();
+                    softly.assertThat(response.body().jsonPath().getString(String.format("[%d].dept_nums[0]", i)))
+                        .isNotEmpty();
                 }
             }
         );

--- a/src/test/java/in/koreatech/koin/acceptance/LandApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/LandApiTest.java
@@ -39,12 +39,9 @@ class LandApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/lands")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -96,12 +93,9 @@ class LandApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/lands/{id}", land.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -62,12 +62,9 @@ class ShopApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/shops/{shopId}/menus/{menuId}", menu.getShopId(), menu.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -142,12 +139,9 @@ class ShopApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/shops/{shopId}/menus/{menuId}", menu.getShopId(), menu.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -219,12 +213,9 @@ class ShopApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/shops/{shopId}/menus/categories", menu.getShopId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
@@ -38,12 +38,9 @@ class TrackApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/tracks")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -91,12 +88,9 @@ class TrackApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/tracks/{id}", track.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -153,12 +147,9 @@ class TrackApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .when()
-            .log().all()
             .get("/tracks/{id}", track.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.acceptance;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,13 +60,10 @@ class UserApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .header("Authorization", "Bearer " + token)
             .when()
-            .log().all()
             .get("/user/student/me")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -122,13 +120,10 @@ class UserApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .header("Authorization", "Bearer " + token)
             .when()
-            .log().all()
             .get("/user/student/me")
             .then()
-            .log().all()
             .statusCode(HttpStatus.UNAUTHORIZED.value())
             .extract();
     }
@@ -153,14 +148,41 @@ class UserApiTest extends AcceptanceTest {
 
         ExtractableResponse<Response> response = RestAssured
             .given()
-            .log().all()
             .header("Authorization", "Bearer " + token)
             .when()
-            .log().all()
             .get("/user/student/me")
             .then()
-            .log().all()
             .statusCode(HttpStatus.NOT_FOUND.value())
             .extract();
+    }
+
+    @Test
+    @DisplayName("회원이 탈퇴한다")
+    void userWithdraw() {
+        User user = User.builder()
+            .password("1234")
+            .nickname("주노")
+            .name("최준호")
+            .phoneNumber("010-1234-5678")
+            .userType(STUDENT)
+            .gender(UserGender.MAN)
+            .email("test@koreatech.ac.kr")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        userRepository.save(user);
+        String token = jwtProvider.createToken(user);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .delete("/user")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+            .extract();
+
+        Assertions.assertThat(userRepository.findById(user.getId())).isNotPresent();
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -174,7 +174,7 @@ class UserApiTest extends AcceptanceTest {
         userRepository.save(user);
         String token = jwtProvider.createToken(user);
 
-        var response = RestAssured
+        RestAssured
             .given()
             .header("Authorization", "Bearer " + token)
             .when()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #16 

# 🚀 작업 내용

1. 회원 탈퇴를 구현했습니다.
2. `@SQLDelete`를 활용해 삭제를 구현했습니다.
3. `@Where`를 이용해 `is_deleted=true` 인 데이터를 조회하지 않도록 구성했습니다.
4. RestAssured의 log().all() 구문을 전부 제거했습니다.

# 💬 리뷰 중점사항

이전에 논의되었던 내용이긴한데 차후 어드민 기능 구현할 때 적용하는게 좋을까요?
(`@Where` 대신 `@Filter`를 활용하여 선택적 softDelete 데이터 조회 조건 구성)

- https://github.com/BCSDLab/KOIN_API_V2/discussions/160

