### PR TITLE
hotfix: 비밀번호 검증 api 비밀번호 틀렸을시에 400 반환하는 것으로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -112,7 +112,7 @@ public class UserService {
     public void checkPassword(UserPasswordCheckRequest request, Integer userId) {
         User user = userRepository.getById(userId);
         if (!user.isSamePassword(passwordEncoder, request.password())) {
-            throw new AuthenticationException("올바르지 않은 비밀번호입니다.");
+            throw new KoinIllegalArgumentException("올바르지 않은 비밀번호입니다.");
         }
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -765,7 +765,7 @@ class UserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다. - 비밀번호가 다르면 401 반환")
+    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다. - 비밀번호가 다르면 400 반환")
     void userCheckPasswordInvalid() {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
@@ -782,6 +782,6 @@ class UserApiTest extends AcceptanceTest {
             .when()
             .post("/user/check/password")
             .then()
-            .statusCode(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #602

# 🚀 작업 내용

1. hotfix가 맞는 것 같다는 의견이 있어서 hotfix로 수정해서 main에다가 날립니다
2. develop에서 checkout한 fix브랜치를 hotfix로 이름만 바꾸고 main에다가 그냥 날려버렸다가 잘못됨을 깨닫고 다시 main에서 checkout해서 pr을 날립니다..
3. 정보 수정 란에 들어가기 전 비밀번호를 통해 자신이 맞는지 확인할 때, 비밀번호가 틀리면 401을 반환하면 로그인이 풀려버리는 문제가 발생하였습니다. 따라서 400으로 반환하게 수정해줬습니다.

# 💬 리뷰 중점사항
여러번 귀찮게 해서 죄송합니다