### PR TITLE
feat: 상점 이벤트 알림에 썸네일이미지 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/EventArticleCreateShopEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/EventArticleCreateShopEvent.java
@@ -3,7 +3,8 @@ package in.koreatech.koin.domain.ownershop;
 public record EventArticleCreateShopEvent(
     Integer shopId,
     String shopName,
-    String title
+    String title,
+    String thumbnailImage
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -288,11 +288,13 @@ public class OwnerShopService {
                     .thumbnailImage(image)
                     .build());
         }
+        List<EventArticleImage> eventArticleImages = savedEventArticle.getThumbnailImages();
         eventPublisher.publishEvent(
             new EventArticleCreateShopEvent(
                 shop.getId(),
                 shop.getName(),
-                savedEventArticle.getTitle()
+                savedEventArticle.getTitle(),
+                eventArticleImages.isEmpty() ? null : eventArticleImages.get(0).getThumbnailImage()
             )
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
@@ -4,12 +4,15 @@ import static in.koreatech.koin.global.domain.notification.model.NotificationSub
 import static in.koreatech.koin.global.fcm.MobileAppPath.SHOP;
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin.domain.ownershop.EventArticleCreateShopEvent;
+import in.koreatech.koin.global.domain.notification.model.Notification;
 import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.global.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.global.domain.notification.service.NotificationService;
@@ -26,11 +29,12 @@ public class ShopEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onShopEventCreate(EventArticleCreateShopEvent event) {
-        var notifications = notificationSubscribeRepository.findAllBySubscribeType(SHOP_EVENT)
+        List<Notification> notifications = notificationSubscribeRepository.findAllBySubscribeType(SHOP_EVENT)
             .stream()
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateShopEventCreateNotification(
                 SHOP,
+                event.thumbnailImage(),
                 event.shopName(),
                 event.title(),
                 subscribe.getUser()

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -10,6 +10,7 @@ public class NotificationFactory {
 
     public Notification generateShopEventCreateNotification(
         MobileAppPath path,
+        String imageUrl,
         String shopName,
         String title,
         User target
@@ -18,7 +19,7 @@ public class NotificationFactory {
             path,
             "%s의 이벤트가 추가되었어요 🎉".formatted(shopName),
             "%s".formatted(title),
-            null,
+            imageUrl,
             NotificationType.MESSAGE,
             target
         );

--- a/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
@@ -10,7 +10,6 @@ import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.domain.notification.dto.NotificationStatusResponse;
 import in.koreatech.koin.global.domain.notification.exception.NotificationNotPermitException;
 import in.koreatech.koin.global.domain.notification.model.Notification;
-import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
 import in.koreatech.koin.global.domain.notification.repository.NotificationRepository;
@@ -25,21 +24,11 @@ public class NotificationService {
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
     private final FcmClient fcmClient;
-    private final NotificationFactory notificationFactory;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
 
     public void push(List<Notification> notifications) {
         for (Notification notification : notifications) {
-            notificationRepository.save(notification);
-            String deviceToken = notification.getUser().getDeviceToken();
-            fcmClient.sendMessage(
-                deviceToken,
-                notification.getTitle(),
-                notification.getMessage(),
-                notification.getImageUrl(),
-                notification.getMobileAppPath(),
-                notification.getType()
-            );
+            push(notification);
         }
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #469 

# 🚀 작업 내용

1. 상점 이벤트 알림에 썸네일이미지를 추가하였습니다.
2. NotificationService의 push함수의 코드중복을 제거하였습니다.

# 💬 리뷰 중점사항
리뷰 잘부탁드립니다!