### PR TITLE
feat: 상점 사장님 휴대폰번호로 회원가입 api작성

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
@@ -13,6 +13,7 @@ import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifyEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifySmsRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateSmsRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerRegisterByPhoneRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerSmsVerifyRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerRegisterRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
@@ -81,11 +82,26 @@ public interface OwnerApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "사장님 회원가입")
+    @Operation(summary = "이메일을 이용한 사장님 회원가입")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/owners/register")
     ResponseEntity<Void> register(
         @Valid @RequestBody OwnerRegisterRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "전화번호를 이용한 사장님 회원가입")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/owners/register/phone")
+    ResponseEntity<Void> registerByPhone(
+        @Valid @RequestBody OwnerRegisterByPhoneRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
@@ -14,6 +14,7 @@ import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifyEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifySmsRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateSmsRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerRegisterByPhoneRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerSmsVerifyRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerRegisterRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
@@ -62,6 +63,14 @@ public class OwnerController implements OwnerApi {
         @Valid @RequestBody OwnerRegisterRequest request
     ) {
         ownerService.register(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/owners/register/phone")
+    public ResponseEntity<Void> registerByPhone(
+        @Valid @RequestBody OwnerRegisterByPhoneRequest request
+    ) {
+        ownerService.registerByPhone(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
@@ -1,0 +1,97 @@
+package in.koreatech.koin.domain.owner.dto;
+
+import static in.koreatech.koin.domain.user.model.UserType.OWNER;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.validator.constraints.URL;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.owner.model.OwnerAttachment;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record OwnerRegisterByPhoneRequest(
+
+    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}", message = "사업자 등록 번호 형식이 올바르지 않습니다. ${validatedValue}")
+    @Schema(description = "사업자 등록 번호", example = "012-34-56789", requiredMode = NOT_REQUIRED)
+    String companyNumber,
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
+    @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    String name,
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
+    String password,
+
+    @NotBlank(message = "휴대폰 번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
+    String phoneNumber,
+
+    @Schema(description = "상점 고유 ID", requiredMode = NOT_REQUIRED)
+    Integer shopId,
+
+    @Schema(description = "상점 이름", example = "고릴라밥", requiredMode = NOT_REQUIRED)
+    String shopName,
+
+    @Size(min = 1, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 1개 최대 5개까지 가능합니다.")
+    @Schema(description = "첨부 이미지들", requiredMode = REQUIRED)
+    @Valid
+    List<InnerAttachmentUrl> attachmentUrls
+) {
+
+    public Owner toOwner(PasswordEncoder passwordEncoder) {
+        var user = User.builder()
+            .password(passwordEncoder.encode(password))
+            .name(name)
+            .email(phoneNumber)
+            .phoneNumber(phoneNumber)
+            .userType(OWNER)
+            .isAuthed(false)
+            .isDeleted(false)
+            .build();
+        Owner owner = Owner.builder()
+            .user(user)
+            .companyRegistrationNumber(companyNumber)
+            .attachments(new ArrayList<>())
+            .grantShop(false)
+            .grantEvent(false)
+            .build();
+        var attachments = attachmentUrls.stream()
+            .map(InnerAttachmentUrl::fileUrl)
+            .map(fileUrl -> OwnerAttachment.builder()
+                .url(fileUrl)
+                .owner(owner)
+                .isDeleted(false)
+                .name(name)
+                .build())
+            .toList();
+        owner.getAttachments().addAll(attachments);
+        return owner;
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record InnerAttachmentUrl(
+        @NotBlank(message = "첨부 파일 URL은 필수입니다.")
+        @URL(protocol = "https", regexp = ".*static\\.koreatech\\.in.*", message = "코인 파일 저장 형식이 아닙니다.")
+        @Schema(description = "첨부 파일 URL (코인 파일 형식이어야 함)", example = "https://static.koreatech.in/1.png", requiredMode = REQUIRED)
+        String fileUrl
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
@@ -52,11 +52,11 @@ public record OwnerRegisterByPhoneRequest(
     @Size(min = 1, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 1개 최대 5개까지 가능합니다.")
     @Schema(description = "첨부 이미지들", requiredMode = REQUIRED)
     @Valid
-    List<InnerAttachmentUrl> attachmentUrls
+    List<OwnerRegisterByPhoneInnerAttachmentUrl> attachmentUrls
 ) {
 
     public Owner toOwner(PasswordEncoder passwordEncoder) {
-        var user = User.builder()
+        User user = User.builder()
             .password(passwordEncoder.encode(password))
             .name(name)
             .email(phoneNumber)
@@ -72,8 +72,8 @@ public record OwnerRegisterByPhoneRequest(
             .grantShop(false)
             .grantEvent(false)
             .build();
-        var attachments = attachmentUrls.stream()
-            .map(InnerAttachmentUrl::fileUrl)
+        List<OwnerAttachment> attachments = attachmentUrls.stream()
+            .map(OwnerRegisterByPhoneInnerAttachmentUrl::fileUrl)
             .map(fileUrl -> OwnerAttachment.builder()
                 .url(fileUrl)
                 .owner(owner)
@@ -86,7 +86,7 @@ public record OwnerRegisterByPhoneRequest(
     }
 
     @JsonNaming(SnakeCaseStrategy.class)
-    public record InnerAttachmentUrl(
+    public record OwnerRegisterByPhoneInnerAttachmentUrl(
         @NotBlank(message = "첨부 파일 URL은 필수입니다.")
         @URL(protocol = "https", regexp = ".*static\\.koreatech\\.in.*", message = "코인 파일 저장 형식이 아닙니다.")
         @Schema(description = "첨부 파일 URL (코인 파일 형식이어야 함)", example = "https://static.koreatech.in/1.png", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -114,17 +114,12 @@ public class OwnerService {
         }
         Owner owner = request.toOwner(passwordEncoder);
         Owner saved = ownerRepository.save(owner);
+        OwnerShop.OwnerShopBuilder ownerShopBuilder = OwnerShop.builder().ownerId(owner.getId());
         if (request.shopId() != null) {
-            var shop = shopRepository.getById(request.shopId());
-            ownerShopRedisRepository.save(OwnerShop.builder()
-                .ownerId(owner.getId())
-                .shopId(shop.getId())
-                .build());
-        } else {
-            ownerShopRedisRepository.save(OwnerShop.builder()
-                .ownerId(owner.getId())
-                .build());
+            Shop shop = shopRepository.getById(request.shopId());
+            ownerShopBuilder.shopId(shop.getId());
         }
+        ownerShopRedisRepository.save(ownerShopBuilder.build());
         eventPublisher.publishEvent(new OwnerRegisterEvent(saved));
     }
 

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -138,17 +138,12 @@ public class OwnerService {
         }
         Owner owner = request.toOwner(passwordEncoder);
         Owner saved = ownerRepository.save(owner);
+        OwnerShop.OwnerShopBuilder ownerShopBuilder = OwnerShop.builder().ownerId(owner.getId());
         if (request.shopId() != null) {
-            var shop = shopRepository.getById(request.shopId());
-            ownerShopRedisRepository.save(OwnerShop.builder()
-                .ownerId(owner.getId())
-                .shopId(shop.getId())
-                .build());
-        } else {
-            ownerShopRedisRepository.save(OwnerShop.builder()
-                .ownerId(owner.getId())
-                .build());
+            Shop shop = shopRepository.getById(request.shopId());
+            ownerShopBuilder.shopId(shop.getId());
         }
+        ownerShopRedisRepository.save(ownerShopBuilder.build());
         eventPublisher.publishEvent(new OwnerRegisterEvent(saved));
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -166,7 +166,7 @@ class OwnerApiTest extends AcceptanceTest {
     class ownerRegister {
 
         @Test
-        @DisplayName("사장님이 회원가입 요청을 한다.")
+        @DisplayName("사장님이 이메일로 회원가입 요청을 한다.")
         void register() {
             // when & then
             var response = RestAssured
@@ -202,6 +202,56 @@ class OwnerApiTest extends AcceptanceTest {
                             softly.assertThat(owner).isNotNull();
                             softly.assertThat(owner.getUser().getName()).isEqualTo("최준호");
                             softly.assertThat(owner.getUser().getEmail()).isEqualTo("helloworld@koreatech.ac.kr");
+                            softly.assertThat(owner.getCompanyRegistrationNumber()).isEqualTo("012-34-56789");
+                            softly.assertThat(owner.getAttachments().size()).isEqualTo(1);
+                            softly.assertThat(owner.getAttachments().get(0).getUrl())
+                                .isEqualTo("https://static.koreatech.in/testimage.png");
+                            softly.assertThat(owner.getUser().isAuthed()).isFalse();
+                            softly.assertThat(owner.getUser().isDeleted()).isFalse();
+                            verify(ownerEventListener).onOwnerRegister(any());
+                        }
+                    );
+                }
+            );
+        }
+
+        @Test
+        @DisplayName("사장님이 전화번호를 아이디로 회원가입 요청을 한다.")
+        void registerByPhoneNumber() {
+            // when & then
+            var response = RestAssured
+                .given()
+                .body("""
+                    {
+                       "attachment_urls": [
+                         {
+                           "file_url": "https://static.koreatech.in/testimage.png"
+                         }
+                       ],
+                       "company_number": "012-34-56789",
+                       "name": "최준호",
+                       "password": "a0240120305812krlakdsflsa;1235",
+                       "phone_number": "010-1234-1234",
+                       "shop_id": null,
+                       "shop_name": "기분좋은 뷔짱"
+                     }
+                    """)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/owners/register/phone")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+            // when
+            transactionTemplate.executeWithoutResult(status -> {
+                    Owner owner = ownerRepository.findByCompanyRegistrationNumber("012-34-56789").get();
+                    assertSoftly(
+                        softly -> {
+                            softly.assertThat(owner).isNotNull();
+                            softly.assertThat(owner.getUser().getName()).isEqualTo("최준호");
+                            softly.assertThat(owner.getUser().getEmail()).isEqualTo("010-1234-1234");
+                            softly.assertThat(owner.getUser().getPhoneNumber()).isEqualTo("010-1234-1234");
                             softly.assertThat(owner.getCompanyRegistrationNumber()).isEqualTo("012-34-56789");
                             softly.assertThat(owner.getAttachments().size()).isEqualTo(1);
                             softly.assertThat(owner.getAttachments().get(0).getUrl())


### PR DESCRIPTION
# 🔥 연관 이슈

- close #560 

# 🚀 작업 내용

1. 전화번호로 회원가입하는 api를 작성했습니다.
2. 기존 api의 dto email필드만 제거하려다가 api를 새로 작성하는게 나을거같아서 새로 작성했습니다.
3. db의 email필드가 notnull이라서 email필드를 전화번호로 채워줬습니다.

# 💬 리뷰 중점사항
