### PR TITLE
feat: 기존 메뉴 카테고리 이름 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
@@ -1,0 +1,41 @@
+package in.koreatech.koin.domain.coop.model;
+
+import static in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType.DINING_SOLD_OUT;
+import static in.koreatech.koin.global.fcm.MobileAppPath.HOME;
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
+import in.koreatech.koin.global.domain.notification.repository.NotificationSubscribeRepository;
+import in.koreatech.koin.global.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class CoopEventListener {
+
+    private final NotificationService notificationService;
+    private final UserRepository userRepository;
+    private final NotificationSubscribeRepository notificationSubscribeRepository;
+    private final NotificationFactory notificationFactory;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
+        var notifications = notificationSubscribeRepository.findAllBySubscribeType(DINING_SOLD_OUT).stream()
+            .map(subscribe -> userRepository.getById(subscribe.getUser().getId()))
+            .filter(user -> user.getDeviceToken() != null)
+            .map(user -> notificationFactory.generateSoldOutNotification(
+                HOME,
+                event.place(),
+                user
+            )).toList();
+        notificationService.push(notifications);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/model/DiningSoldOutEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/DiningSoldOutEvent.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin.domain.coop.model;
+
+public record DiningSoldOutEvent(
+    String place
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -3,11 +3,13 @@ package in.koreatech.koin.domain.coop.service;
 import java.time.Clock;
 import java.time.LocalDateTime;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.coop.dto.DiningImageRequest;
 import in.koreatech.koin.domain.coop.dto.SoldOutRequest;
+import in.koreatech.koin.domain.coop.model.DiningSoldOutEvent;
 import in.koreatech.koin.domain.dining.model.Dining;
 import in.koreatech.koin.domain.dining.repository.DiningRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class CoopService {
     private final DiningRepository diningRepository;
 
     private final Clock clock;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void changeSoldOut(SoldOutRequest soldOutRequest) {
@@ -27,10 +30,10 @@ public class CoopService {
 
         if (Boolean.TRUE.equals(soldOutRequest.soldOut())) {
             dining.setSoldOut(LocalDateTime.now(clock));
-        }
-        else {
+        } else {
             dining.setSoldOut(null);
         }
+        eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getPlace()));
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -23,4 +23,20 @@ public class NotificationFactory {
             target
         );
     }
+
+    public Notification generateSoldOutNotification(
+        MobileAppPath path,
+        String place,
+        User target
+    ) {
+        return new Notification(
+            path,
+            "학식 품절 알림!",
+            "%s 품절되었습니다."
+                .formatted(place),
+            null,
+            NotificationType.MESSAGE,
+            target
+        );
+    }
 }

--- a/src/main/java/in/koreatech/koin/global/domain/notification/repository/NotificationSubscribeRepository.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/repository/NotificationSubscribeRepository.java
@@ -13,6 +13,8 @@ public interface NotificationSubscribeRepository extends Repository<Notification
 
     NotificationSubscribe save(NotificationSubscribe notificationSubscribe);
 
+    List<NotificationSubscribe> findAllBySubscribeType(NotificationSubscribeType type);
+
     Optional<NotificationSubscribe> findByUserIdAndSubscribeType(Integer userId, NotificationSubscribeType type);
 
     default NotificationSubscribe getByUserIdAndSubscribeType(Integer userId, NotificationSubscribeType type) {

--- a/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
@@ -1,15 +1,21 @@
 package in.koreatech.koin.global.domain.notification.service;
 
+import static in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType.DINING_SOLD_OUT;
+import static in.koreatech.koin.global.fcm.MobileAppPath.HOME;
+
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.coop.model.DiningSoldOutEvent;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.domain.notification.dto.NotificationStatusResponse;
 import in.koreatech.koin.global.domain.notification.dto.NotificationSubscribePermitRequest;
 import in.koreatech.koin.global.domain.notification.model.Notification;
+import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
 import in.koreatech.koin.global.domain.notification.repository.NotificationRepository;
@@ -24,6 +30,7 @@ public class NotificationService {
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
     private final FcmClient fcmClient;
+    private final NotificationFactory notificationFactory;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
 
     public void push(List<Notification> notifications) {

--- a/src/main/resources/db/migration/V12__alter_menu_categories_update_category_name.sql
+++ b/src/main/resources/db/migration/V12__alter_menu_categories_update_category_name.sql
@@ -1,0 +1,2 @@
+update `shop_menu_categories` set name = '추천 메뉴' where name = '이벤트 메뉴';
+update `shop_menu_categories` set name = '메인 메뉴' where name = '대표 메뉴';

--- a/src/test/java/in/koreatech/koin/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/AcceptanceTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
 import in.koreatech.koin.domain.bus.util.CityBusOpenApiClient;
+import in.koreatech.koin.domain.coop.model.CoopEventListener;
 import in.koreatech.koin.domain.owner.model.OwnerEventListener;
 import in.koreatech.koin.domain.shop.model.ShopEventListener;
 import in.koreatech.koin.domain.user.model.StudentEventListener;
@@ -59,6 +60,9 @@ public abstract class AcceptanceTest {
 
     @MockBean
     protected ShopEventListener shopEventListener;
+
+    @MockBean
+    protected CoopEventListener coopEventListener;
 
     @Autowired
     private DBInitializer dataInitializer;

--- a/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
@@ -18,7 +18,6 @@ import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.JwtProvider;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
-import in.koreatech.koin.global.domain.notification.repository.NotificationRepository;
 import in.koreatech.koin.global.domain.notification.repository.NotificationSubscribeRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -32,9 +31,6 @@ class NotificationApiTest extends AcceptanceTest {
 
     @Autowired
     private NotificationSubscribeRepository notificationSubscribeRepository;
-
-    @Autowired
-    private NotificationRepository notificationRepository;
 
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #422 

# 🚀 작업 내용

1.shop_menu_categories테이블에 카테고리 이름을 기획에 맞게 변경하는 flyway를 추가했습니다.
이벤트 메뉴 -> 추천 메뉴
대표 메뉴 -> 메인 메뉴

# 💬 리뷰 중점사항
미리 바꿨어야하는데 조금 늦어졌습니다..!