### PR TITLE
feat: 리프레시 토큰 만료 기한을 14일에서 20초로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
@@ -1,7 +1,5 @@
 package in.koreatech.koin.domain.user.model;
 
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -12,14 +10,14 @@ import lombok.Getter;
 @RedisHash("refreshToken")
 public class UserToken {
 
-    private static final long REFRESH_TOKEN_EXPIRE_DAY = 14L;
+    private static final long REFRESH_TOKEN_EXPIRE_SECONDS = 20L;
 
     @Id
     private Integer id;
 
     private final String refreshToken;
 
-    @TimeToLive(unit = TimeUnit.DAYS)
+    @TimeToLive
     private final Long expiration;
 
     private UserToken(Integer id, String refreshToken, Long expiration) {
@@ -29,6 +27,6 @@ public class UserToken {
     }
 
     public static UserToken create(Integer userId, String refreshToken) {
-        return new UserToken(userId, refreshToken, REFRESH_TOKEN_EXPIRE_DAY);
+        return new UserToken(userId, refreshToken, REFRESH_TOKEN_EXPIRE_SECONDS);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 클라이언트 측의 요청으로 잠깐 access 토큰은 10초, 리프레시 토큰 만료 기한을 14일에서 20초로 변경했습니다
2. accesstoken은 build 서버에서 변경 후 젠킨스에서 재 빌드 했습니다

# 💬 리뷰 중점사항
이렇게 하는 것이 맞는지 잘 모르겠네요.. 잘못 된 것 있으면 말씀해주시면 감사하겠습니다!