### PR TITLE
fix: 전공별 커리큘럼 링크 수정, 새로운 과 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
@@ -6,8 +6,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import in.koreatech.koin.domain.dept.dto.DeptListItemResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
+import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -38,5 +38,5 @@ public interface DeptApi {
     )
     @Operation(summary = "학과 목록 조회")
     @GetMapping("/depts")
-    ResponseEntity<List<DeptListItemResponse>> getAllDept();
+    ResponseEntity<List<DeptsResponse>> getAllDept();
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import in.koreatech.koin.domain.dept.dto.DeptListItemResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
+import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import in.koreatech.koin.domain.dept.service.DeptService;
 import lombok.RequiredArgsConstructor;
 
@@ -30,8 +30,8 @@ public class DeptController implements DeptApi {
     }
 
     @GetMapping("/depts")
-    public ResponseEntity<List<DeptListItemResponse>> getAllDept() {
-        List<DeptListItemResponse> response = deptService.getAll();
+    public ResponseEntity<List<DeptsResponse>> getAllDept() {
+        List<DeptsResponse> response = deptService.getAll();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptListItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptListItemResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record DeptListItemResponse(String name, String curriculumLink, List<String> deptNums) {
+public record DeptListItemResponse(String name, String curriculumLink, List<?> deptNums) {
 
     public static DeptListItemResponse from(Dept dept) {
         return new DeptListItemResponse(

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptsResponse.java
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record DeptListItemResponse(String name, String curriculumLink, List<?> deptNums) {
+public record DeptsResponse(String name, String curriculumLink, List<?> deptNums) {
 
-    public static DeptListItemResponse from(Dept dept) {
-        return new DeptListItemResponse(
+    public static DeptsResponse from(Dept dept) {
+        return new DeptsResponse(
             dept.getName(),
             dept.getCurriculumLink(),
             dept.getNumbers()

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptsResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record DeptsResponse(String name, String curriculumLink, List<?> deptNums) {
+public record DeptsResponse(String name, String curriculumLink, List<String> deptNums) {
 
     public static DeptsResponse from(Dept dept) {
         return new DeptsResponse(

--- a/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
@@ -35,10 +35,10 @@ public enum Dept {
 
     // 신설 과는 학과 고유 번호로 Optional.empty()를 넣어줌
     CHEMIACL_ENGINEERING(
-        "화학생명공학부", List.of(Optional.empty()),
+        "화학생명공학부", List.of("N/A"),
         "https://www.koreatech.ac.kr/board.es?mid=b50301000000&bid=0135"),
     ENERGY_MATERIALS_ENGINEERING(
-        "에너지신소재공학부", List.of(Optional.empty()),
+        "에너지신소재공학부", List.of("N/A"),
         "https://www.koreatech.ac.kr/board.es?mid=b40301000000&bid=0128"),
 
     // 없어진 과(고 학번을 위해 유지)
@@ -47,10 +47,10 @@ public enum Dept {
         "https://cms3.koreatech.ac.kr/ace/992/subview.do");
 
     private final String name;
-    private final List<?> numbers;
+    private final List<String> numbers;
     private final String curriculumLink;
 
-    Dept(String name, List<?> numbers, String curriculumLink) {
+    Dept(String name, List<String> numbers, String curriculumLink) {
         this.name = name;
         this.numbers = numbers;
         this.curriculumLink = curriculumLink;

--- a/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
@@ -33,7 +33,7 @@ public enum Dept {
         "컴퓨터공학부", List.of("35", "36"),
         "https://www.koreatech.ac.kr/menu.es?mid=b10402000000"),
 
-    // 신설 과는 학과 고유 번호로 Optional.empty()를 넣어줌
+    // 신설 과는 학과 고유 번호로 N/A를 넣어줌
     CHEMIACL_ENGINEERING(
         "화학생명공학부", List.of("N/A"),
         "https://www.koreatech.ac.kr/board.es?mid=b50301000000&bid=0135"),

--- a/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
@@ -26,22 +26,31 @@ public enum Dept {
     INDUSTRIAL_MANAGEMENT(
         "산업경영학부", List.of("80"),
         "https://cms3.koreatech.ac.kr/sim/1167/subview.do"),
-    NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING(
-        "에너지신소재화학공학부", List.of("74"),
-        "https://cms3.koreatech.ac.kr/ace/992/subview.do"),
     ELECTRICAL_AND_ELECTRONIC_COMMUNICATION_ENGINEERING(
         "전기전자통신공학부", List.of("61"),
         "https://cms3.koreatech.ac.kr/ite/842/subview.do"),
     COMPUTER_SCIENCE(
         "컴퓨터공학부", List.of("35", "36"),
         "https://cse.koreatech.ac.kr/page_izgw21"),
-    ;
+
+    // 신설 과는 학과 고유 번호로 Optional.empty()를 넣어줌
+    CHEMIACL_ENGINEERING(
+        "화학생명공학부", List.of(Optional.empty()),
+        "https://www.koreatech.ac.kr/board.es?mid=b50301000000&bid=0135"),
+    ENERGY_MATERIALS_ENGINEERING(
+        "에너지신소재공학부", List.of(Optional.empty()),
+        "https://www.koreatech.ac.kr/board.es?mid=b40301000000&bid=0128"),
+
+    // 없어진 과(고 학번을 위해 유지)
+    NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING(
+        "에너지신소재화학공학부", List.of("74"),
+        "https://cms3.koreatech.ac.kr/ace/992/subview.do");
 
     private final String name;
-    private final List<String> numbers;
+    private final List<?> numbers;
     private final String curriculumLink;
 
-    Dept(String name, List<String> numbers, String curriculumLink) {
+    Dept(String name, List<?> numbers, String curriculumLink) {
         this.name = name;
         this.numbers = numbers;
         this.curriculumLink = curriculumLink;

--- a/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/model/Dept.java
@@ -10,28 +10,28 @@ import lombok.Getter;
 public enum Dept {
     ARCHITECTURAL_ENGINEERING(
         "건축공학부", List.of("72"),
-        "https://cms3.koreatech.ac.kr/arch/1083/subview.do"),
+        "https://arch.koreatech.ac.kr/menu.es?mid=b30202000000"),
     EMPLOYMENT_SERVICE_POLICY_DEPARTMENT(
         "고용서비스정책학과", List.of("85"),
-        "https://www.koreatech.ac.kr/kor/CMS/UnivOrganMgr/subMain.do?mCode=MN451"),
+        "https://www.koreatech.ac.kr/board.es?mid=b80302000000&bid=0150"),
     MECHANICAL_ENGINEERING(
         "기계공학부", List.of("20"),
-        "https://cms3.koreatech.ac.kr/me/795/subview.do"),
+        "https://me.koreatech.ac.kr/menu.es?mid=a70302000000"),
     DESIGN_ENGINEERING(
         "디자인공학부", List.of("51"),
-        "https://cms3.koreatech.ac.kr/ide/1047/subview.do"),
+        "https://www.koreatech.ac.kr/menu.es?mid=b20302000000"),
     MECHATRONICS_ENGINEERING(
         "메카트로닉스공학부", List.of("40"),
-        "https://www.koreatech.ac.kr/kor/CMS/UnivOrganMgr/subMain.do?mCode=MN076"),
+        "https://mecha.koreatech.ac.kr/menu.es?mid=a80302010200"),
     INDUSTRIAL_MANAGEMENT(
         "산업경영학부", List.of("80"),
-        "https://cms3.koreatech.ac.kr/sim/1167/subview.do"),
+        "https://www.koreatech.ac.kr/menu.es?mid=b60302010100"),
     ELECTRICAL_AND_ELECTRONIC_COMMUNICATION_ENGINEERING(
         "전기전자통신공학부", List.of("61"),
-        "https://cms3.koreatech.ac.kr/ite/842/subview.do"),
+        "https://www.koreatech.ac.kr/menu.es?mid=a90302010200"),
     COMPUTER_SCIENCE(
         "컴퓨터공학부", List.of("35", "36"),
-        "https://cse.koreatech.ac.kr/page_izgw21"),
+        "https://www.koreatech.ac.kr/menu.es?mid=b10402000000"),
 
     // 신설 과는 학과 고유 번호로 Optional.empty()를 넣어줌
     CHEMIACL_ENGINEERING(

--- a/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
@@ -21,6 +21,7 @@ public class DeptService {
     public List<DeptListItemResponse> getAll() {
         return Dept.findAll()
             .stream()
+            .filter(dept -> !dept.getName().equals("에너지신소재화학공학부"))
             .map(DeptListItemResponse::from)
             .toList();
     }

--- a/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.dept.service;
 
+import static in.koreatech.koin.domain.dept.model.Dept.NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -21,7 +23,7 @@ public class DeptService {
     public List<DeptsResponse> getAll() {
         return Dept.findAll()
             .stream()
-            .filter(dept -> !dept.getName().equals("에너지신소재화학공학부"))
+            .filter(dept -> !NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING.equals(dept))
             .map(DeptsResponse::from)
             .toList();
     }

--- a/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import in.koreatech.koin.domain.dept.dto.DeptListItemResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
+import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import in.koreatech.koin.domain.dept.model.Dept;
 
 @Service
@@ -18,11 +18,11 @@ public class DeptService {
         return dept.map(value -> DeptResponse.from(id, value)).orElse(null);
     }
 
-    public List<DeptListItemResponse> getAll() {
+    public List<DeptsResponse> getAll() {
         return Dept.findAll()
             .stream()
             .filter(dept -> !dept.getName().equals("에너지신소재화학공학부"))
-            .map(DeptListItemResponse::from)
+            .map(DeptsResponse::from)
             .toList();
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DeptApiTest.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.acceptance;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -9,7 +11,6 @@ import in.koreatech.koin.domain.dept.model.Dept;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class DeptApiTest extends AcceptanceTest {
 
@@ -41,7 +42,7 @@ class DeptApiTest extends AcceptanceTest {
     @DisplayName("모든 학과 정보를 조회한다.")
     void findAllDepts() {
         //given
-        final int DEPT_SIZE = Dept.values().length;
+        final int DEPT_SIZE = Dept.values().length - 1;
 
         //when then
         ExtractableResponse<Response> response = RestAssured
@@ -59,8 +60,6 @@ class DeptApiTest extends AcceptanceTest {
                 for (int i = 0; i < DEPT_SIZE; i++) {
                     softly.assertThat(response.body().jsonPath().getString(String.format("[%d].name", i))).isNotEmpty();
                     softly.assertThat(response.body().jsonPath().getString(String.format("[%d].curriculum_link", i)))
-                        .isNotEmpty();
-                    softly.assertThat(response.body().jsonPath().getString(String.format("[%d].dept_nums[0]", i)))
                         .isNotEmpty();
                 }
             }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #247 

# 🚀 작업 내용

1. 에너지 신소재 화학 공학부가 에너지 신소재 공학부, 화학생명공학부로 나뉘면서 두개의 과를 추가해줬습니다.
2. 하지만 23 학번 이전은 회원 가입 시에 학번을 입력하면 학부가 자동 완성 되었으면 좋겠다는 요구가 있었기에 기존에 있던 과인 에너지 신소재 화학 공학부를 삭제 하지 않았습니다.
3. get depts api에서는 필요한 과만 반환 하기 위해 에너지 신소재 화학 공학부는 걸러주는 작업을 했습니다.
4. 실제 갖고 있는 과 정보는 11개 이지만(에너지 신소재 화학 공학부 삭제 x) get depts api가 반환하는 값은 10개 이기에 모든 학과 정보 조회 테스트 코드에서 사이즈를 1 줄여 줬습니다.
5. 이제 학번 고유 코드 번호로 null을 갖고 있는 과가 생겼기에, 고유코드번호가 비어있는지 확인하는 테스트 코드는 없앴습니다.
6. 학부 전공별 커리큘럼 링크를 최신걸로 업데이트 하였습니다
7. DeptListItemResponse를 DeptsResponse로 이름을 변경 해주었습니다.


# 💬 리뷰 중점사항
신설과들은 학번 고유 코드번호가 없기에, Optional.empty()를 넣어 줬습니다. 하지만 get depts api를 보면, 반환하는 json의 형태가 학번 코드 자리에 null이 들어가서 괜찮은 것인지 우려가 됩니다.