### PR TITLE
Fix: 회원탈퇴 Hard Delete & 슬랙 알림 발송

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -32,7 +32,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "users")
 @Where(clause = "is_deleted=0")
-@SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = PROTECTED)
 public class User extends BaseEntity {
 

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserDeleteEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserDeleteEvent.java
@@ -1,0 +1,7 @@
+package in.koreatech.koin.domain.user.model;
+
+public record UserDeleteEvent(
+    String email
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.domain.user.model;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin.global.domain.slack.SlackClient;
+import in.koreatech.koin.global.domain.slack.model.SlackNotificationFactory;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class UserEventListener {
+
+    private final SlackClient slackClient;
+    private final SlackNotificationFactory slackNotificationFactory;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onUserDeleteEvent(UserDeleteEvent event) {
+        var notification = slackNotificationFactory.generateUserDeleteNotification(event.email());
+        slackClient.sendMessage(notification);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserDeleteEvent;
 import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
@@ -33,6 +35,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserTokenRepository userTokenRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public UserLoginResponse login(UserLoginRequest request) {
@@ -80,6 +83,7 @@ public class UserService {
     public void withdraw(Long userId) {
         User user = userRepository.getById(userId);
         userRepository.delete(user);
+        eventPublisher.publishEvent(new UserDeleteEvent(user.getEmail()));
     }
 
     public void checkExistsEmail(EmailCheckExistsRequest request) {

--- a/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
@@ -106,4 +106,19 @@ public class SlackNotificationFactory {
             )
             .build();
     }
+
+    /**
+     * 유저 탈퇴 알림
+     */
+    public SlackNotification generateUserDeleteNotification(
+        String content
+    ) {
+        return SlackNotification.builder()
+            .slackUrl(eventNotificationUrl)
+            .text(String.format("""
+                `%s님이 탈퇴하셨습니다.`
+                """, content)
+            )
+            .build();
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #351

# 🚀 작업 내용

1. User에서 기존 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")을 삭제했습니다.
2. 회원탈퇴시 슬랙알림발송 구현을 했습니다.

# 💬 리뷰 중점사항
