### PR TITLE
feat: 사장님 가게 생성 시 알림 발송하도록 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/ShopEventCreateEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/ShopEventCreateEvent.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.domain.ownershop;
+
+public record ShopEventCreateEvent(
+    Integer shopId,
+    String shopName,
+    String title
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/CreateEventRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/CreateEventRequest.java
@@ -18,10 +18,11 @@ public record CreateEventRequest(
     @Schema(example = "감성떡볶이 이벤트합니다!!!", description = "제목")
     @NotBlank String title,
 
-    @Schema(example = "OwnerShopsRequest", description = "이벤트 내용")
-    String content,
+    @Schema(example = "감성떡볶이 이벤트합니다!!! 많은관심 부탁드려요! 감성을 한스푼 더 얹어드립니다", description = "이벤트 내용")
+    @NotBlank String content,
 
     @Schema(description = "이벤트 이미지")
+    @NotNull
     @Size(min = 0, max = 3, message = "사진은 최대 3개까지 입력 가능합니다.")
     List<String> thumbnailImages,
 

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/ModifyEventRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/ModifyEventRequest.java
@@ -3,7 +3,7 @@ package in.koreatech.koin.domain.ownershop.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,10 +16,11 @@ public record ModifyEventRequest(
     @Schema(example = "감성떡볶이 이벤트합니다!!!", description = "제목")
     @NotBlank String title,
 
-    @Schema(example = "OwnerShopsRequest", description = "이벤트 내용")
-    String content,
+    @Schema(example = "감성떡볶이 이벤트합니다!!! 많은관심 부탁드려요! 감성을 한스푼 더 얹어드립니다", description = "이벤트 내용")
+    @NotBlank String content,
 
     @Schema(description = "이벤트 이미지")
+    @NotNull
     @Size(min = 0, max = 3, message = "사진은 최대 3개까지 입력 가능합니다.")
     List<String> thumbnailImages,
 

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.domain.shop.model;
+
+import static in.koreatech.koin.global.fcm.MobileAppPath.SHOP;
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin.domain.ownershop.ShopEventCreateEvent;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
+import in.koreatech.koin.global.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class ShopEventListener {
+
+    private final NotificationService notificationService;
+    private final NotificationFactory notificationFactory;
+    private final UserRepository userRepository;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onShopEventCreate(ShopEventCreateEvent event) {
+        var notifications = userRepository.findAllByDeviceTokenIsNotNull()
+            .stream()
+            .map(user -> notificationFactory.generateShopEventCreateNotification(
+                SHOP,
+                event.shopName(),
+                event.title(),
+                user
+            )).toList();
+        notificationService.push(notifications);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
@@ -44,4 +45,6 @@ public interface UserRepository extends Repository<User, Integer> {
     boolean existsByNickname(String nickname);
 
     void delete(User user);
+
+    List<User> findAllByDeviceTokenIsNotNull();
 }

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/Notification.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/Notification.java
@@ -30,20 +30,20 @@ public class Notification extends BaseEntity {
     private Long id;
 
     @Enumerated(STRING)
-    @Column(name = "app_path", nullable = false)
+    @Column(name = "app_path")
     private MobileAppPath mobileAppPath;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
-    @Column(name = "message", nullable = false)
+    @Column(name = "message")
     private String message;
 
-    @Column(name = "image_url", nullable = false)
+    @Column(name = "image_url")
     private String imageUrl;
 
     @Enumerated(STRING)
-    @Column(nullable = false)
+    @Column(name = "type")
     private NotificationType type;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -8,16 +8,16 @@ import in.koreatech.koin.global.fcm.MobileAppPath;
 @Component
 public class NotificationFactory {
 
-    public Notification generateOwnerNotification(
+    public Notification generateShopEventCreateNotification(
         MobileAppPath path,
         String shopName,
+        String title,
         User target
     ) {
         return new Notification(
             path,
-            "새로운 이벤트가 개설되었어요!",
-            "%s 가게의 이벤트가 오픈되었어요!🎁"
-                .formatted(shopName),
+            "%s의 이벤트가 추가되었어요 🎉".formatted(shopName),
+            "%s".formatted(title),
             null,
             NotificationType.MESSAGE,
             target

--- a/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
@@ -26,6 +26,21 @@ public class NotificationService {
     private final FcmClient fcmClient;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
 
+    public void push(List<Notification> notifications) {
+        for (Notification notification : notifications) {
+            notificationRepository.save(notification);
+            String deviceToken = notification.getUser().getDeviceToken();
+            fcmClient.sendMessage(
+                deviceToken,
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getImageUrl(),
+                notification.getMobileAppPath(),
+                notification.getType()
+            );
+        }
+    }
+
     public void push(Notification notification) {
         notificationRepository.save(notification);
         String deviceToken = notification.getUser().getDeviceToken();

--- a/src/main/java/in/koreatech/koin/global/fcm/MobileAppPath.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/MobileAppPath.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum MobileAppPath {
     HOME("home", "home"),
     LOGIN("login", "login"),
+    SHOP("shop", "shop"),
     ;
 
     private final String android;

--- a/src/main/resources/db/migration/V11__alter_notification_column_nullable.sql
+++ b/src/main/resources/db/migration/V11__alter_notification_column_nullable.sql
@@ -1,0 +1,14 @@
+alter table `notification`
+    modify app_path VARCHAR(255) NULL comment '앱 url';
+
+alter table `notification`
+    modify title VARCHAR(255) NULL comment '제목';
+
+alter table `notification`
+    modify message VARCHAR(255) NULL comment '메시지 내용';
+
+alter table `notification`
+    modify image_url VARCHAR(255) NULL comment '이미지 url';
+
+alter table `notification`
+    modify type VARCHAR(255) NULL comment '알림 타입';

--- a/src/test/java/in/koreatech/koin/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/AcceptanceTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import in.koreatech.koin.domain.bus.util.CityBusOpenApiClient;
 import in.koreatech.koin.domain.owner.model.OwnerEventListener;
+import in.koreatech.koin.domain.shop.model.ShopEventListener;
 import in.koreatech.koin.domain.user.model.StudentEventListener;
 import in.koreatech.koin.support.DBInitializer;
 import io.restassured.RestAssured;
@@ -55,6 +56,9 @@ public abstract class AcceptanceTest {
 
     @MockBean
     protected StudentEventListener studentEventListener;
+
+    @MockBean
+    protected ShopEventListener shopEventListener;
 
     @Autowired
     private DBInitializer dataInitializer;

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.acceptance;
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -1249,6 +1251,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                 }
             );
         });
+        verify(shopEventListener).onShopEventCreate(any());
     }
 
     @Test


### PR DESCRIPTION
# 🔥 연관 이슈

- close #263 

# 🚀 작업 내용

1. 사장님이 가게 생성 시 알림이 발송되도록 로직을 추가했습니다
2. 현수의 수면코딩의 잔해를 걷어냈습니다
    - dto example 구체화
    - dto 제약조건 추가
3. notification의 필드들이 NotNull일 이유가 없어 제약조건을 해지해줬습니다.
    - 이미지가 없는 알림이 있을 수 있지만 현재의 제약조건 상으로는 Notificaiton 테이블에 저장되는 값들은 Not Null이기 때문에 모든 값들이 강제됩니다.
    - 이에 V11 flyway 파일을 추가했습니다.

# 💬 리뷰 중점사항

잘부탁드려요~
@Choon0414 제가 원하던 알림발송 로직 구현의 방향성을 녹여봤습니다 리뷰해주세요

## 알림발송 화면

<img src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/0b5dd14d-de16-43b0-bce2-a3cb8b0c3be0" height="600px">

### 시나리오

- 테스트 기기의 FCM 토큰이 있어야합니다. (클라한테 부탁해서 받아냄 ㅎㅎ)
- users 테이블의 deviceToken 필드에 FCM 토큰값을 넣음
- 로컬에서 사장님 권한으로 로그인해서 이벤트 생성 API 호출

<img width="1017" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/58854d18-cd0d-4182-9162-35b6cb604799">