### PR TITLE
feat: POST /admin/members/{id}/undelete API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -107,4 +107,20 @@ public interface AdminMemberApi {
         @RequestBody @Valid AdminMemberRequest request,
         @Auth(permit = {ADMIN}) Integer adminId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "BCSDLab 회원 삭제 취소")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/admin/members/{id}/undelete")
+    ResponseEntity<Void> undeleteMember(
+        @PathVariable("id") Integer memberId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -74,4 +74,13 @@ public class AdminMemberController implements AdminMemberApi {
         adminMemberService.updateMember(memberId, request);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
+    @PostMapping("/admin/members/{id}/undelete")
+    public ResponseEntity<Void> undeleteMember(
+        @PathVariable("id") Integer memberId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminMemberService.undeleteMember(memberId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -62,7 +62,7 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminMemberService.deleteMember(memberId);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/admin/members/{id}")
@@ -72,7 +72,7 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminMemberService.updateMember(memberId, request);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/admin/members/{id}/undelete")
@@ -81,6 +81,6 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminMemberService.undeleteMember(memberId);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -67,4 +67,10 @@ public class AdminMemberService {
 
         member.update(request.name(), request.studentNumber(), request.position(), request.email(), request.imageUrl());
     }
+
+    @Transactional
+    public void undeleteMember(Integer memberId) {
+        Member member = adminMemberRepository.getById(memberId);
+        member.undelete();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/member/model/Member.java
+++ b/src/main/java/in/koreatech/koin/domain/member/model/Member.java
@@ -85,6 +85,10 @@ public class Member extends BaseEntity {
         this.isDeleted = true;
     }
 
+    public void undelete() {
+        this.isDeleted = false;
+    }
+
     public void update(String name, String studentNumber, String position, String email, String imageUrl) {
         this.name = name;
         this.studentNumber = studentNumber;

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -276,4 +276,35 @@ public class AdminMemberApiTest extends AcceptanceTest {
             softly.assertThat(updatedMember.isDeleted()).isEqualTo(false);
         });
     }
+
+    @Test
+    @DisplayName("BCSDLab 회원 정보를 삭제를 취소한다")
+    void undeleteMember() {
+        Member member = memberFixture.최준호_삭제(trackFixture.backend());
+        Integer memberId = member.getId();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .post("/admin/members/{id}/undelete", memberId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        Member savedMember = adminMemberRepository.getById(memberId);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(savedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(savedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(savedMember.getTrack().getName()).isEqualTo("BackEnd");
+            softly.assertThat(savedMember.getPosition()).isEqualTo("Regular");
+            softly.assertThat(savedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(savedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(savedMember.isDeleted()).isEqualTo(false);
+        });
+    }
 }

--- a/src/test/java/in/koreatech/koin/fixture/MemberFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/MemberFixture.java
@@ -63,4 +63,18 @@ public class MemberFixture {
                 .build()
         );
     }
+
+    public Member 최준호_삭제(Track track) {
+        return memberRepository.save(
+            Member.builder()
+                .isDeleted(true)
+                .studentNumber("2019136135")
+                .imageUrl("https://imagetest.com/juno.jpg")
+                .name("최준호")
+                .position("Regular")
+                .track(track)
+                .email("testjuno@gmail.com")
+                .build()
+        );
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #49 

# 🚀 작업 내용

1. POST /admin/members/{id}/undelete API 추가

# 💬 리뷰 중점사항
- 삭제 상태의 회원을 DB에 저장하기위해 `Fixture`에 `최준호_삭제`를 추가 후 테스트를 진행하였습니다.
