### PR TITLE
feat: stage logback 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 
 application.yml
 *adminsdk.json
+
+logs

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // slack Notification
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/in/koreatech/koin/domain/activity/controller/ActivityController.java
+++ b/src/main/java/in/koreatech/koin/domain/activity/controller/ActivityController.java
@@ -22,4 +22,9 @@ public class ActivityController implements ActivityApi {
         ActivitiesResponse response = activityService.getActivities(year);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/error")
+    public ResponseEntity<Void> error() {
+        throw new IllegalStateException("error!!!!");
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/activity/controller/ActivityController.java
+++ b/src/main/java/in/koreatech/koin/domain/activity/controller/ActivityController.java
@@ -22,9 +22,4 @@ public class ActivityController implements ActivityApi {
         ActivitiesResponse response = activityService.getActivities(year);
         return ResponseEntity.ok(response);
     }
-
-    @GetMapping("/error")
-    public ResponseEntity<Void> error() {
-        throw new IllegalStateException("error!!!!");
-    }
 }

--- a/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
@@ -20,11 +20,4 @@ public class ErrorResponse {
     public static ErrorResponse from(String message) {
         return new ErrorResponse(0, message);
     }
-
-    public record ErrorResponseWrapper(ErrorResponse error) {
-
-        public static ErrorResponseWrapper from(ErrorResponse error) {
-            return new ErrorResponseWrapper(error);
-        }
-    }
 }

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -1,73 +1,182 @@
 package in.koreatech.koin.global.exception;
 
 import java.time.format.DateTimeParseException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.WebUtils;
 
 import in.koreatech.koin.global.auth.exception.AuthenticationException;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+        HttpServletRequest request,
+        IllegalArgumentException e
+    ) {
         log.warn(e.getMessage());
-        return ResponseEntity.badRequest().body(ErrorResponse.from(e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-        log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.from("요청 파라미터가 잘못되었습니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleAuthorizationException(AuthorizationException e) {
+    public ResponseEntity<ErrorResponse> handleAuthorizationException(
+        HttpServletRequest request,
+        AuthorizationException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(ErrorResponse.from("잘못된 권한입니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+        HttpServletRequest request,
+        AuthenticationException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(ErrorResponse.from("잘못된 인증정보입니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleDataNotFoundException(DataNotFoundException e) {
+    public ResponseEntity<ErrorResponse> handleDataNotFoundException(
+        HttpServletRequest request,
+        DataNotFoundException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(ErrorResponse.from("데이터를 찾을 수 없습니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleDataNotFoundException(DuplicationException e) {
+    public ResponseEntity<ErrorResponse> handleDataNotFoundException(
+        HttpServletRequest request,
+        DuplicationException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.CONFLICT)
             .body(ErrorResponse.from("이미 존재하는 데이터입니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleExternalServiceException(ExternalServiceException e) {
+    public ResponseEntity<ErrorResponse> handleExternalServiceException(
+        HttpServletRequest request,
+        ExternalServiceException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.from("외부 API 호출 과정에서 문제가 발생했습니다."));
+            .body(ErrorResponse.from("외부 API 호출 과정에서 문제가 발생했습니다."));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleDateTimeParseException(DateTimeParseException e) {
+    public ResponseEntity<ErrorResponse> handleDateTimeParseException(
+        HttpServletRequest request,
+        DateTimeParseException e
+    ) {
         log.warn(e.getMessage());
+        requestLogging(request);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse.from("잘못된 날짜 형식입니다."));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest webRequest
+    ) {
+        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
+        log.warn("검증과정에서 문제가 발생했습니다. uri: {} {}, ", request.getMethod(), request.getRequestURI(), ex);
+        requestLogging(request);
+        String errorMessages = ex.getBindingResult().getAllErrors().stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest().body(ErrorResponse.from(errorMessages));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+        Exception ex,
+        Object body,
+        HttpHeaders headers,
+        HttpStatusCode statusCode,
+        WebRequest webRequest
+    ) {
+        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
+        log.error("예외가 발생했습니다. uri: {} {}, ", request.getMethod(), request.getRequestURI(), ex);
+        requestLogging(request);
+        return ResponseEntity.status(statusCode)
+            .body(ErrorResponse.from(ex.getMessage()));
+    }
+
+    private void requestLogging(HttpServletRequest request) {
+        log.info("request header: {}", getHeaders(request));
+        log.info("request query string: {}", getQueryString(request));
+        log.info("request body: {}", getRequestBody(request));
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+
+    private String getQueryString(HttpServletRequest httpRequest) {
+        String queryString = httpRequest.getQueryString();
+        if (queryString == null) {
+            return " - ";
+        }
+        return queryString;
+    }
+
+    private String getRequestBody(HttpServletRequest request) {
+        var wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        if (wrapper == null) {
+            return " - ";
+        }
+        try {
+            // body 가 읽히지 않고 예외처리 되는 경우에 캐시하기 위함
+            wrapper.getInputStream().readAllBytes();
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length == 0) {
+                return " - ";
+            }
+            return new String(buf, wrapper.getCharacterEncoding());
+        } catch (Exception e
+        ) {
+            return " - ";
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/global/log/RequestLoggingFilter.java
+++ b/src/main/java/in/koreatech/koin/global/log/RequestLoggingFilter.java
@@ -1,0 +1,79 @@
+package in.koreatech.koin.global.log;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import org.jboss.logging.MDC;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.PathMatcher;
+import org.springframework.util.StopWatch;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RequestLoggingFilter implements Filter {
+
+    public static final String REQUEST_ID = "requestId";
+
+    private final ObjectProvider<PathMatcher> pathMatcherProvider;
+    private final Set<String> setIgnoredUrlPatterns = new HashSet<>();
+
+    public void setIgnoredUrlPatterns(String... ignoredUrlPatterns) {
+        this.setIgnoredUrlPatterns.addAll(Arrays.asList(ignoredUrlPatterns));
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws ServletException, IOException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (CorsUtils.isPreFlightRequest(httpRequest) || isIgnoredUrl(httpRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        var cachedRequest = new ContentCachingRequestWrapper((HttpServletRequest) request);
+        StopWatch stopWatch = new StopWatch();
+        try {
+            MDC.put(REQUEST_ID, getRequestId(httpRequest));
+            stopWatch.start();
+            log.info("request start [uri: {} {}]", httpRequest.getMethod(), httpRequest.getRequestURI());
+            chain.doFilter(cachedRequest, response);
+        } finally {
+            stopWatch.stop();
+            log.info("request end [time: {}ms]", stopWatch.getTotalTimeMillis());
+            MDC.clear();
+        }
+    }
+
+    private boolean isIgnoredUrl(HttpServletRequest request) {
+        PathMatcher pathMatcher = this.pathMatcherProvider.getIfAvailable();
+        Objects.requireNonNull(pathMatcher);
+        return setIgnoredUrlPatterns.stream()
+            .anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+    }
+
+    private String getRequestId(HttpServletRequest httpRequest) {
+        String requestId = httpRequest.getHeader("X-Request-ID");
+        if (ObjectUtils.isEmpty(requestId)) {
+            return UUID.randomUUID().toString().replace("-", "");
+        }
+        return requestId;
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/log/WebLogConfig.java
+++ b/src/main/java/in/koreatech/koin/global/log/WebLogConfig.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.global.log;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebLogConfig {
+
+    private final RequestLoggingFilter requestLoggingFilter;
+
+    @Bean
+    public FilterRegistrationBean<RequestLoggingFilter> firstFilter() {
+        FilterRegistrationBean<RequestLoggingFilter> registrationBean = new FilterRegistrationBean<>();
+        requestLoggingFilter.setIgnoredUrlPatterns(
+            "/error",
+            "/favicon.ico",
+            "/api-docs/**",
+            "/swagger-ui/**"
+        );
+        registrationBean.setFilter(requestLoggingFilter);
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(1);
+        registrationBean.setName("requestLoggingFilter");
+        return registrationBean;
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -39,6 +39,8 @@ swagger:
 slack:
   koin_event_notify_url: https://slack-weehookurl.com
   koin_owner_event_notify_url: https://slack-weehookurl.com
+  logging:
+    error: https://slack-weehookurl.com
 
 aws:
   ses:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,8 +1,10 @@
 <configuration>
+  <springProperty scope="context" name="SLACK_WEBHOOK_URI" source="slack.logging.error"/>
   <property name="defaultLogPattern"
     value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %-5level --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
   <property name="consoleLogPattern"
     value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} : %msg%n"/>
+  <property name="slackLogPattern" value="%msg%n"/>
 
   <springProfile name="default, dev, test">
     <conversionRule conversionWord="clr"
@@ -71,7 +73,24 @@
       </filter>
     </appender>
 
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+      <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+      <layout class="ch.qos.logback.classic.PatternLayout">
+        <pattern>${slackLogPattern}</pattern>
+      </layout>
+      <iconEmoji>:stuck_out_tongue_winking_eye:</iconEmoji>
+      <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="SLACK"/>
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+    </appender>
+
     <root level="info">
+      <appender-ref ref="ASYNC_SLACK"/>
       <appender-ref ref="info-warn-error-appender"/>
       <appender-ref ref="error-appender"/>
     </root>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
   <property name="consoleLogPattern"
     value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} : %msg%n"/>
 
-  <springProfile name="default">
+  <springProfile name="default, dev, test">
     <conversionRule conversionWord="clr"
       converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
@@ -19,7 +19,7 @@
     </root>
   </springProfile>
 
-  <springProfile name="default">
+  <springProfile name="dev">
     <property name="infoLogPath" value="logs/info"/>
     <property name="errorLogPath" value="logs/error"/>
     <property name="fileNamePattern" value="%d{yyyy-MM-dd}_%i.log"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,79 @@
+<configuration>
+  <property name="defaultLogPattern"
+    value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %-5level --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+  <property name="consoleLogPattern"
+    value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} : %msg%n"/>
+
+  <springProfile name="default">
+    <conversionRule conversionWord="clr"
+      converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>${consoleLogPattern}</pattern>
+      </encoder>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="console"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="default">
+    <property name="infoLogPath" value="logs/info"/>
+    <property name="errorLogPath" value="logs/error"/>
+    <property name="fileNamePattern" value="%d{yyyy-MM-dd}_%i.log"/>
+
+    <appender name="info-warn-error-appender"
+      class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${infoLogPath}/info.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <maxHistory>7</maxHistory>
+        <maxFileSize>1GB</maxFileSize>
+        <totalSizeCap>2GB</totalSizeCap>
+        <fileNamePattern>${infoLogPath}/${fileNamePattern}</fileNamePattern>
+      </rollingPolicy>
+      <encoder>
+        <pattern>${defaultLogPattern}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>INFO</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>NEUTRAL</onMismatch>
+      </filter>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>WARN</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>NEUTRAL</onMismatch>
+      </filter>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+    </appender>
+
+    <appender name="error-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${errorLogPath}/error.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <maxHistory>7</maxHistory>
+        <maxFileSize>1GB</maxFileSize>
+        <totalSizeCap>2GB</totalSizeCap>
+        <fileNamePattern>${errorLogPath}/${fileNamePattern}</fileNamePattern>
+      </rollingPolicy>
+      <encoder>
+        <pattern>${defaultLogPattern}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="info-warn-error-appender"/>
+      <appender-ref ref="error-appender"/>
+    </root>
+  </springProfile>
+</configuration>


### PR DESCRIPTION
# 🔥 연관 이슈

- close #295 

# 🚀 작업 내용

stage 환경에서 로깅의 역할은 클라이언트와의 협업 간 빠른 문제인식 및 조치를 위한 도구라고 생각합니다.
이에 requestBody, responseBody에 대해 로깅을 추가하고, 
datadog과 유사한 기능을 제공하려는 측면도 존재합니다.

1. logback 설정 및 request 로깅을 추가했습니다.
2. `dev` profile로 실행했을 때만 로그파일이 생성됩니다. (Stage 환경에 대해서만)
    - https://www.baeldung.com/spring-profiles 참고
3. slack 알림발송 라이브러리를 추가했습니다.
    - Error레벨 이상의 로그가 발생하면 슬랙으로 알림을 발송합니다.

<img width="665" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/c90042a2-6487-4c86-aa9b-0626c9d33062">

참고자료: https://blog.pium.life/server-logging/

# 💬 리뷰 중점사항

## Profile 변경하여 실행하기

<img width="359" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/205edb85-92d4-45fd-a60f-e44dbf11f022">

<img width="944" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/e4245ae4-175d-4364-8395-1e00ec8eab3c">

Dev Profile로 실행하면 로그 파일이 생깁니다.
<img width="1295" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/6611214d-f4db-4c59-87ca-77e1e63205a6">

