### PR TITLE
fix: 상점 이벤트 알림을 구독한 유저에게만 알림

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/EventArticleCreateShopEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/EventArticleCreateShopEvent.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.ownershop;
 
-public record EventArticleCreateEvent(
+public record EventArticleCreateShopEvent(
     Integer shopId,
     String shopName,
     String title

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
-import in.koreatech.koin.domain.ownershop.EventArticleCreateEvent;
+import in.koreatech.koin.domain.ownershop.EventArticleCreateShopEvent;
 import in.koreatech.koin.domain.ownershop.dto.CreateEventRequest;
 import in.koreatech.koin.domain.ownershop.dto.ModifyEventRequest;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopEventsResponse;
@@ -291,7 +291,7 @@ public class OwnerShopService {
                     .build());
         }
         eventPublisher.publishEvent(
-            new EventArticleCreateEvent(
+            new EventArticleCreateShopEvent(
                 shop.getId(),
                 shop.getName(),
                 savedEventArticle.getTitle()

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.model;
 
+import static in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType.SHOP_EVENT;
 import static in.koreatech.koin.global.fcm.MobileAppPath.SHOP;
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
@@ -8,9 +9,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import in.koreatech.koin.domain.ownershop.EventArticleCreateEvent;
-import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.domain.ownershop.EventArticleCreateShopEvent;
 import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
+import in.koreatech.koin.global.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.global.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 
@@ -21,17 +22,18 @@ public class ShopEventListener {
 
     private final NotificationService notificationService;
     private final NotificationFactory notificationFactory;
-    private final UserRepository userRepository;
+    private final NotificationSubscribeRepository notificationSubscribeRepository;
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void onShopEventCreate(EventArticleCreateEvent event) {
-        var notifications = userRepository.findAllByDeviceTokenIsNotNull()
+    public void onShopEventCreate(EventArticleCreateShopEvent event) {
+        var notifications = notificationSubscribeRepository.findAllBySubscribeType(SHOP_EVENT)
             .stream()
-            .map(user -> notificationFactory.generateShopEventCreateNotification(
+            .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
+            .map(subscribe -> notificationFactory.generateShopEventCreateNotification(
                 SHOP,
                 event.shopName(),
                 event.title(),
-                user
+                subscribe.getUser()
             )).toList();
         notificationService.push(notifications);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #441 

# 🚀 작업 내용

1. 디바이스토큰을 가지고 있는 모든 유저에게 알림을 보내고 있던 코드에서 구독을 한 유저에게만 알림을 보내도록 수정했습니다.

# 💬 리뷰 중점사항
기획이 변경되었을때 인지하고 고쳤어야하는데 지금에야 발견했네요.. ㅠ