### PR TITLE
refactor: 기존 로그인 api 이메일 형식 검증 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -3,13 +3,11 @@ package in.koreatech.koin.domain.user.dto;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
-    // @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
-    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     @NotBlank(message = "이메일을 입력해주세요.")
+    // @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     String email,
 
     @Schema(


### PR DESCRIPTION
# 🔥 연관 이슈

<img width="1227" alt="image" src="https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/570ca26b-5aca-4f8c-94dd-9a5405f26deb">

# 🚀 작업 내용


영양사님 계정을 이메일 형식이 아닌 일반 아이디로 사용하기 위해 이메일 형식 검증을 잠시 제거했습니다.
새로운 로그인 api가 배포되고 프론트 레포가 분리되고 영양사 페이지에 적용되면 다시 추가하여 PR 올리겠습니다.

+) 일요일 중으로 프로덕션 배포하겠습니다. 일요일에 슬랙에 공유하고 저녁쯤 배포누르겠습니당

# 💬 리뷰 중점사항
