### PR TITLE
fix: 메뉴 리스트 파싱 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
@@ -121,12 +121,10 @@ public class Dining extends BaseEntity {
         }
         Pattern pattern = Pattern.compile("\"([^\"]*)\"");
         Matcher matcher = pattern.matcher(menu);
-
-        List<String> convertedMenus = new ArrayList<>();
-
+        List<String> parsedMenu = new ArrayList<>();
         while (matcher.find()) {
-            convertedMenus.add(matcher.group(1));
+            parsedMenu.add(matcher.group(1));
         }
-        return convertedMenus;
+        return parsedMenu;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
@@ -6,8 +6,10 @@ import static lombok.AccessLevel.PROTECTED;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import in.koreatech.koin.global.domain.BaseEntity;
 import in.koreatech.koin.global.exception.KoinIllegalStateException;
@@ -117,8 +119,14 @@ public class Dining extends BaseEntity {
         if (menu == null || menu.isBlank()) {
             throw new KoinIllegalStateException("메뉴가 잘못된 형태로 저장되어있습니다.", menu);
         }
-        return Stream.of(menu.substring(1, menu.length() - 1).split(","))
-            .map(str -> str.strip().replace("\"", ""))
-            .toList();
+        Pattern pattern = Pattern.compile("\"([^\"]*)\"");
+        Matcher matcher = pattern.matcher(menu);
+
+        List<String> convertedMenus = new ArrayList<>();
+
+        while (matcher.find()) {
+            convertedMenus.add(matcher.group(1));
+        }
+        return convertedMenus;
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

<img src="https://github.com/BCSDLab/KOIN_API_V2/assets/21010656/0a5ca8fa-e452-4f23-a1ad-80279dd0cc47" width=240px/>


# 🚀 작업 내용
메뉴리스트 문자열의 리스트화를 진행할 때 문자열 split이 아니라 정규식 기준으로 잘라서 메뉴 텍스트 속에 `,`가 들어있는 경우 잘못 파싱되는 문제를 해결했습니다.

# 💬 리뷰 중점사항
