### PR TITLE
refactor: 모든 상점 조회 api 성능개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
@@ -78,7 +78,7 @@ public record ModifyShopRequest(
 
         @Schema(example = "false", description = "휴무 여부", requiredMode = REQUIRED)
         @NotNull(message = "휴무 여부는 필수입니다.")
-        Boolean closed,
+        boolean closed,
 
         @JsonFormat(pattern = "HH:mm")
         @Schema(example = "02:00", description = "오픈 시간", requiredMode = NOT_REQUIRED)
@@ -92,8 +92,8 @@ public record ModifyShopRequest(
         public ShopOpen toEntity(Shop shop) {
             return ShopOpen.builder()
                 .shop(shop)
-                .openTime(openTime)
                 .closed(closed)
+                .openTime(openTime)
                 .closeTime(closeTime)
                 .dayOfWeek(dayOfWeek)
                 .build();

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
@@ -71,7 +71,7 @@ public record ShopResponse(
             shop.getAddress(),
             shop.isDelivery(),
             shop.getDeliveryPrice(),
-            (shop.getDescription() == null || shop.getDescription().isBlank())? "-": shop.getDescription(),
+            (shop.getDescription() == null || shop.getDescription().isBlank()) ? "-" : shop.getDescription(),
             shop.getId(),
             shop.getShopImages().stream()
                 .map(ShopImage::getImageUrl)
@@ -86,7 +86,7 @@ public record ShopResponse(
             shop.getShopOpens().stream().map(shopOpen ->
                 new InnerShopOpen(
                     shopOpen.getDayOfWeek(),
-                    shopOpen.getClosed(),
+                    shopOpen.isClosed(),
                     shopOpen.getOpenTime(),
                     shopOpen.getCloseTime()
                 )
@@ -128,7 +128,7 @@ public record ShopResponse(
         public static InnerShopOpen from(ShopOpen shopOpen) {
             return new InnerShopOpen(
                 shopOpen.getDayOfWeek(),
-                shopOpen.getClosed(),
+                shopOpen.isClosed(),
                 shopOpen.getOpenTime(),
                 shopOpen.getCloseTime()
             );

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
@@ -1,6 +1,9 @@
 package in.koreatech.koin.domain.shop.model;
 
-import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.CascadeType.MERGE;
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REFRESH;
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -215,7 +218,7 @@ public class Shop extends BaseEntity {
             .toUpperCase();
         for (ShopOpen shopOpen : this.shopOpens) {
             if (shopOpen.getDayOfWeek().equals(currDayOfWeek)) {
-                if (!shopOpen.getClosed()) {
+                if (!shopOpen.isClosed()) {
                     if (shopOpen.getOpenTime().isBefore(now.toLocalTime()) && shopOpen.getCloseTime().equals("00:00")) {
                         return true;
                     } else if ((
@@ -227,7 +230,7 @@ public class Shop extends BaseEntity {
                 }
             } else if (shopOpen.getDayOfWeek().equals(prevDayOfWeek)) {
                 LocalDateTime prevDateTime = now.minusDays(1);
-                if (!shopOpen.getClosed()) {
+                if (!shopOpen.isClosed()) {
                     if (
                         (shopOpen.getCloseTime().isBefore(shopOpen.getOpenTime()) ||
                             shopOpen.getCloseTime().equals(shopOpen.getOpenTime())) &&

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
@@ -223,11 +223,9 @@ public class Shop extends BaseEntity {
             if (shopOpen.isClosed()) {
                 continue;
             }
-
             if (shopOpen.getDayOfWeek().equals(currentDayOfWeek) && (isShopOpenToday(shopOpen, currentTime))) {
                 return true;
             }
-
             if (shopOpen.getDayOfWeek().equals(previousDayOfWeek) && (isShopOpenAtNightShift(shopOpen, currentTime))) {
                 return true;
             }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopOpen.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopOpen.java
@@ -62,7 +62,13 @@ public class ShopOpen extends BaseEntity {
     private boolean isDeleted = false;
 
     @Builder
-    private ShopOpen(Shop shop, String dayOfWeek, boolean closed, LocalTime openTime, LocalTime closeTime) {
+    private ShopOpen(
+        Shop shop,
+        String dayOfWeek,
+        boolean closed,
+        LocalTime openTime,
+        LocalTime closeTime
+    ) {
         this.shop = shop;
         this.dayOfWeek = dayOfWeek;
         this.closed = closed;

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopOpen.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopOpen.java
@@ -45,7 +45,7 @@ public class ShopOpen extends BaseEntity {
 
     @NotNull
     @Column(name = "closed", nullable = false)
-    private Boolean closed;
+    private boolean closed;
 
     @NotNull
     @Column(name = "open_time")

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopOpenRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopOpenRepository.java
@@ -1,47 +1,12 @@
 package in.koreatech.koin.domain.shop.repository;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.shop.model.ShopOpen;
 
 public interface ShopOpenRepository extends Repository<ShopOpen, Integer> {
-
-    @Query(value = """
-        SELECT CASE
-            WHEN COUNT(*) > 0 THEN 'true'
-            ELSE 'false'
-        END AS is_open
-        FROM shop_opens s
-        WHERE s.shop_id = :shopId
-          AND (
-            (
-              s.day_of_week = UPPER(DAYNAME(:nowDate)) AND
-              (
-                ((s.open_time <= :nowTime AND s.close_time >= :nowTime)
-                OR (s.open_time <= :nowTime AND s.close_time = '00:00'))
-                AND s.closed = false
-              )
-            )
-            OR
-            (
-              (s.day_of_week = UPPER(DAYNAME(:nowDate - INTERVAL 1 DAY)) AND
-              (s.close_time <= s.open_time AND :nowTime <= s.close_time))
-              AND s.closed = false
-            )
-          )
-    """, nativeQuery = true)
-    boolean isOpen(
-        @Param("shopId") Integer shopId,
-        @Param("nowDate") LocalDate nowDate,
-        @Param("nowTime") LocalTime nowTime
-    );
-
 
     ShopOpen save(ShopOpen shopOpen);
 

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.shop.dto.ShopsResponse.InnerShopResponse;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -29,7 +28,6 @@ import in.koreatech.koin.domain.shop.repository.EventArticleRepository;
 import in.koreatech.koin.domain.shop.repository.MenuCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.MenuRepository;
 import in.koreatech.koin.domain.shop.repository.ShopCategoryRepository;
-import in.koreatech.koin.domain.shop.repository.ShopOpenRepository;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -44,7 +42,6 @@ public class ShopService {
     private final ShopRepository shopRepository;
     private final ShopCategoryRepository shopCategoryRepository;
     private final EventArticleRepository eventArticleRepository;
-    private final ShopOpenRepository shopOpenRepository;
 
     public MenuDetailResponse findMenu(Integer menuId) {
         Menu menu = menuRepository.getById(menuId);
@@ -78,15 +75,9 @@ public class ShopService {
     public ShopsResponse getShops() {
         List<Shop> shops = shopRepository.findAll();
         LocalDateTime now = LocalDateTime.now(clock);
-        LocalDate nowDate = now.toLocalDate();
-        LocalTime nowTime = now.toLocalTime();
-        var innerShopResponses = shops.stream().map(shop -> {
-                boolean isDurationEvent = eventArticleRepository.isDurationEvent(shop.getId(), nowDate);
-                boolean isShopOpen = shopOpenRepository.isOpen(
-                    shop.getId(),
-                    nowDate,
-                    nowTime);
-                return InnerShopResponse.from(shop, isDurationEvent, isShopOpen);
+        List<InnerShopResponse> innerShopResponses = shops.stream().map(shop -> {
+                boolean isDurationEvent = eventArticleRepository.isDurationEvent(shop.getId(), now.toLocalDate());
+                return InnerShopResponse.from(shop, isDurationEvent, shop.isEvent(now));
             })
             .sorted(Comparator.comparing(InnerShopResponse::isOpen, Collections.reverseOrder())).toList();
         return ShopsResponse.from(innerShopResponses);

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -77,7 +77,7 @@ public class ShopService {
         LocalDateTime now = LocalDateTime.now(clock);
         List<InnerShopResponse> innerShopResponses = shops.stream().map(shop -> {
                 boolean isDurationEvent = eventArticleRepository.isDurationEvent(shop.getId(), now.toLocalDate());
-                return InnerShopResponse.from(shop, isDurationEvent, shop.isEvent(now));
+                return InnerShopResponse.from(shop, isDurationEvent, shop.isOpen(now));
             })
             .sorted(Comparator.comparing(InnerShopResponse::isOpen, Collections.reverseOrder())).toList();
         return ShopsResponse.from(innerShopResponses);

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -758,13 +758,13 @@ class OwnerShopApiTest extends AcceptanceTest {
                     softly.assertThat(shopOpens.get(0).getOpenTime()).isEqualTo("10:00");
 
                     softly.assertThat(shopOpens.get(0).getDayOfWeek()).isEqualTo("MONDAY");
-                    softly.assertThat(shopOpens.get(0).getClosed()).isFalse();
+                    softly.assertThat(shopOpens.get(0).isClosed()).isFalse();
 
                     softly.assertThat(shopOpens.get(1).getCloseTime()).isEqualTo("23:30");
                     softly.assertThat(shopOpens.get(1).getOpenTime()).isEqualTo("11:00");
 
                     softly.assertThat(shopOpens.get(1).getDayOfWeek()).isEqualTo("SUNDAY");
-                    softly.assertThat(shopOpens.get(1).getClosed()).isTrue();
+                    softly.assertThat(shopOpens.get(1).isClosed()).isTrue();
                 }
             );
         });

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -1,9 +1,7 @@
 package in.koreatech.koin.acceptance;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.format.TextStyle;
-import java.util.Locale;
+import java.time.LocalDateTime;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import in.koreatech.koin.AcceptanceTest;
-import in.koreatech.koin.config.TestTimeConfig;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.domain.shop.model.Shop;
@@ -353,7 +350,7 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("모든 상점 조회")
     void getAllShop() {
         // given
-        Shop otherShop = shopFixture.신전_떡볶이(owner);
+        shopFixture.신전_떡볶이(owner);
         var response = RestAssured
             .given()
             .when()
@@ -362,33 +359,11 @@ class ShopApiTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract();
 
-        boolean 마슬랜_영업여부 = false;
+        // 2024-01-15 월요일 기준
+        boolean 마슬랜_영업여부 = true;
         boolean 신전_떡볶이_영업여부 = false;
 
-        String dayOfWeek = LocalDate.now(clock).getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.US).toUpperCase();
-        if (
-            dayOfWeek.equals("MONDAY") &&
-            LocalTime.now(clock).isAfter(LocalTime.parse("00:00")) &&
-            LocalTime.now(clock).isBefore(LocalTime.parse("21:00"))
-        ) {
-            마슬랜_영업여부 = true;
-        } else if (dayOfWeek.equals("FRIDAY")) {
-            신전_떡볶이_영업여부 = true;
-        }
-
-        if (
-            dayOfWeek.equals("SUNDAY") &&
-            LocalTime.now(clock).isAfter(LocalTime.parse("00:00")) &&
-            LocalTime.now(clock).isBefore(LocalTime.parse("21:00"))
-        ) {
-            마슬랜_영업여부 = true;
-        } else if (
-            dayOfWeek.equals("FRIDAY") &&
-            LocalTime.now(clock).isAfter(LocalTime.parse("00:00")) &&
-            LocalTime.now(clock).isBefore(LocalTime.parse("21:00"))
-        ) {
-            신전_떡볶이_영업여부 = true;
-        }
+        System.out.println(LocalDateTime.now(clock));
         JsonAssertions.assertThat(response.asPrettyString())
             .isEqualTo(String.format("""
                 {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #484 

# 🚀 작업 내용

1. 모든 상점 조회시 운영중 여부를 쿼리로 조회하고 있었던 로직을 jpa entity를 이용해서 java로직으로 운영중 여부를 판단하게 변경하였습니다.
2. 만약 오늘 일시에 상점이 운영중이라면 `is_open=true`를 반환합니다
3. 오늘 일시에 상점이 운영중이지 않다면 어제 날짜의 운영시간을 참고해서 운영중인지 확인합니다.

## 개선 전 로컬환경에서의 평균 응답속도 700ms
<img width="503" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/127578418/b8941a7c-9559-4e2a-ad5c-0152e818688c">

## 개선 후 로컬환경에서의  평균 응답속도
<img width="550" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/127578418/741e77bb-2bf7-493b-ba6b-bae51b8ba73e">

## 개선 전 스테이지에서 응답속도
<img width="506" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/127578418/ee1063de-bb31-4774-8741-9d7c61ec0c16">

# 💬 리뷰 중점사항
조금 더 최적화해보고싶지만 당장 오늘 밤에 배포를 해야하기 때문에 pr올립니다~!