### PR TITLE
Fix : POST /user/find/password 메일 미발송

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/FindPasswordRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/FindPasswordRequest.java
@@ -2,8 +2,6 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +10,6 @@ public record FindPasswordRequest(
     @Email(message = "아우누리 계정 형식이 아닙니다. ${validatedValue}")
     @NotNull(message = "이메일은 비어있을 수 없습니다.")
     @Schema(description = "이메일 주소", requiredMode = REQUIRED, example = "asdf@koreatech.ac.kr")
-    @JsonProperty(value = "address")
     String email
 ) {
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #344 

# 🚀 작업 내용

1. JsonProperty가 address로 설정되어 삭제했습니다.

# 💬 리뷰 중점사항
고생 많으십니다...