### PR TITLE
feat: 가입 신청한 사장님 페이지네이션 조회(Admin)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
@@ -52,6 +53,8 @@ public interface AdminUserApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/users/new-owners")
     ResponseEntity<AdminNewOwnersResponse> getNewOwners(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -3,10 +3,12 @@ package in.koreatech.koin.admin.user.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.global.auth.Auth;
@@ -35,6 +37,21 @@ public interface AdminUserApi {
     ResponseEntity<AdminStudentUpdateResponse> updateStudent(
         @Valid @RequestBody AdminStudentUpdateRequest adminRequest,
         @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "가입 신청한 사장님 리스트 조회 (페이지네이션)")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/admin/users/new-owners")
+    ResponseEntity<AdminNewOwnersResponse> getNewOwners(
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -3,13 +3,18 @@ package in.koreatech.koin.admin.user.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
@@ -29,5 +34,13 @@ public class AdminUserController {
     ) {
         AdminStudentUpdateResponse adminStudentUpdateResponse = adminUserService.updateStudent(id, adminRequest);
         return ResponseEntity.ok(adminStudentUpdateResponse);
+    }
+
+    @GetMapping("/admin/users/new-owners")
+    public ResponseEntity<AdminNewOwnersResponse> getNewOwners(
+        @ModelAttribute NewOwnersCondition newOwnersCondition,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        return ResponseEntity.ok().body(adminUserService.getNewOwners(newOwnersCondition));
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminNewOwnersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminNewOwnersResponse.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.admin.user.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
@@ -43,16 +44,16 @@ public record AdminNewOwnersResponse(
         @Schema(description = "이메일", requiredMode = REQUIRED)
         String email,
 
-        @Schema(description = "이름")
+        @Schema(description = "이름", requiredMode = NOT_REQUIRED)
         String name,
 
-        @Schema(description = "전화번호")
+        @Schema(description = "전화번호", requiredMode = NOT_REQUIRED)
         String phoneNumber,
 
-        @Schema(description = "요청한 상점ID")
+        @Schema(description = "요청한 상점ID", requiredMode = NOT_REQUIRED)
         Integer shopId,
 
-        @Schema(description = "요청한 상점명")
+        @Schema(description = "요청한 상점명", requiredMode = NOT_REQUIRED)
         String shopName,
 
         @Schema(description = "가입 신청 일자", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminNewOwnersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminNewOwnersResponse.java
@@ -1,0 +1,56 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminNewOwnersResponse(
+    @Schema(description = "조건에 해당하는 총 사장님의 수", example = "57", requiredMode = REQUIRED)
+    Integer totalCount,
+
+    @Schema(description = "조건에 해당하는 사장님중에 현재 페이지에서 조회된 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "조건에 해당하는 사장님들을 조회할 수 있는 최대 페이지", example = "6", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "2", requiredMode = REQUIRED)
+    Integer currentPage,
+
+    @Schema(description = "사장님 리스트", requiredMode = REQUIRED)
+    List<InnerNewOwnerResponse> owners
+) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    private record InnerNewOwnerResponse(
+        @Schema(description = "고유 id", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "이메일", requiredMode = REQUIRED)
+        String email,
+
+        @Schema(description = "이름")
+        String name,
+
+        @Schema(description = "전화번호")
+        String phoneNumber,
+
+        @Schema(description = "요청한 상점ID")
+        Integer shopId,
+
+        @Schema(description = "요청한 상점명")
+        String shopName,
+
+        @Schema(description = "가입 신청 일자", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/NewOwnersCondition.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/NewOwnersCondition.java
@@ -1,0 +1,91 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import java.util.Objects;
+
+import org.springframework.data.domain.Sort.Direction;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+import in.koreatech.koin.global.model.Criteria;
+import io.micrometer.common.util.StringUtils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record NewOwnersCondition(
+    @Schema(description = "페이지", example = "1", defaultValue = "1")
+    Integer page,
+
+    @Schema(description = "페이지당 조회할 최대 개수", example = "10", defaultValue = "10")
+    Integer limit,
+
+    @Schema(description = "검색 대상[`EMAIL` (이메일 검색), NAME` (이름 검색)]", example = "EMAIL", requiredMode = NOT_REQUIRED)
+    SearchType searchType,
+
+    @Schema(description = "검색 문자열", requiredMode = NOT_REQUIRED)
+    String query,
+
+    @Schema(description = "정렬 기준['CREATED_AT_ASC` (오래된순), 'CREATED_AT_DESC` (최신순)]", example = "CREATED_AT_ASC", defaultValue = "CREATED_AT_ASC")
+    Sort sort
+) {
+    @Builder
+    public NewOwnersCondition {
+        if (Objects.isNull(page)) {
+            page = Criteria.DEFAULT_PAGE;
+        }
+        if (Objects.isNull(limit)) {
+            limit = Criteria.DEFAULT_LIMIT;
+        }
+        if (Objects.isNull(sort)) {
+            sort = Sort.CREATED_AT_ASC;
+        }
+    }
+
+    public enum SearchType {
+        EMAIL,
+        NAME
+    }
+
+    public enum Sort {
+        CREATED_AT_ASC,
+        CREATED_AT_DESC
+    }
+
+    public void checkDataConstraintViolation() {
+        if (this.query != null) {
+            checkSearchTypeNotNull();
+            checkQueryIsEmpty();
+            checkQueryIsBlank();
+        }
+    }
+
+    public Direction getDirection() {
+        if (this.sort == Sort.CREATED_AT_ASC) {
+            return Direction.ASC;
+        } else {
+            return Direction.DESC;
+        }
+    }
+
+    private void checkSearchTypeNotNull() {
+        if (this.searchType == null) {
+            throw new KoinIllegalArgumentException("검색 내용이 존재할 경우 검색 대상은 필수입니다.");
+        }
+    }
+
+    private void checkQueryIsEmpty() {
+        if (this.query.length() == 0) {
+            throw new KoinIllegalArgumentException("검색 내용의 최소 길이는 1입니다.");
+        }
+    }
+
+    private void checkQueryIsBlank() {
+        if (StringUtils.isBlank(this.query)) {
+            throw new KoinIllegalArgumentException("검색 내용은 공백 문자로만 이루어져 있으면 안됩니다.");
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminOwnerRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminOwnerRepository.java
@@ -1,0 +1,35 @@
+package in.koreatech.koin.admin.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.owner.exception.OwnerNotFoundException;
+import in.koreatech.koin.domain.owner.model.Owner;
+import io.lettuce.core.dynamic.annotation.Param;
+
+public interface AdminOwnerRepository extends Repository<Owner, Integer> {
+
+    Optional<Owner> findById(Integer ownerId);
+
+    Owner save(Owner owner);
+
+    @Query("SELECT COUNT(o) FROM Owner o WHERE o.user.userType = 'OWNER' AND o.user.isAuthed = false")
+    Integer findUnauthenticatedOwnersCount();
+
+    @Query("SELECT o FROM Owner o WHERE o.user.userType = 'OWNER' AND o.user.isAuthed = false")
+    Page<Owner> findPageUnauthenticatedOwners(Pageable pageable);
+
+    @Query("SELECT o FROM Owner o WHERE o.user.userType = 'OWNER' AND o.user.isAuthed = false AND o.user.email LIKE CONCAT('%', :query, '%')")
+    Page<Owner> findPageUnauthenticatedOwnersByEmail(@Param("query") String query, Pageable pageable);
+
+    @Query("SELECT o FROM Owner o WHERE o.user.userType = 'OWNER' AND o.user.isAuthed = false AND o.user.name LIKE CONCAT('%', :query, '%')")
+    Page<Owner> findPageUnauthenticatedOwnersByName(@Param("query") String query, Pageable pageable);
+
+    default Owner getById(Integer ownerId) {
+        return findById(ownerId).orElseThrow(() -> OwnerNotFoundException.withDetail("ownerId: " + ownerId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminShopRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminShopRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.admin.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.shop.model.Shop;
+
+public interface AdminShopRepository extends Repository<Shop, Integer> {
+
+    List<Shop> findAllByOwnerId(Integer ownerId);
+}

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -1,19 +1,33 @@
 package in.koreatech.koin.admin.user.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
+import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
+import in.koreatech.koin.admin.user.repository.AdminShopRepository;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
+import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;
+import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.user.exception.StudentDepartmentNotValidException;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.StudentDepartment;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.global.model.Criteria;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,7 +36,9 @@ import lombok.RequiredArgsConstructor;
 public class AdminUserService {
 
     private final AdminStudentRepository adminStudentRepository;
+    private final AdminOwnerRepository adminOwnerRepository;
     private final AdminUserRepository adminUserRepository;
+    private final AdminShopRepository adminShopRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -38,6 +54,39 @@ public class AdminUserService {
         adminStudentRepository.save(student);
 
         return AdminStudentUpdateResponse.from(student);
+    }
+
+    public AdminNewOwnersResponse getNewOwners(NewOwnersCondition newOwnersCondition) {
+        newOwnersCondition.checkDataConstraintViolation();
+
+        Integer totalOwners = adminOwnerRepository.findUnauthenticatedOwnersCount();
+        Criteria criteria = Criteria.of(newOwnersCondition.page(), newOwnersCondition.limit(), totalOwners);
+        Sort.Direction direction = newOwnersCondition.getDirection();
+
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), Sort.by(direction, "user.createdAt"));
+        Page<Owner> result;
+
+        if (newOwnersCondition.searchType() == NewOwnersCondition.SearchType.EMAIL) {
+            result = adminOwnerRepository.findPageUnauthenticatedOwnersByEmail(newOwnersCondition.query(),
+                pageRequest);
+        } else if (newOwnersCondition.searchType() == NewOwnersCondition.SearchType.NAME) {
+            result = adminOwnerRepository.findPageUnauthenticatedOwnersByName(newOwnersCondition.query(),
+                pageRequest);
+        } else {
+            result = adminOwnerRepository.findPageUnauthenticatedOwners(pageRequest);
+        }
+
+        List<OwnerIncludingShop> ownerIncludingShop = new ArrayList<>();
+        for(Owner owner : result.getContent()) {
+            List<Shop> shops = adminShopRepository.findAllByOwnerId(owner.getId());
+            if (shops.isEmpty()) {
+                ownerIncludingShop.add(OwnerIncludingShop.of(owner));
+            } else {
+                shops.forEach(shop -> ownerIncludingShop.add(OwnerIncludingShop.of(owner, shop)));
+            }
+        }
+
+        return AdminNewOwnersResponse.of(result, criteria, ownerIncludingShop);
     }
 
     private void validateNicknameDuplication(String nickname, Integer userId) {

--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerIncludingShop.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerIncludingShop.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.domain.owner.model;
+
+import in.koreatech.koin.domain.shop.model.Shop;
+import lombok.Getter;
+
+@Getter
+public class OwnerIncludingShop {
+
+    private Owner owner;
+    private Integer shop_id;
+    private String shop_name;
+
+    public OwnerIncludingShop(Owner owner, Integer shop_id, String shop_name) {
+        this.owner = owner;
+        this.shop_id = shop_id;
+        this.shop_name = shop_name;
+    }
+
+    public static OwnerIncludingShop of(Owner owner, Shop shop) {
+        return new OwnerIncludingShop(
+            owner,
+            shop.getId(),
+            shop.getName()
+        );
+    }
+
+    public static OwnerIncludingShop of(Owner owner) {
+        return new OwnerIncludingShop(
+            owner,
+            null,
+            null
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/model/Criteria.java
+++ b/src/main/java/in/koreatech/koin/global/model/Criteria.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class Criteria {
-    private static final Integer DEFAULT_PAGE = 1;
+    public static final Integer DEFAULT_PAGE = 1;
     private static final Integer MIN_PAGE = 1;
 
-    private static final Integer DEFAULT_LIMIT = 10;
+    public static final Integer DEFAULT_LIMIT = 10;
     private static final Integer MIN_LIMIT = 1;
     private static final Integer MAX_LIMIT = 50;
 

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -1,17 +1,29 @@
 package in.koreatech.koin.admin.acceptance;
 
+import static in.koreatech.koin.domain.user.model.UserGender.MAN;
+import static in.koreatech.koin.domain.user.model.UserType.OWNER;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.List;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
+import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.owner.model.OwnerAttachment;
+import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.fixture.ShopFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
@@ -24,10 +36,19 @@ public class AdminUserApiTest extends AcceptanceTest {
     private AdminStudentRepository adminStudentRepository;
 
     @Autowired
+    private AdminOwnerRepository adminOwnerRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
+    private ShopFixture shopFixture;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("관리자가 특정 학생 정보를 수정한다. - 관리자가 아니면 403 반환")
@@ -115,5 +136,121 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "student_number": "2019136136"
                 }
                 """);
+    }
+
+    @Test
+    @DisplayName("관리자가 가입 신청한 사장님 리스트 조회한다.")
+    void getNewOwnersAdmin() {
+        Owner unauthenticatedOwner = userFixture.철수_사장님();
+        Owner authenticatedOwner = userFixture.준영_사장님();
+
+        Shop shopA = shopFixture.마슬랜(unauthenticatedOwner);
+        Shop shopB = shopFixture.신전_떡볶이(unauthenticatedOwner);
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .param("searchType", "NAME")
+            .param("query", "철수")
+            .param("sort", "CREATED_AT_DESC")
+            .get("/admin/users/new-owners")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "total_count": 1,
+                    "current_count": 1,
+                    "total_page": 1,
+                    "current_page": 1,
+                    "owners": [
+                        {
+                            "id": 1,
+                            "email": "testchulsu@gmail.com",
+                            "name": "테스트용_철수(인증X)",
+                            "phone_number": "010-9776-5112",
+                            "shop_id": 1,
+                            "shop_name": "마슬랜 치킨",
+                            "created_at" : "2024-01-15 12:00:00"
+                        },
+                        {
+                            "id": 1,
+                            "email": "testchulsu@gmail.com",
+                            "name": "테스트용_철수(인증X)",
+                            "phone_number": "010-9776-5112",
+                            "shop_id": 2,
+                            "shop_name": "신전 떡볶이",
+                            "created_at" : "2024-01-15 12:00:00"
+                        }
+                    ]
+                }
+                """
+            ));
+    }
+
+    @Test
+    @DisplayName("관리자가 가입 신청한 사장님 리스트 조회한다 - V2")
+    void getNewOwnersAdminV2() {
+        for (int i = 0; i < 11; i++) {
+            Owner request = Owner.builder()
+                .companyRegistrationNumber("118-80-567" + i)
+                .attachments(List.of(
+                        OwnerAttachment.builder()
+                            .url("https://test.com/사장님_인증사진_1" + i +".jpg")
+                            .isDeleted(false)
+                            .build(),
+                        OwnerAttachment.builder()
+                            .url("https://test.com/사장님_인증사진_2" + i +".jpg")
+                            .isDeleted(false)
+                            .build()
+                    )
+                )
+                .grantShop(true)
+                .grantEvent(true)
+                .user(
+                    User.builder()
+                        .password(passwordEncoder.encode("1234"))
+                        .nickname("사장님" + i)
+                        .name("테스트용(인증X)" + i)
+                        .phoneNumber("010-9776-511" + i)
+                        .userType(OWNER)
+                        .gender(MAN)
+                        .email("testchulsu@gmail.com" + i)
+                        .isAuthed(false)
+                        .isDeleted(false)
+                        .build()
+                )
+                .build();
+
+            adminOwnerRepository.save(request);
+        }
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .get("/admin/users/new-owners")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        assertSoftly(
+            softly -> {
+                softly.assertThat(response.body().jsonPath().getInt("total_count")).isEqualTo(11);
+                softly.assertThat(response.body().jsonPath().getInt("current_count")).isEqualTo(10);
+                softly.assertThat(response.body().jsonPath().getInt("total_page")).isEqualTo(2);
+                softly.assertThat(response.body().jsonPath().getInt("current_page")).isEqualTo(1);
+                softly.assertThat(response.body().jsonPath().getList("owners").size()).isEqualTo(10);
+            }
+        );
     }
 }

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -181,6 +181,40 @@ public final class UserFixture {
         );
     }
 
+    public Owner 철수_사장님() {
+        return ownerRepository.save(
+            Owner.builder()
+                .companyRegistrationNumber("118-80-56789")
+                .attachments(List.of(
+                        OwnerAttachment.builder()
+                            .url("https://test.com/철수_사장님_인증사진_1.jpg")
+                            .isDeleted(false)
+                            .build(),
+                        OwnerAttachment.builder()
+                            .url("https://test.com/철수_사장님_인증사진_2.jpg")
+                            .isDeleted(false)
+                            .build()
+                    )
+                )
+                .grantShop(true)
+                .grantEvent(true)
+                .user(
+                    User.builder()
+                        .password(passwordEncoder.encode("1234"))
+                        .nickname("철수")
+                        .name("테스트용_철수(인증X)")
+                        .phoneNumber("010-9776-5112")
+                        .userType(OWNER)
+                        .gender(MAN)
+                        .email("testchulsu@gmail.com")
+                        .isAuthed(false)
+                        .isDeleted(false)
+                        .build()
+                )
+                .build()
+        );
+    }
+
     public User 준기_영양사() {
         return userRepository.save(
             User.builder()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #87

# 🚀 작업 내용

1. 페이지, 페이지당 조회할 최대 개수, 검색 대상, 검색 문자열, 정렬 기준을 ModelAndView를 이용하여 파라미터 요청을 받습니다. 페이지, 페이지당 조회할 최대 개수, 정렬기준은 컴팩트 생성자를 통해 디폴트값을 가집니다. 검색 대상과 검색 문자열은 null값이면 검색 대상없이 전체 조회됩니다.

2. 조건에 해당하는 총 사장님의 수, 조건에 해당하는 사장님중에 현재 페이지에서 조회된 수, 조건에 해당하는 사장님들을 조회할 수 있는 최대 페이지, 현재 페이지, 사장님 리스트 값을 반환합니다. 

3. 스프링 Page를 이용하고 기존 Criteria을 이용하여 작업하였습니다.

4. 요청dto에서 디폴트값을 넣어주기 위해 Criteria의 DEFAULT_PAGE와 DEFAULT_LIMIT의 접근제어자를 private -> public으로 변경했습니다.


# 💬 리뷰 중점사항
