### PR TITLE
fix: ClientAbortException handle

### DIFF
--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -107,6 +108,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn(e.getMessage());
         requestLogging(request);
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식입니다. " + e.getParsedString());
+    }
+
+    @ExceptionHandler(ClientAbortException.class)
+    public ResponseEntity<Object> handleClientAbortException(
+        HttpServletRequest request,
+        ClientAbortException e
+    ) {
+        logger.warn("클라이언트가 연결을 중단했습니다: " + e.getMessage());
+        requestLogging(request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "클라이언트에 의해 연결이 중단되었습니다");
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #428 

# 🚀 작업 내용

서버에서 ClientAbortException를 핸들링하지 않아 500 에러로 발생
핸들링하여 명확한 메시지를 반환

1. ClientAbortException 핸들링 추가

# 💬 리뷰 중점사항
