### PR TITLE
feat: Admin으로 BCSDLab 기술스택 생성 기능

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackApi.java
@@ -6,7 +6,12 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.admin.member.dto.AdminTechStackRequest;
+import in.koreatech.koin.admin.member.dto.AdminTechStackResponse;
 import in.koreatech.koin.admin.member.dto.AdminTrackResponse;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "(Admin) Track: BCSDLab 트랙", description = "관리자 권한으로 BCSDLab 트랙 정보를 관리한다")
 public interface AdminTrackApi {
@@ -33,5 +39,20 @@ public interface AdminTrackApi {
     @GetMapping("/admin/tracks")
     ResponseEntity<List<AdminTrackResponse>> getTracks(
         @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "기술스택 생성")
+    @PostMapping("/admin/techStacks")
+    ResponseEntity<AdminTechStackResponse> createTechStack(
+        @RequestBody @Valid AdminTechStackRequest techStackRequest,
+        @RequestParam(value = "trackName") String trackName
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackApi.java
@@ -50,9 +50,11 @@ public interface AdminTrackApi {
         }
     )
     @Operation(summary = "기술스택 생성")
+    @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/admin/techStacks")
     ResponseEntity<AdminTechStackResponse> createTechStack(
         @RequestBody @Valid AdminTechStackRequest techStackRequest,
-        @RequestParam(value = "trackName") String trackName
+        @RequestParam(value = "trackName") String trackName,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackController.java
@@ -6,11 +6,17 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.admin.member.dto.AdminTechStackRequest;
+import in.koreatech.koin.admin.member.dto.AdminTechStackResponse;
 import in.koreatech.koin.admin.member.dto.AdminTrackResponse;
 import in.koreatech.koin.admin.member.service.AdminTrackService;
 import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,5 +31,14 @@ public class AdminTrackController implements AdminTrackApi {
     ) {
         List<AdminTrackResponse> adminTrackResponse = adminTrackService.getTracks();
         return ResponseEntity.ok(adminTrackResponse);
+    }
+
+    @PostMapping("/admin/techStacks")
+    public ResponseEntity<AdminTechStackResponse> createTechStack(
+        @RequestBody @Valid AdminTechStackRequest request,
+        @RequestParam String trackName
+    ) {
+        var response = adminTrackService.createTechStack(request, trackName);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminTrackController.java
@@ -36,7 +36,8 @@ public class AdminTrackController implements AdminTrackApi {
     @PostMapping("/admin/techStacks")
     public ResponseEntity<AdminTechStackResponse> createTechStack(
         @RequestBody @Valid AdminTechStackRequest request,
-        @RequestParam String trackName
+        @RequestParam String trackName,
+        @Auth(permit = {ADMIN}) Integer adminId
     ) {
         var response = adminTrackService.createTechStack(request, trackName);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackRequest.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.admin.member.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.member.model.TechStack;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminTechStackRequest(
+
+    @Schema(description = "기술스택 고유 ID", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "이미지 링크", example = "http://url.com", requiredMode = REQUIRED)
+    String image_url,
+
+    @Schema(description = "기술 스택명", example = "Spring", requiredMode = REQUIRED)
+    @NotNull(message = "기술 스택명은 비워둘 수 없습니다.")
+    String name,
+
+    @Schema(description = "기술 스택 설명", example = "스프링은 웹 프레임워크이다", requiredMode = REQUIRED)
+    String description
+) {
+
+    public TechStack toEntity(Integer trackId) {
+        return TechStack.builder()
+            .imageUrl(image_url)
+            .name(name)
+            .description(description)
+            .trackId(trackId)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackRequest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.member.model.TechStack;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record AdminTechStackRequest(
@@ -19,7 +19,7 @@ public record AdminTechStackRequest(
     String image_url,
 
     @Schema(description = "기술 스택명", example = "Spring", requiredMode = REQUIRED)
-    @NotNull(message = "기술 스택명은 비워둘 수 없습니다.")
+    @NotBlank(message = "기술 스택명은 비워둘 수 없습니다.")
     String name,
 
     @Schema(description = "기술 스택 설명", example = "스프링은 웹 프레임워크이다", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminTechStackResponse.java
@@ -1,0 +1,56 @@
+package in.koreatech.koin.admin.member.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.member.model.TechStack;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminTechStackResponse(
+
+    @Schema(description = "기술스택 고유 ID", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "이미지 링크", example = "http://url.com", requiredMode = REQUIRED)
+    String image_url,
+
+    @Schema(description = "기술 스택명", example = "Spring", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "기술 스택 설명", example = "스프링은 웹 프레임워크이다", requiredMode = REQUIRED)
+    String description,
+
+    @Schema(description = "트랙 고유 ID", example = "2", requiredMode = REQUIRED)
+    Integer track_id,
+
+    @Schema(description = "삭제 여부", example = "false", requiredMode = REQUIRED)
+    Boolean is_deleted,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "생성 일자", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
+    LocalDateTime createdAt,
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "수정 일자", example = "2024-01-15 12:00:00", requiredMode = REQUIRED)
+    LocalDateTime updatedAt
+) {
+
+    public static AdminTechStackResponse from(TechStack techStack) {
+        return new AdminTechStackResponse(
+            techStack.getId(),
+            techStack.getImageUrl(),
+            techStack.getName(),
+            techStack.getDescription(),
+            techStack.getTrackId(),
+            techStack.isDeleted(),
+            techStack.getCreatedAt(),
+            techStack.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/dto/AdminTrackResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/member/dto/AdminTrackResponse.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.admin.member.dto;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.member.model.Track;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(value = SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public record AdminTrackResponse(
     @Schema(description = "트랙 고유 ID", example = "1", requiredMode = REQUIRED)
     Integer id,

--- a/src/main/java/in/koreatech/koin/admin/member/exception/AdminTrackNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/member/exception/AdminTrackNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.member.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AdminTrackNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 트랙입니다.";
+
+    protected AdminTrackNotFoundException(String message) {
+        super(message);
+    }
+
+    protected AdminTrackNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AdminTrackNotFoundException withDetail(String detail) {
+        return new AdminTrackNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/member/repository/AdminTechStackRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/member/repository/AdminTechStackRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.member.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.member.model.TechStack;
+
+public interface AdminTechStackRepository extends Repository<TechStack, Integer> {
+
+    TechStack save(TechStack techStack);
+}

--- a/src/main/java/in/koreatech/koin/admin/member/repository/AdminTrackRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/member/repository/AdminTrackRepository.java
@@ -1,9 +1,11 @@
 package in.koreatech.koin.admin.member.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.admin.member.exception.AdminTrackNotFoundException;
 import in.koreatech.koin.domain.member.model.Track;
 
 public interface AdminTrackRepository extends Repository<Track, Integer> {
@@ -11,4 +13,11 @@ public interface AdminTrackRepository extends Repository<Track, Integer> {
     Track save(Track track);
 
     List<Track> findAll();
+
+    Optional<Track> findByName(String name);
+
+    default Track getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> AdminTrackNotFoundException.withDetail("trackName: " + name));
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminTrackService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminTrackService.java
@@ -5,8 +5,13 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.member.dto.AdminTechStackRequest;
+import in.koreatech.koin.admin.member.dto.AdminTechStackResponse;
 import in.koreatech.koin.admin.member.dto.AdminTrackResponse;
+import in.koreatech.koin.admin.member.repository.AdminTechStackRepository;
 import in.koreatech.koin.admin.member.repository.AdminTrackRepository;
+import in.koreatech.koin.domain.member.model.TechStack;
+import in.koreatech.koin.domain.member.model.Track;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -15,10 +20,19 @@ import lombok.RequiredArgsConstructor;
 public class AdminTrackService {
 
     private final AdminTrackRepository adminTrackRepository;
+    private final AdminTechStackRepository adminTechStackRepository;
 
     public List<AdminTrackResponse> getTracks() {
         return adminTrackRepository.findAll().stream()
             .map(AdminTrackResponse::from)
             .toList();
+    }
+
+    @Transactional
+    public AdminTechStackResponse createTechStack(AdminTechStackRequest request, String trackName) {
+        Track track = adminTrackRepository.getByName(trackName);
+        TechStack techStack = request.toEntity(track.getId());
+        TechStack savedTechStack = adminTechStackRepository.save(techStack);
+        return AdminTechStackResponse.from(savedTechStack);
     }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminTrackApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminTrackApiTest.java
@@ -87,4 +87,47 @@ public class AdminTrackApiTest extends AcceptanceTest {
                 ]
                 """);
     }
+
+    @Test
+    @DisplayName("관리자가 BCSDLab 기술스택 정보를 생성한다")
+    void createTechStack() {
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        trackFixture.frontend();
+        String backEndName = trackFixture.backend().getName();
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType("application/json")
+            .body("""
+                {
+                    "id": 3,
+                    "image_url": "http://url.com",
+                    "name": "Spring",
+                    "description": "스프링은 웹 프레임워크이다"
+                }
+                """)
+            .when()
+            .queryParam("trackName", backEndName)
+            .post("/admin/techStacks")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                    "id": 1,
+                    "image_url": "http://url.com",
+                    "name": "Spring",
+                    "description": "스프링은 웹 프레임워크이다",
+                    "track_id": 2,
+                    "is_deleted": false,
+                    "created_at": "2024-01-15 12:00:00",
+                    "updated_at": "2024-01-15 12:00:00"
+                }
+                """);
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #73 

# 🚀 작업 내용

1. Admin으로 BCSDLab TechStack 생성 기능 추가

# 💬 리뷰 중점사항
1. 도메인의 `TrackNotFoundException`가 있지만, `AdminTrackNotFoundException` 을 따로 추가했습니다.  
2. `AdminTrackRepository`에서 name으로 검색했는데 없어서 Null을 반환할 경우를 예외처리했습니다.
3. 2번처럼 쿼리파라미터로 넣은 트랙 이름이 없을 경우 예외를 test에서 확인할까말까 고민이 되었는데, 추가하면 좋을지 궁금합니다.