### PR TITLE
fix: 17시~2시인 경우 오픈 여부를 확인하지 못하는 에러 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
@@ -237,6 +237,9 @@ public class Shop extends BaseEntity {
         long currTime = currentTime.toNanoOfDay();
         long openTime = shopOpen.getOpenTime().toNanoOfDay();
         long closeTime = shopOpen.getCloseTime().toNanoOfDay();
+        if (closeTime < openTime) {
+            closeTime += (LocalTime.of(12, 0).toNanoOfDay() * 2);
+        }
         return (closeTime == 0 && openTime <= currTime) || (openTime <= currTime && currTime <= closeTime);
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #484

# 🚀 작업 내용

1. 17시~2시인 경우 오픈 여부를 확인하지 못하는 에러 해결했습니다.
2. close시간이 open시간보다 적을 경우 close시간에 24시를 더해준 후 비교했습니다.

# 💬 리뷰 중점사항
