### PR TITLE
hotfix: 비밀번호 검증 api 비밀번호 틀렸을시에 400 반환하는 것으로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -87,6 +88,23 @@ public interface AdminMemberApi {
     @DeleteMapping("/admin/members/{id}")
     ResponseEntity<Void> deleteMember(
         @PathVariable("id") Integer memberId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "BCSDLab 회원 수정")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PutMapping("/admin/members/{id}")
+    ResponseEntity<Void> updateMember(
+        @PathVariable("id") Integer memberId,
+        @RequestBody @Valid AdminMemberRequest request,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
+++ b/src/main/java/in/koreatech/koin/admin/member/controller/AdminMemberController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,7 +48,6 @@ public class AdminMemberController implements AdminMemberApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-
     @GetMapping("/admin/members/{id}")
     public ResponseEntity<AdminMemberResponse> getMember(
         @PathVariable("id") Integer memberId,
@@ -62,6 +62,16 @@ public class AdminMemberController implements AdminMemberApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminMemberService.deleteMember(memberId);
-        return null;
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/admin/members/{id}")
+    public ResponseEntity<Void> updateMember(
+        @PathVariable("id") Integer memberId,
+        @RequestBody @Valid AdminMemberRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminMemberService.updateMember(memberId, request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
+++ b/src/main/java/in/koreatech/koin/admin/member/service/AdminMemberService.java
@@ -54,4 +54,17 @@ public class AdminMemberService {
         Member member = adminMemberRepository.getById(memberId);
         member.delete();
     }
+
+    @Transactional
+    public void updateMember(Integer memberId, AdminMemberRequest request) {
+        Member member = adminMemberRepository.getById(memberId);
+
+        String currentTrackName = member.getTrack().getName();
+        String changedTrackName = request.track();
+        if (!currentTrackName.equals(changedTrackName)) {
+            member.updateTrack(adminTrackRepository.getByName(request.track()));
+        }
+
+        member.update(request.name(), request.studentNumber(), request.position(), request.email(), request.imageUrl());
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/bus/model/city/CityBusRoute.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/model/city/CityBusRoute.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.bus.model.city;
+
+import lombok.Builder;
+
+@Builder
+public record CityBusRoute(
+    String endnodenm, // 종점, 병천3리
+    String routeid, // 노선 ID, CAB285000142
+    Long routeno, // 노선 번호, 400
+    String routetp, // 노선 유형, 일반버스
+    String startnodenm // 기점, 종합터미널
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/bus/model/city/CityBusRouteCache.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/model/city/CityBusRouteCache.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.bus.model.city;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("CityBusRoute")
+public class CityBusRouteCache {
+
+    private static final long CACHE_EXPIRE_MINUTE = 2L;
+
+    @Id
+    private final String id;
+
+    private final Set<Long> busNumbers = new HashSet<>();
+
+    @TimeToLive(unit = TimeUnit.MINUTES)
+    private final Long expiration;
+
+    @Builder
+    private CityBusRouteCache(String id, Set<Long> busNumbers, Long expiration) {
+        this.id = id;
+        this.busNumbers.addAll(busNumbers);
+        this.expiration = expiration;
+    }
+
+    public static CityBusRouteCache of(String nodeId, Set<CityBusRoute> busRoutes) {
+        return CityBusRouteCache.builder()
+            .id(nodeId)
+            .busNumbers(busRoutes.stream()
+                .map(CityBusRoute::routeno)
+                .collect(Collectors.toSet())
+            )
+            .expiration(CACHE_EXPIRE_MINUTE)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/bus/repository/CityBusRouteCacheRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/repository/CityBusRouteCacheRepository.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.bus.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.bus.exception.BusCacheNotFoundException;
+import in.koreatech.koin.domain.bus.model.city.CityBusRouteCache;
+
+public interface CityBusRouteCacheRepository extends Repository<CityBusRouteCache, String> {
+
+    CityBusRouteCache save(CityBusRouteCache cityBusRouteCache);
+
+    List<CityBusRouteCache> saveAll(List<CityBusRouteCache> cityBusRouteCaches);
+
+    List<CityBusRouteCache> findAll();
+
+    Optional<CityBusRouteCache> findById(String nodeId);
+
+    default CityBusRouteCache getById(String nodeId) {
+        return findById(nodeId).orElseThrow(() -> BusCacheNotFoundException.withDetail("nodeId: " + nodeId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/bus/util/BusScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/util/BusScheduler.java
@@ -13,11 +13,13 @@ public class BusScheduler {
 
     private final CityBusClient cityBusClient;
     private final TmoneyExpressBusClient tmoneyExpressBusClient;
+    private final CityBusRouteClient cityBusRouteClient;
 
     @Scheduled(cron = "0 * * * * *")
     public void cacheCityBusByOpenApi() {
         try {
             cityBusClient.storeRemainTimeByOpenApi();
+            cityBusRouteClient.storeCityBusRoute();
         } catch (Exception e) {
             log.warn("시내버스 스케줄링 과정에서 오류가 발생했습니다.");
         }

--- a/src/main/java/in/koreatech/koin/domain/coop/controller/CoopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/controller/CoopApi.java
@@ -4,9 +4,12 @@ import static in.koreatech.koin.domain.user.model.UserType.COOP;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import in.koreatech.koin.domain.coop.dto.CoopLoginRequest;
+import in.koreatech.koin.domain.coop.dto.CoopLoginResponse;
 import in.koreatech.koin.domain.coop.dto.DiningImageRequest;
 import in.koreatech.koin.domain.coop.dto.SoldOutRequest;
 import in.koreatech.koin.global.auth.Auth;
@@ -52,5 +55,19 @@ public interface CoopApi {
     ResponseEntity<Void> saveDiningImage(
         @Auth(permit = {COOP}) Integer userId,
         @RequestBody @Valid DiningImageRequest imageRequest
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "영양사 로그인")
+    @PostMapping("/coop/login")
+    ResponseEntity<CoopLoginResponse> coopLogin(
+        @RequestBody @Valid CoopLoginRequest request
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/controller/CoopController.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/controller/CoopController.java
@@ -2,12 +2,17 @@ package in.koreatech.koin.domain.coop.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.COOP;
 
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.coop.dto.CoopLoginRequest;
+import in.koreatech.koin.domain.coop.dto.CoopLoginResponse;
 import in.koreatech.koin.domain.coop.dto.DiningImageRequest;
 import in.koreatech.koin.domain.coop.dto.SoldOutRequest;
 import in.koreatech.koin.domain.coop.service.CoopService;
@@ -38,5 +43,14 @@ public class CoopController implements CoopApi {
     ) {
         coopService.saveDiningImage(imageRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<CoopLoginResponse> coopLogin(
+        @RequestBody @Valid CoopLoginRequest request
+    ) {
+        CoopLoginResponse response = coopService.coopLogin(request);
+        return ResponseEntity.created(URI.create("/"))
+            .body(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/dto/CoopLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/dto/CoopLoginRequest.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.domain.coop.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CoopLoginRequest(
+    @Schema(description = "아이디", example = "koin123", requiredMode = REQUIRED)
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String id,
+
+    @Schema(
+        description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
+        example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+        requiredMode = REQUIRED
+    )
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/dto/CoopLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/dto/CoopLoginResponse.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.user.dto;
+package in.koreatech.koin.domain.coop.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserLoginResponse(
+public record CoopLoginResponse(
     @Schema(
         description = "Jwt accessToken",
         example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
@@ -17,21 +17,10 @@ public record UserLoginResponse(
 
     @Schema(description = "Random UUID refresh token", example = "RANDOM-KEY-VALUE", requiredMode = REQUIRED)
     @JsonProperty("refresh_token")
-    String refreshToken,
+    String refreshToken
+    ) {
 
-    @Schema(
-        description = """
-            로그인한 회원의 신원
-            - `STUDENT`: 학생
-            - `OWNER`: 사장님
-            - `COOP` : 영양사
-            """, example = "STUDENT", requiredMode = REQUIRED
-    )
-    @JsonProperty("user_type")
-    String userType
-) {
-
-    public static UserLoginResponse of(String token, String refreshToken, String userType) {
-        return new UserLoginResponse(token, refreshToken, userType);
+    public static CoopLoginResponse of(String token, String refreshToken) {
+        return new CoopLoginResponse(token, refreshToken);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/exception/CoopNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/exception/CoopNotFoundException.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.coop.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class CoopNotFoundException extends DataNotFoundException {
+    private static final String DEFAULT_MESSAGE = "영양사님 계정이 존재하지 않습니다.";
+
+    public CoopNotFoundException(String message) {
+        super(message);
+    }
+
+    public CoopNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DiningCacheNotFoundException withDetail(String detail) {
+        return new DiningCacheNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/model/Coop.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/Coop.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.domain.coop.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "coop")
+@NoArgsConstructor(access = PROTECTED)
+public class Coop {
+
+    @Id
+    @Column(name = "user_id")
+    private Integer id;
+
+    @Size(max = 255)
+    @Column(name = "coop_id")
+    private String coopId;
+
+    @OneToOne
+    @MapsId
+    private User user;
+
+    @Builder
+    private Coop(
+        String coopId,
+        User user
+    ) {
+        this.coopId = coopId;
+        this.user = user;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/repository/CoopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/repository/CoopRepository.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.coop.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.coop.exception.CoopNotFoundException;
+import in.koreatech.koin.domain.coop.model.Coop;
+
+public interface CoopRepository extends Repository<Coop, Integer> {
+    Optional<Coop> findByCoopId(String coopId);
+
+    default Coop getByCoopId(String coopId){
+        return findByCoopId(coopId).orElseThrow(() -> CoopNotFoundException.withDetail("CoopId : " + coopId));
+    }
+
+    Coop save(Coop coop);
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -2,17 +2,30 @@ package in.koreatech.koin.domain.coop.service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.coop.dto.CoopLoginRequest;
+import in.koreatech.koin.domain.coop.dto.CoopLoginResponse;
 import in.koreatech.koin.domain.coop.dto.DiningImageRequest;
 import in.koreatech.koin.domain.coop.dto.SoldOutRequest;
+import in.koreatech.koin.domain.coop.model.Coop;
 import in.koreatech.koin.domain.coop.model.DiningSoldOutEvent;
+import in.koreatech.koin.domain.coop.repository.CoopRepository;
 import in.koreatech.koin.domain.coop.repository.DiningSoldOutCacheRepository;
 import in.koreatech.koin.domain.dining.model.Dining;
 import in.koreatech.koin.domain.dining.repository.DiningRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.domain.user.model.UserType;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.domain.user.repository.UserTokenRepository;
+import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -24,6 +37,10 @@ public class CoopService {
     private final ApplicationEventPublisher eventPublisher;
     private final DiningRepository diningRepository;
     private final DiningSoldOutCacheRepository diningSoldOutCacheRepository;
+    private final CoopRepository coopRepository;
+    private final UserTokenRepository userTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     @Transactional
     public void changeSoldOut(SoldOutRequest soldOutRequest) {
@@ -47,5 +64,22 @@ public class CoopService {
     public void saveDiningImage(DiningImageRequest imageRequest) {
         Dining dining = diningRepository.getById(imageRequest.menuId());
         dining.setImageUrl(imageRequest.imageUrl());
+    }
+
+    @Transactional
+    public CoopLoginResponse coopLogin(CoopLoginRequest request) {
+        Coop coop = coopRepository.getByCoopId(request.id());
+        User user = coop.getUser();
+
+        if (!user.isSamePassword(passwordEncoder, request.password())) {
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+        }
+
+        String accessToken = jwtProvider.createToken(user);
+        String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
+        UserToken savedToken = userTokenRepository.save(UserToken.create(user.getId(), refreshToken));
+        user.updateLastLoggedTime(LocalDateTime.now());
+
+        return CoopLoginResponse.of(accessToken, savedToken.getRefreshToken());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/model/Dining.java
@@ -6,8 +6,10 @@ import static lombok.AccessLevel.PROTECTED;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import in.koreatech.koin.global.domain.BaseEntity;
 import in.koreatech.koin.global.exception.KoinIllegalStateException;
@@ -117,8 +119,12 @@ public class Dining extends BaseEntity {
         if (menu == null || menu.isBlank()) {
             throw new KoinIllegalStateException("메뉴가 잘못된 형태로 저장되어있습니다.", menu);
         }
-        return Stream.of(menu.substring(1, menu.length() - 1).split(","))
-            .map(str -> str.strip().replace("\"", ""))
-            .toList();
+        Pattern pattern = Pattern.compile("\"([^\"]*)\"");
+        Matcher matcher = pattern.matcher(menu);
+        List<String> parsedMenu = new ArrayList<>();
+        while (matcher.find()) {
+            parsedMenu.add(matcher.group(1));
+        }
+        return parsedMenu;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/member/model/Member.java
+++ b/src/main/java/in/koreatech/koin/domain/member/model/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import in.koreatech.koin.admin.member.dto.AdminMemberRequest;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -82,5 +83,17 @@ public class Member extends BaseEntity {
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public void update(String name, String studentNumber, String position, String email, String imageUrl) {
+        this.name = name;
+        this.studentNumber = studentNumber;
+        this.position = position;
+        this.email = email;
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateTrack(Track track) {
+        this.track = track;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin.domain.owner.dto.OwnerEmailVerifyRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifyEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifySmsRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateEmailRequest;
@@ -48,6 +50,20 @@ public interface OwnerApi {
     @GetMapping("/owner")
     ResponseEntity<OwnerResponse> getOwner(
         @Auth(permit = {OWNER}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "사장님 로그인")
+    @PostMapping("/owner/login")
+    ResponseEntity<OwnerLoginResponse> ownerLogin(
+        @RequestBody @Valid OwnerLoginRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
@@ -2,6 +2,8 @@ package in.koreatech.koin.domain.owner.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.owner.dto.OwnerEmailVerifyRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifyEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifySmsRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateEmailRequest;
@@ -64,6 +68,15 @@ public class OwnerController implements OwnerApi {
     ) {
         ownerService.register(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/owner/login")
+    public ResponseEntity<OwnerLoginResponse> ownerLogin(
+        @RequestBody @Valid OwnerLoginRequest request
+    ) {
+        OwnerLoginResponse response = ownerService.ownerLogin(request);
+        return ResponseEntity.created(URI.create("/"))
+            .body(response);
     }
 
     @PostMapping("/owners/register/phone")

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerLoginRequest.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.owner.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record OwnerLoginRequest(
+    @Schema(description = "전화번호", example = "01012345678", requiredMode = REQUIRED)
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
+    String account,
+
+    @Schema
+        (
+            description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
+            example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+            requiredMode = REQUIRED
+        )
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerLoginResponse.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.user.dto;
+package in.koreatech.koin.domain.owner.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserLoginResponse(
+public record OwnerLoginResponse(
     @Schema(
         description = "Jwt accessToken",
         example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
@@ -17,21 +17,10 @@ public record UserLoginResponse(
 
     @Schema(description = "Random UUID refresh token", example = "RANDOM-KEY-VALUE", requiredMode = REQUIRED)
     @JsonProperty("refresh_token")
-    String refreshToken,
-
-    @Schema(
-        description = """
-            로그인한 회원의 신원
-            - `STUDENT`: 학생
-            - `OWNER`: 사장님
-            - `COOP` : 영양사
-            """, example = "STUDENT", requiredMode = REQUIRED
-    )
-    @JsonProperty("user_type")
-    String userType
+    String refreshToken
 ) {
 
-    public static UserLoginResponse of(String token, String refreshToken, String userType) {
-        return new UserLoginResponse(token, refreshToken, userType);
+    public static OwnerLoginResponse of(String token, String refreshToken) {
+        return new OwnerLoginResponse(token, refreshToken);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterByPhoneRequest.java
@@ -59,7 +59,7 @@ public record OwnerRegisterByPhoneRequest(
         User user = User.builder()
             .password(passwordEncoder.encode(password))
             .name(name)
-            .email(phoneNumber)
+            .email(null)
             .phoneNumber(phoneNumber)
             .userType(OWNER)
             .isAuthed(false)
@@ -71,6 +71,7 @@ public record OwnerRegisterByPhoneRequest(
             .attachments(new ArrayList<>())
             .grantShop(false)
             .grantEvent(false)
+            .account(phoneNumber)
             .build();
         List<OwnerAttachment> attachments = attachmentUrls.stream()
             .map(OwnerRegisterByPhoneInnerAttachmentUrl::fileUrl)

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisterRequest.java
@@ -44,7 +44,7 @@ public record OwnerRegisterRequest(
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
     String password,
 
-    @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다.")
     @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = REQUIRED)
     String phoneNumber,
 

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerResponse.java
@@ -23,6 +23,9 @@ public record OwnerResponse(
     @Schema(description = "사업자 등록 번호", example = "123-45-67890", requiredMode = REQUIRED)
     String company_number,
 
+    @Schema(description = "저장 된 사장님 전화번호", example = "01012345678", requiredMode = REQUIRED)
+    String account,
+
     @Schema(description = "첨부 파일 목록", requiredMode = NOT_REQUIRED)
     List<InnerAttachmentResponse> attachments,
 
@@ -35,6 +38,7 @@ public record OwnerResponse(
             owner.getUser().getEmail(),
             owner.getUser().getName(),
             owner.getCompanyRegistrationNumber(),
+            owner.getAccount(),
             attachments.stream()
                 .map(InnerAttachmentResponse::from)
                 .toList(),

--- a/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/Owner.java
@@ -50,6 +50,10 @@ public class Owner {
     @Column(name = "grant_event", columnDefinition = "TINYINT")
     private boolean grantEvent;
 
+    @Size(max = 255)
+    @Column(name = "account")
+    private String account;
+
     @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true)
     @JoinColumn(name = "owner_id", updatable = false)
     private List<OwnerAttachment> attachments = new ArrayList<>();
@@ -60,12 +64,14 @@ public class Owner {
         String companyRegistrationNumber,
         List<OwnerAttachment> attachments,
         Boolean grantShop,
-        Boolean grantEvent
+        Boolean grantEvent,
+        String account
     ) {
         this.user = user;
         this.companyRegistrationNumber = companyRegistrationNumber;
         this.attachments = attachments;
         this.grantShop = grantShop;
         this.grantEvent = grantEvent;
+        this.account = account;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/repository/OwnerRepository.java
@@ -15,6 +15,12 @@ public interface OwnerRepository extends Repository<Owner, Integer> {
         return findById(ownerId).orElseThrow(() -> OwnerNotFoundException.withDetail("ownerId: " + ownerId));
     }
 
+    Optional<Owner> findByAccount(String account);
+
+    default Owner getByAccount(String account) {
+        return findByAccount(account).orElseThrow(() -> OwnerNotFoundException.withDetail("ownerAccount : " + account));
+    }
+
     Owner save(Owner owner);
 
     Optional<Owner> findByCompanyRegistrationNumber(String companyRegistrationNumber);

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -2,9 +2,11 @@ package in.koreatech.koin.domain.owner.service;
 
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.owner.dto.OwnerEmailVerifyRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifyEmailRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordResetVerifySmsRequest;
 import in.koreatech.koin.domain.owner.dto.OwnerPasswordUpdateEmailRequest;
@@ -41,7 +45,10 @@ import in.koreatech.koin.domain.owner.repository.redis.OwnerVerificationStatusRe
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.domain.user.repository.UserTokenRepository;
 import in.koreatech.koin.global.auth.JwtProvider;
 import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
 import in.koreatech.koin.global.domain.email.form.OwnerRegistrationData;
@@ -67,11 +74,33 @@ public class OwnerService {
     private final OwnerVerificationStatusRepository ownerVerificationStatusRepository;
     private final DailyVerificationLimitRepository dailyVerificationLimitRedisRepository;
     private final NaverSmsService naverSmsService;
+    private final UserTokenRepository userTokenRepository;
 
     public OwnerResponse getOwner(Integer ownerId) {
         Owner foundOwner = ownerRepository.getById(ownerId);
         List<Shop> shops = shopRepository.findAllByOwnerId(ownerId);
         return OwnerResponse.of(foundOwner, foundOwner.getAttachments(), shops);
+    }
+
+    @Transactional
+    public OwnerLoginResponse ownerLogin(OwnerLoginRequest request) {
+        Owner owner = ownerRepository.getByAccount(request.account());
+        User user = owner.getUser();
+
+        if (!user.isSamePassword(passwordEncoder, request.password())) {
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+        }
+
+        if (!user.isAuthed()) {
+            throw new KoinIllegalArgumentException("미인증 상태입니다. 인증을 진행해주세요.");
+        }
+
+        String accessToken = jwtProvider.createToken(user);
+        String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
+        UserToken savedToken = userTokenRepository.save(UserToken.create(user.getId(), refreshToken));
+        user.updateLastLoggedTime(LocalDateTime.now());
+
+        return OwnerLoginResponse.of(accessToken, savedToken.getRefreshToken());
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
@@ -55,6 +55,8 @@ public record OwnerShopsRequest(
     String name,
 
     @Schema(description = "요일별 운영 시간과 휴무 여부", requiredMode = REQUIRED)
+    @Size(min = 7, max = 7, message = "The list must contain exactly 7 elements.")
+    @NotNull
     List<InnerOpenRequest> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -17,6 +17,10 @@ import in.koreatech.koin.domain.user.dto.CoopResponse;
 import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
 import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
 import in.koreatech.koin.domain.user.dto.NicknameCheckExistsRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginResponse;
+import in.koreatech.koin.domain.user.dto.StudentLoginRequest;
+import in.koreatech.koin.domain.user.dto.StudentLoginResponse;
 import in.koreatech.koin.domain.user.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.user.dto.StudentResponse;
 import in.koreatech.koin.domain.user.dto.StudentUpdateRequest;
@@ -99,6 +103,20 @@ public interface UserApi {
     @PostMapping("/user/login")
     ResponseEntity<UserLoginResponse> login(
         @RequestBody @Valid UserLoginRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "학생 로그인")
+    @PostMapping("/student/login")
+    ResponseEntity<StudentLoginResponse> studentLogin(
+        @RequestBody @Valid StudentLoginRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -24,6 +24,10 @@ import in.koreatech.koin.domain.user.dto.CoopResponse;
 import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
 import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
 import in.koreatech.koin.domain.user.dto.NicknameCheckExistsRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerLoginResponse;
+import in.koreatech.koin.domain.user.dto.StudentLoginRequest;
+import in.koreatech.koin.domain.user.dto.StudentLoginResponse;
 import in.koreatech.koin.domain.user.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.user.dto.StudentResponse;
 import in.koreatech.koin.domain.user.dto.StudentUpdateRequest;
@@ -79,6 +83,15 @@ public class UserController implements UserApi {
         @RequestBody @Valid UserLoginRequest request
     ) {
         UserLoginResponse response = userService.login(request);
+        return ResponseEntity.created(URI.create("/"))
+            .body(response);
+    }
+
+    @PostMapping("/student/login")
+    public ResponseEntity<StudentLoginResponse> studentLogin(
+        @RequestBody @Valid StudentLoginRequest request
+    ) {
+        StudentLoginResponse response = studentService.studentLogin(request);
         return ResponseEntity.created(URI.create("/"))
             .body(response);
     }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.domain.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record StudentLoginRequest(
+    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
+    @NotBlank(message = "이메일을 입력해주세요.")
+    String email,
+
+    @Schema(
+        description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
+        example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+        requiredMode = REQUIRED
+    )
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserLoginResponse(
+public record StudentLoginResponse(
     @Schema(
         description = "Jwt accessToken",
         example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
@@ -17,21 +17,10 @@ public record UserLoginResponse(
 
     @Schema(description = "Random UUID refresh token", example = "RANDOM-KEY-VALUE", requiredMode = REQUIRED)
     @JsonProperty("refresh_token")
-    String refreshToken,
-
-    @Schema(
-        description = """
-            로그인한 회원의 신원
-            - `STUDENT`: 학생
-            - `OWNER`: 사장님
-            - `COOP` : 영양사
-            """, example = "STUDENT", requiredMode = REQUIRED
-    )
-    @JsonProperty("user_type")
-    String userType
+    String refreshToken
 ) {
 
-    public static UserLoginResponse of(String token, String refreshToken, String userType) {
-        return new UserLoginResponse(token, refreshToken, userType);
+    public static StudentLoginResponse of(String token, String refreshToken) {
+        return new StudentLoginResponse(token, refreshToken);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -74,7 +74,7 @@ public record StudentRegisterRequest(
     String studentNumber,
 
     @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10}|\\d{11})$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다.")
     String phoneNumber
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
@@ -47,7 +47,7 @@ public record StudentUpdateRequest
         @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
         String nickname,
 
-        @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+        @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = NOT_REQUIRED)
         String phoneNumber,
 
         @Size(min = 10, max = 10, message = "학번은 10자여야 합니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateResponse.java
@@ -42,7 +42,7 @@ public record StudentUpdateResponse(
     @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
     String nickname,
 
-    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+    @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = NOT_REQUIRED)
     String phoneNumber,
 
     @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
@@ -51,11 +51,10 @@ public record StudentUpdateResponse(
 
     public static StudentUpdateResponse from(Student student) {
         User user = student.getUser();
-        Integer userGender = user.getGender() != null ? user.getGender().ordinal() : null;
         return new StudentUpdateResponse(
             student.getAnonymousNickname(),
             user.getEmail(),
-            userGender,
+            user.getGender() != null ? user.getGender().ordinal() : null,
             student.getDepartment(),
             user.getName(),
             user.getNickname(),

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -3,12 +3,10 @@ package in.koreatech.koin.domain.user.dto;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
-    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     @NotBlank(message = "이메일을 입력해주세요.")
     String email,
 

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -59,8 +59,7 @@ public class User extends BaseEntity {
     private UserType userType;
 
     @Size(max = 100)
-    @NotNull
-    @Column(name = "email", nullable = false, length = 100)
+    @Column(name = "email", length = 100)
     private String email;
 
     @Column(name = "gender", columnDefinition = "INT")

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -15,6 +15,8 @@ public interface UserRepository extends Repository<User, Integer> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByEmailAndUserType(String email, UserType userType);
+
     Optional<User> findByPhoneNumberAndUserType(String phoneNumber, UserType userType);
 
     Optional<User> findById(Integer id);
@@ -38,6 +40,11 @@ public interface UserRepository extends Repository<User, Integer> {
     default User getById(Integer userId) {
         return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
+    }
+
+    default User getById(String id, UserType userType) {
+        return findByEmailAndUserType(id, userType)
+            .orElseThrow(() -> UserNotFoundException.withDetail("id: " + id));
     }
 
     default User getByNickname(String nickname) {

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -108,7 +108,7 @@ public class UserService {
     public void checkPassword(UserPasswordCheckRequest request, Integer userId) {
         User user = userRepository.getById(userId);
         if (!user.isSamePassword(passwordEncoder, request.password())) {
-            throw new AuthenticationException("올바르지 않은 비밀번호입니다.");
+            throw new KoinIllegalArgumentException("올바르지 않은 비밀번호입니다.");
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -9,9 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.owner.repository.OwnerAttachmentRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
-import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.CoopResponse;
 import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
@@ -45,8 +43,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
     private final OwnerRepository ownerRepository;
-    private final ShopRepository shopRepository;
-    private final OwnerAttachmentRepository ownerAttachmentRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserTokenRepository userTokenRepository;
     private final ApplicationEventPublisher eventPublisher;

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -32,8 +32,8 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
-            "%s 품절되었습니다.".formatted(getPostposition(place, "이", "가")),
-            "다른 식단 보러 가기.",
+            "%s 품절되었습니다".formatted(getPostposition(place, "이", "가")),
+            "다른 식단 보러 가기",
             null,
             NotificationType.MESSAGE,
             target

--- a/src/main/resources/db/migration/V16__add_account_column_to_owners_table.sql
+++ b/src/main/resources/db/migration/V16__add_account_column_to_owners_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `koin`.`owners`
+    ADD COLUMN `account` VARCHAR(255) NULL COMMENT '사장님 전화번호(“-“ 제거, unique)',
+    ADD UNIQUE INDEX `account_UNIQUE` (`account`);
+
+UPDATE `koin`.`owners` o
+    JOIN `koin`.`users` u ON o.user_id = u.id
+    SET o.account = REPLACE(u.phone_number, '-', '')

--- a/src/main/resources/db/migration/V17__create_coop_table_and_insert_data.sql
+++ b/src/main/resources/db/migration/V17__create_coop_table_and_insert_data.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `coop`
+(
+    `user_id` INT UNSIGNED NOT NULL COMMENT '유저 id, user_type COOP으로 가져옴',
+    `coop_id` VARCHAR(255) COMMENT '영양사 id, 일반 로그인 형식',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT `FK_COOP_ON_USER` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+
+INSERT INTO `coop` (`user_id`, `coop_id`)
+    SELECT `id`, '' FROM `users` WHERE `user_type` = 'COOP';

--- a/src/main/resources/db/migration/V18__alter_user_email_column_nullable.sql
+++ b/src/main/resources/db/migration/V18__alter_user_email_column_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `koin`.`users`
+    CHANGE COLUMN `email` `email` VARCHAR(100) CHARACTER SET 'utf8mb3' NULL COMMENT '학교 email' ;

--- a/src/test/java/in/koreatech/koin/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/AcceptanceTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 import in.koreatech.koin.config.TestJpaConfiguration;
 import in.koreatech.koin.config.TestTimeConfig;
 import in.koreatech.koin.domain.bus.util.CityBusClient;
+import in.koreatech.koin.domain.bus.util.CityBusRouteClient;
 import in.koreatech.koin.domain.coop.model.CoopEventListener;
 import in.koreatech.koin.domain.owner.model.OwnerEventListener;
 import in.koreatech.koin.domain.shop.model.ShopEventListener;
@@ -44,6 +45,9 @@ public abstract class AcceptanceTest {
 
     @SpyBean
     protected CityBusClient cityBusClient;
+
+    @SpyBean
+    protected CityBusRouteClient cityBusRouteClient;
 
     @MockBean
     protected OwnerEventListener ownerEventListener;

--- a/src/test/java/in/koreatech/koin/acceptance/BusApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/BusApiTest.java
@@ -104,6 +104,104 @@ class BusApiTest extends AcceptanceTest {
               }
             }
             """);
+
+        when(cityBusRouteClient.getOpenApiResponse("CAB285000686")).thenReturn("""
+            {
+              "response": {
+                "header": {
+                  "resultCode": "00",
+                  "resultMsg": "NORMAL SERVICE."
+                },
+                "body": {
+                  "items": {
+                    "item": [
+                      {
+                        "endnodenm": "황사동",
+                        "routeid": "CAB285000146",
+                        "routeno": 402,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      },
+                      {
+                        "endnodenm": "방아다리공원",
+                        "routeid": "CAB285000331",
+                        "routeno": 9,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      },
+                      {
+                        "endnodenm": "유관순열사유적지",
+                        "routeid": "CAB285000407",
+                        "routeno": 405,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      },
+                      {
+                        "endnodenm": "병천3리",
+                        "routeid": "CAB285000142",
+                        "routeno": 400,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      }
+                    ]
+                  },
+                  "numOfRows": 50,
+                  "pageNo": 1,
+                  "totalCount": 4
+                }
+              }
+            }
+            """
+        );
+
+        when(cityBusRouteClient.getOpenApiResponse("CAB285000406")).thenReturn("""
+            {
+              "response": {
+                "header": {
+                  "resultCode": "00",
+                  "resultMsg": "NORMAL SERVICE."
+                },
+                "body": {
+                  "items": {
+                    "item": [
+                      {
+                        "endnodenm": "황사동",
+                        "routeid": "CAB285000146",
+                        "routeno": 402,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      },
+                      {
+                        "endnodenm": "병천중고등학교",
+                        "routeid": "CAB285000049",
+                        "routeno": 95,
+                        "routetp": "일반버스",
+                        "startnodenm": "월봉청솔아파트"
+                      },
+                      {
+                        "endnodenm": "유관순열사유적지",
+                        "routeid": "CAB285000407",
+                        "routeno": 405,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      },
+                      {
+                        "endnodenm": "병천3리",
+                        "routeid": "CAB285000142",
+                        "routeno": 400,
+                        "routetp": "일반버스",
+                        "startnodenm": "종합터미널"
+                      }
+                    ]
+                  },
+                  "numOfRows": 50,
+                  "pageNo": 1,
+                  "totalCount": 4
+                }
+              }
+            }
+            """
+        );
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
@@ -49,7 +49,7 @@ class DiningApiTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        coop_준기 = userFixture.준기_영양사();
+        coop_준기 = userFixture.준기_영양사().getUser();
         token_준기 = userFixture.getToken(coop_준기);
         owner_현수 = userFixture.현수_사장님().getUser();
         token_현수 = userFixture.getToken(owner_현수);

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -58,6 +58,29 @@ class OwnerApiTest extends AcceptanceTest {
     private PasswordEncoder passwordEncoder;
 
     @Test
+    @DisplayName("사장님이 로그인을 진행한다")
+    void ownerLogin() {
+        Owner owner = userFixture.원경_사장님();
+        String phoneNumber = owner.getAccount();
+        String password = "1234";
+
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "account" : "%s",
+                  "password" : "%s"
+                }
+                """.formatted(phoneNumber, password))
+            .when()
+            .post("/owner/login")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract();
+    }
+
+    @Test
     @DisplayName("로그인된 사장님 정보를 조회한다.")
     void getOwner() {
         // given
@@ -81,6 +104,7 @@ class OwnerApiTest extends AcceptanceTest {
                     "email": "hysoo@naver.com",
                     "name": "테스트용_현수",
                     "company_number": "123-45-67190",
+                    "account" : "01098765432",
                     "attachments": [
                         {
                             "id": 1,
@@ -182,7 +206,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "email": "helloworld@koreatech.ac.kr",
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-0000-0000",
+                       "phone_number": "01000000000",
                        "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
@@ -250,9 +274,10 @@ class OwnerApiTest extends AcceptanceTest {
                         softly -> {
                             softly.assertThat(owner).isNotNull();
                             softly.assertThat(owner.getUser().getName()).isEqualTo("최준호");
-                            softly.assertThat(owner.getUser().getEmail()).isEqualTo("01012341234");
+                            softly.assertThat(owner.getUser().getEmail()).isEqualTo(null);
                             softly.assertThat(owner.getUser().getPhoneNumber()).isEqualTo("01012341234");
                             softly.assertThat(owner.getCompanyRegistrationNumber()).isEqualTo("012-34-56789");
+                            softly.assertThat(owner.getAccount()).isEqualTo("01012341234");
                             softly.assertThat(owner.getAttachments().size()).isEqualTo(1);
                             softly.assertThat(owner.getAttachments().get(0).getUrl())
                                 .isEqualTo("https://static.koreatech.in/testimage.png");
@@ -311,7 +336,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "email": "helloworld@koreatech.ac.kr",
                        "name": "최준호",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-0000-0000",
+                       "phone_number": "01000000000",
                        "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
@@ -340,7 +365,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "email": "helloworld@koreatech.ac.kr",
                        "name": "",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-0000-0000",
+                       "phone_number": "01000000000",
                        "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }
@@ -370,7 +395,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "email": "helloworld@koreatech.ac.kr",
                        "name": "주노",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-0000-0000",
+                       "phone_number": "01000000000",
                        "shop_id": %d,
                        "shop_name": "기분좋은 뷔짱"
                      }
@@ -408,7 +433,7 @@ class OwnerApiTest extends AcceptanceTest {
                        "email": "helloworld@koreatech.ac.kr",
                        "name": "주노",
                        "password": "a0240120305812krlakdsflsa;1235",
-                       "phone_number": "010-0000-0000",
+                       "phone_number": "01000000000",
                        "shop_id": null,
                        "shop_name": "기분좋은 뷔짱"
                      }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -162,31 +162,50 @@ class OwnerShopApiTest extends AcceptanceTest {
                         "https://test.com/test2.jpg",
                         "https://test.com/test3.jpg"
                     ],
+                    
                     "name": "테스트 상점2",
                     "open": [
                         {
-                            "close_time": [
-                                21,
-                                0
-                            ],
+                            "close_time": "21:00",
                             "closed": false,
                             "day_of_week": "MONDAY",
-                            "open_time": [
-                                9,
-                                0
-                            ]
+                            "open_time": "09:00"
                         },
                         {
-                            "close_time": [
-                                21,
-                                0
-                            ],
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "TUESDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
                             "closed": false,
                             "day_of_week": "WEDNESDAY",
-                            "open_time": [
-                                9,
-                                0
-                            ]
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "THURSDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "FRIDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "SATURDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "SUNDAY",
+                            "open_time": "09:00"
                         }
                     ],
                     "pay_bank": true,
@@ -198,6 +217,7 @@ class OwnerShopApiTest extends AcceptanceTest {
             .when()
             .post("/owner/shops")
             .then()
+            .log().all()
             .statusCode(HttpStatus.CREATED.value())
             .extract();
 
@@ -211,7 +231,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                     softly.assertThat(result.getDescription()).isEqualTo("테스트 상점2입니다.");
                     softly.assertThat(result.getName()).isEqualTo("테스트 상점2");
                     softly.assertThat(result.getShopImages()).hasSize(3);
-                    softly.assertThat(result.getShopOpens()).hasSize(2);
+                    softly.assertThat(result.getShopOpens()).hasSize(7);
                     softly.assertThat(result.getShopCategories()).hasSize(1);
                 }
             );

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.coop.model.Coop;
 import in.koreatech.koin.domain.dept.model.Dept;
+import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
@@ -56,10 +58,79 @@ class UserApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Test
+    @DisplayName("학생이 로그인을 진행한다(구 API(/user/login))")
+    void login() {
+        Student student = userFixture.성빈_학생();
+        String email = student.getUser().getEmail();
+        String password = "1234";
+
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "email" : "%s",
+                  "password" : "%s"
+                }
+                """.formatted(email, password))
+            .when()
+            .post("/user/login")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract();
+    }
+
+    @Test
+    @DisplayName("학생이 로그인을 진행한다(신규 API(/student/login))")
+    void studentLogin() {
+        Student student = userFixture.성빈_학생();
+        String email = student.getUser().getEmail();
+        String password = "1234";
+
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "email" : "%s",
+                  "password" : "%s"
+                }
+                """.formatted(email, password))
+            .when()
+            .post("/student/login")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract();
+    }
+
+    @Test
+    @DisplayName("영양사가 로그인을 진행한다")
+    void coopLogin() {
+        Coop coop = userFixture.준기_영양사();
+        String id = coop.getCoopId();
+        String password = "1234";
+
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "id" : "%s",
+                  "password" : "%s"
+                }
+                """.formatted(id, password))
+            .when()
+            .post("/coop/login")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract();
+    }
+
+    @Test
     @DisplayName("올바른 영양사 계정인지 확인한다")
     void coopCheckMe() {
-        User user = userFixture.준기_영양사();
-        String token = userFixture.getToken(user);
+        Coop coop = userFixture.준기_영양사();
+        String token = userFixture.getToken(coop.getUser());
 
         var response = RestAssured
             .given()
@@ -95,7 +166,7 @@ class UserApiTest extends AcceptanceTest {
                     "major": "컴퓨터공학부",
                     "name": "테스트용_준호",
                     "nickname": "준호",
-                    "phone_number": "010-1234-5678",
+                    "phone_number": "01012345678",
                     "student_number": "2019136135"
                 }
                 """);
@@ -153,7 +224,7 @@ class UserApiTest extends AcceptanceTest {
                     "name" : "서정빈",
                     "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
                     "nickname" : "duehee",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                   }
                 """)
@@ -185,7 +256,7 @@ class UserApiTest extends AcceptanceTest {
                     "major": "기계공학부",
                     "name": "서정빈",
                     "nickname": "duehee",
-                    "phone_number": "010-2345-6789",
+                    "phone_number": "01023456789",
                     "student_number": "2019136136"
                 }
                 """);
@@ -207,7 +278,7 @@ class UserApiTest extends AcceptanceTest {
                     "major" : "메카트로닉스공학부",
                     "name" : "최주노",
                     "nickname" : "juno",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "201913613"
                   }
                 """)
@@ -234,7 +305,7 @@ class UserApiTest extends AcceptanceTest {
                     "major" : "경영학과",
                     "name" : "최주노",
                     "nickname" : "juno",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                   }
                 """)
@@ -261,7 +332,7 @@ class UserApiTest extends AcceptanceTest {
                     "major" : "메카트로닉스공학부",
                     "name" : "최주노",
                     "nickname" : "juno",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                   }
                 """)
@@ -291,7 +362,7 @@ class UserApiTest extends AcceptanceTest {
                     "major" : "메카트로닉스공학부",
                     "name" : "최주노",
                     "nickname" : "juno",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                   }
                 """)
@@ -319,7 +390,7 @@ class UserApiTest extends AcceptanceTest {
                     "major" : "테스트학과",
                     "name" : "최주노",
                     "nickname" : "%s",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                  }
                 """, 성빈.getUser().getNickname()))
@@ -539,7 +610,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "2021136012",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -559,7 +630,7 @@ class UserApiTest extends AcceptanceTest {
                         softly.assertThat(student).isNotNull();
                         softly.assertThat(student.getUser().getNickname()).isEqualTo("koko");
                         softly.assertThat(student.getUser().getName()).isEqualTo("김철수");
-                        softly.assertThat(student.getUser().getPhoneNumber()).isEqualTo("010-0000-0000");
+                        softly.assertThat(student.getUser().getPhoneNumber()).isEqualTo("01000000000");
                         softly.assertThat(student.getUser().getUserType()).isEqualTo(STUDENT);
                         softly.assertThat(student.getUser().getEmail()).isEqualTo("koko123@koreatech.ac.kr");
                         softly.assertThat(student.getUser().isAuthed()).isEqualTo(false);
@@ -588,7 +659,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "2021136012",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -626,7 +697,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "2021136012",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -651,7 +722,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "2021136012",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -676,7 +747,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "20211360123324231",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -697,7 +768,7 @@ class UserApiTest extends AcceptanceTest {
                   "gender": "0",
                   "is_graduated": false,
                   "student_number": "19911360123",
-                  "phone_number": "010-0000-0000"
+                  "phone_number": "01000000000"
                 }
                 """)
             .contentType(ContentType.JSON)
@@ -728,7 +799,7 @@ class UserApiTest extends AcceptanceTest {
                           "gender": "0",
                           "is_graduated": false,
                           "student_number": "2022136012",
-                          "phone_number": "010-0000-0000"
+                          "phone_number": "01000000000"
                         }
                         """)
                     .contentType(ContentType.JSON)

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -836,7 +836,7 @@ class UserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다. - 비밀번호가 다르면 401 반환")
+    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다. - 비밀번호가 다르면 400 반환")
     void userCheckPasswordInvalid() {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
@@ -853,6 +853,6 @@ class UserApiTest extends AcceptanceTest {
             .when()
             .post("/user/check/password")
             .then()
-            .statusCode(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminMemberApiTest.java
@@ -166,7 +166,7 @@ public class AdminMemberApiTest extends AcceptanceTest {
         User adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser);
 
-        var response = RestAssured
+        RestAssured
             .given()
             .header("Authorization", "Bearer " + token)
             .when()
@@ -174,7 +174,6 @@ public class AdminMemberApiTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
-
 
         Member savedMember = adminMemberRepository.getById(memberId);
 
@@ -186,6 +185,95 @@ public class AdminMemberApiTest extends AcceptanceTest {
             softly.assertThat(savedMember.getEmail()).isEqualTo("testjuno@gmail.com");
             softly.assertThat(savedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
             softly.assertThat(savedMember.isDeleted()).isEqualTo(true);
+        });
+    }
+
+    @Test
+    @DisplayName("BCSDLab 회원 정보를 수정한다")
+    void updateMember() {
+        Member member = memberFixture.최준호(trackFixture.backend());
+        Integer memberId = member.getId();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        String jsonBody = """
+            {
+                "name": "최준호",
+                "student_number": "2019136135",
+                "track": "BackEnd",
+                "position": "Mentor",
+                "email": "testjuno@gmail.com",
+                "image_url": "https://imagetest.com/juno.jpg"
+            }
+            """;
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType("application/json")
+            .body(jsonBody)
+            .when()
+            .put("/admin/members/{id}", memberId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        Member updatedMember = adminMemberRepository.getById(memberId);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(updatedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(updatedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(updatedMember.getTrack().getName()).isEqualTo("BackEnd");
+            softly.assertThat(updatedMember.getPosition()).isEqualTo("Mentor");
+            softly.assertThat(updatedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(updatedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(updatedMember.isDeleted()).isEqualTo(false);
+        });
+    }
+
+    @Test
+    @DisplayName("BCSDLab 회원 정보를 트랙과 함께 수정한다")
+    void updateMemberWithTrack() {
+        Member member = memberFixture.최준호(trackFixture.backend());
+        trackFixture.frontend();
+        Integer memberId = member.getId();
+
+        User adminUser = userFixture.코인_운영자();
+        String token = userFixture.getToken(adminUser);
+
+        String jsonBody = """
+            {
+                "name": "최준호",
+                "student_number": "2019136135",
+                "track": "FrontEnd",
+                "position": "Mentor",
+                "email": "testjuno@gmail.com",
+                "image_url": "https://imagetest.com/juno.jpg"
+            }
+            """;
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType("application/json")
+            .body(jsonBody)
+            .when()
+            .put("/admin/members/{id}", memberId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        Member updatedMember = adminMemberRepository.getById(memberId);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(updatedMember.getName()).isEqualTo("최준호");
+            softly.assertThat(updatedMember.getStudentNumber()).isEqualTo("2019136135");
+            softly.assertThat(updatedMember.getTrack().getName()).isEqualTo("FrontEnd");
+            softly.assertThat(updatedMember.getPosition()).isEqualTo("Mentor");
+            softly.assertThat(updatedMember.getEmail()).isEqualTo("testjuno@gmail.com");
+            softly.assertThat(updatedMember.getImageUrl()).isEqualTo("https://imagetest.com/juno.jpg");
+            softly.assertThat(updatedMember.isDeleted()).isEqualTo(false);
         });
     }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -102,7 +102,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "major": "컴퓨터공학부",
                     "name": "테스트용_준호",
                     "nickname": "준호",
-                    "phone_number": "010-1234-5678",
+                    "phone_number": "01012345678",
                     "student_number": "2019136135",
                     "updated_at": "2024-01-15 12:00:00",
                     "user_type": "STUDENT"
@@ -129,7 +129,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "name" : "서정빈",
                     "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
                     "nickname" : "duehee",
-                    "phone_number" : "010-2345-6789",
+                    "phone_number" : "01023456789",
                     "student_number" : "2019136136"
                   }
                 """)
@@ -161,7 +161,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "major": "기계공학부",
                     "name": "서정빈",
                     "nickname": "duehee",
-                    "phone_number": "010-2345-6789",
+                    "phone_number": "01023456789",
                     "student_number": "2019136136"
                 }
                 """);
@@ -201,7 +201,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                     "shops_id": [
                         %d
                     ],
-                    "phone_number": "010-9876-5432",
+                    "phone_number": "01098765432",
                     "is_authed": true,
                     "user_type": "OWNER",
                     "gender": 0,
@@ -249,7 +249,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                             "id": 1,
                             "email": "testchulsu@gmail.com",
                             "name": "테스트용_철수(인증X)",
-                            "phone_number": "010-9776-5112",
+                            "phone_number": "01097765112",
                             "shop_id": 1,
                             "shop_name": "마슬랜 치킨",
                             "created_at" : "2024-01-15 12:00:00"
@@ -258,7 +258,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                             "id": 1,
                             "email": "testchulsu@gmail.com",
                             "name": "테스트용_철수(인증X)",
-                            "phone_number": "010-9776-5112",
+                            "phone_number": "01097765112",
                             "shop_id": 2,
                             "shop_name": "신전 떡볶이",
                             "created_at" : "2024-01-15 12:00:00"
@@ -278,7 +278,7 @@ public class AdminUserApiTest extends AcceptanceTest {
                 .password(passwordEncoder.encode("1234"))
                 .nickname("사장님" + i)
                 .name("테스트용(인증X)" + i)
-                .phoneNumber("010-9776-511" + i)
+                .phoneNumber("0109776511" + i)
                 .userType(OWNER)
                 .gender(MAN)
                 .email("testchulsu@gmail.com" + i)

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import in.koreatech.koin.domain.coop.model.Coop;
+import in.koreatech.koin.domain.coop.repository.CoopRepository;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerAttachment;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
@@ -31,7 +33,9 @@ public final class UserFixture {
     private final UserRepository userRepository;
     private final OwnerRepository ownerRepository;
     private final StudentRepository studentRepository;
+    private final CoopRepository coopRepository;
     private final JwtProvider jwtProvider;
+
 
     @Autowired
     public UserFixture(
@@ -39,12 +43,14 @@ public final class UserFixture {
         UserRepository userRepository,
         OwnerRepository ownerRepository,
         StudentRepository studentRepository,
+        CoopRepository coopRepository,
         JwtProvider jwtProvider
     ) {
         this.passwordEncoder = passwordEncoder;
         this.userRepository = userRepository;
         this.ownerRepository = ownerRepository;
         this.studentRepository = studentRepository;
+        this.coopRepository = coopRepository;
         this.jwtProvider = jwtProvider;
     }
 
@@ -54,7 +60,7 @@ public final class UserFixture {
                 .password(passwordEncoder.encode("1234"))
                 .nickname("코인운영자")
                 .name("테스트용_코인운영자")
-                .phoneNumber("010-1234-2344")
+                .phoneNumber("01012342344")
                 .userType(ADMIN)
                 .gender(MAN)
                 .email("juno@koreatech.ac.kr")
@@ -77,7 +83,7 @@ public final class UserFixture {
                         .password(passwordEncoder.encode("1234"))
                         .nickname("준호")
                         .name("테스트용_준호")
-                        .phoneNumber("010-1234-5678")
+                        .phoneNumber("01012345678")
                         .userType(STUDENT)
                         .gender(MAN)
                         .email("juno@koreatech.ac.kr")
@@ -102,7 +108,7 @@ public final class UserFixture {
                         .password(passwordEncoder.encode("1234"))
                         .nickname("성빈")
                         .name("테스트용_성빈")
-                        .phoneNumber("010-9941-1123")
+                        .phoneNumber("01099411123")
                         .userType(STUDENT)
                         .gender(MAN)
                         .email("testsungbeen@koreatech.ac.kr")
@@ -119,7 +125,7 @@ public final class UserFixture {
             .password(passwordEncoder.encode("1234"))
             .nickname("현수")
             .name("테스트용_현수")
-            .phoneNumber("010-9876-5432")
+            .phoneNumber("01098765432")
             .userType(OWNER)
             .gender(MAN)
             .email("hysoo@naver.com")
@@ -132,6 +138,7 @@ public final class UserFixture {
             .companyRegistrationNumber("123-45-67190")
             .grantShop(true)
             .grantEvent(true)
+            .account("01098765432")
             .attachments(new ArrayList<>())
             .build();
 
@@ -158,7 +165,7 @@ public final class UserFixture {
             .password(passwordEncoder.encode("1234"))
             .nickname("준영")
             .name("테스트용_준영")
-            .phoneNumber("010-9776-5112")
+            .phoneNumber("01097765112")
             .userType(OWNER)
             .gender(MAN)
             .email("testjoonyoung@gmail.com")
@@ -171,6 +178,7 @@ public final class UserFixture {
             .companyRegistrationNumber("112-80-56789")
             .grantShop(true)
             .grantEvent(true)
+            .account("01097765112")
             .attachments(new ArrayList<>())
             .build();
 
@@ -198,7 +206,7 @@ public final class UserFixture {
             .password(passwordEncoder.encode("1234"))
             .nickname("철수")
             .name("테스트용_철수(인증X)")
-            .phoneNumber("010-9776-5112")
+            .phoneNumber("01097765112")
             .userType(OWNER)
             .gender(MAN)
             .email("testchulsu@gmail.com")
@@ -211,6 +219,7 @@ public final class UserFixture {
             .companyRegistrationNumber("118-80-56789")
             .grantShop(true)
             .grantEvent(true)
+            .account("01097765112")
             .attachments(new ArrayList<>())
             .build();
 
@@ -232,20 +241,65 @@ public final class UserFixture {
         return ownerRepository.save(owner);
     }
 
-    public User 준기_영양사() {
-        return userRepository.save(
-            User.builder()
-                .password(passwordEncoder.encode("1234"))
-                .nickname("준기")
-                .name("허준기")
-                .phoneNumber("010-1122-5678")
-                .userType(COOP)
-                .gender(MAN)
-                .email("coop@koreatech.ac.kr")
-                .isAuthed(true)
-                .isDeleted(false)
-                .build()
-        );
+    public Owner 원경_사장님() {
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("원경")
+            .name("테스트용_원경(전화번호 - 없음")
+            .phoneNumber("01024607469")
+            .userType(OWNER)
+            .gender(MAN)
+            .email("wongyeong@naver.com")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        Owner owner = Owner.builder()
+            .user(user)
+            .companyRegistrationNumber("123-45-67890")
+            .grantShop(true)
+            .grantEvent(true)
+            .account("01024607469")
+            .attachments(new ArrayList<>())
+            .build();
+
+        OwnerAttachment attachment1 = OwnerAttachment.builder()
+            .url("https://test.com/원경_사장님_인증사진_1.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        OwnerAttachment attachment2 = OwnerAttachment.builder()
+            .url("https://test.com/원경_사장님_인증사진_2.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        owner.getAttachments().add(attachment1);
+        owner.getAttachments().add(attachment2);
+
+        return ownerRepository.save(owner);
+    }
+
+    public Coop 준기_영양사() {
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("준기")
+            .name("허준기")
+            .phoneNumber("01011225678")
+            .userType(COOP)
+            .gender(MAN)
+            .email("coop@koreatech.ac.kr")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        Coop coop = Coop.builder()
+            .user(user)
+            .coopId("coop")
+            .build();
+
+        return coopRepository.save(coop);
     }
 
     public String getToken(User user) {


### PR DESCRIPTION
# 🔥 연관 이슈
- close #602 

# 🚀 작업 내용
1. hotfix가 맞는 것 같다는 의견이 있어서 hotfix로 수정해서 main에다가 날립니다
2. 정보 수정 란에 들어가기 전 비밀번호를 통해 자신이 맞는지 확인할 때, 비밀번호가 틀리면 401을 반환하면 로그인이 풀려버리는 문제가 발생하였습니다. 따라서 400으로 반환하게 수정해줬습니다.

# 💬 리뷰 중점사항
