### PR TITLE
fix: student Entity 필드 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/Student.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/Student.java
@@ -37,7 +37,7 @@ public class Student {
     private String department;
 
     @Column(name = "identity")
-    @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.ORDINAL)
     private UserIdentity userIdentity;
 
     @Column(name = "is_graduated")

--- a/src/main/java/in/koreatech/koin/domain/user/repository/StudentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/StudentRepository.java
@@ -11,10 +11,10 @@ public interface StudentRepository extends Repository<Student, Long> {
 
     Student save(Student student);
 
-    Optional<Student> findByUserId(Long userId);
+    Optional<Student> findById(Long userId);
 
-    default Student getByUserId(Long userId) {
-        return findByUserId(userId)
+    default Student getById(Long userId) {
+        return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
@@ -25,13 +25,13 @@ public class StudentService {
     private final UserRepository userRepository;
 
     public StudentResponse getStudent(Long userId) {
-        Student student = studentRepository.getByUserId(userId);
+        Student student = studentRepository.getById(userId);
         return StudentResponse.from(student);
     }
 
     @Transactional
     public StudentUpdateResponse updateStudent(Long userId, StudentUpdateRequest request) {
-        Student student = studentRepository.getByUserId(userId);
+        Student student = studentRepository.getById(userId);
         User user = student.getUser();
         checkNicknameDuplication(request.nickname());
         checkDepartmentValid(request.major());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #285 

# 🚀 작업 내용

![image](https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/67ecfd69-e0c2-4101-983f-c5d6200f0b2b)

1. UserIdentity 값을 Ordinal로 정정했습니다.
2. Student의 ID가 User의 ID를 FK 겸 PK로 다루고있어 `@MapsId`로 UserId의 ID를 PK로 다루고있음을 뒤늦게 확인했습니다.
- #283 에 대한 작업내용을 함께 Revert 했습니다.

# 💬 리뷰 중점사항
빠른 리뷰 항상 감사합니다