### PR TITLE
Refactor: 대성 고속(Express) 천안역 확인 조건문 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.domain.bus.service;
 
-import static in.koreatech.koin.domain.bus.model.enums.BusStation.STATION;
 import static in.koreatech.koin.domain.bus.model.enums.BusStation.getDirection;
 
 import java.time.Clock;
@@ -62,7 +61,7 @@ public class BusService {
             return toResponse(busType, remainTimes);
         }
 
-        if (busType == BusType.EXPRESS && depart != STATION && arrival != STATION) {
+        if (busType == BusType.EXPRESS) {
             var remainTimes = tmoneyExpressBusOpenApiClient.getBusRemainTime(depart, arrival);
             return toResponse(busType, remainTimes);
         }
@@ -97,7 +96,7 @@ public class BusService {
         for (BusType busType : BusType.values()) {
             SingleBusTimeResponse busTimeResponse = null;
 
-            if (busType == BusType.EXPRESS && depart != STATION && arrival != STATION) {
+            if (busType == BusType.EXPRESS) {
                 busTimeResponse = tmoneyExpressBusOpenApiClient.searchBusTime(
                     busType.getName(),
                     depart,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #590 

# 🚀 작업 내용

1. api에서 노선 정보가 없을 경우 빈 배열 리턴중
2. 따라서 천안역 조건 확인이 필요 없어져서 제거

# 💬 리뷰 중점사항
