### PR TITLE
refactor: sms회원가입 redis초기화 로직 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
@@ -56,4 +56,17 @@ public class OwnerEventListener {
         );
         slackClient.sendMessage(notification);
     }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onOwnerRegister(OwnerRegisterBySmsEvent event) {
+        Owner owner = event.owner();
+        ownerInVerificationRedisRepository.deleteByVerify(owner.getAccount());
+        String shopsName = shopRepository.findAllByOwnerId(owner.getId())
+            .stream().map(Shop::getName).collect(Collectors.joining(", "));
+        var notification = slackNotificationFactory.generateOwnerRegisterRequestNotification(
+            owner.getUser().getName(),
+            shopsName
+        );
+        slackClient.sendMessage(notification);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
@@ -58,7 +58,7 @@ public class OwnerEventListener {
     }
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void onOwnerRegister(OwnerRegisterBySmsEvent event) {
+    public void onOwnerRegisterBySms(OwnerRegisterBySmsEvent event) {
         Owner owner = event.owner();
         ownerInVerificationRedisRepository.deleteByVerify(owner.getAccount());
         String shopsName = shopRepository.findAllByOwnerId(owner.getId())

--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerRegisterBySmsEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerRegisterBySmsEvent.java
@@ -1,0 +1,7 @@
+package in.koreatech.koin.domain.owner.model;
+
+public record OwnerRegisterBySmsEvent(
+    Owner owner
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -33,6 +33,7 @@ import in.koreatech.koin.domain.owner.exception.DuplicationCompanyNumberExceptio
 import in.koreatech.koin.domain.owner.exception.DuplicationPhoneNumberException;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerEmailRequestEvent;
+import in.koreatech.koin.domain.owner.model.OwnerRegisterBySmsEvent;
 import in.koreatech.koin.domain.owner.model.OwnerRegisterEvent;
 import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.owner.model.OwnerSmsRequestEvent;
@@ -46,7 +47,6 @@ import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserToken;
-import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
 import in.koreatech.koin.global.auth.JwtProvider;
@@ -168,7 +168,7 @@ public class OwnerService {
             ownerShopBuilder.shopId(shop.getId());
         }
         ownerShopRedisRepository.save(ownerShopBuilder.build());
-        eventPublisher.publishEvent(new OwnerRegisterEvent(saved));
+        eventPublisher.publishEvent(new OwnerRegisterBySmsEvent(saved));
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -283,7 +283,7 @@ class OwnerApiTest extends AcceptanceTest {
                                 .isEqualTo("https://static.koreatech.in/testimage.png");
                             softly.assertThat(owner.getUser().isAuthed()).isFalse();
                             softly.assertThat(owner.getUser().isDeleted()).isFalse();
-                            verify(ownerEventListener).onOwnerRegister(any());
+                            verify(ownerEventListener).onOwnerRegisterBySms(any());
                         }
                     );
                 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #620 

# 🚀 작업 내용

1. 기존에 회원가입 후 redis를 초기화 할 때 key는 email로 사용중이였음
2. sms회원가입에서도 key를 email로 처리하고 있는 것을 확인(sms에서는 email이 없음)
3. sms회원가입에서는 account를 key로 처리

# 💬 리뷰 중점사항
