### PR TITLE
feat: 사장님 인증코드 검증

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.domain.community.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import java.util.List;
@@ -13,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin.domain.community.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.dto.HotArticleItemResponse;
-import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
 import in.koreatech.koin.global.ipaddress.IpAddress;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -35,7 +34,7 @@ public interface CommunityApi {
     @Operation(summary = "게시글 단건 조회")
     @GetMapping("/articles/{id}")
     ResponseEntity<ArticleResponse> getArticle(
-        @Auth(permit = {STUDENT}, anonymous = true) Long userId,
+        @UserId Long userId,
         @Parameter(in = PATH) @PathVariable("id") Long articleId,
         @IpAddress String ipAddress
     );

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -1,7 +1,5 @@
 package in.koreatech.koin.domain.community.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
-
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -14,7 +12,7 @@ import in.koreatech.koin.domain.community.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.dto.HotArticleItemResponse;
 import in.koreatech.koin.domain.community.service.CommunityService;
-import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
 import in.koreatech.koin.global.ipaddress.IpAddress;
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +24,7 @@ public class CommunityController implements CommunityApi {
 
     @GetMapping("/articles/{id}")
     public ResponseEntity<ArticleResponse> getArticle(
-        @Auth(permit = {STUDENT}, anonymous = true) Long userId,
+        @UserId Long userId,
         @PathVariable("id") Long articleId,
         @IpAddress String ipAddress
     ) {

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin.domain.owner.dto.OwnerRegisterRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
+import in.koreatech.koin.domain.owner.dto.OwnerVerificationRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerVerifyResponse;
 import in.koreatech.koin.domain.owner.dto.VerifyEmailRequest;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,5 +65,21 @@ public interface OwnerApi {
     @PostMapping("/owners/register")
     ResponseEntity<Void> register(
         @Valid @RequestBody OwnerRegisterRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "사장님 인증번호 입력")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/owners/verification/code")
+    ResponseEntity<OwnerVerifyResponse> codeVerification(
+        @Valid @RequestBody OwnerVerificationRequest request
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.owner.dto.OwnerRegisterRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
+import in.koreatech.koin.domain.owner.dto.OwnerVerificationRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerVerifyResponse;
 import in.koreatech.koin.domain.owner.dto.VerifyEmailRequest;
 import in.koreatech.koin.domain.owner.service.OwnerService;
 import in.koreatech.koin.global.auth.Auth;
@@ -44,5 +46,13 @@ public class OwnerController implements OwnerApi {
     ) {
         ownerService.register(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/owners/verification/code")
+    public ResponseEntity<OwnerVerifyResponse> codeVerification(
+        @Valid @RequestBody OwnerVerificationRequest request
+    ) {
+        OwnerVerifyResponse response = ownerService.verifyCode(request);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerVerificationRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerVerificationRequest.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.owner.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record OwnerVerificationRequest(
+    @JsonProperty(value = "address")
+    @Schema(description = "사장님 이메일", example = "junho5336@gmail.com")
+    String email,
+
+    @Schema(description = "인증 코드", example = "123456")
+    String certificationCode
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerVerifyResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerVerifyResponse.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.domain.owner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OwnerVerifyResponse(
+    @Schema(description = "임시 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+    String token
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
@@ -40,7 +40,7 @@ public class OwnerEventListener {
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onOwnerRegister(OwnerRegisterEvent event) {
         Owner owner = event.owner();
-        ownerInVerificationRedisRepository.deleteById(owner.getUser().getEmail());
+        ownerInVerificationRedisRepository.deleteByEmail(owner.getUser().getEmail());
         String shopsName = shopRepository.findAllByOwnerId(owner.getId())
             .stream().map(Shop::getName).collect(Collectors.joining(", "));
         var notification = slackNotificationFactory.generateOwnerRegisterRequestNotification(

--- a/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerInVerificationRedisRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerInVerificationRedisRepository.java
@@ -15,6 +15,10 @@ public interface OwnerInVerificationRedisRepository extends Repository<OwnerInVe
 
     void deleteById(String email);
 
+    default void deleteByEmail(String email) {
+        deleteById(email);
+    }
+
     default OwnerInVerification getByEmail(String email) {
         return findById(email).orElseThrow(() -> EmailNotFoundException.withDetail("email: " + email));
     }

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -98,9 +98,10 @@ public class OwnerService {
 
     public OwnerVerifyResponse verifyCode(OwnerVerificationRequest request) {
         var verify = ownerInVerificationRedisRepository.getByEmail(request.email());
-        if (Objects.equals(verify.getCertificationCode(), request.certificationCode())) {
+        if (!Objects.equals(verify.getCertificationCode(), request.certificationCode())) {
             throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
         }
+        ownerInVerificationRedisRepository.deleteById(request.email());
         String token = jwtProvider.createTemporaryToken();
         return new OwnerVerifyResponse(token);
     }

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -101,7 +101,7 @@ public class OwnerService {
         if (!Objects.equals(verify.getCertificationCode(), request.certificationCode())) {
             throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
         }
-        ownerInVerificationRedisRepository.deleteById(request.email());
+        ownerInVerificationRedisRepository.deleteByEmail(request.email());
         String token = jwtProvider.createTemporaryToken();
         return new OwnerVerifyResponse(token);
     }

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
@@ -9,6 +9,8 @@ public enum UserType {
     COOP("COOP", "영양사"),
     ;
 
+    public static final Long ANONYMOUS_ID = 0L;
+
     private final String value;
     private final String description;
 

--- a/src/main/java/in/koreatech/koin/global/auth/AuthArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/global/auth/AuthArgumentResolver.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.global.auth;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -10,12 +12,11 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import jakarta.servlet.http.HttpServletRequest;
-import static java.util.Objects.requireNonNull;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -37,25 +38,15 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         Auth authAt = parameter.getParameterAnnotation(Auth.class);
         requireNonNull(authAt);
         List<UserType> permitStatus = Arrays.asList(authAt.permit());
-        Long userId = authContext.getUserId();
-        if (isAnonymous(userId, authAt)) {
+        if (authContext.isAnonymous() && authAt.anonymous()) {
             return null;
         }
+        Long userId = authContext.getUserId();
         User user = userRepository.getById(userId);
         if (permitStatus.contains(user.getUserType())) {
             return user.getId();
         }
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         throw AuthorizationException.withDetail("header: " + request);
-    }
-
-    private static boolean isAnonymous(Long userId, Auth authAt) {
-        if (userId == null) {
-            if (authAt.anonymous()) {
-                return true;
-            }
-            throw AuthorizationException.withDetail("userId is null");
-        }
-        return false;
     }
 }

--- a/src/main/java/in/koreatech/koin/global/auth/ExtractAuthenticationInterceptor.java
+++ b/src/main/java/in/koreatech/koin/global/auth/ExtractAuthenticationInterceptor.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.global.auth;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -9,7 +11,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Component
 @RequiredArgsConstructor
@@ -20,12 +21,16 @@ public class ExtractAuthenticationInterceptor implements HandlerInterceptor {
 
     private final JwtProvider jwtProvider;
     private final AuthContext authContext;
+    private final UserIdContext userIdContext;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         Optional.ofNullable(extractAccessToken(request))
             .map(jwtProvider::getUserId)
-            .ifPresent(authContext::setUserId);
+            .ifPresent(userId -> {
+                authContext.setUserId(userId);
+                userIdContext.setUserId(userId);
+            });
         return true;
     }
 

--- a/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
+++ b/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.auth.exception.AuthenticationException;
-import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -36,7 +35,6 @@ public class JwtProvider {
         if (user == null) {
             throw UserNotFoundException.withDetail("user: " + null);
         }
-
         Key key = getSecretKey();
         return Jwts.builder()
             .signWith(key)
@@ -45,7 +43,22 @@ public class JwtProvider {
             .add("alg", key.getAlgorithm())
             .and()
             .claim("id", user.getId())
-            .expiration(new Date(Instant.now().toEpochMilli() + expirationTime))
+            .expiration(Date.from(Instant.now().plusMillis(expirationTime)))
+            .compact();
+    }
+
+    /**
+     * 임시 회원가입 토큰 생성
+     */
+    public String createTemporaryToken() {
+        Key key = getSecretKey();
+        return Jwts.builder()
+            .signWith(getSecretKey())
+            .header()
+            .add("typ", "JWT")
+            .add("alg", key.getAlgorithm())
+            .and()
+            .expiration(Date.from(Instant.now().plusMillis(expirationTime)))
             .compact();
     }
 
@@ -69,5 +82,4 @@ public class JwtProvider {
         String encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());
         return Keys.hmacShaKeyFor(encoded.getBytes());
     }
-
 }

--- a/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
+++ b/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
@@ -54,7 +54,7 @@ public class JwtProvider {
     public String createTemporaryToken() {
         Key key = getSecretKey();
         return Jwts.builder()
-            .signWith(getSecretKey())
+            .signWith(key)
             .header()
             .add("typ", "JWT")
             .add("alg", key.getAlgorithm())

--- a/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
+++ b/src/main/java/in/koreatech/koin/global/auth/JwtProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.auth.exception.AuthenticationException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -58,6 +59,7 @@ public class JwtProvider {
             .add("typ", "JWT")
             .add("alg", key.getAlgorithm())
             .and()
+            .claim("id", UserType.ANONYMOUS_ID)
             .expiration(Date.from(Instant.now().plusMillis(expirationTime)))
             .compact();
     }
@@ -72,7 +74,6 @@ public class JwtProvider {
                 .get("id")
                 .toString();
             return Long.parseLong(userId);
-
         } catch (JwtException e) {
             throw AuthenticationException.withDetail("token: " + token);
         }

--- a/src/main/java/in/koreatech/koin/global/auth/UserId.java
+++ b/src/main/java/in/koreatech/koin/global/auth/UserId.java
@@ -6,18 +6,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import in.koreatech.koin.domain.user.model.UserType;
 import io.swagger.v3.oas.annotations.Hidden;
 
+/**
+ * 토큰으로부터 사용자 ID를 추출하여 가져온다.
+ * <p>
+ * Nullable: 사용자 ID가 없을 수도 있다.
+ */
 @Hidden // Swagger 문서에 표시하지 않음
 @Target(PARAMETER)
 @Retention(RUNTIME)
-public @interface Auth {
+public @interface UserId {
 
-    UserType[] permit() default {};
-
-    /**
-     * 임시토큰을 허용하는 옵션이다.
-     */
-    boolean anonymous() default false;
 }

--- a/src/main/java/in/koreatech/koin/global/auth/UserIdArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/global/auth/UserIdArgumentResolver.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.global.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 토큰에 있는 사용자 ID를 가져온다 (인증 X)
+ */
+@Component
+@RequiredArgsConstructor
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserIdContext userIdContext;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        return userIdContext.getUserId();
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/auth/UserIdContext.java
+++ b/src/main/java/in/koreatech/koin/global/auth/UserIdContext.java
@@ -6,23 +6,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 import in.koreatech.koin.domain.user.model.UserType;
-import in.koreatech.koin.global.auth.exception.AuthenticationException;
 
 @Component
 @RequestScope
-public class AuthContext {
+public class UserIdContext {
 
     private Long userId;
 
     public Long getUserId() {
-        if (userId == null) {
-            throw AuthenticationException.withDetail("userId is null");
+        if (Objects.equals(userId, UserType.ANONYMOUS_ID)) {
+            return null;
         }
         return userId;
-    }
-
-    public boolean isAnonymous() {
-        return Objects.equals(userId, UserType.ANONYMOUS_ID);
     }
 
     public void setUserId(Long userId) {

--- a/src/main/java/in/koreatech/koin/global/auth/exception/AuthenticationException.java
+++ b/src/main/java/in/koreatech/koin/global/auth/exception/AuthenticationException.java
@@ -4,9 +4,6 @@ public class AuthenticationException extends RuntimeException {
 
     private static final String DEFAULT_MESSAGE = "올바르지 않은 인증정보입니다.";
 
-    public AuthenticationException() {
-    }
-
     public AuthenticationException(String message) {
         super(message);
     }

--- a/src/main/java/in/koreatech/koin/global/auth/exception/AuthorizationException.java
+++ b/src/main/java/in/koreatech/koin/global/auth/exception/AuthorizationException.java
@@ -4,9 +4,6 @@ public class AuthorizationException extends RuntimeException {
 
     private static final String DEFAULT_MESSAGE = "권한이 없습니다.";
 
-    public AuthorizationException() {
-    }
-
     public AuthorizationException(String message) {
         super(message);
     }

--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import in.koreatech.koin.global.auth.AuthArgumentResolver;
 import in.koreatech.koin.global.auth.ExtractAuthenticationInterceptor;
+import in.koreatech.koin.global.auth.UserIdArgumentResolver;
 import in.koreatech.koin.global.domain.upload.controller.ImageUploadDomainEnumConverter;
 import in.koreatech.koin.global.ipaddress.IpAddressArgumentResolver;
 import in.koreatech.koin.global.ipaddress.IpAddressInterceptor;
@@ -22,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final ExtractAuthenticationInterceptor extractAuthenticationInterceptor;
     private final IpAddressArgumentResolver ipAddressArgumentResolver;
+    private final UserIdArgumentResolver userIdArgumentResolver;
     private final AuthArgumentResolver authArgumentResolver;
     private final IpAddressInterceptor ipAddressInterceptor;
 
@@ -39,6 +41,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authArgumentResolver);
         resolvers.add(ipAddressArgumentResolver);
+        resolvers.add(userIdArgumentResolver);
     }
 
     @Override

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
@@ -1,6 +1,11 @@
 package in.koreatech.koin.global.domain.upload.controller;
 
 
+import static in.koreatech.koin.domain.user.model.UserType.COOP;
+import static in.koreatech.koin.domain.user.model.UserType.OWNER;
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
 import java.util.List;
 
 import org.springframework.http.MediaType;
@@ -19,9 +24,6 @@ import in.koreatech.koin.global.domain.upload.dto.UploadUrlResponse;
 import in.koreatech.koin.global.domain.upload.model.ImageUploadDomain;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-
-import static in.koreatech.koin.domain.user.model.UserType.*;
-import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -88,7 +90,7 @@ public interface UploadApi {
     ResponseEntity<UploadFileResponse> uploadFile(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
     );
 
     @ApiResponses(
@@ -119,6 +121,6 @@ public interface UploadApi {
     ResponseEntity<UploadFilesResponse> uploadFiles(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
     );
 }

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
@@ -59,7 +59,7 @@ public interface UploadApi {
     ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     );
 
     @ApiResponses(
@@ -90,7 +90,7 @@ public interface UploadApi {
     ResponseEntity<UploadFileResponse> uploadFile(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     );
 
     @ApiResponses(
@@ -121,6 +121,6 @@ public interface UploadApi {
     ResponseEntity<UploadFilesResponse> uploadFiles(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     );
 }

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
@@ -1,6 +1,8 @@
 package in.koreatech.koin.global.domain.upload.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.*;
+import static in.koreatech.koin.domain.user.model.UserType.COOP;
+import static in.koreatech.koin.domain.user.model.UserType.OWNER;
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
 
@@ -48,7 +50,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFileResponse> uploadFile(
         @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
     ) {
         var response = uploadService.uploadFile(domain, multipartFile);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -62,7 +64,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFilesResponse> uploadFiles(
         @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
     ) {
         var response = uploadService.uploadFiles(domain, files);
         return new ResponseEntity<>(response, HttpStatus.CREATED);

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
@@ -36,7 +36,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     ) {
         var response = uploadService.getPresignedUrl(domain, request);
         return ResponseEntity.ok(response);
@@ -50,7 +50,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFileResponse> uploadFile(
         @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     ) {
         var response = uploadService.uploadFile(domain, multipartFile);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -64,7 +64,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFilesResponse> uploadFiles(
         @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP}) Long memberId
+        @Auth(permit = {OWNER, STUDENT, COOP}, anonymous = true) Long memberId
     ) {
         var response = uploadService.uploadFiles(domain, files);
         return new ResponseEntity<>(response, HttpStatus.CREATED);

--- a/src/main/resources/db/migration/V5__update_owners_table.sql
+++ b/src/main/resources/db/migration/V5__update_owners_table.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `owners` DROP `company_registration_certificate_image_url`;

--- a/src/test/java/in/koreatech/koin/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/AcceptanceTest.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin;
 
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
 import java.time.Clock;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +21,6 @@ import org.testcontainers.utility.DockerImageName;
 import in.koreatech.koin.domain.owner.model.OwnerEventListener;
 import in.koreatech.koin.support.DBInitializer;
 import io.restassured.RestAssured;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @Import(DBInitializer.class)
@@ -63,7 +64,7 @@ public abstract class AcceptanceTest {
     }
 
     static {
-        mySqlContainer = (MySQLContainer)new MySQLContainer("mysql:5.7.34")
+        mySqlContainer = (MySQLContainer)new MySQLContainer("mysql:8.0.29")
             .withDatabaseName("test")
             .withUsername(ROOT)
             .withPassword(ROOT_PASSWORD)

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -492,8 +492,6 @@ class OwnerApiTest extends AcceptanceTest {
             .when()
             .post("/owners/verification/code")
             .then()
-            .statusCode(HttpStatus.OK.value());
-        var result = ownerInVerificationRedisRepository.findById(verification.getEmail());
-        Assertions.assertThat(result).isNotPresent();
+            .statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerAttachment;
+import in.koreatech.koin.domain.owner.model.OwnerInVerification;
 import in.koreatech.koin.domain.owner.model.OwnerRegisterEvent;
 import in.koreatech.koin.domain.owner.repository.OwnerInVerificationRedisRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
@@ -157,6 +159,40 @@ class OwnerApiTest extends AcceptanceTest {
         assertDoesNotThrow(() ->
             ownerInVerificationRedisRepository.getByEmail("test@gmail.com")
         );
+    }
+
+    @Test
+    @DisplayName("사장님이 회원가입 인증번호 전송 요청을 한다 - 전송한 코드로 인증요청이 성공한다")
+    void requestAndVerifySign() {
+        String ownerEmail = "junho5336@gmail.com";
+        RestAssured
+            .given()
+            .body(String.format("""
+                {
+                  "email": "%s"
+                }
+                """, ownerEmail))
+            .contentType(ContentType.JSON)
+            .when()
+            .post("/owners/verification/email")
+            .then()
+            .statusCode(HttpStatus.OK.value());
+        var verify = ownerInVerificationRedisRepository.getByEmail(ownerEmail);
+        RestAssured
+            .given()
+            .body(String.format("""
+                    {
+                      "address": "%s",
+                      "certification_code": "%s"
+                    }
+                """, ownerEmail, verify.getCertificationCode()))
+            .contentType(ContentType.JSON)
+            .when()
+            .post("/owners/verification/code")
+            .then()
+            .statusCode(HttpStatus.OK.value());
+        var result = ownerInVerificationRedisRepository.findById(ownerEmail);
+        Assertions.assertThat(result).isNotPresent();
     }
 
     @Test
@@ -413,5 +449,51 @@ class OwnerApiTest extends AcceptanceTest {
                 }
             );
         }
+    }
+
+    @Test
+    @DisplayName("사장님이 회원가입 인증번호를 확인한다")
+    void ownerCodeVerification() {
+        // given
+        OwnerInVerification verification = OwnerInVerification.of("junho5336@gmail.com", "123456");
+        ownerInVerificationRedisRepository.save(verification);
+        RestAssured
+            .given()
+            .body("""
+                    {
+                      "address": "junho5336@gmail.com",
+                      "certification_code": "123456"
+                    }
+                """)
+            .contentType(ContentType.JSON)
+            .when()
+            .post("/owners/verification/code")
+            .then()
+            .statusCode(HttpStatus.OK.value());
+        var result = ownerInVerificationRedisRepository.findById(verification.getEmail());
+        Assertions.assertThat(result).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("사장님이 회원가입 인증번호를 확인한다 - 존재하지 않는 이메일로 요청을 보낸다")
+    void ownerCodeVerificationNotExistEmail() {
+        // given
+        OwnerInVerification verification = OwnerInVerification.of("junho5336@gmail.com", "123456");
+        ownerInVerificationRedisRepository.save(verification);
+        RestAssured
+            .given()
+            .body("""
+                    {
+                      "address": "someone@gmail.com",
+                      "certification_code": "123456"
+                    }
+                """)
+            .contentType(ContentType.JSON)
+            .when()
+            .post("/owners/verification/code")
+            .then()
+            .statusCode(HttpStatus.OK.value());
+        var result = ownerInVerificationRedisRepository.findById(verification.getEmail());
+        Assertions.assertThat(result).isNotPresent();
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #123 

# 🚀 작업 내용

1. Redis에 저장되어있는 값을 기반으로 인증코드를 검증하는 로직을 추가했습니다.
2. 임시 엑세스 토큰 발급로직을 추가했습니다.
  - 사장님이 임시 인증을 수행하고 회원가입을 진행하는 과정에서 파일 업로드를 수행해야합니다.
  - 파일 업로드 작업은 인증된 유저만 수행할 수 있도록 구성되어있기 때문에 임시 엑세스 토큰을 발급하여 이를 수행할 수 있도록 구성해야 했습니다.
3. @UserId 어노테이션 추가
  - 인증을 거치지 않고 사용자의 ID만 추출해야하는 경우가 존재하여 만들었습니다. (/articles API)
4. `@Auth(anonymous = true)` 동작방식 변경
  - 기존에 `@Auth(anonymous = true)`는 인증 토큰이 없어도 API를 사용 가능하도록 설정하는 옵션이였습니다.
  - 이는 인증을 오구하는 `@Auth` 어노테이션의 맥락에서 벗어나는 행위인 것 같아 위에서 이야기한 `@UserId` 어노테이션을 별도로 구성했습니다.
  - 회원가입 과정에서 이미지 업로드를 수행할 수 있도록 임시 토큰을 발급하는 로직을 추가했습니다.
    - 임시 회원은 token 내부의 id가 0인 토큰에 대하여 임시 토큰이다 라고 선언했습니다.
    - 해당 0이라는 값은 UserType에 상수로 ANONYMOUS_ID 로 선언해뒀습니다.
    - 생성 로직은 `jwtProvider.createTemporaryToken()` 참고해주세요
  - 정리하면 `@Auth(anonymous = true)` 옵션은 **임시토큰을 허용한다** 라는 옵션으로 인지해주시면 되겠습니다.

5. V5__update_owners_table.sql 파일을 제거했습니다.
  - 레거시 API의 Query에서 참고중인 것으로 파악하여 제거했습니다 😅

# 💬 리뷰 중점사항

작업간 인증 부분을 좀 건드리게 되어 file change양이 예기치 못하게 많아졌습니다.
양해 부탁드려요 :)

post 테스트코드에 하드코딩된 값들이 꽤나 거슬렸는데 String.format으로 어느정도 해결할 수 있다는걸 이제야 알아버려네요 꽤나 좋은 방식인것 같아 공유해봅니다.

```java
// before
RestAssured
    .given()
    .body("""
            {
              "address": "junho5336@gmail.com",
              "certification_code": "123456"
            }
        """)
    .contentType(ContentType.JSON)
    .when()
    .post("/owners/verification/code")
    .then()
    .statusCode(HttpStatus.OK.value());

// after
RestAssured
    .given()
    .body(String.format("""
            {
              "address": "%s",
              "certification_code": "%s"
            }
        """, ownerEmail, code)
    .contentType(ContentType.JSON)
    .when()
    .post("/owners/verification/code")
    .then()
    .statusCode(HttpStatus.OK.value());
```