### PR TITLE
Fix: 사장님 회원탈퇴 오류

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
@@ -29,6 +29,4 @@ public interface ShopRepository extends Repository<Shop, Integer> {
     }
 
     List<Shop> findAll();
-
-    void deleteByOwnerId(Integer ownerId);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
@@ -30,5 +30,5 @@ public interface ShopRepository extends Repository<Shop, Integer> {
 
     List<Shop> findAll();
 
-    void deleteByOwnerId(Long ownerId);
+    void deleteByOwnerId(Integer ownerId);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
@@ -29,4 +29,6 @@ public interface ShopRepository extends Repository<Shop, Long> {
     }
 
     List<Shop> findAll();
+
+    void deleteByOwnerId(Long ownerId);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.owner.repository.OwnerAttachmentRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
+import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
 import in.koreatech.koin.domain.user.dto.NicknameCheckExistsRequest;
@@ -39,6 +40,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
     private final OwnerRepository ownerRepository;
+    private final ShopRepository shopRepository;
     private final OwnerAttachmentRepository ownerAttachmentRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserTokenRepository userTokenRepository;
@@ -92,9 +94,12 @@ public class UserService {
         switch (user.getUserType()) {
             case STUDENT:
                 studentRepository.deleteByUserId(userId);
+                break;
             case OWNER:
-                ownerRepository.deleteByUserId(userId);
+                shopRepository.deleteByOwnerId(userId);
                 ownerAttachmentRepository.deleteByOwnerId(userId);
+                ownerRepository.deleteByUserId(userId);
+                break;
         }
         userRepository.delete(user);
         eventPublisher.publishEvent(new UserDeleteEvent(user.getEmail()));

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -95,8 +95,6 @@ public class UserService {
         if (user.getUserType() == UserType.STUDENT) {
             studentRepository.deleteByUserId(userId);
         } else if (user.getUserType() == UserType.OWNER) {
-            shopRepository.deleteByOwnerId(userId);
-            ownerAttachmentRepository.deleteByOwnerId(userId);
             ownerRepository.deleteByUserId(userId);
         }
         userRepository.delete(user);

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -41,6 +41,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
     private final OwnerRepository ownerRepository;
+    private final ShopRepository shopRepository;
     private final OwnerAttachmentRepository ownerAttachmentRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserTokenRepository userTokenRepository;

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -679,4 +679,67 @@ class OwnerApiTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.BAD_REQUEST.value());
     }
+
+    @Test
+    @DisplayName("사장님이 회원탈퇴를 한다.")
+    void ownerDelete(){
+        // given
+        User user = User.builder()
+            .password("1234")
+            .nickname("주노")
+            .name("최준호")
+            .phoneNumber("010-1234-5678")
+            .userType(OWNER)
+            .gender(UserGender.MAN)
+            .email("test@koreatech.ac.kr")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        OwnerAttachment attachment = OwnerAttachment.builder()
+            .url("https://test.com/test.jpg")
+            .isDeleted(false)
+            .build();
+
+        Owner ownerRequest = Owner.builder()
+            .companyRegistrationNumber("123-45-67890")
+            .attachments(List.of(attachment))
+            .grantShop(true)
+            .grantEvent(true)
+            .user(user)
+            .build();
+        Owner owner = ownerRepository.save(ownerRequest);
+
+        Shop shopRequest = Shop.builder()
+            .owner(owner)
+            .name("테스트 상점")
+            .internalName("테스트")
+            .chosung("테스트")
+            .phone("010-1234-5678")
+            .address("대전광역시 유성구 대학로 291")
+            .description("테스트 상점입니다.")
+            .delivery(true)
+            .deliveryPrice(3000L)
+            .payCard(true)
+            .payBank(true)
+            .isDeleted(false)
+            .isEvent(false)
+            .remarks("비고")
+            .hit(0L)
+            .build();
+        shopRepository.save(shopRequest);
+        String token = jwtProvider.createToken(owner.getUser());
+
+        // when then
+        ExtractableResponse<Response> response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .delete("/user")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+            .extract();
+
+        assertThat(userRepository.findById(user.getId())).isNotPresent();
+    }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -709,25 +709,6 @@ class OwnerApiTest extends AcceptanceTest {
             .user(user)
             .build();
         Owner owner = ownerRepository.save(ownerRequest);
-
-        Shop shopRequest = Shop.builder()
-            .owner(owner)
-            .name("테스트 상점")
-            .internalName("테스트")
-            .chosung("테스트")
-            .phone("010-1234-5678")
-            .address("대전광역시 유성구 대학로 291")
-            .description("테스트 상점입니다.")
-            .delivery(true)
-            .deliveryPrice(3000)
-            .payCard(true)
-            .payBank(true)
-            .isDeleted(false)
-            .isEvent(false)
-            .remarks("비고")
-            .hit(0)
-            .build();
-        shopRepository.save(shopRequest);
         String token = jwtProvider.createToken(owner.getUser());
 
         // when then

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -719,13 +719,13 @@ class OwnerApiTest extends AcceptanceTest {
             .address("대전광역시 유성구 대학로 291")
             .description("테스트 상점입니다.")
             .delivery(true)
-            .deliveryPrice(3000L)
+            .deliveryPrice(3000)
             .payCard(true)
             .payBank(true)
             .isDeleted(false)
             .isEvent(false)
             .remarks("비고")
-            .hit(0L)
+            .hit(0)
             .build();
         shopRepository.save(shopRequest);
         String token = jwtProvider.createToken(owner.getUser());

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -682,7 +682,7 @@ class OwnerApiTest extends AcceptanceTest {
 
     @Test
     @DisplayName("사장님이 회원탈퇴를 한다.")
-    void ownerDelete(){
+    void ownerDelete() {
         // given
         User user = User.builder()
             .password("1234")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #379

# 🚀 작업 내용

1. UserService에서 owner만 삭제하는 로직을 추가했습니다. 
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/148550522/41c4b695-d212-417a-9703-8eea67e18174)
이 이미지가 무엇을 의미하는지 잘 이해가 안갑니다. 일단 OwnerAttachment의 owner_id에 해당하는 문제로 발생한것으로 인지했습니다.
>> @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
    @JoinColumn(name = "owner_id")
    private List<OwnerAttachment> attachments = new ArrayList<>(); 

Owner 클래스의 위 코드에서 자식개체를 자동으로 삭제되는 orphanRemoval=true코드가 이미 있어서, UserService에서 따로 OwnerAttachment를 삭제하는 로직을 추가하지 않고, owner만 삭제했습니다.

user_id가 fk참조돼있는 데이터를 모두 지울필요는 없을것같아 다시 수정했는데, 정확히 오류가 무엇때문에 일어나는지 정확힌 모르겠습니다..
# 💬 리뷰 중점사항
