### PR TITLE
fix: DB의 상점 설명이 null인 경우 예외처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -105,13 +105,9 @@ public class OwnerService {
                 .ownerId(owner.getId())
                 .shopId(shop.getId())
                 .build());
-            ownerShopRedisRepository.save(OwnerShop.builder()
-                .build());
         } else {
             ownerShopRedisRepository.save(OwnerShop.builder()
                 .ownerId(owner.getId())
-                .build());
-            ownerShopRedisRepository.save(OwnerShop.builder()
                 .build());
         }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
@@ -71,7 +71,7 @@ public record ShopResponse(
             shop.getAddress(),
             shop.isDelivery(),
             shop.getDeliveryPrice(),
-            shop.getDescription().isBlank()? "-": shop.getDescription(),
+            (shop.getDescription() == null || shop.getDescription().isBlank())? "-": shop.getDescription(),
             shop.getId(),
             shop.getShopImages().stream()
                 .map(ShopImage::getImageUrl)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #467

# 🚀 작업 내용

1. DB의 상점 설명이 null인 경우 예외처리를 해주었습니다.
2. owner register에 있는 의미 없는 save코드를 삭제하였습니다.

# 💬 리뷰 중점사항
리뷰 잘부탁드립니당