### PR TITLE
fix: 회원가입 동시성 이슈 처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
@@ -36,9 +36,7 @@ import in.koreatech.koin.global.domain.email.model.EmailAddress;
 import in.koreatech.koin.global.domain.email.service.MailService;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
@@ -99,7 +99,8 @@ public class StudentService {
             mailService.sendMail(request.email(), new StudentRegistrationData(serverURL, student.getUser().getAuthToken()));
             eventPublisher.publishEvent(new StudentEmailRequestEvent(request.email()));
         } catch (DataIntegrityViolationException e) {
-            throw KoinIllegalArgumentException.withDetail("회원 가입 데이터 중복 동시성 발생");
+            // 동시성 문제를 처리하기 위한 코드
+            throw KoinIllegalArgumentException.withDetail("요청이 너무 빠릅니다.");
         }
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -740,7 +740,7 @@ class UserApiTest extends AcceptanceTest {
         doneSignal.await();
         executorService.shutdown();
 
-        assertThat(capturedOutput.toString()).contains("회원 가입 데이터 중복 동시성 발생");
+        assertThat(capturedOutput.toString()).contains("요청이 너무 빠릅니다.");
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -7,10 +7,17 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
@@ -30,6 +37,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(OutputCaptureExtension.class)
 class UserApiTest extends AcceptanceTest {
 
     @Autowired
@@ -697,6 +705,43 @@ class UserApiTest extends AcceptanceTest {
             .post("/user/student/register")
             .then()
             .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("회원가입시 동시성 발생 예외를 적절하게 처리하는지 체크한다.")
+    void concurrencyStudentRegister(CapturedOutput capturedOutput) throws InterruptedException{
+        int threads = 2;
+        CountDownLatch doneSignal = new CountDownLatch(threads);
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+
+        for (int i = 0; i < threads; i++) {
+            executorService.execute(() -> {
+                RestAssured
+                    .given()
+                    .body("""
+                {
+                  "major": "컴퓨터공학부",
+                  "email": "koko123@koreatech.ac.kr",
+                  "name": "김철수",
+                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                  "nickname": "koko",
+                  "gender": "0",
+                  "is_graduated": false,
+                  "student_number": "2022136012",
+                  "phone_number": "010-0000-0000"
+                }
+                """)
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .post("/user/student/register");
+                doneSignal.countDown();
+
+            });
+        }
+        doneSignal.await();
+        executorService.shutdown();
+
+        assertThat(capturedOutput.toString()).contains("회원 가입 데이터 중복 동시성 발생");
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -709,7 +709,7 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     @DisplayName("회원가입시 동시성 발생 예외를 적절하게 처리하는지 체크한다.")
-    void concurrencyStudentRegister(CapturedOutput capturedOutput) throws InterruptedException{
+    void concurrencyStudentRegister(CapturedOutput capturedOutput) throws InterruptedException {
         int threads = 2;
         CountDownLatch doneSignal = new CountDownLatch(threads);
         ExecutorService executorService = Executors.newFixedThreadPool(threads);
@@ -719,23 +719,22 @@ class UserApiTest extends AcceptanceTest {
                 RestAssured
                     .given()
                     .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@koreatech.ac.kr",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "2022136012",
-                  "phone_number": "010-0000-0000"
-                }
-                """)
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@koreatech.ac.kr",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2022136012",
+                          "phone_number": "010-0000-0000"
+                        }
+                        """)
                     .contentType(ContentType.JSON)
                     .when()
                     .post("/user/student/register");
                 doneSignal.countDown();
-
             });
         }
         doneSignal.await();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #557

# 🚀 작업 내용

1. 해당 로직 과정에서 동시성 제어 방식에는 비관적인 방식이 있으나, 현재 리소스가 많은 곳에서 쓰이는 공유자원인 학생인만큼 전체적인 서비스 성능 저하가 유발될것이며, 단순 데이터 중복에 대한 에러를 반환하는것이기에 try-catch문으로 처리했습니다.

2. 동시성 환경에서 발생할 수 있는 로그를 검증하는 테스트를 작성했습니다.

# 💬 리뷰 중점사항
https://velog.io/@kwoo28/%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%9D%B4%EC%8A%88-%ED%95%B4%EA%B2%B0