### PR TITLE
fix: /bus/search 천안역에서 출발할 경우 Exception 발생 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
@@ -93,7 +93,7 @@ public class BusService {
         for (BusType busType : BusType.values()) {
             SingleBusTimeResponse busTimeResponse = null;
 
-            if (busType == BusType.EXPRESS) {
+            if (busType == BusType.EXPRESS && depart != BusStation.STATION) {
                 busTimeResponse = expressBusOpenApiClient.searchBusTime(
                     busType.name().toLowerCase(),
                     depart,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #474 

# 🚀 작업 내용

1. /bus/search에서 천안역에서 출발할 경우 Exception이 발생하는 문제를 수정했습니다.
    - 버스 타입이 시외버스이고 출발지점이 천안역이 아닌 경우에만 탐색하도록 수정했습니다.

# 💬 리뷰 중점사항
