### PR TITLE
fix : 식단의 Kcal가 null 일 경우 0을 반환하도록 롤백

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/dining/dto/DiningResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/dto/DiningResponse.java
@@ -72,7 +72,7 @@ public record DiningResponse(
             dining.getPlace(),
             dining.getPriceCard(),
             dining.getPriceCash(),
-            dining.getKcal(),
+            dining.getKcal() != null ? dining.getKcal() : 0,
             dining.getMenu(),
             dining.getImageUrl(),
             dining.getCreatedAt(),


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 식단의 Kcal 정보가 null일 경우 0을 반환하도록 롤백했습니다.

# 💬 리뷰 중점사항
