### PR TITLE
fix : 품절 알림 발송 조건에 날짜 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -31,15 +31,13 @@ public class CoopService {
     public void changeSoldOut(SoldOutRequest soldOutRequest) {
         Dining dining = diningRepository.getById(soldOutRequest.menuId());
         LocalDateTime now = LocalDateTime.now(clock);
-        LocalDate today = now.toLocalDate();
-        LocalTime nowTime = now.toLocalTime();
 
         if (soldOutRequest.soldOut()) {
             dining.setSoldOut(now);
-            LocalTime startTime = dining.getType().getStartTime();
-            LocalTime endTime = dining.getType().getEndTime();
-            if (today.equals(dining.getDate()) && (!nowTime.isBefore(startTime) && !nowTime.isAfter(endTime)) &&
-                diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty()) {
+            LocalDateTime startTime = dining.getType().getStartTime().atDate(now.toLocalDate());
+            LocalDateTime endTime = dining.getType().getEndTime().atDate(now.toLocalDate());
+            if (diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty() &&
+                (!now.isBefore(startTime) && !now.isAfter(endTime))) {
                 eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getPlace(), dining.getType()));
             }
         } else {

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.coop.service;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
@@ -30,14 +31,15 @@ public class CoopService {
     public void changeSoldOut(SoldOutRequest soldOutRequest) {
         Dining dining = diningRepository.getById(soldOutRequest.menuId());
         LocalDateTime now = LocalDateTime.now(clock);
+        LocalDate today = now.toLocalDate();
         LocalTime nowTime = now.toLocalTime();
 
         if (soldOutRequest.soldOut()) {
             dining.setSoldOut(now);
             LocalTime startTime = dining.getType().getStartTime();
             LocalTime endTime = dining.getType().getEndTime();
-            if (diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty() &&
-                (!nowTime.isBefore(startTime) && !nowTime.isAfter(endTime))) {
+            if (today.equals(dining.getDate()) && (!nowTime.isBefore(startTime) && !nowTime.isAfter(endTime)) &&
+                diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty()) {
                 eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getPlace(), dining.getType()));
             }
         } else {

--- a/src/main/java/in/koreatech/koin/domain/dining/model/DiningType.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/model/DiningType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum DiningType {
-    BREAKFAST("아침", LocalTime.of(8, 30), LocalTime.of(9, 30)),
+    BREAKFAST("아침", LocalTime.of(8, 0), LocalTime.of(9, 30)),
     LUNCH("점심", LocalTime.of(11, 30), LocalTime.of(13, 30)),
     DINNER("저녁", LocalTime.of(17, 30), LocalTime.of(18, 30)),
     ;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 품절 알림 발송 조건에 날짜도 추가하였습니다.
- 각 코너에 대해 `최초 1회`, `오늘 날짜`, `해당 식사시간 내` 에만 발송 됩니다.

# 💬 리뷰 중점사항
