### PR TITLE
fix: CityBusRoute 저장시 null 제외 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/util/CityBusRouteClient.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/util/CityBusRouteClient.java
@@ -80,12 +80,10 @@ public class CityBusRouteClient {
         List<String> nodeIds = BusStationNode.getNodeIds();
 
         for (String node : nodeIds) {
-            cityBusRouteCacheRepository.save(
-                CityBusRouteCache.of(
-                    node,
-                    Set.copyOf(extractBusRouteInfo(getOpenApiResponse(node)))
-                )
-            );
+            Set<CityBusRoute> routes = Set.copyOf(extractBusRouteInfo(getOpenApiResponse(node)));
+            if (routes.isEmpty()) { continue; }
+
+            cityBusRouteCacheRepository.save(CityBusRouteCache.of(node, routes));
         }
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #628 

# 🚀 작업 내용

1. redis에 저장하기 전에 `Set<CityBusRoute>`가 empty인지 확인
2. empty가 아닐 경우에만 저장

# 💬 리뷰 중점사항
이래도 터지면 모르겠어요...