### PR TITLE
refactor: 전화번호 하이픈 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerPasswordResetVerifySmsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerPasswordResetVerifySmsRequest.java
@@ -13,8 +13,8 @@ import jakarta.validation.constraints.Pattern;
 @JsonNaming(SnakeCaseStrategy.class)
 public record OwnerPasswordResetVerifySmsRequest(
     @NotBlank(message = "휴대폰번호는 필수입니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @NotBlank(message = "인증 코드는 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerPasswordUpdateSmsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerPasswordUpdateSmsRequest.java
@@ -12,8 +12,8 @@ import jakarta.validation.constraints.Pattern;
 @JsonNaming(SnakeCaseStrategy.class)
 public record OwnerPasswordUpdateSmsRequest(
     @NotBlank(message = "휴대폰번호는 필수입니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @NotBlank(message = "비밀번호는 비워둘 수 없습니다.")

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
@@ -39,8 +39,8 @@ public record OwnerRegisterByPhoneRequest(
     String password,
 
     @NotBlank(message = "휴대폰 번호는 필수입니다.")
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @Schema(description = "상점 고유 ID", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerSendSmsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerSendSmsRequest.java
@@ -12,8 +12,8 @@ import jakarta.validation.constraints.Pattern;
 @JsonNaming(SnakeCaseStrategy.class)
 public record OwnerSendSmsRequest(
     @NotBlank(message = "휴대폰번호는 필수입니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerSmsVerifyRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerSmsVerifyRequest.java
@@ -13,8 +13,8 @@ import jakarta.validation.constraints.Pattern;
 @JsonNaming(SnakeCaseStrategy.class)
 public record OwnerSmsVerifyRequest(
     @NotBlank(message = "휴대폰번호는 필수입니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @NotBlank(message = "인증 코드는 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/VerifySmsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/VerifySmsRequest.java
@@ -12,8 +12,8 @@ import jakarta.validation.constraints.Pattern;
 @JsonNaming(SnakeCaseStrategy.class)
 public record VerifySmsRequest(
     @NotBlank(message = "휴대폰번호는 필수입니다.")
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = REQUIRED)
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -202,7 +202,7 @@ public class OwnerService {
     private void sendCertificationSms(String phoneNumber) {
         setVerificationCount(phoneNumber);
         String certificationCode = CertificateNumberGenerator.generate();
-        naverSmsService.sendVerificationCode(certificationCode, phoneNumber.replace("-", ""));
+        naverSmsService.sendVerificationCode(certificationCode, phoneNumber);
         OwnerVerificationStatus ownerVerificationStatus = new OwnerVerificationStatus(
             phoneNumber,
             certificationCode

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -231,7 +231,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "company_number": "012-34-56789",
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-1234-1234",
+                       "phone_number": "01012341234",
                        "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
@@ -250,8 +250,8 @@ class OwnerApiTest extends AcceptanceTest {
                         softly -> {
                             softly.assertThat(owner).isNotNull();
                             softly.assertThat(owner.getUser().getName()).isEqualTo("최준호");
-                            softly.assertThat(owner.getUser().getEmail()).isEqualTo("010-1234-1234");
-                            softly.assertThat(owner.getUser().getPhoneNumber()).isEqualTo("010-1234-1234");
+                            softly.assertThat(owner.getUser().getEmail()).isEqualTo("01012341234");
+                            softly.assertThat(owner.getUser().getPhoneNumber()).isEqualTo("01012341234");
                             softly.assertThat(owner.getCompanyRegistrationNumber()).isEqualTo("012-34-56789");
                             softly.assertThat(owner.getAttachments().size()).isEqualTo(1);
                             softly.assertThat(owner.getAttachments().get(0).getUrl())


### PR DESCRIPTION
# 🔥 연관 이슈

- close #580

# 🚀 작업 내용

1. 전화번호를 이용한 사장님 회원가입, 비밀번호변경, 인증번호발송 api전화번호필드의 형식을 변경하였습니다.
     - `xxx-xxxx-xxxx`에서 `xxxxxxxxxxx`로 변경하였습니다.

변경 사유: 로그인, 네이버인증에서 하이픈이 없는 전화번호 형식을 사용해서 더이상 하이픈을 받을 필요가 없음

# 💬 리뷰 중점사항
