### PR TITLE
feat : 특정상점 전체메뉴조회 api작성

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -5,12 +5,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
+import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,9 +32,23 @@ public interface ShopApi {
     )
     @Operation(summary = "메뉴 단건 조회")
     @GetMapping("/shops/{shopId}/menus/{menuId}")
-    ResponseEntity<ShopMenuResponse> findMenu(
+    ResponseEntity<MenuDetailResponse> findMenu(
         @Parameter(in = PATH) @PathVariable Long shopId,
         @Parameter(in = PATH) @PathVariable Long menuId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 상점의 모든 메뉴 조회")
+    @GetMapping("/shops/{id}/menus")
+    ResponseEntity<ShopMenuResponse> findMenu(
+        @Parameter(in = PATH) @PathVariable Long id
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -1,7 +1,5 @@
 package in.koreatech.koin.domain.shop.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -1,11 +1,14 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
+import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.service.ShopService;
@@ -18,12 +21,17 @@ public class ShopController implements ShopApi {
     private final ShopService shopService;
 
     @GetMapping("/shops/{shopId}/menus/{menuId}")
-    public ResponseEntity<ShopMenuResponse> findMenu(
+    public ResponseEntity<MenuDetailResponse> findMenu(
         @PathVariable Long shopId,
         @PathVariable Long menuId
     ) {
-        ShopMenuResponse shopMenu = shopService.findMenu(menuId);
+        MenuDetailResponse shopMenu = shopService.findMenu(menuId);
         return ResponseEntity.ok(shopMenu);
+    }
+
+    public ResponseEntity<ShopMenuResponse> findMenu(Long id) {
+        ShopMenuResponse shopMenuResponse = shopService.getShopMenu(id);
+        return ResponseEntity.ok(shopMenuResponse);
     }
 
     @GetMapping("/shops/{shopId}/menus/categories")

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/MenuDetailResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/MenuDetailResponse.java
@@ -1,0 +1,64 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.Menu;
+import in.koreatech.koin.domain.shop.model.MenuCategory;
+import in.koreatech.koin.domain.shop.model.MenuImage;
+import in.koreatech.koin.domain.shop.model.MenuOption;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record MenuDetailResponse(Long id, Long shopId, String name, Boolean isHidden, Boolean isSingle,
+                                 Integer singlePrice, List<InnerOptionPriceResponse> optionPrices, String description,
+                                 List<Long> categoryIds, List<String> imageUrls) {
+
+    public static MenuDetailResponse createForSingleOption(Menu menu, List<MenuCategory> shopMenuCategories) {
+        if (menu.hasMultipleOption()) {
+            log.warn("{}는 옵션이 하나 이상인 메뉴입니다. createForMultipleOption 메서드를 이용해야 합니다.", menu);
+            throw new IllegalStateException("서버에 에러가 발생했습니다.");
+        }
+
+        return new MenuDetailResponse(
+            menu.getId(),
+            menu.getShopId(),
+            menu.getName(),
+            menu.getIsHidden(),
+            true,
+            menu.getMenuOptions().get(0).getPrice(),
+            null,
+            menu.getDescription(),
+            shopMenuCategories.stream().map(MenuCategory::getId).toList(),
+            menu.getMenuImages().stream().map(MenuImage::getImageUrl).toList()
+        );
+    }
+
+    public static MenuDetailResponse createForMultipleOption(Menu menu, List<MenuCategory> shopMenuCategories) {
+        if (!menu.hasMultipleOption()) {
+            log.error("{}는 옵션이 하나인 메뉴입니다. createForSingleOption 메서드를 이용해야 합니다.", menu);
+            throw new IllegalStateException("서버에 에러가 발생했습니다.");
+        }
+
+        return new MenuDetailResponse(
+            menu.getId(),
+            menu.getShopId(),
+            menu.getName(),
+            menu.getIsHidden(),
+            false,
+            null,
+            menu.getMenuOptions().stream().map(InnerOptionPriceResponse::of).toList(), menu.getDescription(),
+            shopMenuCategories.stream().map(MenuCategory::getId).toList(),
+            menu.getMenuImages().stream().map(MenuImage::getImageUrl).toList()
+        );
+    }
+
+    private record InnerOptionPriceResponse(String option, Integer price) {
+        public static InnerOptionPriceResponse of(MenuOption menuOption) {
+            return new InnerOptionPriceResponse(menuOption.getOption(), menuOption.getPrice());
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/MenuDetailResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/MenuDetailResponse.java
@@ -9,13 +9,42 @@ import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.MenuImage;
 import in.koreatech.koin.domain.shop.model.MenuOption;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record MenuDetailResponse(Long id, Long shopId, String name, Boolean isHidden, Boolean isSingle,
-                                 Integer singlePrice, List<InnerOptionPriceResponse> optionPrices, String description,
-                                 List<Long> categoryIds, List<String> imageUrls) {
+public record MenuDetailResponse(
+    @Schema(example = "1", description = "고유id")
+    Long id,
+
+    @Schema(example = "1", description = "메뉴가 소속된 상점의 고유 id ")
+    Long shopId,
+
+    @Schema(example = "탕수육", description = "이름")
+    String name,
+
+    @Schema(example = "false", description = "숨김 여부")
+    Boolean isHidden,
+
+    @Schema(example = "false", description = "단일 메뉴 여부")
+    Boolean isSingle,
+
+    @Schema(example = "7000", description = "단일 메뉴일때(is_single이 true일때)의 가격")
+    Integer singlePrice,
+
+    @Schema(description = "옵션이 있는 메뉴일때(is_single이 false일때)의 가격")
+    List<InnerOptionPriceResponse> optionPrices,
+
+    @Schema(example = "돼지고기 + 튀김", description = "구성 설명")
+    String description,
+
+    @Schema(description = "소속되어 있는 메뉴 카테고리 고유 id 리스트")
+    List<Long> categoryIds,
+
+    @Schema(description = "이미지 URL 리스트")
+    List<String> imageUrls
+) {
 
     public static MenuDetailResponse createForSingleOption(Menu menu, List<MenuCategory> shopMenuCategories) {
         if (menu.hasMultipleOption()) {
@@ -56,7 +85,13 @@ public record MenuDetailResponse(Long id, Long shopId, String name, Boolean isHi
         );
     }
 
-    private record InnerOptionPriceResponse(String option, Integer price) {
+    private record InnerOptionPriceResponse(
+        @Schema(example = "소", description = "옵션명")
+        String option,
+
+        @Schema(example = "10000", description = "옵션에 대한 가격")
+        Integer price
+    ) {
         public static InnerOptionPriceResponse of(MenuOption menuOption) {
             return new InnerOptionPriceResponse(menuOption.getOption(), menuOption.getPrice());
         }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
@@ -1,27 +1,56 @@
 package in.koreatech.koin.domain.shop.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.MenuCategoryMap;
 import in.koreatech.koin.domain.shop.model.MenuImage;
 import in.koreatech.koin.domain.shop.model.MenuOption;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ShopMenuResponse(
+    @Schema(example = "20", description = "개수")
     Integer count,
-    List<InnerMenuCategoriesResponse> menuCategories
+
+    @Schema(description = "카테고리 별로 분류된 소속 메뉴 리스트")
+    List<InnerMenuCategoriesResponse> menuCategories,
+
+    @Schema(example = "2024-03-16", description = "해당 상점 마지막 메뉴 업데이트 날짜")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDateTime updatedAt
 ) {
     public static ShopMenuResponse createShopMenuResponse(List<MenuCategory> menuCategories) {
+        LocalDateTime lastUpdatedDate = LocalDateTime.of(1900,1,1,0,0);
+        int count = 0;
+        for(MenuCategory menuCategory: menuCategories) {
+            for(MenuCategoryMap menuCategoryMap: menuCategory.getMenuCategoryMaps()) {
+                LocalDateTime updatedAt = menuCategoryMap.getMenu().getUpdatedAt();
+                if(updatedAt.isAfter(lastUpdatedDate)) lastUpdatedDate = updatedAt;
+                ++count;
+            }
+        }
         return new ShopMenuResponse(
-            menuCategories.size(),
-            menuCategories.stream().map(InnerMenuCategoriesResponse::of).toList()
+            count,
+            menuCategories.stream().map(InnerMenuCategoriesResponse::of).toList(),
+            lastUpdatedDate
         );
     }
-
-    public record InnerMenuCategoriesResponse(
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    private record InnerMenuCategoriesResponse(
+        @Schema(example = "1", description = "카테고리 id")
         Long id,
+
+        @Schema(example = "중식", description = "카테고리 이름")
         String name,
+
+        @Schema(description = "해당 상점의 모든 메뉴 리스트")
         List<InnerMenuResponse> menuResponses
     ) {
         public static InnerMenuCategoriesResponse of(MenuCategory menuCategory) {
@@ -31,34 +60,52 @@ public record ShopMenuResponse(
                 menuCategory.getMenuCategoryMaps().stream().map(InnerMenuResponse::of).toList()
             );
         }
-
-        public record InnerMenuResponse(
+        @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+        private record InnerMenuResponse(
+            @Schema(example = "저희 식당의 대표 메뉴 탕수육입니다.", description = "설명")
             String description,
+
+            @Schema(example = "1", description = "고유 id")
             Long id,
+
+            @Schema(description = "이미지 URL리스트")
             List<String> imageUrls,
+
+            @Schema(example = "false", description = "숨김 여부")
             Boolean isHidden,
+
+            @Schema(example = "false", description = "단일 메뉴 여부")
             Boolean isSingle,
+
+            @Schema(example = "탕수육", description = "이름")
             String name,
+
+            @Schema(description = "옵션이 있는 메뉴일때(is_single이 false일때)의 옵션에 따른 가격 리스트")
             List<InnerOptionPrice> optionPrices,
+
+            @Schema(example = "10000", description = "단일 메뉴일때(is_single이 true일때)의 가격")
             Integer singlePrice
         ) {
             public static InnerMenuResponse of(MenuCategoryMap menuCategoryMap) {
                 Menu menu = menuCategoryMap.getMenu();
-                boolean isMultipleOption = menu.hasMultipleOption();
+                boolean isSingle = !menu.hasMultipleOption();
                 return new InnerMenuResponse(
                     menu.getDescription(),
                     menu.getId(),
                     menu.getMenuImages().stream().map(MenuImage::getImageUrl).toList(),
                     menu.getIsHidden(),
-                    isMultipleOption,
+                    isSingle,
                     menu.getName(),
-                    isMultipleOption? menu.getMenuOptions().stream().map(InnerOptionPrice::of).toList(): null,
-                    isMultipleOption? menu.getMenuOptions().get(0).getPrice(): null
+                    isSingle? null: menu.getMenuOptions().stream().map(InnerOptionPrice::of).toList(),
+                    isSingle? menu.getMenuOptions().get(0).getPrice(): null
                 );
             }
-
-            public record InnerOptionPrice(
+            @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+            private record InnerOptionPrice(
+                @Schema(example = "대", description = "옵션명")
                 String option,
+
+                @Schema(example = "26000", description = "가격")
                 Integer price
             ) {
                 public static InnerOptionPrice of(MenuOption menuOption) {

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
@@ -32,8 +32,9 @@ public record ShopMenuResponse(
         for (MenuCategory menuCategory : menuCategories) {
             for (MenuCategoryMap menuCategoryMap : menuCategory.getMenuCategoryMaps()) {
                 LocalDateTime updatedAt = menuCategoryMap.getMenu().getUpdatedAt();
-                if (updatedAt.isAfter(lastUpdatedDate))
+                if (updatedAt.isAfter(lastUpdatedDate)) {
                     lastUpdatedDate = updatedAt;
+                }
                 ++count;
             }
         }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMenuResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.Menu;
@@ -14,7 +14,7 @@ import in.koreatech.koin.domain.shop.model.MenuImage;
 import in.koreatech.koin.domain.shop.model.MenuOption;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record ShopMenuResponse(
     @Schema(example = "20", description = "개수")
     Integer count,
@@ -26,23 +26,25 @@ public record ShopMenuResponse(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDateTime updatedAt
 ) {
-    public static ShopMenuResponse createShopMenuResponse(List<MenuCategory> menuCategories) {
-        LocalDateTime lastUpdatedDate = LocalDateTime.of(1900,1,1,0,0);
+    public static ShopMenuResponse from(List<MenuCategory> menuCategories) {
+        LocalDateTime lastUpdatedDate = LocalDateTime.of(1900, 1, 1, 0, 0);
         int count = 0;
-        for(MenuCategory menuCategory: menuCategories) {
-            for(MenuCategoryMap menuCategoryMap: menuCategory.getMenuCategoryMaps()) {
+        for (MenuCategory menuCategory : menuCategories) {
+            for (MenuCategoryMap menuCategoryMap : menuCategory.getMenuCategoryMaps()) {
                 LocalDateTime updatedAt = menuCategoryMap.getMenu().getUpdatedAt();
-                if(updatedAt.isAfter(lastUpdatedDate)) lastUpdatedDate = updatedAt;
+                if (updatedAt.isAfter(lastUpdatedDate))
+                    lastUpdatedDate = updatedAt;
                 ++count;
             }
         }
         return new ShopMenuResponse(
             count,
-            menuCategories.stream().map(InnerMenuCategoriesResponse::of).toList(),
+            menuCategories.stream().map(InnerMenuCategoriesResponse::from).toList(),
             lastUpdatedDate
         );
     }
-    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
     private record InnerMenuCategoriesResponse(
         @Schema(example = "1", description = "카테고리 id")
         Long id,
@@ -53,14 +55,15 @@ public record ShopMenuResponse(
         @Schema(description = "해당 상점의 모든 메뉴 리스트")
         List<InnerMenuResponse> menuResponses
     ) {
-        public static InnerMenuCategoriesResponse of(MenuCategory menuCategory) {
+        public static InnerMenuCategoriesResponse from(MenuCategory menuCategory) {
             return new InnerMenuCategoriesResponse(
                 menuCategory.getId(),
                 menuCategory.getName(),
-                menuCategory.getMenuCategoryMaps().stream().map(InnerMenuResponse::of).toList()
+                menuCategory.getMenuCategoryMaps().stream().map(InnerMenuResponse::from).toList()
             );
         }
-        @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+
+        @JsonNaming(value = SnakeCaseStrategy.class)
         private record InnerMenuResponse(
             @Schema(example = "저희 식당의 대표 메뉴 탕수육입니다.", description = "설명")
             String description,
@@ -86,7 +89,7 @@ public record ShopMenuResponse(
             @Schema(example = "10000", description = "단일 메뉴일때(is_single이 true일때)의 가격")
             Integer singlePrice
         ) {
-            public static InnerMenuResponse of(MenuCategoryMap menuCategoryMap) {
+            public static InnerMenuResponse from(MenuCategoryMap menuCategoryMap) {
                 Menu menu = menuCategoryMap.getMenu();
                 boolean isSingle = !menu.hasMultipleOption();
                 return new InnerMenuResponse(
@@ -96,11 +99,12 @@ public record ShopMenuResponse(
                     menu.getIsHidden(),
                     isSingle,
                     menu.getName(),
-                    isSingle? null: menu.getMenuOptions().stream().map(InnerOptionPrice::of).toList(),
-                    isSingle? menu.getMenuOptions().get(0).getPrice(): null
+                    isSingle ? null : menu.getMenuOptions().stream().map(InnerOptionPrice::from).toList(),
+                    isSingle ? menu.getMenuOptions().get(0).getPrice() : null
                 );
             }
-            @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+
+            @JsonNaming(value = SnakeCaseStrategy.class)
             private record InnerOptionPrice(
                 @Schema(example = "대", description = "옵션명")
                 String option,
@@ -108,7 +112,7 @@ public record ShopMenuResponse(
                 @Schema(example = "26000", description = "가격")
                 Integer price
             ) {
-                public static InnerOptionPrice of(MenuOption menuOption) {
+                public static InnerOptionPrice from(MenuOption menuOption) {
                     return new InnerOptionPrice(
                         menuOption.getOption(),
                         menuOption.getPrice()

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -71,6 +71,6 @@ public class ShopService {
 
     public ShopMenuResponse getShopMenu(Long shopId) {
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shopId);
-        return ShopMenuResponse.createShopMenuResponse(menuCategories);
+        return ShopMenuResponse.from(menuCategories);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
+import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.model.Menu;
@@ -35,7 +36,7 @@ public class ShopService {
     private final ShopCategoryMapRepository shopCategoryMapRepository;
     private final ShopImageRepository shopImageRepository;
 
-    public ShopMenuResponse findMenu(Long menuId) {
+    public MenuDetailResponse findMenu(Long menuId) {
         Menu menu = menuRepository.getById(menuId);
 
         List<MenuCategory> menuCategories = menu.getMenuCategoryMaps()
@@ -43,14 +44,14 @@ public class ShopService {
             .map(MenuCategoryMap::getMenuCategory)
             .toList();
 
-        return createShopMenuResponse(menu, menuCategories);
+        return createMenuDetailResponse(menu, menuCategories);
     }
 
-    private ShopMenuResponse createShopMenuResponse(Menu menu, List<MenuCategory> menuCategories) {
+    private MenuDetailResponse createMenuDetailResponse(Menu menu, List<MenuCategory> menuCategories) {
         if (menu.hasMultipleOption()) {
-            return ShopMenuResponse.createForMultipleOption(menu, menuCategories);
+            return MenuDetailResponse.createForMultipleOption(menu, menuCategories);
         }
-        return ShopMenuResponse.createForSingleOption(menu, menuCategories);
+        return MenuDetailResponse.createForSingleOption(menu, menuCategories);
     }
 
     public MenuCategoriesResponse getMenuCategories(Long shopId) {
@@ -66,5 +67,10 @@ public class ShopService {
         List<ShopCategoryMap> shopCategoryMaps = shopCategoryMapRepository.findAllByShopId(shopId);
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shopId);
         return ShopResponse.of(shop, shopOpens, shopImages, shopCategoryMaps, menuCategories);
+    }
+
+    public ShopMenuResponse getShopMenu(Long shopId) {
+        List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shopId);
+        return ShopMenuResponse.createShopMenuResponse(menuCategories);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -462,7 +462,6 @@ class ShopApiTest extends AcceptanceTest {
         MenuCategoryMap menuCategoryMap1 = MenuCategoryMap.create();
         menuCategoryRepository.save(menuCategory1);
 
-        // when then
         menuOption1.setMenu(menu1);
         menuOption2.setMenu(menu1);
         menuImage1.setMenu(menu1);
@@ -503,7 +502,6 @@ class ShopApiTest extends AcceptanceTest {
         MenuCategoryMap menuCategoryMap2 = MenuCategoryMap.create();
         menuCategoryRepository.save(menuCategory2);
 
-        // when then
         menuOption3.setMenu(menu2);
         menuOption4.setMenu(menu2);
         menuImage3.setMenu(menu2);
@@ -533,7 +531,6 @@ class ShopApiTest extends AcceptanceTest {
 
         MenuCategoryMap menuCategoryMap3 = MenuCategoryMap.create();
 
-        // when then
         menuOption5.setMenu(menu3);
         menuImage5.setMenu(menu3);
         menuImage6.setMenu(menu3);
@@ -547,7 +544,6 @@ class ShopApiTest extends AcceptanceTest {
             .when()
             .get("/shops/1/menus")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -3,8 +3,8 @@ package in.koreatech.koin.acceptance;
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
@@ -423,6 +423,211 @@ class ShopApiTest extends AcceptanceTest {
                 softly.assertThat(response.body().jsonPath().getList("open")).hasSize(savedShopOpens.size());
                 softly.assertThat(response.body().jsonPath().getList("shop_categories"))
                     .hasSize(savedShopCategoryMaps.size());
+            }
+        );
+    }
+
+    @Test
+    @DisplayName("특정 상점 모든 메뉴 조회")
+    void getShopMenus() {
+        // given
+        MenuOption menuOption1 = MenuOption.builder()
+            .option("일반")
+            .price(7000)
+            .build();
+
+        MenuOption menuOption2 = MenuOption.builder()
+            .option("곱빼기")
+            .price(7500)
+            .build();
+
+        MenuImage menuImage1 = MenuImage.builder()
+            .imageUrl("https://test.com/test.jpg")
+            .build();
+        MenuImage menuImage2 = MenuImage.builder()
+            .imageUrl("https://test.com/hello.jpg")
+            .build();
+
+        Menu menu1 = Menu.builder()
+            .shopId(1L)
+            .name("짜장면")
+            .description("맛있는 짜장면")
+            .build();
+
+        MenuCategory menuCategory1 = MenuCategory.builder()
+            .shopId(1L)
+            .name("중식")
+            .build();
+
+        MenuCategoryMap menuCategoryMap1 = MenuCategoryMap.create();
+        menuCategoryRepository.save(menuCategory1);
+
+        // when then
+        menuOption1.setMenu(menu1);
+        menuOption2.setMenu(menu1);
+        menuImage1.setMenu(menu1);
+        menuImage2.setMenu(menu1);
+
+        menuCategoryMap1.map(menu1, menuCategory1);
+
+        menuRepository.save(menu1);
+
+        MenuOption menuOption3 = MenuOption.builder()
+            .option("일반")
+            .price(7000)
+            .build();
+
+        MenuOption menuOption4 = MenuOption.builder()
+            .option("곱빼기")
+            .price(7500)
+            .build();
+
+        MenuImage menuImage3 = MenuImage.builder()
+            .imageUrl("https://test.com/test.jpg")
+            .build();
+        MenuImage menuImage4 = MenuImage.builder()
+            .imageUrl("https://test.com/hello.jpg")
+            .build();
+
+        Menu menu2 = Menu.builder()
+            .shopId(1L)
+            .name("짜장면2")
+            .description("맛있는 짜장면")
+            .build();
+
+        MenuCategory menuCategory2 = MenuCategory.builder()
+            .shopId(1L)
+            .name("한식")
+            .build();
+
+        MenuCategoryMap menuCategoryMap2 = MenuCategoryMap.create();
+        menuCategoryRepository.save(menuCategory2);
+
+        // when then
+        menuOption3.setMenu(menu2);
+        menuOption4.setMenu(menu2);
+        menuImage3.setMenu(menu2);
+        menuImage4.setMenu(menu2);
+
+        menuCategoryMap2.map(menu2, menuCategory2);
+
+        menuRepository.save(menu2);
+
+        MenuOption menuOption5 = MenuOption.builder()
+            .option("일반")
+            .price(7000)
+            .build();
+
+        MenuImage menuImage5 = MenuImage.builder()
+            .imageUrl("https://test.com/test.jpg")
+            .build();
+        MenuImage menuImage6 = MenuImage.builder()
+            .imageUrl("https://test.com/hello.jpg")
+            .build();
+
+        Menu menu3 = Menu.builder()
+            .shopId(1L)
+            .name("짜장면3")
+            .description("맛있는 짜장면")
+            .build();
+
+        MenuCategoryMap menuCategoryMap3 = MenuCategoryMap.create();
+
+        // when then
+        menuOption5.setMenu(menu3);
+        menuImage5.setMenu(menu3);
+        menuImage6.setMenu(menu3);
+
+        menuCategoryMap3.map(menu3, menuCategory2);
+
+        menuRepository.save(menu3);
+
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .when()
+            .get("/shops/1/menus")
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        SoftAssertions.assertSoftly(
+            softly -> {
+                softly.assertThat(response.body().jsonPath().getLong("count")).isEqualTo(3);
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[0].id"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenuCategory().getId());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].name"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenuCategory().getName());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].menu_responses[0].description"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getDescription());
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[0].menu_responses[0].id"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getId());
+                softly.assertThat(response.body().jsonPath().getList("menu_categories[0].menu_responses[0].image_urls"))
+                    .hasSize(2);
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[0].menu_responses[0].is_hidden"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getIsHidden());
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[0].menu_responses[0].is_single"))
+                    .isEqualTo(false);
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].menu_responses[0].name"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getName());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].menu_responses[0].option_prices[0].option"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(0).getOption());
+                softly.assertThat(response.body().jsonPath().getInt("menu_categories[0].menu_responses[0].option_prices[0].price"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(0).getPrice());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[0].menu_responses[0].option_prices[1].option"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(1).getOption());
+                softly.assertThat(response.body().jsonPath().getInt("menu_categories[0].menu_responses[0].option_prices[1].price"))
+                    .isEqualTo(menu1.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(1).getPrice());
+                softly.assertThat((Object) response.body().jsonPath().get("menu_categories[0].menu_responses[0].single_price")).isNull();
+                softly.assertThat(response.body().jsonPath().getString("updated_at"))
+                    .isEqualTo(LocalDate.now().toString());
+
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[1].id"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenuCategory().getId());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].name"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenuCategory().getName());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[0].description"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getDescription());
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[1].menu_responses[0].id"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getId());
+                softly.assertThat(response.body().jsonPath().getList("menu_categories[1].menu_responses[0].image_urls"))
+                    .hasSize(2);
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[1].menu_responses[0].is_hidden"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getIsHidden());
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[1].menu_responses[0].is_single"))
+                    .isEqualTo(false);
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[0].name"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getName());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[0].option_prices[0].option"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(0).getOption());
+                softly.assertThat(response.body().jsonPath().getInt("menu_categories[1].menu_responses[0].option_prices[0].price"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(0).getPrice());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[0].option_prices[1].option"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(1).getOption());
+                softly.assertThat(response.body().jsonPath().getInt("menu_categories[1].menu_responses[0].option_prices[1].price"))
+                    .isEqualTo(menu2.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(1).getPrice());
+                softly.assertThat((Object) response.body().jsonPath().get("menu_categories[1].menu_responses[0].single_price")).isNull();
+                softly.assertThat(response.body().jsonPath().getString("updated_at"))
+                    .isEqualTo(LocalDate.now().toString());
+
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[1].description"))
+                    .isEqualTo(menu3.getMenuCategoryMaps().get(0).getMenu().getDescription());
+                softly.assertThat(response.body().jsonPath().getLong("menu_categories[1].menu_responses[1].id"))
+                    .isEqualTo(menu3.getMenuCategoryMaps().get(0).getMenu().getId());
+                softly.assertThat(response.body().jsonPath().getList("menu_categories[1].menu_responses[1].image_urls"))
+                    .hasSize(2);
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[1].menu_responses[1].is_hidden"))
+                    .isEqualTo(menu3.getMenuCategoryMaps().get(0).getMenu().getIsHidden());
+                softly.assertThat(response.body().jsonPath().getBoolean("menu_categories[1].menu_responses[1].is_single"))
+                    .isEqualTo(true);
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[1].name"))
+                    .isEqualTo(menu3.getMenuCategoryMaps().get(0).getMenu().getName());
+                softly.assertThat(response.body().jsonPath().getString("menu_categories[1].menu_responses[1].option_prices"))
+                    .isEqualTo(null);
+                softly.assertThat(response.body().jsonPath().getInt("menu_categories[1].menu_responses[1].single_price"))
+                    .isEqualTo(menu3.getMenuCategoryMaps().get(0).getMenu().getMenuOptions().get(0).getPrice());
+                softly.assertThat(response.body().jsonPath().getString("updated_at"))
+                    .isEqualTo(LocalDate.now().toString());
             }
         );
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #39 

# 🚀 작업 내용

1. 특정 상점의 모든 메뉴를 조회하는 api를 구현했습니다.
2. 해당 상점의 마지막 메뉴 업데이트 날짜를 제공하도록 하였습니다.
3. 꼼꼼한 테스트를 위해 메뉴 3개를 넣어서 최대한 많은 경우를 테스트했습니다.

# 💬 리뷰 중점사항
테스트코드가 조금 복잡하다고 느꼈습니다. 테스트코드를 어떻게 개선할 수 있을지, 또 테스트코드가 올바르게 작성되었는지 위주로 봐주시면 감사하겠습니다.
