### PR TITLE
refactor: 메뉴 카테고리 피그마 UI에 맞게 정렬

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -151,8 +151,9 @@ public class OwnerShopService {
 
     public ShopMenuResponse getMenus(Integer shopId, Integer ownerId) {
         Shop shop = getOwnerShopById(shopId, ownerId);
-        List<Menu> menus = menuRepository.findAllByShopId(shop.getId());
-        return ShopMenuResponse.from(menus);
+        List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
+        MenuCategory.sortMenuCategories(menuCategories);
+        return ShopMenuResponse.from(menuCategories);
     }
 
     public MenuCategoriesResponse getCategories(Integer shopId, Integer ownerId) {

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.ownershop.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -152,7 +153,7 @@ public class OwnerShopService {
     public ShopMenuResponse getMenus(Integer shopId, Integer ownerId) {
         Shop shop = getOwnerShopById(shopId, ownerId);
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
-        MenuCategory.sortMenuCategories(menuCategories);
+        Collections.sort(menuCategories);
         return ShopMenuResponse.from(menuCategories);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
@@ -6,12 +6,12 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopCategory;
 import in.koreatech.koin.domain.shop.model.ShopImage;
@@ -68,7 +68,7 @@ public record ShopResponse(
 ) {
 
     public static ShopResponse from(Shop shop, Boolean isEvent) {
-        MenuCategory.sortMenuCategories(shop.getMenuCategories());
+        Collections.sort(shop.getMenuCategories());
         return new ShopResponse(
             shop.getAddress(),
             shop.isDelivery(),

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.shop.model.MenuCategory;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopCategory;
 import in.koreatech.koin.domain.shop.model.ShopImage;
@@ -67,6 +68,7 @@ public record ShopResponse(
 ) {
 
     public static ShopResponse from(Shop shop, Boolean isEvent) {
+        MenuCategory.sortMenuCategories(shop.getMenuCategories());
         return new ShopResponse(
             shop.getAddress(),
             shop.isDelivery(),

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
@@ -5,8 +5,6 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,6 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -30,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "shop_menu_categories")
 @NoArgsConstructor(access = PROTECTED)
-public final class MenuCategory extends BaseEntity {
+public final class MenuCategory extends BaseEntity implements Comparable<MenuCategory> {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -49,6 +48,14 @@ public final class MenuCategory extends BaseEntity {
     @OneToMany(mappedBy = "menuCategory", orphanRemoval = true, cascade = ALL)
     private List<MenuCategoryMap> menuCategoryMaps = new ArrayList<>();
 
+    @Transient
+    private Map<String, Integer> priorityMap = Map.of(
+        "추천 메뉴", 1,
+        "메인 메뉴", 2,
+        "세트 메뉴", 3,
+        "사이드 메뉴", 4
+    );
+
     @Builder
     private MenuCategory(Shop shop, String name) {
         this.shop = shop;
@@ -59,16 +66,8 @@ public final class MenuCategory extends BaseEntity {
         this.name = name;
     }
 
-    public static void sortMenuCategories(List<MenuCategory> menuCategories) {
-        Map<String, Integer> priorityMap = new HashMap<>();
-        priorityMap.put("추천 메뉴", 1);
-        priorityMap.put("메인 메뉴", 2);
-        priorityMap.put("세트 메뉴", 3);
-        priorityMap.put("사이드 메뉴", 4);
-        Collections.sort(menuCategories, (cat1, cat2) -> {
-            Integer priority1 = priorityMap.getOrDefault(cat1.getName(), 5);
-            Integer priority2 = priorityMap.getOrDefault(cat2.getName(), 5);
-            return priority1.compareTo(priority2);
-        });
+    @Override
+    public int compareTo(MenuCategory other) {
+        return priorityMap.getOrDefault(name, 5) - priorityMap.getOrDefault(other.name, 5);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/MenuCategory.java
@@ -5,7 +5,10 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
@@ -40,7 +43,7 @@ public final class MenuCategory extends BaseEntity {
 
     @Size(max = 255)
     @NotNull
-    @Column(name = "name", nullable = false, unique = true)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @OneToMany(mappedBy = "menuCategory", orphanRemoval = true, cascade = ALL)
@@ -54,5 +57,18 @@ public final class MenuCategory extends BaseEntity {
 
     public void modifyName(String name) {
         this.name = name;
+    }
+
+    public static void sortMenuCategories(List<MenuCategory> menuCategories) {
+        Map<String, Integer> priorityMap = new HashMap<>();
+        priorityMap.put("추천 메뉴", 1);
+        priorityMap.put("메인 메뉴", 2);
+        priorityMap.put("세트 메뉴", 3);
+        priorityMap.put("사이드 메뉴", 4);
+        Collections.sort(menuCategories, (cat1, cat2) -> {
+            Integer priority1 = priorityMap.getOrDefault(cat1.getName(), 5);
+            Integer priority2 = priorityMap.getOrDefault(cat2.getName(), 5);
+            return priority1.compareTo(priority2);
+        });
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -57,6 +57,7 @@ public class ShopService {
     public MenuCategoriesResponse getMenuCategories(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
+        MenuCategory.sortMenuCategories(menuCategories);
         return MenuCategoriesResponse.from(menuCategories);
     }
 
@@ -67,9 +68,10 @@ public class ShopService {
     }
 
     public ShopMenuResponse getShopMenus(Integer shopId) {
-        shopRepository.getById(shopId);
-        List<Menu> menus = menuRepository.findAllByShopId(shopId);
-        return ShopMenuResponse.from(menus);
+        Shop shop = shopRepository.getById(shopId);
+        List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
+        MenuCategory.sortMenuCategories(menuCategories);
+        return ShopMenuResponse.from(menuCategories);
     }
 
     public ShopsResponse getShops() {

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -57,7 +57,7 @@ public class ShopService {
     public MenuCategoriesResponse getMenuCategories(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
-        MenuCategory.sortMenuCategories(menuCategories);
+        Collections.sort(menuCategories);
         return MenuCategoriesResponse.from(menuCategories);
     }
 
@@ -70,7 +70,7 @@ public class ShopService {
     public ShopMenuResponse getShopMenus(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
         List<MenuCategory> menuCategories = menuCategoryRepository.findAllByShopId(shop.getId());
-        MenuCategory.sortMenuCategories(menuCategories);
+        Collections.sort(menuCategories);
         return ShopMenuResponse.from(menuCategories);
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -246,11 +246,11 @@ class OwnerShopApiTest extends AcceptanceTest {
                      "menu_categories": [
                          {
                              "id": 1,
-                             "name": "메인메뉴"
+                             "name": "메인 메뉴"
                          },
                          {
                              "id": 2,
-                             "name": "사이드메뉴"
+                             "name": "사이드 메뉴"
                          }
                      ],
                      "name": "마슬랜 치킨",
@@ -302,7 +302,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                      "menu_categories": [
                          {
                              "id": 1,
-                             "name": "메인메뉴",
+                             "name": "메인 메뉴",
                              "menus": [
                                  {
                                      "id": 1,
@@ -356,11 +356,11 @@ class OwnerShopApiTest extends AcceptanceTest {
                     "menu_categories": [
                         {
                             "id": 1,
-                            "name": "메인메뉴"
+                            "name": "메인 메뉴"
                         },
                         {
                             "id": 2,
-                            "name": "사이드메뉴"
+                            "name": "사이드 메뉴"
                         }
                     ]
                 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -194,16 +194,16 @@ class ShopApiTest extends AcceptanceTest {
                     "count": 3,
                     "menu_categories": [
                         {
-                            "id": 1,
-                            "name": "사이드메뉴"
+                            "id": 3,
+                            "name": "추천 메뉴"
                         },
                         {
                             "id": 2,
-                            "name": "세트메뉴"
+                            "name": "세트 메뉴"
                         },
                         {
-                            "id": 3,
-                            "name": "추천메뉴"
+                            "id": 1,
+                            "name": "사이드 메뉴"
                         }
                     ]
                 }
@@ -238,13 +238,13 @@ class ShopApiTest extends AcceptanceTest {
                     ],
                     "menu_categories": [
                         {
-                            "id": 1,
-                            "name": "사이드메뉴"
+                            "id": 2,
+                            "name": "세트 메뉴"
                         },
                         {
-                            "id": 2,
-                            "name": "세트메뉴"
-                        }
+                            "id": 1,
+                            "name": "사이드 메뉴"
+                        }                        
                     ],
                     "name": "마슬랜 치킨",
                     "open": [
@@ -294,7 +294,7 @@ class ShopApiTest extends AcceptanceTest {
                     "menu_categories": [
                         {
                             "id": 1,
-                            "name": "추천메뉴",
+                            "name": "추천 메뉴",
                             "menus": [
                                 {
                                     "id": 1,
@@ -313,7 +313,7 @@ class ShopApiTest extends AcceptanceTest {
                         },
                         {
                             "id": 2,
-                            "name": "세트메뉴",
+                            "name": "세트 메뉴",
                             "menus": [
                                 {
                                     "id": 2,

--- a/src/test/java/in/koreatech/koin/fixture/MenuCategoryFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/MenuCategoryFixture.java
@@ -20,7 +20,7 @@ public class MenuCategoryFixture {
         return menuCategoryRepository.save(
             MenuCategory.builder()
                 .shop(shop)
-                .name("추천메뉴")
+                .name("추천 메뉴")
                 .build()
         );
     }
@@ -29,7 +29,7 @@ public class MenuCategoryFixture {
         return menuCategoryRepository.save(
             MenuCategory.builder()
                 .shop(shop)
-                .name("사이드메뉴")
+                .name("사이드 메뉴")
                 .build()
         );
     }
@@ -38,7 +38,7 @@ public class MenuCategoryFixture {
         return menuCategoryRepository.save(
             MenuCategory.builder()
                 .shop(shop)
-                .name("세트메뉴")
+                .name("세트 메뉴")
                 .build()
         );
     }
@@ -47,7 +47,7 @@ public class MenuCategoryFixture {
         return menuCategoryRepository.save(
             MenuCategory.builder()
                 .shop(shop)
-                .name("메인메뉴")
+                .name("메인 메뉴")
                 .build()
         );
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #468 

# 🚀 작업 내용

1. 메뉴 카테고리가 피그마 UI에 맞게 정렬되어 응답되게 변경하였습니다.
2. 자꾸 테스트가 duplicate menu_category name으로 터지길래 왜그런가 했더니 유니크가 true로 설정되어있었습니다.. 그래서 유니크 false로 바꿔줬습니다(내30분...)
<img width="475" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/127578418/83236969-3729-4764-8f1c-9d2cdf1120c5">

3. 테스트코드에 있는 "추천메뉴", "메인메뉴", "세트메뉴", "사이드메뉴"의 이름에 공백을 추가했습니다. "추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴"


# 💬 리뷰 중점사항
자세한 요구사항은 이슈를 확인부탁드립니다!!
