### PR TITLE
feat : 회원 정보 수정에 비밀번호 수정 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
@@ -39,6 +39,10 @@ public record StudentUpdateRequest
         @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
         String name,
 
+        @Size(message = "SHA 256 해시 알고리즘으로 암호화 된 비밀번호")
+        @Schema(description = "비밀번호", example = "a0240120305812krlakdsflsa;1235", requiredMode = NOT_REQUIRED)
+        String password,
+
         @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
         @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
         String nickname,

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -170,6 +170,11 @@ public class User extends BaseEntity {
         this.gender = gender;
     }
 
+    public void updateStudentPassword(PasswordEncoder passwordEncoder, String password) {
+        if (password != null && !password.isEmpty())
+            this.password = passwordEncoder.encode(password);
+    }
+
     public void auth() {
         this.isAuthed = true;
     }

--- a/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
@@ -60,6 +60,7 @@ public class StudentService {
         checkDepartmentValid(request.major());
         user.update(request.nickname(), request.name(),
             request.phoneNumber(), UserGender.from(request.gender()));
+        user.updateStudentPassword(passwordEncoder, request.password());
         student.update(request.studentNumber(), request.major());
         studentRepository.save(student);
 

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -61,7 +61,6 @@ class UserApiTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
-
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -62,7 +62,6 @@ class UserApiTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract();
 
-
     }
 
     @Test
@@ -145,6 +144,7 @@ class UserApiTest extends AcceptanceTest {
                     "gender" : 1,
                     "major" : "기계공학부",
                     "name" : "서정빈",
+                    "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
                     "nickname" : "duehee",
                     "phone_number" : "010-2345-6789",
                     "student_number" : "2019136136"
@@ -340,7 +340,6 @@ class UserApiTest extends AcceptanceTest {
 
         assertThat(userRepository.findById(student.getId())).isNotPresent();
     }
-
 
     @Test
     @DisplayName("이메일이 중복인지 확인한다")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #421 

# 🚀 작업 내용

1. 회원 정보 수정에 비밀번호 수정 로직을 추가했습니다.

# 💬 리뷰 중점사항
시간을 많이 쓸 로직은 아니었는데, 이런저런 문제로 테스트 상으로 시간을 너무 많이 썼습니다😢
더 일찍 못 드려서 죄송합니당