### PR TITLE
refactor: 유저 로그인에서 swagger에 400에러 표시

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.domain.user.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -73,7 +71,7 @@ public interface UserApi {
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "201"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }


### PR DESCRIPTION
# 🚀 작업 내용

- 기존
  - 비밀번호가 틀렸을 때 400에러를 반환하지만 스웨거 문서에는 401에러를 반환한다고 나와있습니다.
- 변경 후
  - 스웨거 문서에 400에러가 반환된다고 표시하였습니다.

<img src="https://github.com/BCSDLab/KOIN_API_V2/assets/106418303/82744255-8d1f-4fb3-aa8c-01956e72105b" width="500" height="500">


# 💬 리뷰 중점사항
 
