### PR TITLE
fix: 상점 이미지, 카테고리id중복되는 요소 입력 시 발생하는 에러 핸들링

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.Shop;
+import in.koreatech.koin.global.validation.UniqueId;
+import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -26,6 +28,7 @@ public record OwnerShopsRequest(
     @Schema(description = "상점 카테고리 고유 id 리스트", example = "[1]", requiredMode = REQUIRED)
     @NotNull(message = "카테고리를 입력해주세요.")
     @Size(min = 1, message = "최소 한 개의 카테고리가 필요합니다.")
+    @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     List<Integer> categoryIds,
 
     @Schema(description = "배달 가능 여부", example = "false", requiredMode = REQUIRED)
@@ -44,6 +47,7 @@ public record OwnerShopsRequest(
     @Schema(description = "이미지 URL 리스트", example = """
         [ "https://testimage.com" ]
         """, requiredMode = REQUIRED)
+    @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
     List<String> imageUrls,
 
     @Schema(description = "가게명", example = "써니 숯불 도시락", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/CreateMenuRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/CreateMenuRequest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.Menu;
+import in.koreatech.koin.global.validation.UniqueId;
+import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -17,6 +19,7 @@ import jakarta.validation.constraints.Size;
 public record CreateMenuRequest(
     @Schema(example = "[1, 2, 3]", description = "선택된 카테고리 고유 id 리스트", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
+    @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     List<Integer> categoryIds,
 
     @Schema(example = "저희 가게의 대표 메뉴 짜장면입니다.", description = "메뉴 구성 설명", requiredMode = REQUIRED)
@@ -27,6 +30,7 @@ public record CreateMenuRequest(
         [ "https://static.koreatech.in/example.png" ]
         """, description = "이미지 URL 리스트", requiredMode = REQUIRED)
     @Size(max = 3, message = "이미지는 최대 3개까지 입력 가능합니다.")
+    @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
     List<String> imageUrls,
 
     @Schema(example = "true", description = "단일 메뉴 여부", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyMenuRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyMenuRequest.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.global.validation.UniqueId;
+import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,6 +18,7 @@ import jakarta.validation.constraints.Size;
 public record ModifyMenuRequest(
     @Schema(example = "[1, 2, 3]", description = "선택된 카테고리 고유 id 리스트", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
+    @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     List<Integer> categoryIds,
 
     @Schema(example = "저희 가게의 대표 메뉴 짜장면입니다.", description = "메뉴 구성 설명", requiredMode = REQUIRED)
@@ -26,6 +29,7 @@ public record ModifyMenuRequest(
         [ "https://static.koreatech.in/example.png" ]
         """, description = "이미지 URL 리스트", requiredMode = NOT_REQUIRED)
     @Size(max = 3, message = "이미지는 최대 3개까지 입력 가능합니다.")
+    @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
     List<String> imageUrls,
 
     @Schema(example = "true", description = "단일 메뉴 여부", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopOpen;
+import in.koreatech.koin.global.validation.UniqueId;
+import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -24,6 +26,7 @@ public record ModifyShopRequest(
 
     @Schema(example = "[1, 2]", description = "상점 카테고리 고유 id 리스트", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
+    @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     List<Integer> categoryIds,
 
     @Schema(example = "true", description = "배달 가능 여부", requiredMode = REQUIRED)
@@ -41,6 +44,7 @@ public record ModifyShopRequest(
     @Schema(description = "이미지 URL 리스트", example = """
         [ "https://static.koreatech.in/example.png" ]
         """, requiredMode = NOT_REQUIRED)
+    @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
     List<String> imageUrls,
 
     @Schema(example = "수신반점", description = "이름", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueId.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueId.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.global.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = UniqueIdValidator.class)
+@Target({ FIELD, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+public @interface UniqueId {
+
+    String message() default "중복된 요소가 존재합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.global.validation;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UniqueIdValidator implements ConstraintValidator<UniqueId, List<Integer>> {
+
+    @Override
+    public void initialize(UniqueId constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<Integer> elements, ConstraintValidatorContext context) {
+        Set<Integer> set = new HashSet<>(elements.size());
+        for (Integer element : elements) {
+            if (!set.add(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.global.validation;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -16,12 +14,6 @@ public class UniqueIdValidator implements ConstraintValidator<UniqueId, List<Int
 
     @Override
     public boolean isValid(List<Integer> elements, ConstraintValidatorContext context) {
-        Set<Integer> set = new HashSet<>(elements.size());
-        for (Integer element : elements) {
-            if (!set.add(element)) {
-                return false;
-            }
-        }
-        return true;
+        return elements.stream().distinct().count() == elements.size();
     }
 }

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueUrl.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueUrl.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.global.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = UniqueUrlsValidator.class)
+@Target({ FIELD, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+public @interface UniqueUrl {
+
+    String message() default "중복된 요소가 존재합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.global.validation;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -16,12 +14,6 @@ public class UniqueUrlsValidator implements ConstraintValidator<UniqueUrl, List<
 
     @Override
     public boolean isValid(List<String> elements, ConstraintValidatorContext context) {
-        Set<String> set = new HashSet<>(elements.size());
-        for (String element : elements) {
-            if (!set.add(element)) {
-                return false;
-            }
-        }
-        return true;
+        return elements.stream().distinct().count() == elements.size();
     }
 }

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.global.validation;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UniqueUrlsValidator implements ConstraintValidator<UniqueUrl, List<String>> {
+
+    @Override
+    public void initialize(UniqueUrl constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> elements, ConstraintValidatorContext context) {
+        Set<String> set = new HashSet<>(elements.size());
+        for (String element : elements) {
+            if (!set.add(element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #447 

# 🚀 작업 내용

1. 같은 상점 이미지 url을 입력할 때 발생하는 서버 에러를 해결했습니다.
2. 하는김에 같은 카테고리 id를 입력할 경우도 핸들링해줬습니다.
3. custom어노테이션을 만들어서 dto단에서 중복을 체크해줬습니다.
`@UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")`
`@UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")`
4. 해싱 기반 Set자료구조를 이용해서 중복 여부를 체크해줬습니다.

# 💬 리뷰 중점사항
List를 받는 dto의 요소 중복 체크를 할 때 이번에 작성한 것을 이용하면 좋을 것 같습니다.
