### PR TITLE
feat: 어드민 계정으로 특정 학생 조회

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandApi.java
+++ b/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandApi.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.admin.land.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin.admin.land.dto.AdminLandsRequest;
 import in.koreatech.koin.admin.land.dto.AdminLandsResponse;
 
+import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,7 +35,8 @@ public interface AdminLandApi {
     ResponseEntity<AdminLandsResponse> getLands(
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
-        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 
     @ApiResponses(
@@ -46,7 +50,8 @@ public interface AdminLandApi {
     @Operation(summary = "복덕방 생성")
     @PostMapping("/admin/lands")
     ResponseEntity<AdminLandsResponse> postLands(
-        @RequestBody @Valid AdminLandsRequest adminLandsRequest
+        @RequestBody @Valid AdminLandsRequest adminLandsRequest,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 
 }

--- a/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandApi.java
+++ b/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -31,6 +32,7 @@ public interface AdminLandApi {
         }
     )
     @Operation(summary = "복덕방 목록 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/lands")
     ResponseEntity<AdminLandsResponse> getLands(
         @RequestParam(name = "page", defaultValue = "1") Integer page,
@@ -48,6 +50,7 @@ public interface AdminLandApi {
         }
     )
     @Operation(summary = "복덕방 생성")
+    @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/admin/lands")
     ResponseEntity<AdminLandsResponse> postLands(
         @RequestBody @Valid AdminLandsRequest adminLandsRequest,

--- a/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandController.java
+++ b/src/main/java/in/koreatech/koin/admin/land/controller/AdminLandController.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.admin.land.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin.admin.land.dto.AdminLandsRequest;
 import in.koreatech.koin.admin.land.dto.AdminLandsResponse;
 import in.koreatech.koin.admin.land.service.AdminLandService;
+import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -24,13 +27,17 @@ public class AdminLandController implements AdminLandApi {
     public ResponseEntity<AdminLandsResponse> getLands(
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
-        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted,
+        @Auth(permit = {ADMIN}) Integer adminId
     ) {
         return ResponseEntity.ok().body(adminLandService.getLands(page, limit, isDeleted));
     }
 
     @PostMapping("/admin/lands")
-    public ResponseEntity<AdminLandsResponse> postLands(@RequestBody @Valid AdminLandsRequest adminLandsRequest) {
+    public ResponseEntity<AdminLandsResponse> postLands(
+        @RequestBody @Valid AdminLandsRequest adminLandsRequest,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
         adminLandService.createLands(adminLandsRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -1,11 +1,14 @@
 package in.koreatech.koin.admin.member.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
+import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,6 +31,7 @@ public interface AdminMemberApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
         @RequestParam(name = "track") TrackTag track,
-        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "(Admin) AdminLand: BCSDLab 회원", description = "관리자 권한으로 BCSDLab 회원 정보를 관리한다")
@@ -26,6 +27,7 @@ public interface AdminMemberApi {
         }
     )
     @Operation(summary = "페이지별 BCSDLab 회원 리스트 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/members")
     ResponseEntity<AdminMembersResponse> getMembers(
         @RequestParam(name = "page", defaultValue = "1") Integer page,

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.admin.member.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
 import in.koreatech.koin.admin.member.service.AdminMemberService;
+import in.koreatech.koin.global.auth.Auth;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,7 +24,8 @@ public class AdminMemberController implements AdminMemberApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
         @RequestParam(name = "track") TrackTag track,
-        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted
+        @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted,
+        @Auth(permit = {ADMIN}) Integer adminId
     ) {
         return ResponseEntity.ok().body(adminMemberService.getMembers(page, limit, track, isDeleted));
     }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -3,10 +3,12 @@ package in.koreatech.koin.admin.user.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.global.auth.Auth;
@@ -30,6 +32,23 @@ public interface AdminUserApi {
         }
     )
     @Operation(summary = "회원 정보 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/admin/users/student/{id}")
+    ResponseEntity<AdminStudentResponse> getStudent(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "회원 정보 수정")
     @SecurityRequirement(name = "Jwt Authentication")
     @PutMapping("/admin/users/student/{id}")
     ResponseEntity<AdminStudentUpdateResponse> updateStudent(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -39,7 +39,6 @@ public interface AdminUserApi {
         @Auth(permit = {ADMIN}) Integer adminId
     );
 
-
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "200"),

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -3,11 +3,13 @@ package in.koreatech.koin.admin.user.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.service.AdminUserService;
@@ -20,6 +22,15 @@ import lombok.RequiredArgsConstructor;
 public class AdminUserController {
 
     private final AdminUserService adminUserService;
+
+    @GetMapping("/admin/users/student/{id}")
+    public ResponseEntity<AdminStudentResponse> getStudent(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminStudentResponse adminStudentResponse = adminUserService.getStudent(id);
+        return ResponseEntity.ok(adminStudentResponse);
+    };
 
     @PutMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentUpdateResponse> updateStudent(

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.admin.user.dto;
+
+import java.time.LocalDateTime;
+
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+
+public record AdminStudentResponse (
+    Integer id,
+    String nickname,
+    String name,
+    String phoneNumber,
+    String userType,
+    String email,
+    Integer gender,
+    Boolean isAuthed,
+    LocalDateTime lastLoggedAt,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    String anonymousNickname,
+    String studentNumber,
+    String major,
+    Boolean isGraduated
+) {
+    public static AdminStudentResponse from(Student student) {
+        User user = student.getUser();
+        return new AdminStudentResponse(
+            user.getId(),
+            user.getNickname(),
+            user.getName(),
+            user.getPhoneNumber(),
+            user.getUserType().toString(),
+            user.getEmail(),
+            user.getGender().ordinal(),
+            user.isAuthed(),
+            user.getLastLoggedAt(),
+            user.getCreatedAt(),
+            user.getUpdatedAt(),
+            student.getAnonymousNickname(),
+            student.getStudentNumber(),
+            student.getDepartment(),
+            student.isGraduated()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
@@ -19,13 +19,13 @@ public record AdminStudentResponse (
     @Schema(description = "id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
-    @Schema(description = "닉네임", example = "seongjae", requiredMode = REQUIRED)
+    @Schema(description = "닉네임", example = "seongjae", requiredMode = NOT_REQUIRED)
     String nickname,
 
-    @Schema(description = "이름", example = "김성재", requiredMode = REQUIRED)
+    @Schema(description = "이름", example = "김성재", requiredMode = NOT_REQUIRED)
     String name,
 
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
     String phoneNumber,
 
     @Schema(description = "유저 타입", example = "STUDENT", requiredMode = REQUIRED)
@@ -34,14 +34,14 @@ public record AdminStudentResponse (
     @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     String email,
 
-    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
     Integer gender,
 
     @Schema(description = "인증 여부", example = "true", requiredMode = REQUIRED)
     Boolean isAuthed,
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    @Schema(description = "마지막 로그인 시간", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
+    @Schema(description = "마지막 로그인 시간", example = "2024-01-15 12:00:00", requiredMode = NOT_REQUIRED)
     LocalDateTime lastLoggedAt,
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -52,10 +52,10 @@ public record AdminStudentResponse (
     @Schema(description = "수정 일자", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
     LocalDateTime updatedAt,
 
-    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = REQUIRED)
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = NOT_REQUIRED)
     String anonymousNickname,
 
-    @Schema(description = "학번", example = "2020174015", requiredMode = REQUIRED)
+    @Schema(description = "학번", example = "2020174015", requiredMode = NOT_REQUIRED)
     String studentNumber,
 
     @Schema(description = """
@@ -70,19 +70,14 @@ public record AdminStudentResponse (
         - 에너지신소재공학부
         - 산업경영학부
         - 고용서비스정책학부
-        """, example = "컴퓨터공학부", requiredMode = REQUIRED)
+        """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
     String major,
 
-    @Schema(description = "졸업 여부", example = "false", requiredMode = REQUIRED)
+    @Schema(description = "졸업 여부", example = "false", requiredMode = NOT_REQUIRED)
     Boolean isGraduated
 ) {
     public static AdminStudentResponse from(Student student) {
-        Integer userGender = null;
-
         User user = student.getUser();
-        if (user.getGender() != null) {
-            userGender = user.getGender().ordinal();
-        }
 
         return new AdminStudentResponse(
             user.getId(),
@@ -91,7 +86,7 @@ public record AdminStudentResponse (
             user.getPhoneNumber(),
             user.getUserType().toString(),
             user.getEmail(),
-            userGender,
+            user.getGender() == null ? null : user.getGender().ordinal(),
             user.isAuthed(),
             user.getLastLoggedAt(),
             user.getCreatedAt(),

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
@@ -2,9 +2,13 @@ package in.koreatech.koin.admin.user.dto;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.User;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminStudentResponse (
     Integer id,
     String nickname,

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
@@ -1,29 +1,79 @@
 package in.koreatech.koin.admin.user.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminStudentResponse (
+
+    @Schema(description = "id", example = "1", requiredMode = REQUIRED)
     Integer id,
+
+    @Schema(description = "닉네임", example = "seongjae", requiredMode = REQUIRED)
     String nickname,
+
+    @Schema(description = "이름", example = "김성재", requiredMode = REQUIRED)
     String name,
+
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
     String phoneNumber,
+
+    @Schema(description = "유저 타입", example = "STUDENT", requiredMode = REQUIRED)
     String userType,
+
+    @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     String email,
+
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = REQUIRED)
     Integer gender,
+
+    @Schema(description = "인증 여부", example = "true", requiredMode = REQUIRED)
     Boolean isAuthed,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "마지막 로그인 시간", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
     LocalDateTime lastLoggedAt,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "생성 일자", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
     LocalDateTime createdAt,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "수정 일자", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
     LocalDateTime updatedAt,
+
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = REQUIRED)
     String anonymousNickname,
+
+    @Schema(description = "학번", example = "2020174015", requiredMode = REQUIRED)
     String studentNumber,
+
+    @Schema(description = """
+        전공
+        - 기계공학부
+        - 컴퓨터공학부
+        - 메카트로닉스공학부
+        - 전기전자통신공학부
+        - 디자인공학부
+        - 건축공학부
+        - 화학생명공학부
+        - 에너지신소재공학부
+        - 산업경영학부
+        - 고용서비스정책학부
+        """, example = "컴퓨터공학부", requiredMode = REQUIRED)
     String major,
+
+    @Schema(description = "졸업 여부", example = "false", requiredMode = REQUIRED)
     Boolean isGraduated
 ) {
     public static AdminStudentResponse from(Student student) {

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentResponse.java
@@ -77,7 +77,13 @@ public record AdminStudentResponse (
     Boolean isGraduated
 ) {
     public static AdminStudentResponse from(Student student) {
+        Integer userGender = null;
+
         User user = student.getUser();
+        if (user.getGender() != null) {
+            userGender = user.getGender().ordinal();
+        }
+
         return new AdminStudentResponse(
             user.getId(),
             user.getNickname(),
@@ -85,7 +91,7 @@ public record AdminStudentResponse (
             user.getPhoneNumber(),
             user.getUserType().toString(),
             user.getEmail(),
-            user.getGender().ordinal(),
+            userGender,
             user.isAuthed(),
             user.getLastLoggedAt(),
             user.getCreatedAt(),

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
@@ -12,13 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminStudentUpdateResponse(
-    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = NOT_REQUIRED)
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = REQUIRED)
     String anonymousNickname,
 
     @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     String email,
 
-    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = REQUIRED)
     Integer gender,
 
     @Schema(description = """
@@ -33,19 +33,19 @@ public record AdminStudentUpdateResponse(
         - 에너지신소재공학부
         - 산업경영학부
         - 고용서비스정책학부
-        """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
+        """, example = "컴퓨터공학부", requiredMode = REQUIRED)
     String major,
 
-    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
     String name,
 
-    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    @Schema(description = "닉네임", example = "juno", requiredMode = REQUIRED)
     String nickname,
 
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
     String phoneNumber,
 
-    @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
+    @Schema(description = "학번", example = "2029136012", requiredMode = REQUIRED)
     String studentNumber
 ) {
     public static AdminStudentUpdateResponse from(Student student) {

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
@@ -12,13 +12,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminStudentUpdateResponse(
-    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = REQUIRED)
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = NOT_REQUIRED)
     String anonymousNickname,
 
     @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     String email,
 
-    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
     Integer gender,
 
     @Schema(description = """
@@ -33,28 +33,28 @@ public record AdminStudentUpdateResponse(
         - 에너지신소재공학부
         - 산업경영학부
         - 고용서비스정책학부
-        """, example = "컴퓨터공학부", requiredMode = REQUIRED)
+        """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
     String major,
 
-    @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
     String name,
 
-    @Schema(description = "닉네임", example = "juno", requiredMode = REQUIRED)
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
     String nickname,
 
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
     String phoneNumber,
 
-    @Schema(description = "학번", example = "2029136012", requiredMode = REQUIRED)
+    @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
     String studentNumber
 ) {
     public static AdminStudentUpdateResponse from(Student student) {
         User user = student.getUser();
-        Integer userGender = user.getGender() != null ? user.getGender().ordinal() : null;
+
         return new AdminStudentUpdateResponse(
             student.getAnonymousNickname(),
             user.getEmail(),
-            userGender,
+            user.getGender() != null ? user.getGender().ordinal() : null,
             student.getDepartment(),
             user.getName(),
             user.getNickname(),

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -4,6 +4,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
@@ -24,6 +25,11 @@ public class AdminUserService {
     private final AdminStudentRepository adminStudentRepository;
     private final AdminUserRepository adminUserRepository;
     private final PasswordEncoder passwordEncoder;
+
+    public AdminStudentResponse getStudent(Integer userId) {
+        Student student = adminStudentRepository.getById(userId);
+        return AdminStudentResponse.from(student);
+    }
 
     @Transactional
     public AdminStudentUpdateResponse updateStudent(Integer id, AdminStudentUpdateRequest adminRequest) {

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminLandApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminLandApiTest.java
@@ -19,6 +19,8 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.admin.land.dto.AdminLandsRequest;
 import in.koreatech.koin.admin.land.repository.AdminLandRepository;
 import in.koreatech.koin.domain.land.model.Land;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.UserFixture;
 import io.restassured.RestAssured;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -26,6 +28,9 @@ class AdminLandApiTest extends AcceptanceTest {
 
     @Autowired
     private AdminLandRepository adminLandRepository;
+
+    @Autowired
+    private UserFixture userFixture;
 
     @Test
     @DisplayName("관리자 권한으로 복덕방 목록을 검색한다.")
@@ -44,8 +49,12 @@ class AdminLandApiTest extends AcceptanceTest {
             adminLandRepository.save(request);
         }
 
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
         var response = RestAssured
             .given()
+            .header("Authorization", "Bearer " + token)
             .when()
             .param("page", 1)
             .param("is_deleted", false)
@@ -96,8 +105,12 @@ class AdminLandApiTest extends AcceptanceTest {
     }
     """;
 
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
         RestAssured
             .given()
+            .header("Authorization", "Bearer " + token)
             .contentType("application/json")
             .body(jsonBody)
             .when()

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatus;
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.member.model.Track;
 import in.koreatech.koin.domain.member.repository.TrackRepository;
+import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.MemberFixture;
 import in.koreatech.koin.fixture.TrackFixture;
+import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
 
@@ -23,13 +25,20 @@ public class AdminMemberApiTest extends AcceptanceTest {
     @Autowired
     private TrackFixture trackFixture;
 
+    @Autowired
+    private UserFixture userFixture;
+
     @Test
     @DisplayName("BCSDLab 회원들의 정보를 조회한다")
     void getMembers() {
         memberFixture.최준호(trackFixture.backend());
 
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
         var response = RestAssured
             .given()
+            .header("Authorization", "Bearer " + token)
             .when()
             .param("page", 1)
             .param("track", "BACKEND")

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -30,34 +30,62 @@ public class AdminUserApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Test
-    @DisplayName("관리자가 특정 학생 정보를 수정한다. - 관리자가 아니면 403 반환")
+    @DisplayName("관리자가 특정 학생 정보를 조회한다. - 관리자가 아니면 403 반환")
     void studentUpdateAdminNoAuth() {
         Student student = userFixture.준호_학생();
-
-        User adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(student.getUser());
 
         var response = RestAssured
             .given()
             .header("Authorization", "Bearer " + token)
             .contentType(ContentType.JSON)
-            .body("""
-                  {
-                    "gender" : 1,
-                    "major" : "기계공학부",
-                    "name" : "서정빈",
-                    "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
-                    "nickname" : "duehee",
-                    "phone_number" : "010-2345-6789",
-                    "student_number" : "2019136136"
-                  }
-                """)
             .when()
             .pathParam("id", student.getUser().getId())
-            .put("/admin/users/student/{id}")
+            .get("/admin/users/student/{id}")
             .then()
             .statusCode(HttpStatus.FORBIDDEN.value())
             .extract();
+    }
+
+    @Test
+    @DisplayName("관리자가 특정 학생 정보를 조회한다.")
+    void studentGetAdmin() {
+        Student student = userFixture.준호_학생();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .when()
+            .pathParam("id", student.getUser().getId())
+            .get("/admin/users/student/{id}")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                    "anonymous_nickname": "익명",
+                    "created_at": "2024-01-15T12:00:00",
+                    "email": "juno@koreatech.ac.kr",
+                    "gender": 0,
+                    "id": 1,
+                    "is_authed": true,
+                    "is_graduated": false,
+                    "last_logged_at": null,
+                    "major": "컴퓨터공학부",
+                    "name": "테스트용_준호",
+                    "nickname": "준호",
+                    "phone_number": "010-1234-5678",
+                    "student_number": "2019136135",
+                    "updated_at": "2024-01-15T12:00:00",
+                    "user_type": "STUDENT"
+                }
+                """);
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -70,7 +70,7 @@ public class AdminUserApiTest extends AcceptanceTest {
             .isEqualTo("""
                 {
                     "anonymous_nickname": "익명",
-                    "created_at": "2024-01-15T12:00:00",
+                    "created_at": "2024-01-15 12:00:00",
                     "email": "juno@koreatech.ac.kr",
                     "gender": 0,
                     "id": 1,
@@ -82,7 +82,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "nickname": "준호",
                     "phone_number": "010-1234-5678",
                     "student_number": "2019136135",
-                    "updated_at": "2024-01-15T12:00:00",
+                    "updated_at": "2024-01-15 12:00:00",
                     "user_type": "STUDENT"
                 }
                 """);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #91

# 🚀 작업 내용

1. 어드민 계정으로 특정 학생 조회 api를 구현 했습니다.
2. 전에 구현된 어드민 api들도 @auth를 붙여서 권한 필터링 되게 해줬습니다.

# 💬 리뷰 중점사항
