### PR TITLE
fix: 복덕방 전제 조회 응답 객체 미스매치 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/activity/dto/ActivitiesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/activity/dto/ActivitiesResponse.java
@@ -4,14 +4,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Getter;
-
-@Getter
-public class ActivitiesResponse {
-
+public record ActivitiesResponse(
     @JsonProperty("Activities")
-    private List<ActivityResponse> activities;
-
+    List<ActivityResponse> activities
+) {
     public ActivitiesResponse(List<ActivityResponse> activities) {
         this.activities = activities;
     }

--- a/src/main/java/in/koreatech/koin/domain/activity/dto/ActivityResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/activity/dto/ActivityResponse.java
@@ -32,7 +32,9 @@ public record ActivityResponse(
     @Schema(description = "활동 설명", example = "더 편리한 서비스 제공을 위해 시간표 기능을 추가했습니다.")
     String description,
 
-    @Schema(description = "이미지 URL 목록", example = "[\"https://test2.com.png\", \"https://test3.com.png]\"")
+    @Schema(description = "이미지 URL 목록", example = """
+        ["https://test2.com.png", "https://test3.com.png"]
+        """)
     List<String> imageUrls,
 
     @Schema(description = "고유 식별자", example = "1")

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandApi.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandApi.java
@@ -1,16 +1,17 @@
 package in.koreatech.koin.domain.land.controller;
 
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import in.koreatech.koin.domain.land.dto.LandListItemResponse;
 import in.koreatech.koin.domain.land.dto.LandResponse;
+import in.koreatech.koin.domain.land.dto.LandsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,7 +29,7 @@ public interface LandApi {
     )
     @Operation(summary = "복덕방 목록 조회")
     @GetMapping("/lands")
-    ResponseEntity<List<LandListItemResponse>> getLands();
+    ResponseEntity<List<LandsResponse>> getLands();
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandApi.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandApi.java
@@ -2,14 +2,12 @@ package in.koreatech.koin.domain.land.controller;
 
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import in.koreatech.koin.domain.land.dto.LandResponse;
-import in.koreatech.koin.domain.land.dto.LandsResponse;
+import in.koreatech.koin.domain.land.dto.LandsGroupResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,7 +27,7 @@ public interface LandApi {
     )
     @Operation(summary = "복덕방 목록 조회")
     @GetMapping("/lands")
-    ResponseEntity<List<LandsResponse>> getLands();
+    ResponseEntity<LandsGroupResponse> getLands();
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import in.koreatech.koin.domain.land.dto.LandListItemResponse;
 import in.koreatech.koin.domain.land.dto.LandResponse;
+import in.koreatech.koin.domain.land.dto.LandsResponse;
 import in.koreatech.koin.domain.land.service.LandService;
 import lombok.RequiredArgsConstructor;
 
@@ -19,8 +19,8 @@ public class LandController implements LandApi {
     private final LandService landService;
 
     @GetMapping("/lands")
-    public ResponseEntity<List<LandListItemResponse>> getLands() {
-        List<LandListItemResponse> responses = landService.getLands();
+    public ResponseEntity<List<LandsResponse>> getLands() {
+        List<LandsResponse> responses = landService.getLands();
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
+++ b/src/main/java/in/koreatech/koin/domain/land/controller/LandController.java
@@ -1,14 +1,12 @@
 package in.koreatech.koin.domain.land.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.land.dto.LandResponse;
-import in.koreatech.koin.domain.land.dto.LandsResponse;
+import in.koreatech.koin.domain.land.dto.LandsGroupResponse;
 import in.koreatech.koin.domain.land.service.LandService;
 import lombok.RequiredArgsConstructor;
 
@@ -19,8 +17,8 @@ public class LandController implements LandApi {
     private final LandService landService;
 
     @GetMapping("/lands")
-    public ResponseEntity<List<LandsResponse>> getLands() {
-        List<LandsResponse> responses = landService.getLands();
+    public ResponseEntity<LandsGroupResponse> getLands() {
+        LandsGroupResponse responses = landService.getLands();
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandResponse.java
@@ -1,12 +1,13 @@
 package in.koreatech.koin.domain.land.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import in.koreatech.koin.domain.land.model.Land;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandsGroupResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandsGroupResponse.java
@@ -4,10 +4,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class LandsGroupResponse {
+public record LandsGroupResponse(
     @JsonProperty("lands")
-    private List<LandsResponse> lands;
-
+    List<LandsResponse> lands
+) {
     public LandsGroupResponse(List<LandsResponse> lands) {
         this.lands = lands;
     }

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandsGroupResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandsGroupResponse.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.land.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LandsGroupResponse {
+    @JsonProperty("lands")
+    private List<LandsResponse> lands;
+
+    public LandsGroupResponse(List<LandsResponse> lands) {
+        this.lands = lands;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/land/dto/LandsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/land/dto/LandsResponse.java
@@ -1,13 +1,14 @@
 package in.koreatech.koin.domain.land.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import in.koreatech.koin.domain.land.model.Land;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record LandListItemResponse(
+public record LandsResponse(
     @Schema(description = "상세 이름", example = "럭키빌(투베이)")
     String internalName,
 
@@ -33,8 +34,8 @@ public record LandListItemResponse(
     String roomType
 ) {
 
-    public static LandListItemResponse from(Land land) {
-        return new LandListItemResponse(
+    public static LandsResponse from(Land land) {
+        return new LandsResponse(
             land.getInternalName(),
             land.getMonthlyFee(),
             land.getLatitude(),

--- a/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
+++ b/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
@@ -8,8 +8,8 @@ import org.json.JSONArray;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.land.dto.LandListItemResponse;
 import in.koreatech.koin.domain.land.dto.LandResponse;
+import in.koreatech.koin.domain.land.dto.LandsResponse;
 import in.koreatech.koin.domain.land.model.Land;
 import in.koreatech.koin.domain.land.repository.LandRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +21,10 @@ public class LandService {
 
     private final LandRepository landRepository;
 
-    public List<LandListItemResponse> getLands() {
+    public List<LandsResponse> getLands() {
         return landRepository.findAll()
             .stream()
-            .map(LandListItemResponse::from)
+            .map(LandsResponse::from)
             .toList();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
+++ b/src/main/java/in/koreatech/koin/domain/land/service/LandService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.land.dto.LandResponse;
+import in.koreatech.koin.domain.land.dto.LandsGroupResponse;
 import in.koreatech.koin.domain.land.dto.LandsResponse;
 import in.koreatech.koin.domain.land.model.Land;
 import in.koreatech.koin.domain.land.repository.LandRepository;
@@ -21,11 +22,13 @@ public class LandService {
 
     private final LandRepository landRepository;
 
-    public List<LandsResponse> getLands() {
-        return landRepository.findAll()
+    public LandsGroupResponse getLands() {
+        List<LandsResponse> lands = landRepository.findAll()
             .stream()
             .map(LandsResponse::from)
             .toList();
+
+        return new LandsGroupResponse(lands);
     }
 
     public LandResponse getLand(Long id) {

--- a/src/test/java/in/koreatech/koin/acceptance/LandApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/LandApiTest.java
@@ -34,8 +34,18 @@ class LandApiTest extends AcceptanceTest {
             .monthlyFee("100")
             .charterFee("1000")
             .build();
+        Land request2 = Land.builder()
+            .internalName("복덕방2")
+            .name("복덕방2")
+            .roomType("원룸2")
+            .latitude(37.5552)
+            .longitude(126.5552)
+            .monthlyFee("102")
+            .charterFee("1002")
+            .build();
 
         Land land = landRepository.save(request);
+        Land land2 = landRepository.save(request2);
 
         ExtractableResponse<Response> response = RestAssured
             .given()
@@ -47,21 +57,36 @@ class LandApiTest extends AcceptanceTest {
 
         SoftAssertions.assertSoftly(
             softly -> {
-                softly.assertThat(response.body().jsonPath().getList(".").size()).isEqualTo(1);
-                softly.assertThat(response.body().jsonPath().getLong("[0].id")).isEqualTo(land.getId());
-                softly.assertThat(response.body().jsonPath().getString("[0].internal_name"))
+                softly.assertThat(response.body().jsonPath().getList("lands").size()).isEqualTo(2);
+                softly.assertThat(response.body().jsonPath().getLong("lands[0].id")).isEqualTo(land.getId());
+                softly.assertThat(response.body().jsonPath().getString("lands[0].internal_name"))
                     .isEqualTo(land.getInternalName());
-                softly.assertThat(response.body().jsonPath().getString("[0].name")).isEqualTo(land.getName());
-                softly.assertThat(response.body().jsonPath().getString("[0].room_type"))
+                softly.assertThat(response.body().jsonPath().getString("lands[0].name")).isEqualTo(land.getName());
+                softly.assertThat(response.body().jsonPath().getString("lands[0].room_type"))
                     .isEqualTo(land.getRoomType());
-                softly.assertThat(response.body().jsonPath().getDouble("[0].latitude"))
+                softly.assertThat(response.body().jsonPath().getDouble("lands[0].latitude"))
                     .isEqualTo(land.getLatitude());
-                softly.assertThat(response.body().jsonPath().getDouble("[0].longitude"))
+                softly.assertThat(response.body().jsonPath().getDouble("lands[0].longitude"))
                     .isEqualTo(land.getLongitude());
-                softly.assertThat(response.body().jsonPath().getString("[0].monthly_fee"))
+                softly.assertThat(response.body().jsonPath().getString("lands[0].monthly_fee"))
                     .isEqualTo(land.getMonthlyFee());
-                softly.assertThat(response.body().jsonPath().getString("[0].charter_fee"))
+                softly.assertThat(response.body().jsonPath().getString("lands[0].charter_fee"))
                     .isEqualTo(land.getCharterFee());
+
+                softly.assertThat(response.body().jsonPath().getLong("lands[1].id")).isEqualTo(land2.getId());
+                softly.assertThat(response.body().jsonPath().getString("lands[1].internal_name"))
+                    .isEqualTo(land2.getInternalName());
+                softly.assertThat(response.body().jsonPath().getString("lands[1].name")).isEqualTo(land2.getName());
+                softly.assertThat(response.body().jsonPath().getString("lands[1].room_type"))
+                    .isEqualTo(land2.getRoomType());
+                softly.assertThat(response.body().jsonPath().getDouble("lands[1].latitude"))
+                    .isEqualTo(land2.getLatitude());
+                softly.assertThat(response.body().jsonPath().getDouble("lands[1].longitude"))
+                    .isEqualTo(land2.getLongitude());
+                softly.assertThat(response.body().jsonPath().getString("lands[1].monthly_fee"))
+                    .isEqualTo(land2.getMonthlyFee());
+                softly.assertThat(response.body().jsonPath().getString("lands[1].charter_fee"))
+                    .isEqualTo(land2.getCharterFee());
             }
         );
     }

--- a/src/test/java/in/koreatech/koin/global/domain/upload/UploadServiceTest.java
+++ b/src/test/java/in/koreatech/koin/global/domain/upload/UploadServiceTest.java
@@ -1,5 +1,10 @@
 package in.koreatech.koin.global.domain.upload;
 
+import static in.koreatech.koin.global.domain.upload.model.ImageUploadDomain.OWNERS;
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import java.time.Clock;
 import java.time.ZonedDateTime;
 
@@ -11,12 +16,8 @@ import org.testcontainers.utility.DockerImageName;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlRequest;
-import static in.koreatech.koin.global.domain.upload.model.ImageUploadDomain.OWNERS;
 import in.koreatech.koin.global.domain.upload.service.UploadService;
 import in.koreatech.koin.global.s3.S3Utils;
-import static java.time.format.DateTimeFormatter.ofPattern;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -62,8 +63,7 @@ class UploadServiceTest extends AcceptanceTest {
         assertThat(url.preSignedUrl()).contains(
             "https://test-bucket.s3.amazonaws.com/",
             "OWNERS/",
-            "hello.png",
-            "X-Amz-Expires=" + 60 * 10
+            "hello.png"
         );
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈
- close #188 

# 🚀 작업 내용
1. 복덕방 전체 조회(get-lands)의 응답 객체가 미스매치 되어 있는 것을 수정해줬습니다.(반환 값을 list에서 key:value의 형태로 바꾸어 줬습니다.) -> ex) {lands : [ ]}의 형태로 만들어줬습니다.
2. 복덕방 전체 조회의 응답 객체를 맡은 dto의 이름에 자료형(list)가 들어가 있어서 LandsResponse로 이름을 바꿔줬습니다.
3. 전체 조회 관련 테스트 코드를 추가 작성해줬습니다.
4. 원래 제가 맡은 부분은 아니지만 UploadServiceTest가 통과를 못해서 수정해줬습니다(준호와 이야기 됨)
5. 어제 제가 맡았던 부분 마음에 안 드는 것이 있어서 ActivityResponse의 example 관련 코드를 살짝 수정해줬습니다.(준호와 이야기 됨)
6. 추가로 맡았던 Activity 도메인에서 일반 클래스로 작성 된 ActivitiesResponse dto를 일반 클래스에서 record 클래스로 변경 시켜 줬습니다

# 💬 리뷰 중점사항
key:value 형태로 묶어주기 위해서 dto를 하나 더 만들었는데 dto의 이름을 적당하게 잘 작명 한 것인지 모르겠습니다. 그 외 수정 했으면 하는 부분이 있다면, 말씀 해주시면 성실하게 수정하도록 하겠습니다.!
