### PR TITLE
fix: @Query에 @Param추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/EventArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/EventArticleRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.shop.model.EventArticle;
 
@@ -19,5 +20,5 @@ public interface EventArticleRepository extends Repository<EventArticle, Long> {
         WHERE :now BETWEEN e.startDate AND e.endDate
         AND e.shop.id = :shopId
         """)
-    Boolean isEvent(Long shopId, LocalDate now);
+    Boolean isEvent(@Param("shopId") Long shopId, @Param("now") LocalDate now);
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #326 
# 🚀 작업 내용

1. EventArticleRepository의 @Query에서 @Param을 수식했습니다.

# 💬 리뷰 중점사항
실행 환경에 따라 @Param이 없을 시 500에러가 뜨는것을 확인했습니다.
궁금한점: 기본적으로 파라미터명으로 매핑된다고 알고있는데 환경에 따라 @Param을 사용하지 않으면 서버에러가 나는것은 관련 설정이 있는것인지 궁금합니다