### PR TITLE
fix: attributeConverter milli second 길이가 두개인 경우도 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -71,7 +71,7 @@ public record StudentRegisterRequest(
             .isDeleted(false)
             .userType(UserType.STUDENT)
             .authToken(UUID.randomUUID().toString())
-            .authExpiredAt(LocalDateTime.now(clock).plusHours(1))
+            .authExpiredAt(LocalDateTime.now(clock).plusHours(10))
             .build();
 
         return Student.builder()

--- a/src/main/java/in/koreatech/koin/global/config/LocalDateTimeAttributeConverter.java
+++ b/src/main/java/in/koreatech/koin/global/config/LocalDateTimeAttributeConverter.java
@@ -9,14 +9,15 @@ import jakarta.persistence.Converter;
 @Converter(autoApply = true)
 public class LocalDateTimeAttributeConverter implements AttributeConverter<LocalDateTime, String> {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]");
+    private final DateTimeFormatter formatterWithMillis = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]");
+    private final DateTimeFormatter formatterWithTwoMillis = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SS");
 
     @Override
     public String convertToDatabaseColumn(LocalDateTime localDateTime) {
         if (localDateTime == null) {
             return null;
         }
-        return localDateTime.format(formatter);
+        return localDateTime.format(formatterWithMillis);
     }
 
     @Override
@@ -24,7 +25,11 @@ public class LocalDateTimeAttributeConverter implements AttributeConverter<Local
         if (dbData == null) {
             return null;
         }
-        return LocalDateTime.parse(dbData, formatter);
+
+        if (dbData.matches(".*\\.\\d{3}$")) {
+            return LocalDateTime.parse(dbData, formatterWithMillis);
+        } else {
+            return LocalDateTime.parse(dbData, formatterWithTwoMillis);
+        }
     }
 }
-

--- a/src/main/java/in/koreatech/koin/global/config/LocalDateTimeAttributeConverter.java
+++ b/src/main/java/in/koreatech/koin/global/config/LocalDateTimeAttributeConverter.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Converter;
 @Converter(autoApply = true)
 public class LocalDateTimeAttributeConverter implements AttributeConverter<LocalDateTime, String> {
 
-    private final DateTimeFormatter formatterWithMillis = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]");
+    private final DateTimeFormatter formatterWithThreeMillis = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS]");
     private final DateTimeFormatter formatterWithTwoMillis = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SS");
 
     @Override
@@ -17,7 +17,7 @@ public class LocalDateTimeAttributeConverter implements AttributeConverter<Local
         if (localDateTime == null) {
             return null;
         }
-        return localDateTime.format(formatterWithMillis);
+        return localDateTime.format(formatterWithThreeMillis);
     }
 
     @Override
@@ -27,7 +27,7 @@ public class LocalDateTimeAttributeConverter implements AttributeConverter<Local
         }
 
         if (dbData.matches(".*\\.\\d{3}$")) {
-            return LocalDateTime.parse(dbData, formatterWithMillis);
+            return LocalDateTime.parse(dbData, formatterWithThreeMillis);
         } else {
             return LocalDateTime.parse(dbData, formatterWithTwoMillis);
         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #343

# 🚀 작업 내용

1. AttributeConverter에서 밀리 초가 3자리와 null만 고려가 되게 코드가 짜여있었는데 두개인 경우도 가능하도록 코드를 수정했습니다.
2. 기존 코인과 동일하게 authExpiredAt시간을 한시간에서 10시간으로 조정해줬습니다.

# 💬 리뷰 중점사항
에러 수정되었으면 좋겠네요 😢 