### PR TITLE
fix: 게시판 공지사항 판단 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/model/BoardTag.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/BoardTag.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.community.model;
+
+import lombok.Getter;
+
+@Getter
+public enum BoardTag {
+    자유게시판("FA001"),
+    취업게시판("JA001"),
+    익명게시판("AA001"),
+    공지사항("NA000"),
+    일반공지("NA001"),
+    장학공지("NA002"),
+    학사공지("NA003"),
+    취업공지("NA004"),
+    코인공지("NA005"),
+    질문게시판("QA001"),
+    홍보게시판("EA001"),
+    ;
+
+    private final String tag;
+
+    BoardTag(String tag) {
+        this.tag = tag;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
@@ -19,6 +20,8 @@ public interface ArticleRepository extends Repository<Article, Long> {
     Optional<Article> findById(Long articleId);
 
     List<Article> findAll(Pageable pageable);
+
+    Page<Article> findByBoardId(Long boardId, PageRequest pageRequest);
 
     default Article getById(Long articleId) {
         return findById(articleId).orElseThrow(

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -14,11 +14,7 @@ public interface ArticleRepository extends Repository<Article, Long> {
 
     Article save(Article article);
 
-    Page<Article> findByBoardId(Long boardId, Pageable pageable);
-
-    default Page<Article> getByBoardId(Long boardId, Pageable pageable) {
-        return findByBoardId(boardId, pageable);
-    }
+    Page<Article> findByIsNotice(Boolean isNotice, Pageable pageable);
 
     Optional<Article> findById(Long articleId);
 

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -74,7 +74,7 @@ public class CommunityService {
         Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-        Page<Article> articles = articleRepository.getByBoardId(boardId, pageRequest);
+        Page<Article> articles = articleRepository.findByIsNotice(board.getIsNotice(), pageRequest);
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -74,7 +74,11 @@ public class CommunityService {
         Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-        Page<Article> articles = articleRepository.findByIsNotice(board.getIsNotice(), pageRequest);
+        if (board.getIsNotice() && board.getTag().equals("NA000")) {
+            Page<Article> articles = articleRepository.findByIsNotice(board.getIsNotice(), pageRequest);
+            return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
+        }
+        Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -17,6 +17,7 @@ import in.koreatech.koin.domain.community.dto.HotArticleItemResponse;
 import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.domain.community.model.ArticleViewLog;
 import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.domain.community.model.BoardTag;
 import in.koreatech.koin.domain.community.model.Criteria;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.repository.ArticleViewLogRepository;
@@ -74,10 +75,12 @@ public class CommunityService {
         Criteria criteria = Criteria.of(page, limit);
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-        if (board.getIsNotice() && board.getTag().equals("NA000")) {
+
+        if (board.getIsNotice() && board.getTag().equals(BoardTag.공지사항.getTag())) {
             Page<Article> articles = articleRepository.findByIsNotice(board.getIsNotice(), pageRequest);
             return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
         }
+
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
         return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #187 

# 🚀 작업 내용

코인 페이지 상에서 게시판 공지사항이 뜨지 않는 현상을 수정했습니다.
응답 객체 형태 미스매치 이슈는 아니었고 내부 로직 문제였습니다.
공지사항(boardId=4) 조회 시 isNotice가 1인 모든 board를 조회해야 했기에 해당 로직으로 수정했습니다.

# 💬 리뷰 중점사항

### 한글 변수의 사용에 대해 여러분의 의견이 궁금합니다. 다들 꼭 의견 남겨주세요! 😁