### PR TITLE
Feature: 시간표 DB 변경

### DIFF
--- a/src/main/resources/db/migration/V16__add_group_timetable.sql
+++ b/src/main/resources/db/migration/V16__add_group_timetable.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `group_timetable` (
+    id INT UNSIGNED AUTO_INCREMENT NOT NULL comment '고유 id',
+    user_id INT UNSIGNED NOT NULL comment '유저 id',
+    semester_id INT UNSIGNED NOT NULL comment '학기 id',
+    name VARCHAR(255) NULL comment '시간표 이름',
+    is_main TINYINT(1) NOT NULL DEFAULT 0 comment '메인 시간표 여부',
+    created_at   timestamp  default CURRENT_TIMESTAMP not null comment '생성 일자',
+    updated_at   timestamp  default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '업데이트 일자',
+    PRIMARY KEY (`id`)
+);

--- a/src/main/resources/db/migration/V17__insert_group_timetable.sql
+++ b/src/main/resources/db/migration/V17__insert_group_timetable.sql
@@ -1,0 +1,3 @@
+INSERT INTO group_timetable (`user_id`, `semester_id`, `name`, `is_main`)
+SELECT `user_id`, `semester_id`, '메인시간표', 1
+FROM timetables GROUP BY `user_id`, `semester_id`;

--- a/src/main/resources/db/migration/V18__alter_timetable_group_timetable_id.sql
+++ b/src/main/resources/db/migration/V18__alter_timetable_group_timetable_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `timetables` ADD COLUMN `group_timetable_id` INT UNSIGNED NULL;

--- a/src/main/resources/db/migration/V19__update_timetable_group_timetable_id_fk.sql
+++ b/src/main/resources/db/migration/V19__update_timetable_group_timetable_id_fk.sql
@@ -1,0 +1,6 @@
+UPDATE `timetables` t
+    JOIN `group_timetable` gt ON t.user_id = gt.user_id AND t.semester_id = gt.semester_id
+    SET t.group_timetable_id = gt.id;
+
+ALTER TABLE `timetables` ADD CONSTRAINT `FK_TIMETABLE_ON_GROUP_TIMETABLE FOREIGN KEY`
+    FOREIGN KEY (`group_timetable_id`) REFERENCES group_timetable(`id`);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #575 

# 🚀 작업 내용
총 4개의 Flyway버전을 추가했습니다.

1. 시간표그룹 스키마를 추가

2. 시간표의 유저_id와 학기_id가 같은 여러개의 튜플을 하나로 묶어 시간표그룹에 삽입

3. 시간표에 시간표그룹_id를 참조하는 속성 추가

4. 2번과정에서 추가된 시간표 그룹의 id를 시간표의 추가된 속성에 삽입하고 FK제약조건 설정

# 💬 리뷰 중점사항
연관 이슈를 확인해주세요.