### PR TITLE
feat: GET /admin/members api 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.admin.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
+import in.koreatech.koin.admin.member.enums.TrackTag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "(Admin) AdminLand: BCSDLab 회원", description = "관리자 권한으로 BCSDLab 회원 정보를 관리한다")
+public interface AdminMemberApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "페이지별 BCSDLab 회원 리스트 조회")
+    @GetMapping("/admin/members")
+    ResponseEntity<AdminMembersResponse> getMembers(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
+        @RequestParam(name = "track") TrackTag track,
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+    );
+}

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -16,7 +16,6 @@ public class AdminMemberController implements AdminMemberApi {
 
     private final AdminMemberService adminMemberService;
 
-    @Override
     @GetMapping("/admin/members")
     public ResponseEntity<AdminMembersResponse> getMembers(
         @RequestParam(name = "page", defaultValue = "1") Integer page,

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.admin.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
+import in.koreatech.koin.admin.member.enums.TrackTag;
+import in.koreatech.koin.admin.member.service.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminMemberController implements AdminMemberApi {
+
+    private final AdminMemberService adminMemberService;
+
+    @Override
+    @GetMapping("/admin/members")
+    public ResponseEntity<AdminMembersResponse> getMembers(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
+        @RequestParam(name = "track") TrackTag track,
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+    ) {
+        return ResponseEntity.ok().body(adminMemberService.getMembers(page, limit, track, isDeleted));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminMembersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminMembersResponse.java
@@ -68,7 +68,7 @@ public record AdminMembersResponse(
         String imageUrl,
 
         @Schema(description = "삭제(soft delete) 여부", example = "false", requiredMode = REQUIRED)
-        Boolean isDeleted
+        boolean isDeleted
     ) {
 
         public static SimpleMemberInformation from(Member member) {

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminMembersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminMembersResponse.java
@@ -1,0 +1,87 @@
+package in.koreatech.koin.admin.member.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.member.model.Member;
+import in.koreatech.koin.global.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminMembersResponse(
+    @Schema(description = "조건에 해당하는 총 회원의 수", example = "57", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "조건에 해당하는 회원 중에 현재 페이지에서 조회된 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "조건에 해당하는 회원들을 조회할 수 있는 최대 페이지", example = "6", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "2", requiredMode = REQUIRED)
+    Integer currentPage,
+
+    @Schema(description = "회원 정보 리스트", requiredMode = REQUIRED)
+    List<SimpleMemberInformation> members
+) {
+    public static AdminMembersResponse of(Page<Member> pagedResult, Criteria criteria) {
+        return new AdminMembersResponse(
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1,
+            pagedResult.getContent()
+                .stream()
+                .map(SimpleMemberInformation::from)
+                .collect(Collectors.toList())
+        );
+    }
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    private record SimpleMemberInformation(
+        @Schema(description = "고유 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "이름", example = "김주원", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "학번", example = "2019136037")
+        String studentNumber,
+
+        @Schema(description = "트랙 이름", example = "BackEnd", requiredMode = REQUIRED)
+        String track,
+
+        @Schema(description = "직책", example = "Regular", requiredMode = REQUIRED)
+        String position,
+
+        @Schema(description = "이메일", example = "damiano102777@naver.com")
+        String email,
+
+        @Schema(description = "이미지 url", example = "https://static.koreatech.in/test.png")
+        String imageUrl,
+
+        @Schema(description = "삭제(soft delete) 여부", example = "false", requiredMode = REQUIRED)
+        Boolean isDeleted
+    ) {
+
+        public static SimpleMemberInformation from(Member member) {
+            return new SimpleMemberInformation(
+                member.getId(),
+                member.getName(),
+                member.getStudentNumber(),
+                member.getTrack().getName(),
+                member.getPosition(),
+                member.getEmail(),
+                member.getImageUrl(),
+                member.isDeleted()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/enums/TrackTag.java
+++ b/src/main/java/in/koreatech/koin/admin/member/enums/TrackTag.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.admin.member.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum TrackTag {
+    ANDROID("Android"),
+    BACKEND("BackEnd"),
+    FRONTEND("FrontEnd"),
+    GAME("Game"),
+    PM("P&M"),
+    HR("HR"),
+    UI_UX("UI/UX"),
+    IOS("iOS")
+    ;
+
+    private final String tag;
+
+    TrackTag(String tag) {
+        this.tag = tag;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/enums/TrackTag.java
+++ b/src/main/java/in/koreatech/koin/admin/member/enums/TrackTag.java
@@ -11,7 +11,7 @@ public enum TrackTag {
     PM("P&M"),
     HR("HR"),
     UI_UX("UI/UX"),
-    IOS("iOS")
+    IOS("iOS"),
     ;
 
     private final String tag;

--- a/src/main/java/in/koreatech/koin/admin/member/repository/AdminMemberRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/member/repository/AdminMemberRepository.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.member.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.member.model.Member;
+
+public interface AdminMemberRepository extends Repository<Member, Integer> {
+
+    @EntityGraph(attributePaths = {"track"})
+    @Query("select m from Member m where m.track.name = :trackName and m.isDeleted = :isDeleted")
+    Page<Member> findAllByTrackAndIsDeleted(String trackName, Boolean isDeleted, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"track"})
+    @Query("select count(m) from Member m where m.track.name = :trackName and m.isDeleted = :isDeleted")
+    Integer countAllByTrackAndIsDeleted(String trackName, Boolean isDeleted);
+}

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminMemberService {
 
     private final AdminMemberRepository adminMemberRepository;

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.admin.member.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
+import in.koreatech.koin.admin.member.enums.TrackTag;
+import in.koreatech.koin.admin.member.repository.AdminMemberRepository;
+import in.koreatech.koin.domain.member.model.Member;
+import in.koreatech.koin.domain.member.model.Track;
+import in.koreatech.koin.global.model.Criteria;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final AdminMemberRepository adminMemberRepository;
+
+    public AdminMembersResponse getMembers(Integer page, Integer limit, TrackTag track, Boolean isDeleted) {
+        Integer total = adminMemberRepository.countAllByTrackAndIsDeleted(track.getTag(), isDeleted);
+
+        Criteria criteria = Criteria.of(page, limit, total);
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), Sort.by(Sort.Direction.ASC, "id"));
+
+        Page<Member> result = adminMemberRepository.findAllByTrackAndIsDeleted(track.getTag(), isDeleted, pageRequest);
+
+        return AdminMembersResponse.of(result, criteria);
+    }
+
+}

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -1,0 +1,81 @@
+package in.koreatech.koin.admin.acceptance;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.member.model.Track;
+import in.koreatech.koin.domain.member.repository.TrackRepository;
+import in.koreatech.koin.fixture.MemberFixture;
+import in.koreatech.koin.support.JsonAssertions;
+import io.restassured.RestAssured;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class AdminMemberApiTest extends AcceptanceTest {
+
+    @Autowired
+    private TrackRepository trackRepository;
+
+    @Autowired
+    private MemberFixture memberFixture;
+
+    Track backend;
+    Track frontend;
+
+    @BeforeEach
+    void setUp() {
+        backend = trackRepository.save(
+            Track.builder()
+                .name("BackEnd")
+                .build()
+        );
+        frontend = trackRepository.save(
+            Track.builder()
+                .name("FrontEnd")
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("BCSDLab 회원들의 정보를 조회한다")
+    void getMembers() {
+        memberFixture.최준호(backend);
+
+        var response = RestAssured
+            .given()
+            .when()
+            .param("page", 1)
+            .param("track", "BACKEND")
+            .param("is_deleted", false)
+            .get("/admin/members")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                    "total_count": 1,
+                    "current_count": 1,
+                    "total_page": 1,
+                    "current_page": 1,
+                    "members": [
+                        {
+                            "id": 1,
+                            "name": "최준호",
+                            "student_number": "2019136135",
+                            "track": "BackEnd",
+                            "position": "Regular",
+                            "email": "testjuno@gmail.com",
+                            "image_url": "https://imagetest.com/juno.jpg",
+                            "is_deleted": false
+                        }
+                    ]
+                }
+                """
+            );
+    }
+}

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -10,6 +10,7 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.member.model.Track;
 import in.koreatech.koin.domain.member.repository.TrackRepository;
 import in.koreatech.koin.fixture.MemberFixture;
+import in.koreatech.koin.fixture.TrackFixture;
 import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
 
@@ -17,32 +18,15 @@ import io.restassured.RestAssured;
 public class AdminMemberApiTest extends AcceptanceTest {
 
     @Autowired
-    private TrackRepository trackRepository;
-
-    @Autowired
     private MemberFixture memberFixture;
 
-    Track backend;
-    Track frontend;
-
-    @BeforeEach
-    void setUp() {
-        backend = trackRepository.save(
-            Track.builder()
-                .name("BackEnd")
-                .build()
-        );
-        frontend = trackRepository.save(
-            Track.builder()
-                .name("FrontEnd")
-                .build()
-        );
-    }
+    @Autowired
+    private TrackFixture trackFixture;
 
     @Test
     @DisplayName("BCSDLab 회원들의 정보를 조회한다")
     void getMembers() {
-        memberFixture.최준호(backend);
+        memberFixture.최준호(trackFixture.backend());
 
         var response = RestAssured
             .given()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #44 

# 🚀 작업 내용

1. GET /admin/members API를 추가했습니다.

# 💬 리뷰 중점사항
조인을 사용해야 해서 `@EntityGraph`와  JPQL을 사용하여 개발을 진행하였습니다. 