### PR TITLE
feat: POST /admin/members API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -4,8 +4,11 @@ import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.admin.member.dto.AdminMemberRequest;
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
 import in.koreatech.koin.global.auth.Auth;
@@ -16,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "(Admin) AdminLand: BCSDLab 회원", description = "관리자 권한으로 BCSDLab 회원 정보를 관리한다")
 public interface AdminMemberApi {
@@ -35,5 +39,17 @@ public interface AdminMemberApi {
         @RequestParam(name = "track") TrackTag track,
         @RequestParam(name = "is_deleted", defaultValue = "false") Boolean isDeleted,
         @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "BCSDLab 회원 생성")
+    @PostMapping("/admin/members")
+    ResponseEntity<Void> createMember(
+        @RequestBody @Valid AdminMemberRequest request
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -50,6 +50,7 @@ public interface AdminMemberApi {
     @Operation(summary = "BCSDLab 회원 생성")
     @PostMapping("/admin/members")
     ResponseEntity<Void> createMember(
-        @RequestBody @Valid AdminMemberRequest request
+        @RequestBody @Valid AdminMemberRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -2,15 +2,20 @@ package in.koreatech.koin.admin.member.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.admin.member.dto.AdminMemberRequest;
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
 import in.koreatech.koin.admin.member.service.AdminMemberService;
 import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -28,5 +33,11 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         return ResponseEntity.ok().body(adminMemberService.getMembers(page, limit, track, isDeleted));
+    }
+
+    @PostMapping("/admin/members")
+    public ResponseEntity<Void> createMember(@RequestBody @Valid AdminMemberRequest request) {
+        adminMemberService.createMember(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -36,7 +36,10 @@ public class AdminMemberController implements AdminMemberApi {
     }
 
     @PostMapping("/admin/members")
-    public ResponseEntity<Void> createMember(@RequestBody @Valid AdminMemberRequest request) {
+    public ResponseEntity<Void> createMember(
+        @RequestBody @Valid AdminMemberRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
         adminMemberService.createMember(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminMemberRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminMemberRequest.java
@@ -1,0 +1,55 @@
+package in.koreatech.koin.admin.member.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.member.model.Member;
+import in.koreatech.koin.domain.member.model.Track;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminMemberRequest(
+    @NotNull(message = "이름은 필수입니다.")
+    @Size(max = 50, message = "이름의 길이는 최대 50자입니다.")
+    @Schema(description = "이름", example = "김주원", requiredMode = REQUIRED)
+    String name,
+
+    @Size(max = 10, message = "학번의 길이는 최대 10자입니다.")
+    @Schema(description = "소속 트랙", example = "2019136037")
+    String studentNumber,
+
+    @NotNull(message = "트랙은 필수입니다.")
+    @Pattern(regexp = "^(Android|BackEnd|FrontEnd|Game|UI\\/UX|HR|iOS|P&M)$", message = "트랙의 형식이 올바르지 않습니다.")
+    @Schema(description = "고유 id", example = "BackEnd", requiredMode = REQUIRED)
+    String track,
+
+    @NotNull(message = "직급은 필수입니다.")
+    @Pattern(regexp = "^(Mentor|Regular)$", message = "직급의 형식이 올바르지 않습니다.")
+    @Schema(description = "직급", example = "Regular", requiredMode = REQUIRED)
+    String position,
+
+    @Email(message = "이메일의 길이는 최대 100자입니다.")
+    @Schema(description = "이메일", example = "damiano102777@naver.com")
+    String email,
+
+    @Size(max = 65535, message = "이미지 링크의 길이는 최대 65535자입니다.")
+    @Schema(description = "이미지 링크", example = "https://example.com")
+    String imageUrl
+) {
+    public Member toMember(Track track) {
+        return Member.builder()
+            .name(name)
+            .studentNumber(studentNumber)
+            .track(track)
+            .position(position)
+            .email(email)
+            .imageUrl(imageUrl)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/repository/AdminMemberRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/member/repository/AdminMemberRepository.java
@@ -1,11 +1,14 @@
 package in.koreatech.koin.admin.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.member.exception.MemberNotFoundException;
 import in.koreatech.koin.domain.member.model.Member;
 
 public interface AdminMemberRepository extends Repository<Member, Integer> {
@@ -17,4 +20,14 @@ public interface AdminMemberRepository extends Repository<Member, Integer> {
     @EntityGraph(attributePaths = {"track"})
     @Query("select count(m) from Member m where m.track.name = :trackName and m.isDeleted = :isDeleted")
     Integer countAllByTrackAndIsDeleted(String trackName, Boolean isDeleted);
+
+    Member save(Member member);
+
+    @EntityGraph(attributePaths = {"track"})
+    Optional<Member> findByName(String name);
+
+    default Member getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> MemberNotFoundException.withDetail("name: " + name));
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/repository/AdminTrackRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/member/repository/AdminTrackRepository.java
@@ -14,10 +14,10 @@ public interface AdminTrackRepository extends Repository<Track, Integer> {
 
     List<Track> findAll();
 
-    Optional<Track> findByName(String name);
+    Optional<Track> findByName(String trackName);
 
-    default Track getByName(String name) {
-        return findByName(name)
-            .orElseThrow(() -> TrackNotFoundException.withDetail("trackName: " + name));
+    default Track getByName(String trackName) {
+        return findByName(trackName)
+            .orElseThrow(() -> TrackNotFoundException.withDetail("name: " + trackName));
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -12,6 +12,7 @@ import in.koreatech.koin.admin.member.enums.TrackTag;
 import in.koreatech.koin.admin.member.repository.AdminMemberRepository;
 import in.koreatech.koin.admin.member.repository.AdminTrackRepository;
 import in.koreatech.koin.domain.member.model.Member;
+import in.koreatech.koin.domain.member.model.Track;
 import in.koreatech.koin.global.model.Criteria;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -6,9 +6,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.member.dto.AdminMemberRequest;
 import in.koreatech.koin.admin.member.dto.AdminMembersResponse;
 import in.koreatech.koin.admin.member.enums.TrackTag;
 import in.koreatech.koin.admin.member.repository.AdminMemberRepository;
+import in.koreatech.koin.admin.member.repository.AdminTrackRepository;
 import in.koreatech.koin.domain.member.model.Member;
 import in.koreatech.koin.global.model.Criteria;
 import lombok.RequiredArgsConstructor;
@@ -19,16 +21,25 @@ import lombok.RequiredArgsConstructor;
 public class AdminMemberService {
 
     private final AdminMemberRepository adminMemberRepository;
+    private final AdminTrackRepository adminTrackRepository;
 
     public AdminMembersResponse getMembers(Integer page, Integer limit, TrackTag track, Boolean isDeleted) {
         Integer total = adminMemberRepository.countAllByTrackAndIsDeleted(track.getTag(), isDeleted);
 
         Criteria criteria = Criteria.of(page, limit, total);
-        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), Sort.by(Sort.Direction.ASC, "id"));
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(),
+            Sort.by(Sort.Direction.ASC, "id"));
 
         Page<Member> result = adminMemberRepository.findAllByTrackAndIsDeleted(track.getTag(), isDeleted, pageRequest);
 
         return AdminMembersResponse.of(result, criteria);
     }
 
+    @Transactional
+    public void createMember(AdminMemberRequest request) {
+        Track track = adminTrackRepository.getByName(request.track());
+
+        Member member = request.toMember(track);
+        adminMemberRepository.save(member);
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -39,7 +39,6 @@ public class AdminMemberService {
     @Transactional
     public void createMember(AdminMemberRequest request) {
         Track track = adminTrackRepository.getByName(request.track());
-
         Member member = request.toMember(track);
         adminMemberRepository.save(member);
     }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -1,5 +1,8 @@
 package in.koreatech.koin.admin.acceptance;
 
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.admin.member.repository.AdminMemberRepository;
+import in.koreatech.koin.domain.land.model.Land;
+import in.koreatech.koin.domain.member.model.Member;
 import in.koreatech.koin.domain.member.model.Track;
 import in.koreatech.koin.domain.member.repository.TrackRepository;
 import in.koreatech.koin.domain.user.model.User;
@@ -27,6 +33,7 @@ public class AdminMemberApiTest extends AcceptanceTest {
 
     @Autowired
     private UserFixture userFixture;
+    private AdminMemberRepository adminMemberRepository;
 
     @Test
     @DisplayName("BCSDLab 회원들의 정보를 조회한다")
@@ -70,5 +77,44 @@ public class AdminMemberApiTest extends AcceptanceTest {
                 }
                 """
             );
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 BCSDLab 회원을 추가한다.")
+    void postMember() {
+        trackFixture.backend();
+
+        String jsonBody = """
+            {
+                "name": "최준호",
+                "student_number": "2019136135",
+                "track": "BackEnd",
+                "position": "Regular",
+                "email": "testjuno@gmail.com",
+                "image_url": "https://imagetest.com/juno.jpg"
+            }
+            """;
+
+        RestAssured
+            .given()
+            .contentType("application/json")
+            .body(jsonBody)
+            .when()
+            .post("/admin/members")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract().asString();
+
+        Member savedMember = adminMemberRepository.getByName("최준호");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(savedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(savedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(savedMember.getTrack().getName()).isEqualTo("BackEnd");
+            softly.assertThat(savedMember.getPosition()).isEqualTo("Regular");
+            softly.assertThat(savedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(savedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(savedMember.isDeleted()).isEqualTo(false);
+        });
     }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -33,6 +33,8 @@ public class AdminMemberApiTest extends AcceptanceTest {
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
     private AdminMemberRepository adminMemberRepository;
 
     @Test
@@ -84,6 +86,9 @@ public class AdminMemberApiTest extends AcceptanceTest {
     void postMember() {
         trackFixture.backend();
 
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
         String jsonBody = """
             {
                 "name": "최준호",
@@ -97,6 +102,7 @@ public class AdminMemberApiTest extends AcceptanceTest {
 
         RestAssured
             .given()
+            .header("Authorization", "Bearer " + token)
             .contentType("application/json")
             .body(jsonBody)
             .when()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #45 

# 🚀 작업 내용

1. POST /admin/members API를 추가하였습니다.

# 💬 리뷰 중점사항
- `TrackNotFoundException`과 `MemberNotFoundException`을 기존 domain의 Member 패키지에서 사용하던 것들을 단순 재사용했는데, 따로 `AdminTrackNotFoundException`을 추가해서 관리해야 할지 아니면 그냥 쓸지에 대한 고민을 해보았고, 당장은 불필요하다고 생각해서 기존 예외를 재사용하는 방향으로 선택하였습니다.
- 기존 `GET /admin/members` API에서는 트랙 관련 파라미터를 enum으로 처리했는데, Request DTO에서는 `track`을 String으로 받고 `@Pattern`을 통해 검증하도록 하였습니다(기존 KOIN_API 방식). 기존처럼 String으로 처리할지, 혹은 enum으로 처리하도록 수정할지에 대해 고민중이라 의견 주시면 감사하겠습니다.
- 기타 DTO 검증은 KOIN_API에서 하던 방식 그대로 적용하였습니다.
