### PR TITLE
feat: admin으로 학생 정보 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.admin.user.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,6 +34,7 @@ public interface AdminUserApi {
     @PutMapping("/admin/users/student/{id}")
     ResponseEntity<AdminStudentUpdateResponse> updateStudent(
         @Valid @RequestBody AdminStudentUpdateRequest adminRequest,
-        @PathVariable Integer id
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.admin.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Admin) User: 회원", description = "관리자 권한으로 회원 정보를 관리한다")
+public interface AdminUserApi {
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "회원 정보 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PutMapping("/admin/users/student/{id}")
+    ResponseEntity<AdminStudentUpdateResponse> updateStudent(
+        @Valid @RequestBody AdminStudentUpdateRequest adminRequest,
+        @PathVariable Integer id
+    );
+}

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.admin.user.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.service.AdminUserService;
+import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +24,8 @@ public class AdminUserController {
     @PutMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentUpdateResponse> updateStudent(
         @Valid @RequestBody AdminStudentUpdateRequest adminRequest,
-        @PathVariable Integer id
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
     ) {
         AdminStudentUpdateResponse adminStudentUpdateResponse = adminUserService.updateStudent(id, adminRequest);
         return ResponseEntity.ok(adminStudentUpdateResponse);

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.admin.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.service.AdminUserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @PutMapping("/admin/users/student/{id}")
+    public ResponseEntity<AdminStudentUpdateResponse> updateStudent(
+        @Valid @RequestBody AdminStudentUpdateRequest adminRequest,
+        @PathVariable Integer id
+    ) {
+        AdminStudentUpdateResponse adminStudentUpdateResponse = adminUserService.updateStudent(id, adminRequest);
+        return ResponseEntity.ok(adminStudentUpdateResponse);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateRequest.java
@@ -1,0 +1,57 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminStudentUpdateRequest(
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
+    Integer gender,
+
+    @Schema(description = "[NOT UPDATE]신원(학생, 사장님)", example = "학생", requiredMode = NOT_REQUIRED)
+    Integer userIdentity,
+
+    @Schema(description = "[NOT UPDATE]졸업 여부(true, false)", example = "false", requiredMode = NOT_REQUIRED)
+    Boolean isGraduated,
+
+    @Schema(description = """
+        전공
+        - 기계공학부
+        - 컴퓨터공학부
+        - 메카트로닉스공학부
+        - 전기전자통신공학부
+        - 디자인공학부
+        - 건축공학부
+        - 화학생명공학부
+        - 에너지신소재공학부
+        - 산업경영학부
+        - 고용서비스정책학부
+        """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
+    String major,
+
+    @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    String name,
+
+    @Size(message = "SHA 256 해시 알고리즘으로 암호화 된 비밀번호")
+    @Schema(description = "비밀번호", example = "a0240120305812krlakdsflsa;1235", requiredMode = NOT_REQUIRED)
+    String password,
+
+    @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    String nickname,
+
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+    String phoneNumber,
+
+    @Size(min = 10, max = 10, message = "학번은 10자여야 합니다.")
+    @Schema(description = "학번", example = "2020136065", requiredMode = NOT_REQUIRED)
+    String studentNumber
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
@@ -1,0 +1,65 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminStudentUpdateResponse(
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = NOT_REQUIRED)
+    String anonymousNickname,
+
+    @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
+    String email,
+
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
+    Integer gender,
+
+    @Schema(description = """
+        전공
+        - 기계공학부
+        - 컴퓨터공학부
+        - 메카트로닉스공학부
+        - 전기전자통신공학부
+        - 디자인공학부
+        - 건축공학부
+        - 화학생명공학부
+        - 에너지신소재공학부
+        - 산업경영학부
+        - 고용서비스정책학부
+        """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
+    String major,
+
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    String name,
+
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    String nickname,
+
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+    String phoneNumber,
+
+    @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
+    String studentNumber
+) {
+    public static AdminStudentUpdateResponse from(Student student) {
+        User user = student.getUser();
+        Integer userGender = user.getGender() != null ? user.getGender().ordinal() : null;
+        return new AdminStudentUpdateResponse(
+            student.getAnonymousNickname(),
+            user.getEmail(),
+            userGender,
+            student.getDepartment(),
+            user.getName(),
+            user.getNickname(),
+            user.getPhoneNumber(),
+            student.getStudentNumber()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.domain.user.model.Student;
+
+public interface AdminStudentRepository extends Repository<Student, Integer> {
+
+    Student save(Student student);
+
+    Optional<Student> findById(Integer userId);
+
+    default Student getById(Integer userId) {
+        return findById(userId)
+            .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.admin.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.domain.user.model.User;
+
+public interface AdminUserRepository extends Repository<User, Integer> {
+
+    User save(User user);
+
+    Optional<User> findById(Integer id);
+
+    default User getById(Integer userId) {
+        return findById(userId)
+            .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
+    }
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -18,5 +18,5 @@ public interface AdminUserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndIdNot(String nickname, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -41,9 +41,8 @@ public class AdminUserService {
     }
 
     private void checkNicknameDuplication(String nickname, Integer userId) {
-        User checkUser = adminUserRepository.getById(userId);
-        if (nickname != null && !nickname.equals(checkUser.getNickname())
-            && adminUserRepository.existsByNickname(nickname)) {
+        if (nickname != null &&
+            adminUserRepository.existsByNicknameAndIdNot(nickname, userId)) {
             throw DuplicationNicknameException.withDetail("nickname : " + nickname);
         }
     }

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -6,14 +6,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
+import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.user.exception.StudentDepartmentNotValidException;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.StudentDepartment;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
-import in.koreatech.koin.domain.user.repository.StudentRepository;
-import in.koreatech.koin.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,13 +21,13 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AdminUserService {
 
-    private final StudentRepository studentRepository;
-    private final UserRepository userRepository;
+    private final AdminStudentRepository adminStudentRepository;
+    private final AdminUserRepository adminUserRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public AdminStudentUpdateResponse updateStudent(Integer id, AdminStudentUpdateRequest adminRequest) {
-        Student student = studentRepository.getById(id);
+        Student student = adminStudentRepository.getById(id);
         User user = student.getUser();
         checkNicknameDuplication(adminRequest.nickname(), id);
         checkDepartmentValid(adminRequest.major());
@@ -35,15 +35,15 @@ public class AdminUserService {
             adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
         user.updateStudentPassword(passwordEncoder, adminRequest.password());
         student.update(adminRequest.studentNumber(), adminRequest.major());
-        studentRepository.save(student);
+        adminStudentRepository.save(student);
 
         return AdminStudentUpdateResponse.from(student);
     }
 
     public void checkNicknameDuplication(String nickname, Integer userId) {
-        User checkUser = userRepository.getById(userId);
+        User checkUser = adminUserRepository.getById(userId);
         if (nickname != null && !nickname.equals(checkUser.getNickname())
-            && userRepository.existsByNickname(nickname)) {
+            && adminUserRepository.existsByNickname(nickname)) {
             throw DuplicationNicknameException.withDetail("nickname : " + nickname);
         }
     }

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -29,8 +29,8 @@ public class AdminUserService {
     public AdminStudentUpdateResponse updateStudent(Integer id, AdminStudentUpdateRequest adminRequest) {
         Student student = adminStudentRepository.getById(id);
         User user = student.getUser();
-        checkNicknameDuplication(adminRequest.nickname(), id);
-        checkDepartmentValid(adminRequest.major());
+        validateNicknameDuplication(adminRequest.nickname(), id);
+        validateDepartmentValid(adminRequest.major());
         user.update(adminRequest.nickname(), adminRequest.name(),
             adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
         user.updateStudentPassword(passwordEncoder, adminRequest.password());
@@ -40,14 +40,14 @@ public class AdminUserService {
         return AdminStudentUpdateResponse.from(student);
     }
 
-    private void checkNicknameDuplication(String nickname, Integer userId) {
+    private void validateNicknameDuplication(String nickname, Integer userId) {
         if (nickname != null &&
             adminUserRepository.existsByNicknameAndIdNot(nickname, userId)) {
             throw DuplicationNicknameException.withDetail("nickname : " + nickname);
         }
     }
 
-    private void checkDepartmentValid(String department) {
+    private void validateDepartmentValid(String department) {
         if (department != null && !StudentDepartment.isValid(department)) {
             throw StudentDepartmentNotValidException.withDetail("학부(학과) : " + department);
         }

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -1,0 +1,56 @@
+package in.koreatech.koin.admin.user.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
+import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
+import in.koreatech.koin.domain.user.exception.StudentDepartmentNotValidException;
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.StudentDepartment;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.domain.user.repository.StudentRepository;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final StudentRepository studentRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public AdminStudentUpdateResponse updateStudent(Integer id, AdminStudentUpdateRequest adminRequest) {
+        Student student = studentRepository.getById(id);
+        User user = student.getUser();
+        checkNicknameDuplication(adminRequest.nickname(), id);
+        checkDepartmentValid(adminRequest.major());
+        user.update(adminRequest.nickname(), adminRequest.name(),
+            adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
+        user.updateStudentPassword(passwordEncoder, adminRequest.password());
+        student.update(adminRequest.studentNumber(), adminRequest.major());
+        studentRepository.save(student);
+
+        return AdminStudentUpdateResponse.from(student);
+    }
+
+    public void checkNicknameDuplication(String nickname, Integer userId) {
+        User checkUser = userRepository.getById(userId);
+        if (nickname != null && !nickname.equals(checkUser.getNickname())
+            && userRepository.existsByNickname(nickname)) {
+            throw DuplicationNicknameException.withDetail("nickname : " + nickname);
+        }
+    }
+
+    public void checkDepartmentValid(String department) {
+        if (department != null && !StudentDepartment.isValid(department)) {
+            throw StudentDepartmentNotValidException.withDetail("학부(학과) : " + department);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -40,7 +40,7 @@ public class AdminUserService {
         return AdminStudentUpdateResponse.from(student);
     }
 
-    public void checkNicknameDuplication(String nickname, Integer userId) {
+    private void checkNicknameDuplication(String nickname, Integer userId) {
         User checkUser = adminUserRepository.getById(userId);
         if (nickname != null && !nickname.equals(checkUser.getNickname())
             && adminUserRepository.existsByNickname(nickname)) {
@@ -48,7 +48,7 @@ public class AdminUserService {
         }
     }
 
-    public void checkDepartmentValid(String department) {
+    private void checkDepartmentValid(String department) {
         if (department != null && !StudentDepartment.isValid(department)) {
             throw StudentDepartmentNotValidException.withDetail("학부(학과) : " + department);
         }

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
@@ -7,7 +7,8 @@ public enum UserType {
     STUDENT("STUDENT", "학생"),
     OWNER("OWNER", "사장님"),
     COOP("COOP", "영양사"),
-    ADMIN("ADMIN", "어드민");
+    ADMIN("ADMIN", "어드민"),
+    ;
 
     public static final int ANONYMOUS_ID = 0;
 

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
@@ -7,7 +7,7 @@ public enum UserType {
     STUDENT("STUDENT", "학생"),
     OWNER("OWNER", "사장님"),
     COOP("COOP", "영양사"),
-    ;
+    ADMIN("ADMIN", "어드민");
 
     public static final int ANONYMOUS_ID = 0;
 

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -1,0 +1,88 @@
+package in.koreatech.koin.admin.acceptance;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.fixture.UserFixture;
+import in.koreatech.koin.support.JsonAssertions;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class AdminUserApiTest extends AcceptanceTest {
+
+    @Autowired
+    private AdminStudentRepository adminStudentRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Test
+    @DisplayName("관리자가 특정 학생 정보를 수정한다.")
+    void studentUpdateAdmin() {
+        Student student = userFixture.준호_학생();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given().log().all()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .body("""
+                  {
+                    "gender" : 1,
+                    "major" : "기계공학부",
+                    "name" : "서정빈",
+                    "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
+                    "nickname" : "duehee",
+                    "phone_number" : "010-2345-6789",
+                    "student_number" : "2019136136"
+                  }
+                """)
+            .when().log().all()
+            .pathParam("id", student.getUser().getId())
+            .put("/admin/users/student/{id}")
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        transactionTemplate.executeWithoutResult(status -> {
+            Student result = adminStudentRepository.getById(student.getId());
+            SoftAssertions.assertSoftly(
+                softly -> {
+                    softly.assertThat(result.getUser().getName()).isEqualTo("서정빈");
+                    softly.assertThat(result.getUser().getNickname()).isEqualTo("duehee");
+                    softly.assertThat(result.getUser().getGender()).isEqualTo(UserGender.from(1));
+                    softly.assertThat(result.getStudentNumber()).isEqualTo("2019136136");
+                }
+            );
+        });
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                    "anonymous_nickname": "익명",
+                    "email": "juno@koreatech.ac.kr",
+                    "gender": 1,
+                    "major": "기계공학부",
+                    "name": "서정빈",
+                    "nickname": "duehee",
+                    "phone_number": "010-2345-6789",
+                    "student_number": "2019136136"
+                }
+                """);
+    }
+}

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -30,15 +30,15 @@ public class AdminUserApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Test
-    @DisplayName("관리자가 특정 학생 정보를 수정한다.")
-    void studentUpdateAdmin() {
+    @DisplayName("관리자가 특정 학생 정보를 수정한다. - 관리자가 아니면 403 반환")
+    void studentUpdateAdminNoAuth() {
         Student student = userFixture.준호_학생();
 
         User adminUser = userFixture.코인_운영자();
-        String token = userFixture.getToken(adminUser);
+        String token = userFixture.getToken(student.getUser());
 
         var response = RestAssured
-            .given().log().all()
+            .given()
             .header("Authorization", "Bearer " + token)
             .contentType(ContentType.JSON)
             .body("""
@@ -52,10 +52,41 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "student_number" : "2019136136"
                   }
                 """)
-            .when().log().all()
+            .when()
             .pathParam("id", student.getUser().getId())
             .put("/admin/users/student/{id}")
-            .then().log().all()
+            .then()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .extract();
+    }
+
+    @Test
+    @DisplayName("관리자가 특정 학생 정보를 수정한다.")
+    void studentUpdateAdmin() {
+        Student student = userFixture.준호_학생();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .body("""
+                  {
+                    "gender" : 1,
+                    "major" : "기계공학부",
+                    "name" : "서정빈",
+                    "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
+                    "nickname" : "duehee",
+                    "phone_number" : "010-2345-6789",
+                    "student_number" : "2019136136"
+                  }
+                """)
+            .when()
+            .pathParam("id", student.getUser().getId())
+            .put("/admin/users/student/{id}")
+            .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -2,9 +2,7 @@ package in.koreatech.koin.fixture;
 
 import static in.koreatech.koin.domain.user.model.UserGender.MAN;
 import static in.koreatech.koin.domain.user.model.UserIdentity.UNDERGRADUATE;
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,6 +45,22 @@ public final class UserFixture {
         this.ownerRepository = ownerRepository;
         this.studentRepository = studentRepository;
         this.jwtProvider = jwtProvider;
+    }
+
+    public User 코인_운영자() {
+        return userRepository.save(
+            User.builder()
+                .password(passwordEncoder.encode("1234"))
+                .nickname("코인운영자")
+                .name("테스트용_코인운영자")
+                .phoneNumber("010-1234-2344")
+                .userType(ADMIN)
+                .gender(MAN)
+                .email("juno@koreatech.ac.kr")
+                .isAuthed(true)
+                .isDeleted(false)
+                .build()
+        );
     }
 
     public Student 준호_학생() {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #92 

# 🚀 작업 내용

1. 관리자 권한으로 특정 학생 정보를 수정할 수 있게 하였습니다.

# 💬 리뷰 중점사항
우선 관리자 계정이 맞는지 확인하기 위해 @Auth를 썼는데 가져온 관리자 id가 사용이 안되어서 이렇게 해도 되는가 고민이 많이 됩니다.. 관련해서 좋은 의견 있으면 말씀해주시면 감사하겠습니다