### PR TITLE
fix: 임시토큰 비교 자료형 불일치 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
@@ -9,7 +9,7 @@ public enum UserType {
     COOP("COOP", "영양사"),
     ;
 
-    public static final Long ANONYMOUS_ID = 0L;
+    public static final int ANONYMOUS_ID = 0;
 
     private final String value;
     private final String description;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #392 

# 🚀 작업 내용

임시토큰임을 userId = 0 으로 비교하고있습니다.
지난번 Entity 대규모 패치 과정에서 임시토큰 기준을 Long으로 놔둬서 이를 Integer를 비교하여 발생하는 문제가 발생했습니다.
0 != 0L

1. long을 int로 변경했습니다.

# 💬 리뷰 중점사항

꼼꼼하게 보겠습니다 😅