### PR TITLE
feat: 리프레시 토큰 만료 기한 14일로 원상 복구

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.user.model;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -10,14 +12,14 @@ import lombok.Getter;
 @RedisHash("refreshToken")
 public class UserToken {
 
-    private static final long REFRESH_TOKEN_EXPIRE_SECONDS = 20L;
+    private static final long REFRESH_TOKEN_EXPIRE_DAY = 14L;
 
     @Id
     private Integer id;
 
     private final String refreshToken;
 
-    @TimeToLive
+    @TimeToLive(unit = TimeUnit.DAYS)
     private final Long expiration;
 
     private UserToken(Integer id, String refreshToken, Long expiration) {
@@ -27,6 +29,6 @@ public class UserToken {
     }
 
     public static UserToken create(Integer userId, String refreshToken) {
-        return new UserToken(userId, refreshToken, REFRESH_TOKEN_EXPIRE_SECONDS);
+        return new UserToken(userId, refreshToken, REFRESH_TOKEN_EXPIRE_DAY);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 리프레시 토큰 기한 14일로 원상 복구 시켰습니다.
2. access 토큰 시간 다시 변경 후 jenkins 빌드 하였습니다.

# 💬 리뷰 중점사항
