### PR TITLE
feat: admin 이슈 83~86 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -14,7 +14,9 @@ import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
+import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +29,22 @@ import jakarta.validation.Valid;
 
 @Tag(name = "(Admin) User: 회원", description = "관리자 권한으로 회원 정보를 관리한다")
 public interface AdminUserApi {
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "학생 리스트 조회(페이지네이션)")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/admin/students")
+    ResponseEntity<AdminStudentsResponse> getStudents(
+        @ModelAttribute StudentsCondition studentsCondition,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "200"),

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -6,9 +6,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
+import in.koreatech.koin.admin.user.dto.AdminLoginResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
@@ -43,6 +46,20 @@ public interface AdminUserApi {
     ResponseEntity<AdminStudentsResponse> getStudents(
         @ModelAttribute StudentsCondition studentsCondition,
         @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "어드민 로그인")
+    @PostMapping("/admin/user/login")
+    ResponseEntity<AdminLoginResponse> adminLogin(
+        @RequestBody @Valid AdminLoginRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -18,6 +18,8 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
+import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
+import in.koreatech.koin.admin.user.dto.AdminTokenRefreshResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
 import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.global.auth.Auth;
@@ -60,6 +62,35 @@ public interface AdminUserApi {
     @PostMapping("/admin/user/login")
     ResponseEntity<AdminLoginResponse> adminLogin(
         @RequestBody @Valid AdminLoginRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "로그아웃")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("admin/user/logout")
+    ResponseEntity<Void> logout(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "어드민 액세스 토큰 재발급")
+    @PostMapping("/admin/user/refresh")
+    public ResponseEntity<AdminTokenRefreshResponse> refresh(
+        @RequestBody @Valid AdminTokenRefreshRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
 import in.koreatech.koin.admin.user.dto.AdminLoginResponse;
@@ -45,8 +46,12 @@ public interface AdminUserApi {
     @Operation(summary = "학생 리스트 조회(페이지네이션)")
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/students")
-    ResponseEntity<AdminStudentsResponse> getStudents(
-        @ModelAttribute StudentsCondition studentsCondition,
+    public ResponseEntity<AdminStudentsResponse> getStudents(
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) Boolean isAuthed,
+        @RequestParam(required = false) String nickname,
+        @RequestParam(required = false) String email,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 
@@ -72,7 +77,7 @@ public interface AdminUserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "로그아웃")
+    @Operation(summary = "어드민 로그아웃")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("admin/user/logout")
     ResponseEntity<Void> logout(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -17,6 +17,7 @@ import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
+import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
@@ -30,9 +31,10 @@ public class AdminUserController implements AdminUserApi{
 
     @GetMapping("/admin/students")
     public ResponseEntity<AdminStudentsResponse> getStudents(
+        @ModelAttribute StudentsCondition studentsCondition,
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
-        AdminStudentsResponse adminStudentsResponse = adminUserService.getStudents();
+        AdminStudentsResponse adminStudentsResponse = adminUserService.getStudents(studentsCondition);
         return ResponseEntity.ok(adminStudentsResponse);
     }
 

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
 import in.koreatech.koin.global.auth.Auth;
@@ -26,6 +27,14 @@ import lombok.RequiredArgsConstructor;
 public class AdminUserController implements AdminUserApi{
 
     private final AdminUserService adminUserService;
+
+    @GetMapping("/admin/students")
+    public ResponseEntity<AdminStudentsResponse> getStudents(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminStudentsResponse adminStudentsResponse = adminUserService.getStudents();
+        return ResponseEntity.ok(adminStudentsResponse);
+    }
 
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -52,6 +52,14 @@ public class AdminUserController implements AdminUserApi{
             .body(response);
     }
 
+    @PostMapping("admin/user/logout")
+    public ResponseEntity<Void> logout(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminUserService.logout(adminId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(
         @PathVariable Integer id,

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
@@ -38,9 +39,14 @@ public class AdminUserController implements AdminUserApi{
 
     @GetMapping("/admin/students")
     public ResponseEntity<AdminStudentsResponse> getStudents(
-        @ModelAttribute StudentsCondition studentsCondition,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) Boolean isAuthed,
+        @RequestParam(required = false) String nickname,
+        @RequestParam(required = false) String email,
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
+        StudentsCondition studentsCondition = new StudentsCondition(page, limit, isAuthed, nickname, email);
         AdminStudentsResponse adminStudentsResponse = adminUserService.getStudents(studentsCondition);
         return ResponseEntity.ok(adminStudentsResponse);
     }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -21,6 +21,8 @@ import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
+import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
+import in.koreatech.koin.admin.user.dto.AdminTokenRefreshResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
 import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
@@ -56,9 +58,19 @@ public class AdminUserController implements AdminUserApi{
     public ResponseEntity<Void> logout(
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
-        adminUserService.logout(adminId);
+        adminUserService.adminLogout(adminId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/admin/user/refresh")
+    public ResponseEntity<AdminTokenRefreshResponse> refresh(
+        @RequestBody @Valid AdminTokenRefreshRequest request
+    ) {
+        AdminTokenRefreshResponse tokenGroupResponse = adminUserService.adminRefresh(request);
+        return ResponseEntity.created(URI.create("/"))
+            .body(tokenGroupResponse);
+    }
+
 
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -2,14 +2,19 @@ package in.koreatech.koin.admin.user.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
+import in.koreatech.koin.admin.user.dto.AdminLoginResponse;
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
@@ -36,6 +41,15 @@ public class AdminUserController implements AdminUserApi{
     ) {
         AdminStudentsResponse adminStudentsResponse = adminUserService.getStudents(studentsCondition);
         return ResponseEntity.ok(adminStudentsResponse);
+    }
+
+    @PostMapping("/admin/user/login")
+    public ResponseEntity<AdminLoginResponse> adminLogin(
+        @RequestBody @Valid AdminLoginRequest request
+    ) {
+        AdminLoginResponse response = adminUserService.adminLogin(request);
+        return ResponseEntity.created(URI.create("/"))
+            .body(response);
     }
 
     @GetMapping("/admin/users/student/{id}")

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminLoginRequest.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+    @Schema(description = "이메일", example = "abc@koreatech.ac.kr", requiredMode = REQUIRED)
+    @NotBlank(message = "이메일을 입력해주세요.")
+    String email,
+
+    @Schema(
+        description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
+        example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+        requiredMode = REQUIRED
+    )
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminLoginResponse.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminLoginResponse (
+    @Schema(
+        description = "Jwt accessToken",
+        example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        requiredMode = REQUIRED
+    )
+    @JsonProperty("token")
+    String accessToken,
+
+    @Schema(description = "Random UUID refresh token", example = "RANDOM-KEY-VALUE", requiredMode = REQUIRED)
+    @JsonProperty("refresh_token")
+    String refreshToken
+) {
+
+    public static AdminLoginResponse of(String token, String refreshToken) {
+        return new AdminLoginResponse(token, refreshToken);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentUpdateResponse.java
@@ -48,6 +48,7 @@ public record AdminStudentUpdateResponse(
     @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
     String studentNumber
 ) {
+    
     public static AdminStudentUpdateResponse from(Student student) {
         User user = student.getUser();
 

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
@@ -18,6 +18,7 @@ public record AdminStudentsResponse(
     Long totalCount,
     Integer totalPage
 ) {
+
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record StudentInfo(
         String email,
@@ -27,6 +28,7 @@ public record AdminStudentsResponse(
         String nickname,
         String studentNumber
     ) {
+
         public static StudentInfo fromStudent(Student student) {
             return new StudentInfo(
                 student.getUser().getEmail(),

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
@@ -5,8 +5,12 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import in.koreatech.koin.domain.user.model.Student;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminStudentsResponse(
     Integer currentCount,
     Integer currentPage,

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
@@ -1,4 +1,46 @@
 package in.koreatech.koin.admin.user.dto;
 
-public class AdminStudentsResponse {
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import in.koreatech.koin.domain.user.model.Student;
+
+public record AdminStudentsResponse(
+    Integer currentCount,
+    Integer currentPage,
+    List<StudentInfo> students,
+    Long totalCount,
+    Integer totalPage
+) {
+    public record StudentInfo(
+        String email,
+        Integer id,
+        String major,
+        String name,
+        String nickname,
+        String studentNumber
+    ) {
+        public static StudentInfo fromStudent(Student student) {
+            return new StudentInfo(
+                student.getUser().getEmail(),
+                student.getUser().getId(),
+                student.getDepartment(),
+                student.getUser().getName(),
+                student.getUser().getNickname(),
+                student.getStudentNumber()
+            );
+        }
+    }
+
+    public static AdminStudentsResponse of(Page<Student> studentsPage) {
+        return new AdminStudentsResponse(
+            studentsPage.getNumberOfElements(),
+            studentsPage.getNumber() + 1,
+            studentsPage.getContent().stream().map(StudentInfo::fromStudent).collect(Collectors.toList()),
+            studentsPage.getTotalElements(),
+            studentsPage.getTotalPages()
+        );
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
@@ -1,0 +1,4 @@
+package in.koreatech.koin.admin.user.dto;
+
+public class AdminStudentsResponse {
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminStudentsResponse.java
@@ -18,6 +18,7 @@ public record AdminStudentsResponse(
     Long totalCount,
     Integer totalPage
 ) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
     public record StudentInfo(
         String email,
         Integer id,

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminTokenRefreshRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminTokenRefreshRequest.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminTokenRefreshRequest (
+    @Schema(description = "refresh_token", example = "eyJhbGciOiJIUzI1NiJ9", requiredMode = REQUIRED)
+    @NotNull(message = "refresh_token을 입력해주세요.")
+    @JsonProperty("refresh_token")
+    String refreshToken
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminTokenRefreshResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminTokenRefreshResponse.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminTokenRefreshResponse (
+    @Schema(
+        description = "Jwt accessToken",
+        example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        requiredMode = REQUIRED
+    )
+    @JsonProperty("token")
+    String accessToken,
+
+    @Schema(description = "Random UUID refreshToken", example = "RANDOM-KEY-VALUE", requiredMode = REQUIRED)
+    @JsonProperty("refresh_token")
+    String refreshToken
+) {
+
+    public static AdminTokenRefreshResponse of(String accessToken, String refreshToken) {
+        return new AdminTokenRefreshResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import java.util.Objects;
+
+import in.koreatech.koin.global.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentsCondition (
+    @Schema(description = "페이지", example = "1", defaultValue = "1", requiredMode = NOT_REQUIRED)
+    Integer page,
+
+    @Schema(description = "페이지당 조회할 최대 개수", example = "10", defaultValue = "10", requiredMode = NOT_REQUIRED)
+    Integer limit,
+
+    @Schema(description = "인증 되었는지 여부", requiredMode = NOT_REQUIRED)
+    Boolean isAuthed,
+
+    @Schema(description = "닉네임", requiredMode = NOT_REQUIRED)
+    String nickname,
+
+    @Schema(description = "이메일", requiredMode = NOT_REQUIRED)
+    String email
+) {
+    public StudentsCondition {
+        if (Objects.isNull(page)) {
+            page = Criteria.DEFAULT_PAGE;
+        }
+        if (Objects.isNull(limit)) {
+            limit = Criteria.DEFAULT_LIMIT;
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
@@ -4,9 +4,13 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import in.koreatech.koin.global.model.Criteria;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record StudentsCondition (
     @Schema(description = "페이지", example = "1", defaultValue = "1", requiredMode = NOT_REQUIRED)
     Integer page,

--- a/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/StudentsCondition.java
@@ -27,6 +27,7 @@ public record StudentsCondition (
     @Schema(description = "이메일", requiredMode = NOT_REQUIRED)
     String email
 ) {
+
     public StudentsCondition {
         if (Objects.isNull(page)) {
             page = Criteria.DEFAULT_PAGE;

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
@@ -26,12 +26,9 @@ public interface AdminStudentRepository extends Repository<Student, Integer> {
     @Query(" SELECT COUNT(s) FROM Student s ")
     Integer findAllStudentCount();
 
-    @Query(
-        """
-        SELECT s FROM Student s WHERE
-        (:#{#condition.isAuthed} IS NULL OR s.user.isAuthed = :#{#condition.isAuthed})
-        AND (:#{#condition.nickname} IS NULL OR s.user.nickname LIKE %:#{#condition.nickname}%)
-        AND (:#{#condition.email} IS NULL OR s.user.email LIKE %:#{#condition.email}%)
-        """)
+    @Query("SELECT s FROM Student s WHERE " +
+        "(:#{#condition.isAuthed} IS NULL OR s.user.isAuthed = :#{#condition.isAuthed}) AND " +
+        "(:#{#condition.nickname} IS NULL OR s.user.nickname LIKE CONCAT('%', :#{#condition.nickname}, '%')) AND " +
+        "(:#{#condition.email} IS NULL OR s.user.email LIKE CONCAT('%', :#{#condition.email}, '%'))")
     Page<Student> findByConditions(@Param("condition") StudentsCondition condition, Pageable pageable);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
@@ -2,8 +2,13 @@ package in.koreatech.koin.admin.user.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.Student;
 
@@ -17,4 +22,16 @@ public interface AdminStudentRepository extends Repository<Student, Integer> {
         return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
+
+    @Query(" SELECT COUNT(s) FROM Student s ")
+    Integer findAllStudentCount();
+
+    @Query(
+        """
+        SELECT s FROM Student s WHERE
+        (:#{#condition.isAuthed} IS NULL OR s.user.isAuthed = :#{#condition.isAuthed})
+        AND (:#{#condition.nickname} IS NULL OR s.user.nickname LIKE %:#{#condition.nickname}%)
+        AND (:#{#condition.email} IS NULL OR s.user.email LIKE %:#{#condition.email}%)
+        """)
+    Page<Student> findByConditions(@Param("condition") StudentsCondition condition, Pageable pageable);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminStudentRepository.java
@@ -26,9 +26,12 @@ public interface AdminStudentRepository extends Repository<Student, Integer> {
     @Query(" SELECT COUNT(s) FROM Student s ")
     Integer findAllStudentCount();
 
-    @Query("SELECT s FROM Student s WHERE " +
-        "(:#{#condition.isAuthed} IS NULL OR s.user.isAuthed = :#{#condition.isAuthed}) AND " +
-        "(:#{#condition.nickname} IS NULL OR s.user.nickname LIKE CONCAT('%', :#{#condition.nickname}, '%')) AND " +
-        "(:#{#condition.email} IS NULL OR s.user.email LIKE CONCAT('%', :#{#condition.email}, '%'))")
+    @Query(
+        """
+        SELECT s FROM Student s WHERE\s
+        (:#{#condition.isAuthed} IS NULL OR s.user.isAuthed = :#{#condition.isAuthed}) AND
+        (:#{#condition.nickname} IS NULL OR s.user.nickname LIKE CONCAT('%', :#{#condition.nickname}, '%')) AND
+        (:#{#condition.email} IS NULL OR s.user.email LIKE CONCAT('%', :#{#condition.email}, '%'))
+        """)
     Page<Student> findByConditions(@Param("condition") StudentsCondition condition, Pageable pageable);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminTokenRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminTokenRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.user.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.user.model.UserToken;
+
+public interface AdminTokenRepository extends Repository<UserToken, Integer> {
+
+    UserToken save(UserToken userToken);
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminTokenRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminTokenRepository.java
@@ -1,10 +1,22 @@
 package in.koreatech.koin.admin.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 
 public interface AdminTokenRepository extends Repository<UserToken, Integer> {
 
     UserToken save(UserToken userToken);
+
+    Optional<UserToken> findById(Integer userId);
+
+    void deleteById(Integer id);
+
+    default UserToken getById(Integer userId) {
+        return findById(userId)
+            .orElseThrow(() -> new KoinIllegalArgumentException("refresh token이 존재하지 않습니다. ", "userId: " + userId));
+    }
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -24,7 +24,5 @@ public interface AdminUserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
 
-    void deleteById(Integer id);
-
     boolean existsByNicknameAndIdNot(String nickname, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -24,5 +24,7 @@ public interface AdminUserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
 
+    void deleteById(Integer id);
+
     boolean existsByNicknameAndIdNot(String nickname, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -19,6 +19,7 @@ public interface AdminUserRepository extends Repository<User, Integer> {
         return findByEmail(email)
             .orElseThrow(() -> UserNotFoundException.withDetail("email: " + email));
     }
+
     default User getById(Integer userId) {
         return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminUserRepository.java
@@ -11,8 +11,14 @@ public interface AdminUserRepository extends Repository<User, Integer> {
 
     User save(User user);
 
+    Optional<User> findByEmail(String Email);
+
     Optional<User> findById(Integer id);
 
+    default User getByEmail(String email) {
+        return findByEmail(email)
+            .orElseThrow(() -> UserNotFoundException.withDetail("email: " + email));
+    }
     default User getById(Integer userId) {
         return findById(userId)
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -1,15 +1,22 @@
 package in.koreatech.koin.admin.user.service;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
+import in.koreatech.koin.admin.user.dto.AdminLoginResponse;
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
@@ -21,16 +28,21 @@ import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
 import in.koreatech.koin.admin.user.repository.AdminShopRepository;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
+import in.koreatech.koin.admin.user.repository.AdminTokenRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.user.exception.StudentDepartmentNotValidException;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.model.StudentDepartment;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import in.koreatech.koin.global.model.Criteria;
 import lombok.RequiredArgsConstructor;
 
@@ -39,11 +51,13 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AdminUserService {
 
+    private final JwtProvider jwtProvider;
     private final AdminStudentRepository adminStudentRepository;
     private final AdminOwnerRepository adminOwnerRepository;
     private final AdminUserRepository adminUserRepository;
     private final AdminShopRepository adminShopRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AdminTokenRepository adminTokenRepository;
 
     public AdminStudentsResponse getStudents(StudentsCondition studentsCondition) {
         Integer totalStudents = adminStudentRepository.findAllStudentCount();
@@ -53,6 +67,28 @@ public class AdminUserService {
         Page<Student> studentsPage = adminStudentRepository.findByConditions(studentsCondition, pageRequest);
 
         return AdminStudentsResponse.of(studentsPage);
+    }
+
+    @Transactional
+    public AdminLoginResponse adminLogin(AdminLoginRequest request) {
+        User user = adminUserRepository.getByEmail(request.email());
+
+        /* 어드민 권한이 없으면 없는 회원으로 간주 */
+        if(user.getUserType() != ADMIN) {
+            throw UserNotFoundException.withDetail("email" + request.email());
+        }
+
+        if (!user.isSamePassword(passwordEncoder, request.password())) {
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+        }
+
+        String accessToken = jwtProvider.createToken(user);
+        String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
+        UserToken savedtoken = adminTokenRepository.save(UserToken.create(user.getId(), refreshToken));
+        user.updateLastLoggedTime(LocalDateTime.now());
+        adminUserRepository.save(user);
+
+        return AdminLoginResponse.of(accessToken, savedtoken.getRefreshToken());
     }
 
     public AdminStudentResponse getStudent(Integer userId) {

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -91,6 +91,10 @@ public class AdminUserService {
         return AdminLoginResponse.of(accessToken, savedtoken.getRefreshToken());
     }
 
+    @Transactional
+    public void logout(Integer adminId) {
+        adminUserRepository.deleteById(adminId);
+    }
     public AdminStudentResponse getStudent(Integer userId) {
         Student student = adminStudentRepository.getById(userId);
         return AdminStudentResponse.from(student);

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
 import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
 import in.koreatech.koin.admin.user.repository.AdminShopRepository;
@@ -42,6 +43,9 @@ public class AdminUserService {
     private final AdminUserRepository adminUserRepository;
     private final AdminShopRepository adminShopRepository;
     private final PasswordEncoder passwordEncoder;
+
+    public AdminStudentsResponse getStudents() {
+    }
 
     public AdminStudentResponse getStudent(Integer userId) {
         Student student = adminStudentRepository.getById(userId);

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -17,6 +17,7 @@ import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.NewOwnersCondition;
+import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
 import in.koreatech.koin.admin.user.repository.AdminShopRepository;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
@@ -44,7 +45,14 @@ public class AdminUserService {
     private final AdminShopRepository adminShopRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public AdminStudentsResponse getStudents() {
+    public AdminStudentsResponse getStudents(StudentsCondition studentsCondition) {
+        Integer totalStudents = adminStudentRepository.findAllStudentCount();
+        Criteria criteria = Criteria.of(studentsCondition.page(), studentsCondition.limit(), totalStudents);
+
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit());
+        Page<Student> studentsPage = adminStudentRepository.findByConditions(studentsCondition, pageRequest);
+
+        return AdminStudentsResponse.of(studentsPage);
     }
 
     public AdminStudentResponse getStudent(Integer userId) {

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -55,7 +55,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     private PasswordEncoder passwordEncoder;
 
     @Test
-    @DisplayName("관리자가 특정 학생 리스트를 파라미터가 없이 조회한다.(페이지네이션)")
+    @DisplayName("관리자가 학생 리스트를 파라미터가 없이 조회한다.(페이지네이션)")
     void getStudentsWithoutParameterAdmin() {
         Student student = userFixture.준호_학생();
         User adminUser = userFixture.코인_운영자();
@@ -94,7 +94,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("관리자가 특정 학생 리스트를 페이지 수와 limit으로 조회한다.(페이지네이션)")
+    @DisplayName("관리자가 학생 리스트를 페이지 수와 limit으로 조회한다.(페이지네이션)")
     void getStudentsWithPageAndLimitAdmin() {
         for (int i = 0; i < 11; i++) {
             Student student = Student.builder()
@@ -159,7 +159,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("관리자가 특정 학생 리스트를 닉네임으로 조회한다.(페이지네이션)")
+    @DisplayName("관리자가 학생 리스트를 닉네임으로 조회한다.(페이지네이션)")
     void getStudentsWithNicknameAdmin() {
         Student student1 = userFixture.성빈_학생();
         Student student2 = userFixture.준호_학생();
@@ -264,7 +264,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("관리자 액세스 토큰 재발급")
+    @DisplayName("관리자가 액세스 토큰 재발급 한다")
     void adminRefresh() {
         User adminUser = userFixture.코인_운영자();
         String email = adminUser.getEmail();

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -52,6 +52,81 @@ public class AdminUserApiTest extends AcceptanceTest {
     private PasswordEncoder passwordEncoder;
 
     @Test
+    @DisplayName("관리자가 특정 학생 리스트를 파라미터가 없이 조회한다.(페이지네이션)")
+    void getStudentsWithoutParameterAdmin() {
+        User adminUser = userFixture.코인_운영자();
+
+        String token = userFixture.getToken(adminUser);
+
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .when()
+            .get("/admin/students")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                {
+                     "current_count": 0,
+                     "current_page": 1,
+                     "students": [
+                         {
+                             "email": "juno@koreatech.ac.kr",
+                             "id": 1,
+                             "major": "컴퓨터공학부",
+                             "name": "테스트용_준호",
+                             "nickname": "준호",
+                             "studentNumber": 2019136135
+                         }
+                     ],
+                     "total_count": 1,
+                     "total_page": 1
+                 }
+                """);
+    }
+
+    @Test
+    @DisplayName("관리자가 특정 학생 리스트를 페이지 수와 limit으로 조회한다.(페이지네이션)")
+    void getStudentsWithPageAndLimitAdmin() {
+
+    }
+
+    @Test
+    @DisplayName("관리자가 특정 학생 리스트를 닉네임으로 조회한다.(페이지네이션)")
+    void getStudentsWithNicknameAdmin() {
+
+    }
+
+    @Test
+    @DisplayName("관리자가 로그인 한다.")
+    void adminLogin() {
+
+    }
+
+    @Test
+    @DisplayName("관리자가 로그인 한다. - 관리자가 아니면 404 반환")
+    void adminLoginNoAuth() {
+
+    }
+
+    @Test
+    @DisplayName("관리자가 로그아웃한다")
+    void adminLogout() {
+
+    }
+
+    @Test
+    @DisplayName("관리자 액세스 토큰 재발급")
+    void adminRefresh() {
+
+    }
+
+
+    @Test
     @DisplayName("관리자가 특정 학생 정보를 조회한다. - 관리자가 아니면 403 반환")
     void studentUpdateAdminNoAuth() {
         Student student = userFixture.준호_학생();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #83
- close #84
- close #85
- close #86 

# 🚀 작업 내용

1. 학생 목록 조회 페이지네이션 구현 했습니다.
2. 어드민 로그인 구현했습니다
3. 어드민 로그아웃 구현했습니다.
4. 어드민 리프레시 구현했습니다.

# 💬 리뷰 중점사항
현재 회원이 hard delete로 되어서 회원 삭제 해제는 불가능하기에 [이슈 95번](https://github.com/BCSDLab/KOIN_API_V2/issues/95) post/admin/users/{id}/undelete
는 우선 구현하지 않았습니다.