### PR TITLE
fix: 강의시간 문자열 분리 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/LectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/LectureResponse.java
@@ -71,7 +71,7 @@ public record LectureResponse(
         }
 
         classTime = classTime.substring(1, classTime.length() - 1);
-        List<String> numbers = List.of(classTime.split(","));
+        List<String> numbers = List.of(classTime.split(", "));
 
         return numbers.stream()
             .map(String::strip)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #307

# 🚀 작업 내용

1. Lecture 응답객체에서 강의 시간을 분리하는 오류를 수정했습니다.


# 💬 리뷰 중점사항
