### PR TITLE
fix: 시내버스 API 실패시 예외 핸들링

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/util/BusScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/util/BusScheduler.java
@@ -17,7 +17,7 @@ public class BusScheduler {
         cityBusOpenApiClient.storeRemainTimeByOpenApi();
     }
 
-    // 시외버스 Open API 복구되면 주석 해제
+    // TODO: 시외버스 Open API 복구되면 주석 해제
 /*    @Scheduled(cron = "0 0 * * * *")
     public void cacheExpressBusByOpenApi() {
         expressBusOpenApiClient.storeRemainTimeByOpenApi();

--- a/src/main/java/in/koreatech/koin/domain/bus/util/CityBusOpenApiClient.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/util/CityBusOpenApiClient.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.domain.bus.util;
 import static java.net.URLEncoder.encode;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
@@ -27,6 +26,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import in.koreatech.koin.domain.bus.exception.BusOpenApiException;
 import in.koreatech.koin.domain.bus.model.city.CityBusArrival;
 import in.koreatech.koin.domain.bus.model.city.CityBusCache;
 import in.koreatech.koin.domain.bus.model.city.CityBusCacheInfo;
@@ -131,8 +131,8 @@ public class CityBusOpenApiClient {
             input.close();
             conn.disconnect();
             return response.toString();
-        } catch (IOException | NullPointerException e) {
-            return null;
+        } catch (Exception e) {
+            throw BusOpenApiException.withDetail("nodeId: " + nodeId);
         }
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #509 

# 🚀 작업 내용

간헐적으로 시내버스 API 호출에 실패하는 것으로 보입니다.

<img width="779" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/49794401/15a883c4-e727-47ef-9325-117231d77f4b">

1. 시내버스 API 호출 시 예외를 핸들링해줬습니다.

# 💬 리뷰 중점사항
