### PR TITLE
fix: 사장님 탈퇴 이슈 예외 처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
@@ -50,7 +50,7 @@ public class Owner {
     @Column(name = "grant_event", columnDefinition = "TINYINT")
     private boolean grantEvent;
 
-    @OneToMany(cascade = {PERSIST, MERGE, REMOVE})
+    @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
     @JoinColumn(name = "owner_id")
     private List<OwnerAttachment> attachments = new ArrayList<>();
 

--- a/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
@@ -51,7 +51,7 @@ public class Owner {
     private boolean grantEvent;
 
     @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
-    @JoinColumn(name = "owner_id")
+    @JoinColumn(name = "owner_id", updatable = false)
     private List<OwnerAttachment> attachments = new ArrayList<>();
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
@@ -50,7 +50,7 @@ public class Owner {
     @Column(name = "grant_event", columnDefinition = "TINYINT")
     private boolean grantEvent;
 
-    @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
+    @OneToMany(cascade = {PERSIST, MERGE, REMOVE})
     @JoinColumn(name = "owner_id")
     private List<OwnerAttachment> attachments = new ArrayList<>();
 

--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerAttachment.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerAttachment.java
@@ -40,7 +40,7 @@ public class OwnerAttachment extends BaseEntity {
     private Integer id;
 
     @ManyToOne(cascade = {PERSIST, MERGE, REMOVE})
-    @JoinColumn(name = "owner_id")
+    @JoinColumn(name = "owner_id", nullable = false)
     private Owner owner;
 
     @NotNull

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -5,12 +5,10 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.owner.exception.OwnerNotFoundException;
 import in.koreatech.koin.domain.owner.repository.OwnerAttachmentRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -5,10 +5,12 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.owner.exception.OwnerNotFoundException;
 import in.koreatech.koin.domain.owner.repository.OwnerAttachmentRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;
@@ -103,7 +105,12 @@ public class UserService {
         if (user.getUserType() == UserType.STUDENT) {
             studentRepository.deleteByUserId(userId);
         } else if (user.getUserType() == UserType.OWNER) {
-            ownerRepository.deleteByUserId(userId);
+            try{
+                ownerRepository.deleteByUserId(userId);
+            } catch (DataIntegrityViolationException e){
+                throw OwnerNotFoundException.withDetail("owner userId: " + userId);
+            }
+
         }
         userRepository.delete(user);
         eventPublisher.publishEvent(new UserDeleteEvent(user.getEmail(), user.getUserType()));

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -105,12 +105,7 @@ public class UserService {
         if (user.getUserType() == UserType.STUDENT) {
             studentRepository.deleteByUserId(userId);
         } else if (user.getUserType() == UserType.OWNER) {
-            try{
-                ownerRepository.deleteByUserId(userId);
-            } catch (DataIntegrityViolationException e){
-                throw OwnerNotFoundException.withDetail("owner userId: " + userId);
-            }
-
+            ownerRepository.deleteByUserId(userId);
         }
         userRepository.delete(user);
         eventPublisher.publishEvent(new UserDeleteEvent(user.getEmail(), user.getUserType()));

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -4,6 +4,7 @@ import static in.koreatech.koin.domain.user.model.UserGender.MAN;
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.assertj.core.api.SoftAssertions;
@@ -271,38 +272,44 @@ public class AdminUserApiTest extends AcceptanceTest {
     @Test
     @DisplayName("관리자가 가입 신청한 사장님 리스트 조회한다 - V2")
     void getNewOwnersAdminV2() {
+
         for (int i = 0; i < 11; i++) {
-            Owner request = Owner.builder()
-                .companyRegistrationNumber("118-80-567" + i)
-                .attachments(List.of(
-                        OwnerAttachment.builder()
-                            .url("https://test.com/사장님_인증사진_1" + i + ".jpg")
-                            .isDeleted(false)
-                            .build(),
-                        OwnerAttachment.builder()
-                            .url("https://test.com/사장님_인증사진_2" + i + ".jpg")
-                            .isDeleted(false)
-                            .build()
-                    )
-                )
-                .grantShop(true)
-                .grantEvent(true)
-                .user(
-                    User.builder()
-                        .password(passwordEncoder.encode("1234"))
-                        .nickname("사장님" + i)
-                        .name("테스트용(인증X)" + i)
-                        .phoneNumber("010-9776-511" + i)
-                        .userType(OWNER)
-                        .gender(MAN)
-                        .email("testchulsu@gmail.com" + i)
-                        .isAuthed(false)
-                        .isDeleted(false)
-                        .build()
-                )
+            User user = User.builder()
+                .password(passwordEncoder.encode("1234"))
+                .nickname("사장님" + i)
+                .name("테스트용(인증X)" + i)
+                .phoneNumber("010-9776-511" + i)
+                .userType(OWNER)
+                .gender(MAN)
+                .email("testchulsu@gmail.com" + i)
+                .isAuthed(false)
+                .isDeleted(false)
                 .build();
 
-            adminOwnerRepository.save(request);
+            Owner owner = Owner.builder()
+                .user(user)
+                .companyRegistrationNumber("118-80-567" + i)
+                .grantShop(true)
+                .grantEvent(true)
+                .attachments(new ArrayList<>())
+                .build();
+
+            OwnerAttachment attachment1 = OwnerAttachment.builder()
+                .url("https://test.com/사장님_인증사진_1" + i + ".jpg")
+                .isDeleted(false)
+                .owner(owner)
+                .build();
+
+            OwnerAttachment attachment2 = OwnerAttachment.builder()
+                .url("https://test.com/사장님_인증사진_2" + i + ".jpg")
+                .isDeleted(false)
+                .owner(owner)
+                .build();
+
+            owner.getAttachments().add(attachment1);
+            owner.getAttachments().add(attachment2);
+
+            adminOwnerRepository.save(owner);
         }
 
         User adminUser = userFixture.코인_운영자();

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -154,71 +154,82 @@ public final class UserFixture {
     }
 
     public Owner 준영_사장님() {
-        return ownerRepository.save(
-            Owner.builder()
-                .companyRegistrationNumber("112-80-56789")
-                .attachments(List.of(
-                        OwnerAttachment.builder()
-                            .url("https://test.com/준영_사장님_인증사진_1.jpg")
-                            .isDeleted(false)
-                            .build(),
-                        OwnerAttachment.builder()
-                            .url("https://test.com/준영_사장님_인증사진_2.jpg")
-                            .isDeleted(false)
-                            .build()
-                    )
-                )
-                .grantShop(true)
-                .grantEvent(true)
-                .user(
-                    User.builder()
-                        .password(passwordEncoder.encode("1234"))
-                        .nickname("준영")
-                        .name("테스트용_준영")
-                        .phoneNumber("010-9776-5112")
-                        .userType(OWNER)
-                        .gender(MAN)
-                        .email("testjoonyoung@gmail.com")
-                        .isAuthed(true)
-                        .isDeleted(false)
-                        .build()
-                )
-                .build()
-        );
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("준영")
+            .name("테스트용_준영")
+            .phoneNumber("010-9776-5112")
+            .userType(OWNER)
+            .gender(MAN)
+            .email("testjoonyoung@gmail.com")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        Owner owner = Owner.builder()
+            .user(user)
+            .companyRegistrationNumber("112-80-56789")
+            .grantShop(true)
+            .grantEvent(true)
+            .attachments(new ArrayList<>())
+            .build();
+
+        OwnerAttachment attachment1 = OwnerAttachment.builder()
+            .url("https://test.com/준영_사장님_인증사진_1.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        OwnerAttachment attachment2 = OwnerAttachment.builder()
+            .url("https://test.com/준영_사장님_인증사진_2.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        owner.getAttachments().add(attachment1);
+        owner.getAttachments().add(attachment2);
+
+        return ownerRepository.save(owner);
+
     }
 
     public Owner 철수_사장님() {
-        return ownerRepository.save(
-            Owner.builder()
-                .companyRegistrationNumber("118-80-56789")
-                .attachments(List.of(
-                        OwnerAttachment.builder()
-                            .url("https://test.com/철수_사장님_인증사진_1.jpg")
-                            .isDeleted(false)
-                            .build(),
-                        OwnerAttachment.builder()
-                            .url("https://test.com/철수_사장님_인증사진_2.jpg")
-                            .isDeleted(false)
-                            .build()
-                    )
-                )
-                .grantShop(true)
-                .grantEvent(true)
-                .user(
-                    User.builder()
-                        .password(passwordEncoder.encode("1234"))
-                        .nickname("철수")
-                        .name("테스트용_철수(인증X)")
-                        .phoneNumber("010-9776-5112")
-                        .userType(OWNER)
-                        .gender(MAN)
-                        .email("testchulsu@gmail.com")
-                        .isAuthed(false)
-                        .isDeleted(false)
-                        .build()
-                )
-                .build()
-        );
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("철수")
+            .name("테스트용_철수(인증X)")
+            .phoneNumber("010-9776-5112")
+            .userType(OWNER)
+            .gender(MAN)
+            .email("testchulsu@gmail.com")
+            .isAuthed(false)
+            .isDeleted(false)
+            .build();
+
+        Owner owner = Owner.builder()
+            .user(user)
+            .companyRegistrationNumber("118-80-56789")
+            .grantShop(true)
+            .grantEvent(true)
+            .attachments(new ArrayList<>())
+            .build();
+
+        OwnerAttachment attachment1 = OwnerAttachment.builder()
+            .url("https://test.com/철수_사장님_인증사진_1.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        OwnerAttachment attachment2 = OwnerAttachment.builder()
+            .url("https://test.com/철수_사장님_인증사진_2.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        owner.getAttachments().add(attachment1);
+        owner.getAttachments().add(attachment2);
+
+        return ownerRepository.save(owner);
     }
 
     public User 준기_영양사() {

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.domain.user.model.UserIdentity.UNDERGRADUATE;
 import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,37 +115,42 @@ public final class UserFixture {
     }
 
     public Owner 현수_사장님() {
-        return ownerRepository.save(
-            Owner.builder()
-                .companyRegistrationNumber("123-45-67190")
-                .attachments(List.of(
-                        OwnerAttachment.builder()
-                            .url("https://test.com/현수_사장님_인증사진_1.jpg")
-                            .isDeleted(false)
-                            .build(),
-                        OwnerAttachment.builder()
-                            .url("https://test.com/현수_사장님_인증사진_2.jpg")
-                            .isDeleted(false)
-                            .build()
-                    )
-                )
-                .grantShop(true)
-                .grantEvent(true)
-                .user(
-                    User.builder()
-                        .password(passwordEncoder.encode("1234"))
-                        .nickname("현수")
-                        .name("테스트용_현수")
-                        .phoneNumber("010-9876-5432")
-                        .userType(OWNER)
-                        .gender(MAN)
-                        .email("hysoo@naver.com")
-                        .isAuthed(true)
-                        .isDeleted(false)
-                        .build()
-                )
-                .build()
-        );
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("현수")
+            .name("테스트용_현수")
+            .phoneNumber("010-9876-5432")
+            .userType(OWNER)
+            .gender(MAN)
+            .email("hysoo@naver.com")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        Owner owner = Owner.builder()
+            .user(user)
+            .companyRegistrationNumber("123-45-67190")
+            .grantShop(true)
+            .grantEvent(true)
+            .attachments(new ArrayList<>())
+            .build();
+
+        OwnerAttachment attachment1 = OwnerAttachment.builder()
+            .url("https://test.com/현수_사장님_인증사진_1.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        OwnerAttachment attachment2 = OwnerAttachment.builder()
+            .url("https://test.com/현수_사장님_인증사진_2.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        owner.getAttachments().add(attachment1);
+        owner.getAttachments().add(attachment2);
+
+        return ownerRepository.save(owner);
     }
 
     public Owner 준영_사장님() {


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용
```
Exception: DataIntegrityViolationException
Location: HibernateJpaDialect.java Line 269
could not execute statement [Column 'owner_id' cannot be null] [update owner_attachments set owner_id=null where owner_id=? and ((is_deleted=0) )];
```
위와 같은 에러를 수정했습니다. 

* 동시성으로 이유를 파악했었는데 동시성이 문제가 아니였습니다.

해당 문제는 (orphanremoval = true)와 (cascade = remove)와 같은 자식 개체를 같이 삭제하게 해놓은 설정의 문제였습니다.
위와 같은 설정을 하게 되면 
부모 객체를 삭제할 때 해당 설정의 자식 엔티티는 자신이 참조하고 있던 부모 키(fk)를 null로 만들어서 고아 상태로 만드는 update 쿼리 문을 날립니다. 

위처럼 자식 객체도 같이 삭제되게 하는 설정을 하면 회원 탈퇴를 할 때 날라가는 쿼리문은 다음의 순서와 같습니다.

1. owner attachment의 owner_id(fk)를 null로 만드는 update 쿼리문 
2. owner attachment delete 쿼리문
3. owner delete 쿼리문
4. user delete 쿼리문

이때 외래키 설정이 NOT NULL로 되어있으면 부모 외래키를 null로 만들려고 하는 위 설정들과 충돌이 일어나게 됩니다.
따라서 fk값을 null로 만들 수 없게 many인 쪽에 (updatable = false)라는 설정을 추가 해줬습니다.
해당 설정을 적용하면 fk를 null로 만드는 1번을 실행하지 않고 2,3,4번을 수행하게 됩니다.

참고글: https://www.inflearn.com/questions/990032/onetomany%EC%97%90%EC%84%9C-joincolumn-nullable-false-updatable-false-%EC%97%90-%EB%8C%80%ED%95%98%EC%97%AC 

위와 같은 문제를 해결하기 위해 다음의 것들을 하였습니다.
1. owner attachment 테이블과 엔티티의 제약 조건을 맞추기 위해 nullable = false를 추가했습니다.
2. fk를 null로 만들지 않게 updatable = false를 추가했습니다
3. owner_attachment의 owner_id를 not null로 설정하면서 문제가 생긴 fixture들을 다 리팩토링 해줬습니다.
(owner와 attachment가 단방향 관계로 설계 되어있던 것을 양방향 관계로 다시 만들어줬습니다)

# 💬 리뷰 중점사항
삽질도 많이 했지만 삽질을 함으로 인해 jpa의 영속성과 동시성 처리에 대해 생각해볼 수 있는 좋은 기회를 가진 것 같습니다.