### PR TITLE
feat: 신규상점 생성시 기본 카테고리 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -77,7 +77,7 @@ public class OwnerShopService {
         Shop newShop = ownerShopsRequest.toEntity(owner);
         Shop savedShop = shopRepository.save(newShop);
         List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
-        for(String categoryName: categoryNames) {
+        for (String categoryName : categoryNames) {
             MenuCategory menuCategory = MenuCategory.builder()
                 .shop(savedShop)
                 .name(categoryName)

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -76,7 +76,14 @@ public class OwnerShopService {
         Owner owner = ownerRepository.getById(ownerId);
         Shop newShop = ownerShopsRequest.toEntity(owner);
         Shop savedShop = shopRepository.save(newShop);
-
+        List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
+        for(String categoryName: categoryNames) {
+            MenuCategory menuCategory = MenuCategory.builder()
+                .shop(savedShop)
+                .name(categoryName)
+                .build();
+            menuCategoryRepository.save(menuCategory);
+        }
         for (String imageUrl : ownerShopsRequest.imageUrls()) {
             ShopImage shopImage = ShopImage.builder()
                 .shop(savedShop)

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/EventArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/EventArticleRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.shop.model.EventArticle;
 
@@ -19,5 +20,5 @@ public interface EventArticleRepository extends Repository<EventArticle, Long> {
         WHERE :now BETWEEN e.startDate AND e.endDate
         AND e.shop.id = :shopId
         """)
-    Boolean isEvent(Long shopId, LocalDate now);
+    Boolean isEvent(@Param("shopId") Long shopId, @Param("now") LocalDate now);
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #330 

# 🚀 작업 내용

1. 신규 상점 생성 시 기본 카테고리 4종(추천 메뉴, 메인 메뉴, 세트 메뉴, 사이드 메뉴)를 자동으로 추가하는 작업을 진행했습니다.

# 💬 리뷰 중점사항
신규 상점 생성시 기본 카테고리를 제공해줘야한다는 생각을 못했었네요 ㅠ
