### PR TITLE
feat: 커스텀 시간표 API

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
@@ -35,11 +35,11 @@ public record TimeTableCreateRequest(
         @Schema(description = "과목 코드", example = "CPC490", requiredMode = NOT_REQUIRED)
         String code,
 
-        @Schema(description = "강의 이름", example = "운영체제", requiredMode = REQUIRED)
+        @Schema(description = "강의(커스텀) 이름", example = "운영체제", requiredMode = REQUIRED)
         @NotBlank(message = "강의 이름을 입력해주세요.")
         String classTitle,
 
-        @Schema(description = "강의 시간", example = "[210, 211]", requiredMode = REQUIRED)
+        @Schema(description = "강의(커스텀) 시간", example = "[210, 211]", requiredMode = REQUIRED)
         @NotNull(message = "강의 시간을 입력해주세요.")
         List<Integer> classTime,
 
@@ -49,11 +49,10 @@ public record TimeTableCreateRequest(
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(description = "대상 학년", example = "3", requiredMode = REQUIRED)
-        @NotBlank(message = "대상 학년을 입력해주세요.")
+        @Schema(description = "대상 학년", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
-        @Schema(name = "분반", example = "01", requiredMode = REQUIRED)
+        @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
         @Size(max = 3, message = "분반은 3자 이하로 입력해주세요.")
         String lectureClass,
 

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
@@ -51,7 +51,7 @@ public record TimeTableCreateRequest(
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
+        @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
         @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
@@ -18,7 +18,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimeTableCreateRequest(

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -17,6 +18,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimeTableCreateRequest(
@@ -49,7 +51,7 @@ public record TimeTableCreateRequest(
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(description = "대상 학년", example = "3", requiredMode = NOT_REQUIRED)
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
         String grades,
 
         @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
@@ -76,6 +78,12 @@ public record TimeTableCreateRequest(
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {
+        @Builder
+        public InnerTimeTableRequest {
+            if (Objects.isNull(grades)) {
+                grades = "0";
+            }
+        }
 
         public TimeTable toTimeTable(User user, Semester semester) {
             return TimeTable.builder()

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableCreateRequest.java
@@ -78,7 +78,6 @@ public record TimeTableCreateRequest(
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {
-        @Builder
         public InnerTimeTableRequest {
             if (Objects.isNull(grades)) {
                 grades = "0";

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableResponse.java
@@ -42,19 +42,19 @@ public record TimeTableResponse(
         @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
         String designScore,
 
-        @Schema(description = "강의 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
+        @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
         List<Integer> classTime,
 
-        @Schema(description = "강의 장소", example = "2 공학관", requiredMode = REQUIRED)
+        @Schema(description = "강의 장소", example = "2 공학관", requiredMode = NOT_REQUIRED)
         String classPlace,
 
         @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
         String memo,
 
-        @Schema(name = "대상 학년", example = "3", requiredMode = REQUIRED)
+        @Schema(name = "대상 학년", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
-        @Schema(name = "강의 이름", example = "한국사", requiredMode = REQUIRED)
+        @Schema(name = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
         String classTitle,
 
         @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableResponse.java
@@ -51,7 +51,7 @@ public record TimeTableResponse(
         @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
         String memo,
 
-        @Schema(name = "대상 학년", example = "3", requiredMode = NOT_REQUIRED)
+        @Schema(name = "학점", example = "3", requiredMode = REQUIRED)
         String grades,
 
         @Schema(name = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimeTableUpdateRequest.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -13,6 +14,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimeTableUpdateRequest(
@@ -49,8 +51,7 @@ public record TimeTableUpdateRequest(
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(description = "대상 학년", example = "3", requiredMode = REQUIRED)
-        @NotBlank(message = "대상 학년을 입력해주세요.")
+        @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
         @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
@@ -77,6 +78,11 @@ public record TimeTableUpdateRequest(
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {
-
+        @Builder
+        public InnerTimeTableRequest {
+            if (Objects.isNull(grades)) {
+                grades = "0";
+            }
+        }
     }
 }

--- a/src/main/resources/db/migration/V16__alter_timetables_colum_nullabe.sql
+++ b/src/main/resources/db/migration/V16__alter_timetables_colum_nullabe.sql
@@ -1,2 +1,0 @@
-alter table `timetables`
-    modify column grades VARCHAR(2);

--- a/src/main/resources/db/migration/V16__alter_timetables_colum_nullabe.sql
+++ b/src/main/resources/db/migration/V16__alter_timetables_colum_nullabe.sql
@@ -1,0 +1,2 @@
+alter table `timetables`
+    modify column grades VARCHAR(2);

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -335,7 +335,7 @@ class TimetableApiTest extends AcceptanceTest {
                       ],
                       "class_place": null,
                       "professor": "이돈우",
-                      "grades": "3",
+                      "grades": null,
                       "lecture_class": "01",
                       "target": "디자 1 건축",
                       "regular_number": "25",
@@ -384,7 +384,7 @@ class TimetableApiTest extends AcceptanceTest {
                             ],
                             "class_place": null,
                             "memo": null,
-                            "grades": "3",
+                            "grades": "0",
                             "class_title": "운영체제",
                             "lecture_class": "01",
                             "target": "디자 1 건축",
@@ -409,8 +409,8 @@ class TimetableApiTest extends AcceptanceTest {
                             "department": "컴퓨터공학부"
                         }
                     ],
-                    "grades": 4,
-                    "total_grades": 4
+                    "grades": 1,
+                    "total_grades": 1
                 }
                 """);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #542

# 🚀 작업 내용

기존 강의 시간표 생성하는 API를 이용하였습니다.
커스텀 시간표 추가할때 (학기, 이름, 시간)에 대한 요청값만 필요하기 때문에 기존 시간표 생성API를 커스텀 시간표를 고려하여 변경했습니다.

1. DTO 스키마 이름 변경
`@Schema(description = "강의(커스텀) 이름", example = "운영체제", requiredMode = REQUIRED)`
`@Schema(description = "강의(커스텀) 시간", example = "[210, 211]", requiredMode = REQUIRED)`

2. requiredMode 변경
커스텀 시간표를 고려하여 기존에 필수값이였던 학점하고 분반에 대한 요청과 응답 requiredMode를 REQUIRED에서 NOT_REQUIRED로 변경했습니다. <br/>
분반은 DB에서 필수값이 아니므로 NOT_REQUIRED로 변경하였으며, 학점은 DB에서NULL값을 허용하지않으며 시간표 조회시 시간표의 학점으로부터 총 이수학점이 계산되어 나오므로 학점 디폴트값을 0으로 설정하고 NOT_REQUIRED로 변경하였습니다.

# 💬 리뷰 중점사항
