### PR TITLE
refactor: docker 파일 wget설치 명령어 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ RUN yum install -y tzdata
 
 RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 
+RUN wget -O /dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+
 WORKDIR /app
 
 COPY ./build/libs/KOIN_API_V2.jar /app/app.jar
 
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["sh", "-c", "java -javaagent:/dd-java-agent.jar -Ddd.service=koin-api -Ddd.env=${DD_ENV} -Ddd.version=1.0 -Ddd.agent.host=datadog-agent -Ddd.agent.port=8126 -jar /app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM amazoncorretto:17
 
 RUN yum install -y tzdata
 
+RUN yum install -y wget
+
 RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 
 RUN wget -O /dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM amazoncorretto:17
 
-RUN yum install -y tzdata
+RUN if ! rpm -q tzdata; then yum install -y tzdata; fi
 
-RUN yum install -y wget
+RUN if ! command -v wget >/dev/null 2>&1; then yum install -y wget; fi
 
-RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
+RUN if [ "$(readlink /etc/localtime)" != "/usr/share/zoneinfo/Asia/Seoul" ]; then ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime; fi
 
-RUN wget -O /dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+RUN if [ ! -f /dd-java-agent.jar ]; then wget -O /dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'; fi
 
 WORKDIR /app
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

![image](https://github.com/BCSDLab/KOIN_API_V2/assets/79901434/fc4a5ff3-7b84-4907-bcef-b45a764169c5)
빌드를 하던 도중 Docker에 wget이 안깔려 있어 빌드가 실패하였습니다.(그리하여 로컬에서 테스트를 하였습니다.)
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/79901434/3bc572be-c9e6-41f9-8823-5899f140619c)
처음 빌드시 전체가 빌드가 되는 모습을 볼 수 있으며,
![image](https://github.com/BCSDLab/KOIN_API_V2/assets/79901434/4d5f2d2a-6cb9-43a8-ab12-6e35d1b78f25)
두번째 빌드에선 이미 설치가 되었기에 생략되는 모습을 볼 수 있습니다.
이로서 빌드시간을 감축할 수 있습니다.

