### PR TITLE
feat : put /admin/members/{id} api 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -87,6 +88,23 @@ public interface AdminMemberApi {
     @DeleteMapping("/admin/members/{id}")
     ResponseEntity<Void> deleteMember(
         @PathVariable("id") Integer memberId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "BCSDLab 회원 수정")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PutMapping("/admin/members/{id}")
+    ResponseEntity<Void> updateMember(
+        @PathVariable("id") Integer memberId,
+        @RequestBody @Valid AdminMemberRequest request,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,7 +48,6 @@ public class AdminMemberController implements AdminMemberApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-
     @GetMapping("/admin/members/{id}")
     public ResponseEntity<AdminMemberResponse> getMember(
         @PathVariable("id") Integer memberId,
@@ -62,6 +62,16 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminMemberService.deleteMember(memberId);
-        return null;
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/admin/members/{id}")
+    public ResponseEntity<Void> updateMember(
+        @PathVariable("id") Integer memberId,
+        @RequestBody @Valid AdminMemberRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminMemberService.updateMember(memberId, request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -59,15 +59,12 @@ public class AdminMemberService {
     public void updateMember(Integer memberId, AdminMemberRequest request) {
         Member member = adminMemberRepository.getById(memberId);
 
-        Track track = null;
-        if (!isSameTrack(member.getTrack(), request.track())) {
-            track = adminTrackRepository.getByName(request.track());
+        String currentTrackName = member.getTrack().getName();
+        String changedTrackName = request.track();
+        if (!currentTrackName.equals(changedTrackName)) {
+            member.updateTrack(adminTrackRepository.getByName(request.track()));
         }
 
-        member.update(request, track);
-    }
-    
-    private boolean isSameTrack(Track track, String trackName) {
-        return track.getName().equals(trackName);
+        member.update(request.name(), request.studentNumber(), request.position(), request.email(), request.imageUrl());
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -60,10 +60,14 @@ public class AdminMemberService {
         Member member = adminMemberRepository.getById(memberId);
 
         Track track = null;
-        if (!member.getTrack().getName().equals(request.track())) {
+        if (!isSameTrack(member.getTrack(), request.track())) {
             track = adminTrackRepository.getByName(request.track());
         }
 
         member.update(request, track);
+    }
+    
+    private boolean isSameTrack(Track track, String trackName) {
+        return track.getName().equals(trackName);
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -54,4 +54,16 @@ public class AdminMemberService {
         Member member = adminMemberRepository.getById(memberId);
         member.delete();
     }
+
+    @Transactional
+    public void updateMember(Integer memberId, AdminMemberRequest request) {
+        Member member = adminMemberRepository.getById(memberId);
+
+        Track track = null;
+        if (!member.getTrack().getName().equals(request.track())) {
+            track = adminTrackRepository.getByName(request.track());
+        }
+
+        member.update(request, track);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/member/model/Member.java
+++ b/src/main/java/in/koreatech/koin/domain/member/model/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import in.koreatech.koin.admin.member.dto.AdminMemberRequest;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -82,5 +83,17 @@ public class Member extends BaseEntity {
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public void update(AdminMemberRequest request, Track track) {
+        this.name = request.name();
+        this.studentNumber = request.studentNumber();
+        this.position = request.position();
+        this.email = request.email();
+        this.imageUrl = request.imageUrl();
+
+        if (track != null) {
+            this.track = track;
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/member/model/Member.java
+++ b/src/main/java/in/koreatech/koin/domain/member/model/Member.java
@@ -85,15 +85,15 @@ public class Member extends BaseEntity {
         this.isDeleted = true;
     }
 
-    public void update(AdminMemberRequest request, Track track) {
-        this.name = request.name();
-        this.studentNumber = request.studentNumber();
-        this.position = request.position();
-        this.email = request.email();
-        this.imageUrl = request.imageUrl();
+    public void update(String name, String studentNumber, String position, String email, String imageUrl) {
+        this.name = name;
+        this.studentNumber = studentNumber;
+        this.position = position;
+        this.email = email;
+        this.imageUrl = imageUrl;
+    }
 
-        if (track != null) {
-            this.track = track;
-        }
+    public void updateTrack(Track track) {
+        this.track = track;
     }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -166,7 +166,7 @@ public class AdminMemberApiTest extends AcceptanceTest {
         User adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser);
 
-        var response = RestAssured
+        RestAssured
             .given()
             .header("Authorization", "Bearer " + token)
             .when()
@@ -174,7 +174,6 @@ public class AdminMemberApiTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
-
 
         Member savedMember = adminMemberRepository.getById(memberId);
 
@@ -186,6 +185,95 @@ public class AdminMemberApiTest extends AcceptanceTest {
             softly.assertThat(savedMember.getEmail()).isEqualTo("testjuno@gmail.com");
             softly.assertThat(savedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
             softly.assertThat(savedMember.isDeleted()).isEqualTo(true);
+        });
+    }
+
+    @Test
+    @DisplayName("BCSDLab 회원 정보를 수정한다")
+    void updateMember() {
+        Member member = memberFixture.최준호(trackFixture.backend());
+        Integer memberId = member.getId();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        String jsonBody = """
+            {
+                "name": "최준호",
+                "student_number": "2019136135",
+                "track": "BackEnd",
+                "position": "Mentor",
+                "email": "testjuno@gmail.com",
+                "image_url": "https://imagetest.com/juno.jpg"
+            }
+            """;
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType("application/json")
+            .body(jsonBody)
+            .when()
+            .put("/admin/members/{id}", memberId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        Member updatedMember = adminMemberRepository.getById(memberId);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(updatedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(updatedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(updatedMember.getTrack().getName()).isEqualTo("BackEnd");
+            softly.assertThat(updatedMember.getPosition()).isEqualTo("Mentor");
+            softly.assertThat(updatedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(updatedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(updatedMember.isDeleted()).isEqualTo(false);
+        });
+    }
+
+    @Test
+    @DisplayName("BCSDLab 회원 정보를 트랙과 함께 수정한다")
+    void updateMemberWithTrack() {
+        Member member = memberFixture.최준호(trackFixture.backend());
+        trackFixture.frontend();
+        Integer memberId = member.getId();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        String jsonBody = """
+            {
+                "name": "최준호",
+                "student_number": "2019136135",
+                "track": "FrontEnd",
+                "position": "Mentor",
+                "email": "testjuno@gmail.com",
+                "image_url": "https://imagetest.com/juno.jpg"
+            }
+            """;
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType("application/json")
+            .body(jsonBody)
+            .when()
+            .put("/admin/members/{id}", memberId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        Member updatedMember = adminMemberRepository.getById(memberId);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(updatedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(updatedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(updatedMember.getTrack().getName()).isEqualTo("FrontEnd");
+            softly.assertThat(updatedMember.getPosition()).isEqualTo("Mentor");
+            softly.assertThat(updatedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(updatedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(updatedMember.isDeleted()).isEqualTo(false);
         });
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #48 

# 🚀 작업 내용

1. PUT /admin/members/{id} api 추가하였습니다.

# 💬 리뷰 중점사항
- `POST /admin/members` 와 request가 동일하여 `AdminMemberRequest` dto를 그대로 사용하였습니다.
- track이 변경되었을 때와 변경되지 않았을 때의 2가지 경우를 테스트하였습니다.
