### PR TITLE
fix: 삭제된 멤버 조회 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/member/repository/MemberRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/member/repository/MemberRepository.java
@@ -3,6 +3,10 @@ package in.koreatech.koin.domain.member.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.member.exception.MemberNotFoundException;
@@ -12,7 +16,7 @@ public interface MemberRepository extends Repository<Member, Integer> {
 
     Member save(Member member);
 
-    List<Member> findAllByTrackId(Integer id);
+    List<Member> findByTrackIdAndIsDeletedFalse(Integer id);
 
     List<Member> findAll();
 

--- a/src/main/java/in/koreatech/koin/domain/member/service/TrackService.java
+++ b/src/main/java/in/koreatech/koin/domain/member/service/TrackService.java
@@ -30,7 +30,7 @@ public class TrackService {
 
     public TrackSingleResponse getTrack(Integer id) {
         Track track = trackRepository.getById(id);
-        List<Member> member = memberRepository.findAllByTrackId(id);
+        List<Member> member = memberRepository.findByTrackIdAndIsDeletedFalse(id);
         List<TechStack> techStacks = techStackRepository.findAllByTrackId(id);
 
         return TrackSingleResponse.of(track, member, techStacks);

--- a/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
@@ -72,6 +72,56 @@ class TrackApiTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("BCSDLab 트랙 정보 단건 조회 - 삭제된 멤버는 조회하지 않는다.")
+    void findingTracksExcludingDeletedMember() {
+        Track track = trackFixture.backend();
+        memberFixture.배진호(track); // 삭제된 멤버
+        memberFixture.최준호(track);
+        techStackFixture.java(track);
+
+        var response = RestAssured
+            .given()
+            .when()
+            .get("/tracks/{id}", track.getId())
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                     "TrackName": "BackEnd",
+                     "TechStacks": [
+                         {
+                             "id": 1,
+                             "name": "Java",
+                             "description": "Language",
+                             "image_url": "https://testimageurl.com",
+                             "track_id": 1,
+                             "is_deleted": false,
+                             "created_at": "2024-01-15 12:00:00",
+                             "updated_at": "2024-01-15 12:00:00"
+                         }
+                     ],
+                     "Members": [
+                         {
+                             "id": 2,
+                             "name": "최준호",
+                             "student_number": "2019136135",
+                             "position": "Regular",
+                             "track": "BackEnd",
+                             "email": "testjuno@gmail.com",
+                             "image_url": "https://imagetest.com/juno.jpg",
+                             "is_deleted": false,
+                             "created_at": "2024-01-15 12:00:00",
+                             "updated_at": "2024-01-15 12:00:00"
+                         }
+                     ]
+                 }
+                """);
+    }
+
+    @Test
     @DisplayName("BCSDLab 트랙 정보 단건 조회")
     void findTrack() {
         Track track = trackFixture.backend();

--- a/src/test/java/in/koreatech/koin/fixture/MemberFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/MemberFixture.java
@@ -49,4 +49,18 @@ public class MemberFixture {
                 .build()
         );
     }
+
+    public Member 배진호(Track track) {
+        return memberRepository.save(
+            Member.builder()
+                .isDeleted(true)
+                .studentNumber("2020136061")
+                .imageUrl("https://imagetest.com/jino.jpg")
+                .name("배진호")
+                .position("Regular")
+                .track(track)
+                .email("testjhb@gmail.com")
+                .build()
+        );
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #538 

# 🚀 작업 내용

1. isDelete = true 인 멤버 조회 안하도록 수정

# 💬 리뷰 중점사항
MemberRepository에서 findByTrackId를 findByTrackIdAndIsDeletedFalse로 수정
isDelete = true여도 DB상 남아있기 때문에 테스트에서 id 순서 고려