### PR TITLE
fix : notification FK 회원 삭제 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -136,6 +136,7 @@ public interface UserApi {
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", content = @Content(schema = @Schema(hidden = true)))
         }
     )
     @Operation(summary = "회원가입")

--- a/src/main/resources/db/migration/V15__delete_notification_subscribe.sql
+++ b/src/main/resources/db/migration/V15__delete_notification_subscribe.sql
@@ -1,0 +1,16 @@
+ALTER TABLE `koin`.`notification_subscribe`
+DROP FOREIGN KEY `FK_NOTIFICATION_SUBSCRIBE_ON_USER`;
+ALTER TABLE `koin`.`notification_subscribe`
+    ADD CONSTRAINT `FK_NOTIFICATION_SUBSCRIBE_ON_USER`
+        FOREIGN KEY (`user_id`)
+            REFERENCES `koin`.`users` (`id`)
+            ON DELETE CASCADE
+            ON UPDATE RESTRICT;
+
+ALTER TABLE `koin`.`notification`
+DROP FOREIGN KEY `FK_NOTIFICATION_ON_USER FOREIGN KEY`;
+ALTER TABLE `koin`.`notification`
+    ADD CONSTRAINT `FK_NOTIFICATION_ON_USER FOREIGN KEY`
+        FOREIGN KEY (`users_id`)
+            REFERENCES `koin`.`users` (`id`)
+            ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V15__delete_notification_subscribe.sql
+++ b/src/main/resources/db/migration/V15__delete_notification_subscribe.sql
@@ -1,15 +1,15 @@
-ALTER TABLE `koin`.`notification_subscribe`
+ALTER TABLE `notification_subscribe`
 DROP FOREIGN KEY `FK_NOTIFICATION_SUBSCRIBE_ON_USER`;
-ALTER TABLE `koin`.`notification_subscribe`
+ALTER TABLE `notification_subscribe`
     ADD CONSTRAINT `FK_NOTIFICATION_SUBSCRIBE_ON_USER`
         FOREIGN KEY (`user_id`)
             REFERENCES `koin`.`users` (`id`)
             ON DELETE CASCADE
             ON UPDATE RESTRICT;
 
-ALTER TABLE `koin`.`notification`
+ALTER TABLE `notification`
 DROP FOREIGN KEY `FK_NOTIFICATION_ON_USER FOREIGN KEY`;
-ALTER TABLE `koin`.`notification`
+ALTER TABLE `notification`
     ADD CONSTRAINT `FK_NOTIFICATION_ON_USER FOREIGN KEY`
         FOREIGN KEY (`users_id`)
             REFERENCES `koin`.`users` (`id`)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #513 

# 🚀 작업 내용

1. notification / notification_subscribe에 대해 FK 오류 수정을 위해 DELETE CASCADE flyway sql문을 추가했습니다.

# 💬 리뷰 중점사항
FK에 관해서 CASCADE 처리를 현재 notification과 notification_subscribe에 적용시켰는데, 다른 부분에도 이를 적용해도 되는지, 그리고 추가적으로 CASCADE 처리를 다른 FK 값에 대해서 진행하는 것이 안전한가? 에 대해서 의논이 필요할 것 같습니다.(선권씨 입장)
확인하신다면 의견 부탁드립니당.