### PR TITLE
feat: 파일 다중 업로드 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
@@ -1,6 +1,8 @@
 package in.koreatech.koin.global.domain.upload.controller;
 
 
+import java.util.List;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,15 +11,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-import in.koreatech.koin.domain.user.model.UserType;
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.domain.upload.dto.UploadFileResponse;
+import in.koreatech.koin.global.domain.upload.dto.UploadFilesResponse;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlRequest;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlResponse;
 import in.koreatech.koin.global.domain.upload.model.ImageUploadDomain;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -52,7 +56,7 @@ public interface UploadApi {
     ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {UserType.OWNER, STUDENT}) Long memberId
+        @Auth(permit = {OWNER, STUDENT}) Long memberId
     );
 
     @ApiResponses(
@@ -81,8 +85,39 @@ public interface UploadApi {
         produces = MediaType.APPLICATION_JSON_VALUE
     )
     ResponseEntity<UploadFileResponse> uploadFile(
-        @PathVariable ImageUploadDomain domain,
+        @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
+        @Auth(permit = {OWNER, STUDENT}) Long memberId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "413", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "415", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "단건 파일 업로드", description = """
+        {domain} 지원 목록
+        - items
+        - lands
+        - circles
+        - market
+        - shops
+        - members
+        - owners
+        """)
+    @PostMapping(
+        value = "/{domain}/upload/files",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    ResponseEntity<UploadFilesResponse> uploadFiles(
+        @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
+        @RequestPart List<MultipartFile> files,
         @Auth(permit = {OWNER, STUDENT}) Long memberId
     );
 }

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
@@ -100,7 +100,7 @@ public interface UploadApi {
             @ApiResponse(responseCode = "415", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "단건 파일 업로드", description = """
+    @Operation(summary = "다중 파일 업로드", description = """
         {domain} 지원 목록
         - items
         - lands

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.global.domain.upload.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +16,7 @@ import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.domain.upload.dto.UploadFileResponse;
+import in.koreatech.koin.global.domain.upload.dto.UploadFilesResponse;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlRequest;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlResponse;
 import in.koreatech.koin.global.domain.upload.model.ImageUploadDomain;
@@ -48,6 +51,20 @@ public class UploadController implements UploadApi {
         @Auth(permit = {OWNER, STUDENT}) Long memberId
     ) {
         var response = uploadService.uploadFile(domain, multipartFile);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping(
+        value = "/{domain}/upload/files",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<UploadFilesResponse> uploadFiles(
+        @PathVariable ImageUploadDomain domain,
+        @RequestPart List<MultipartFile> files,
+        @Auth(permit = {OWNER, STUDENT}) Long memberId
+    ) {
+        var response = uploadService.uploadFiles(domain, files);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/in/koreatech/koin/global/domain/upload/dto/UploadFilesResponse.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/dto/UploadFilesResponse.java
@@ -1,0 +1,13 @@
+package in.koreatech.koin.global.domain.upload.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record UploadFilesResponse(
+    List<String> fileUrls
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/global/domain/upload/service/UploadService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/service/UploadService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.global.domain.upload.service;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import in.koreatech.koin.global.domain.upload.dto.UploadFileResponse;
+import in.koreatech.koin.global.domain.upload.dto.UploadFilesResponse;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlRequest;
 import in.koreatech.koin.global.domain.upload.dto.UploadUrlResponse;
 import in.koreatech.koin.global.domain.upload.model.ImageUploadDomain;
@@ -41,6 +43,14 @@ public class UploadService {
             log.warn("파일 업로드중 문제가 발생했습니다. file: {} \n message: {}", multipartFile, e.getMessage());
             throw new IllegalArgumentException("파일 업로드중 오류가 발생했습니다.");
         }
+    }
+
+    public UploadFilesResponse uploadFiles(ImageUploadDomain domain, List<MultipartFile> files) {
+        var response = files.stream()
+            .map(file -> uploadFile(domain, file))
+            .map(UploadFileResponse::fileUrl)
+            .toList();
+        return new UploadFilesResponse(response);
     }
 
     private String generateFilePath(String domainName, String fileNameExt) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #8 
- close #6

# 🚀 작업 내용

1. 다중 파일 업로드를 구현했습니다.

# 💬 리뷰 중점사항

기존 파일 업로드에서 반복문 돌리는게 대부분이라 큰 변경사항은 없습니다.