### PR TITLE
fix: 사장님 이벤트 날짜조건 제거한 DTO 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopApi.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.ownershop.dto.CreateEventRequest;
 import in.koreatech.koin.domain.ownershop.dto.ModifyEventRequest;
+import in.koreatech.koin.domain.ownershop.dto.OwnerShopEventsResponse;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsRequest;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsResponse;
 import in.koreatech.koin.domain.shop.dto.CreateCategoryRequest;
@@ -22,7 +23,6 @@ import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ModifyCategoryRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyMenuRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyShopRequest;
-import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.global.auth.Auth;
@@ -315,7 +315,7 @@ public interface OwnerShopApi {
     )
     @Operation(summary = "특정 상점 모든 이벤트 조회")
     @GetMapping("/owner/shops/{shopId}/event")
-    ResponseEntity<ShopEventsResponse> getShopAllEvent(
+    ResponseEntity<OwnerShopEventsResponse> getShopAllEvent(
         @Auth(permit = {OWNER}) Integer ownerId,
         @PathVariable("shopId") Integer shopId
     );

--- a/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.ownershop.dto.CreateEventRequest;
 import in.koreatech.koin.domain.ownershop.dto.ModifyEventRequest;
+import in.koreatech.koin.domain.ownershop.dto.OwnerShopEventsResponse;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsRequest;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsResponse;
 import in.koreatech.koin.domain.ownershop.service.OwnerShopService;
@@ -25,10 +26,8 @@ import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ModifyCategoryRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyMenuRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyShopRequest;
-import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
-import in.koreatech.koin.domain.shop.repository.EventArticleRepository;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +37,6 @@ import lombok.RequiredArgsConstructor;
 public class OwnerShopController implements OwnerShopApi {
 
     private final OwnerShopService ownerShopService;
-    private final EventArticleRepository eventArticleRepository;
 
     @GetMapping("/owner/shops")
     public ResponseEntity<OwnerShopsResponse> getOwnerShops(
@@ -193,11 +191,11 @@ public class OwnerShopController implements OwnerShopApi {
     }
 
     @GetMapping("/owner/shops/{shopId}/event")
-    public ResponseEntity<ShopEventsResponse> getShopAllEvent(
+    public ResponseEntity<OwnerShopEventsResponse> getShopAllEvent(
         @Auth(permit = {OWNER}) Integer ownerId,
         @PathVariable("shopId") Integer shopId
     ) {
-        ShopEventsResponse shopEventsResponse = ownerShopService.getShopEvent(shopId, ownerId);
+        OwnerShopEventsResponse shopEventsResponse = ownerShopService.getShopEvent(shopId, ownerId);
         return ResponseEntity.ok(shopEventsResponse);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopEventsResponse.java
@@ -1,0 +1,84 @@
+package in.koreatech.koin.domain.ownershop.dto;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.EventArticle;
+import in.koreatech.koin.domain.shop.model.EventArticleImage;
+import in.koreatech.koin.domain.shop.model.Shop;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record OwnerShopEventsResponse(
+
+    @Schema(description = "이벤트 목록")
+    List<InnerOwnerShopEventResponse> events
+) {
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerOwnerShopEventResponse(
+        @Schema(description = "상점 ID", example = "1")
+        Integer shopId,
+
+        @Schema(description = "상점 이름", example = "술꾼")
+        String shopName,
+
+        @Schema(description = "이벤트 ID", example = "1")
+        Integer eventId,
+
+        @Schema(description = "이벤트 제목", example = "콩순이 사장님이 미쳤어요!!")
+        String title,
+
+        @Schema(description = "이벤트 내용", example = "콩순이 가게 전메뉴 90% 할인! 가게 폐업 임박...")
+        String content,
+
+        @Schema(description = "이벤트 이미지")
+        List<String> thumbnailImages,
+
+        @Schema(description = "시작일", example = "2024-10-22")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @Schema(description = "종료일", example = "2024-10-25")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate
+    ) {
+
+        public static InnerOwnerShopEventResponse from(EventArticle eventArticle) {
+            return new InnerOwnerShopEventResponse(
+                eventArticle.getShop().getId(),
+                eventArticle.getShop().getName(),
+                eventArticle.getId(),
+                eventArticle.getTitle(),
+                eventArticle.getContent(),
+                eventArticle.getThumbnailImages()
+                    .stream().map(EventArticleImage::getThumbnailImage)
+                    .toList(),
+                eventArticle.getStartDate(),
+                eventArticle.getEndDate()
+            );
+        }
+    }
+
+    public static OwnerShopEventsResponse from(List<Shop> shops) {
+        List<InnerOwnerShopEventResponse> innerShopEventResponses = new ArrayList<>();
+        for (Shop shop : shops) {
+            shop.getEventArticles().stream()
+                .map(InnerOwnerShopEventResponse::from)
+                .forEach(innerShopEventResponses::add);
+        }
+        return new OwnerShopEventsResponse(innerShopEventResponses);
+    }
+
+    public static OwnerShopEventsResponse from(Shop shop) {
+        var innerShopEventResponses = shop.getEventArticles().stream()
+            .map(InnerOwnerShopEventResponse::from)
+            .toList();
+        return new OwnerShopEventsResponse(innerShopEventResponses);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.ownershop.ShopEventCreateEvent;
 import in.koreatech.koin.domain.ownershop.dto.CreateEventRequest;
 import in.koreatech.koin.domain.ownershop.dto.ModifyEventRequest;
+import in.koreatech.koin.domain.ownershop.dto.OwnerShopEventsResponse;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsRequest;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsResponse;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsResponse.InnerShopResponse;
@@ -25,7 +26,6 @@ import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ModifyCategoryRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyMenuRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyShopRequest;
-import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.model.EventArticle;
@@ -319,8 +319,8 @@ public class OwnerShopService {
         eventArticleRepository.deleteById(eventId);
     }
 
-    public ShopEventsResponse getShopEvent(Integer shopId, Integer ownerId) {
+    public OwnerShopEventsResponse getShopEvent(Integer shopId, Integer ownerId) {
         Shop shop = getOwnerShopById(shopId, ownerId);
-        return ShopEventsResponse.of(shop, clock);
+        return OwnerShopEventsResponse.from(shop);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #394 

# 🚀 작업 내용

1. `GET /owner/shops/{shopId}/event`의 반환값을 ShopEventsResponse  -> OwnerShopEventsResponse로 변경했습니다.
  - 기존 ShopEventsResponse는 오늘 진행중인 이벤트에 대한 값만 반환합니다. (이벤트 배너 조회에 활용되는 DTO)
  - OwnerShopEventsResponse는 사장님이 가지고있는 모든 이벤트를 조회하도록 수정했습니다.

# 💬 리뷰 중점사항

dto 재활용.. 가급적이면 하지 맙시다!!
각 API 별 요구사항이 변동될때 유연하지 못합니다