### PR TITLE
fix: shopId null일때 처리하기

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerRepository.java
@@ -15,12 +15,6 @@ public interface OwnerRepository extends Repository<Owner, Long> {
         return findById(ownerId).orElseThrow(() -> OwnerNotFoundException.withDetail("ownerId: " + ownerId));
     }
 
-    Optional<Owner> findByUserId(Long userId);
-
-    default Owner getByUserId(Long userId) {
-        return findByUserId(userId).orElseThrow(() -> OwnerNotFoundException.withDetail("userId: " + userId));
-    }
-
     Owner save(Owner owner);
 
     Optional<Owner> findByCompanyRegistrationNumber(String companyRegistrationNumber);

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -86,14 +86,22 @@ public class OwnerService {
         }
         Owner owner = request.toOwner(passwordEncoder);
         Owner saved = ownerRepository.save(owner);
-        var shop = shopRepository.findById(request.shopId())
-            .orElse(null);
-        ownerShopRedisRepository.save(OwnerShop.builder()
-            .ownerId(owner.getId())
-            .shopId(shop == null ? null : shop.getId())
-            .build());
-        ownerShopRedisRepository.save(OwnerShop.builder()
-            .build());
+        if (request.shopId() != null) {
+            var shop = shopRepository.getById(request.shopId());
+            ownerShopRedisRepository.save(OwnerShop.builder()
+                .ownerId(owner.getId())
+                .shopId(shop.getId())
+                .build());
+            ownerShopRedisRepository.save(OwnerShop.builder()
+                .build());
+        } else {
+            ownerShopRedisRepository.save(OwnerShop.builder()
+                .ownerId(owner.getId())
+                .build());
+            ownerShopRedisRepository.save(OwnerShop.builder()
+                .build());
+        }
+
         eventPublisher.publishEvent(new OwnerRegisterEvent(saved));
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -257,7 +257,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 0,
+                       "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
                     """)
@@ -309,7 +309,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 0,
+                       "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
                     """)
@@ -338,7 +338,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 0,
+                       "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
                     """)
@@ -367,7 +367,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 0,
+                       "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
                     """)
@@ -403,7 +403,7 @@ class OwnerApiTest extends AcceptanceTest {
 
             RestAssured
                 .given()
-                .body("""
+                .body(String.format("""
                     {
                        "attachment_urls": [
                          {
@@ -415,10 +415,10 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "주노",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 1,
+                       "shop_id": %d,
                        "shop_name": "기분좋은 뷔짱"
                      }
-                    """)
+                    """, shopRequest.getId()))
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/owners/register")
@@ -452,7 +452,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "name": "주노",
                        "password": "a0240120305812krlakdsflsa;1235",
                        "phone_number": "010-0000-0000",
-                       "shop_id": 0,
+                       "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
                     """)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #339 

# 🚀 작업 내용

1. Repository의 인자에 null이 들어오면 예외가 발생합니다. 이에 null처리를 해줬습니다.

# 💬 리뷰 중점사항

<img width="691" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/df23d787-e900-49bd-875b-b555778f4220">
