### PR TITLE
refactor: 메뉴, 메뉴카테고리 Soft Delete로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -246,7 +246,7 @@ public class OwnerShopService {
     public void modifyCategory(Integer ownerId, Integer categoryId, ModifyCategoryRequest modifyCategoryRequest) {
         MenuCategory menuCategory = menuCategoryRepository.getById(categoryId);
         getOwnerShopById(menuCategory.getShop().getId(), ownerId);
-        menuCategory.modifyCategory(modifyCategoryRequest.name());
+        menuCategory.modifyName(modifyCategoryRequest.name());
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -246,7 +246,7 @@ public class OwnerShopService {
     public void modifyCategory(Integer ownerId, Integer categoryId, ModifyCategoryRequest modifyCategoryRequest) {
         MenuCategory menuCategory = menuCategoryRepository.getById(categoryId);
         getOwnerShopById(menuCategory.getShop().getId(), ownerId);
-        menuCategory.modifyCategory(modifyCategoryRequest);
+        menuCategory.modifyCategory(modifyCategoryRequest.name());
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Menu.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Menu.java
@@ -1,15 +1,11 @@
 package in.koreatech.koin.domain.shop.model;
 
-import static jakarta.persistence.CascadeType.MERGE;
-import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.domain.shop.dto.ModifyMenuRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyMenuRequest.InnerOptionPrice;
@@ -30,8 +26,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "shop_menus")
-@Where(clause = "is_deleted=0")
-@SQLDelete(sql = "UPDATE shop_menus SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = PROTECTED)
 public class Menu extends BaseEntity {
 
@@ -58,17 +52,13 @@ public class Menu extends BaseEntity {
     @Column(name = "is_hidden", nullable = false)
     private boolean isHidden = false;
 
-    @NotNull
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
-    @OneToMany(mappedBy = "menu", cascade = {MERGE, PERSIST})
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
     private List<MenuCategoryMap> menuCategoryMaps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "menu", cascade = {MERGE, PERSIST})
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
     private List<MenuOption> menuOptions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "menu", cascade = {MERGE, PERSIST})
+    @OneToMany(mappedBy = "menu", orphanRemoval = true, cascade = ALL)
     private List<MenuImage> menuImages = new ArrayList<>();
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Menu.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Menu.java
@@ -90,7 +90,6 @@ public class Menu extends BaseEntity {
     }
 
     public void modifyMenuImages(List<String> imageUrls, EntityManager entityManager) {
-        this.menuImages.forEach(entityManager::remove);
         this.menuImages.clear();
         entityManager.flush();
         for (String imageUrl : imageUrls) {
@@ -103,7 +102,6 @@ public class Menu extends BaseEntity {
     }
 
     public void modifyMenuCategories(List<MenuCategory> menuCategories, EntityManager entityManager) {
-        this.menuCategoryMaps.forEach(entityManager::remove);
         this.menuCategoryMaps.clear();
         entityManager.flush();
         for (MenuCategory menuCategory : menuCategories) {
@@ -116,7 +114,6 @@ public class Menu extends BaseEntity {
     }
 
     public void modifyMenuSingleOptions(ModifyMenuRequest modifyMenuRequest, EntityManager entityManager) {
-        this.menuOptions.forEach(entityManager::remove);
         this.menuOptions.clear();
         entityManager.flush();
         MenuOption menuOption = MenuOption.builder()
@@ -127,7 +124,6 @@ public class Menu extends BaseEntity {
     }
 
     public void modifyMenuMultipleOptions(List<InnerOptionPrice> innerOptionPrice, EntityManager entityManager) {
-        this.menuOptions.forEach(entityManager::remove);
         this.menuOptions.clear();
         entityManager.flush();
         for (var option : innerOptionPrice) {

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
@@ -1,13 +1,11 @@
 package in.koreatech.koin.domain.shop.model;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.domain.shop.dto.ModifyCategoryRequest;
 import in.koreatech.koin.global.domain.BaseEntity;
@@ -29,8 +27,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "shop_menu_categories")
-@Where(clause = "is_deleted=0")
-@SQLDelete(sql = "UPDATE shop_menu_categories SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = PROTECTED)
 public final class MenuCategory extends BaseEntity {
 
@@ -48,11 +44,7 @@ public final class MenuCategory extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    @NotNull
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
-    @OneToMany(mappedBy = "menuCategory")
+    @OneToMany(mappedBy = "menuCategory", orphanRemoval = true, cascade = ALL)
     private List<MenuCategoryMap> menuCategoryMaps = new ArrayList<>();
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
@@ -52,7 +52,7 @@ public final class MenuCategory extends BaseEntity {
         this.name = name;
     }
 
-    public void modifyCategory(String name) {
+    public void modifyName(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
@@ -7,7 +7,6 @@ import static lombok.AccessLevel.PROTECTED;
 import java.util.ArrayList;
 import java.util.List;
 
-import in.koreatech.koin.domain.shop.dto.ModifyCategoryRequest;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -53,7 +52,7 @@ public final class MenuCategory extends BaseEntity {
         this.name = name;
     }
 
-    public void modifyCategory(ModifyCategoryRequest modifyCategoryRequest) {
-        this.name = modifyCategoryRequest.name();
+    public void modifyCategory(String name) {
+        this.name = name;
     }
 }

--- a/src/main/resources/db/migration/V12__alter_menu_and_menu_categories_column_remove_is_deleted.sql
+++ b/src/main/resources/db/migration/V12__alter_menu_and_menu_categories_column_remove_is_deleted.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `shop_menus` DROP COLUMN is_deleted;
+ALTER TABLE `shop_menu_categories` DROP COLUMN is_deleted;

--- a/src/main/resources/db/migration/V12__alter_menu_and_menu_categories_column_remove_is_deleted.sql
+++ b/src/main/resources/db/migration/V12__alter_menu_and_menu_categories_column_remove_is_deleted.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `shop_menus` DROP COLUMN is_deleted;
-ALTER TABLE `shop_menu_categories` DROP COLUMN is_deleted;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #408 

# 🚀 작업 내용

1. flyway를 이용해 shop_menu, shop_menu_categories의 is_deleted컬럼을 삭제했습니다.
2. 그에 따른 Menu, MenuCategory Entity의 설정을 변경하였습니다.
<img width="636" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/127578418/803d03f7-b78f-4336-8888-d49c505e6fb7">

# 💬 리뷰 중점사항
메뉴 수정을 어떻게 해야 좋을지 고민하다가 pr이 늦어졌네요.. 일단 id_deleted만 삭제했습니다!