### PR TITLE
fix: 상점 생성,수정 / 메뉴 추가,수정 버그 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateMenuRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateMenuRequest.java
@@ -52,7 +52,11 @@ public record AdminCreateMenuRequest(
     @PositiveOrZero(message = "가격은 0원 이상이어야 합니다.")
     Integer singlePrice
 ) {
-
+    public AdminCreateMenuRequest {
+        if (imageUrls == null) {
+            imageUrls = List.of();
+        }
+    }
     public Menu toEntity(Integer shopId) {
         return Menu.builder()
             .name(name)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateMenuRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateMenuRequest.java
@@ -12,6 +12,7 @@ import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.global.validation.UniqueId;
 import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -61,6 +62,7 @@ public record AdminCreateMenuRequest(
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)
+    @Valid
     public record InnerOptionPrice(
         @Schema(example = "대", description = "옵션명", requiredMode = REQUIRED)
         @NotNull @Size(min = 1, max = 50) String option,

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
@@ -62,7 +62,6 @@ public record AdminCreateShopRequest(
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
     @NotNull
-    @Size(min = 7, max = 7, message = "7개의 요일의 운영시간을 모두 입력해주세요.")
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
@@ -78,6 +78,11 @@ public record AdminCreateShopRequest(
     @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "전화번호 형식이 유효하지 않습니다.")
     String phone
 ) {
+    public AdminCreateShopRequest {
+        if (imageUrls == null) {
+            imageUrls = List.of();
+        }
+    }
 
     public Shop toShop() {
         return Shop.builder()

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
@@ -62,7 +62,7 @@ public record AdminCreateShopRequest(
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
     @NotNull
-    @Size(min = 7, max = 7)
+    @Size(min = 7, max = 7, message = "7개의 요일의 운영시간을 모두 입력해주세요.")
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
@@ -61,6 +61,8 @@ public record AdminCreateShopRequest(
     String name,
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
+    @NotNull
+    @Size(min = 7, max = 7)
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyMenuRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyMenuRequest.java
@@ -50,7 +50,11 @@ public record AdminModifyMenuRequest(
     @PositiveOrZero(message = "가격은 0원 이상이어야 합니다.")
     Integer singlePrice
 ) {
-
+    public AdminModifyMenuRequest {
+        if (imageUrls == null) {
+            imageUrls = List.of();
+        }
+    }
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerOptionPrice(
         @Schema(example = "대", description = "옵션명", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
@@ -62,7 +62,6 @@ public record AdminModifyShopRequest(
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
     @NotNull
-    @Size(min = 7, max = 7, message = "7개의 요일의 운영시간을 모두 입력해주세요.")
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
@@ -78,7 +78,11 @@ public record AdminModifyShopRequest(
     @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "전화번호 형식이 유효하지 않습니다.")
     String phone
 ) {
-
+    public AdminModifyShopRequest {
+        if (imageUrls == null) {
+            imageUrls = List.of();
+        }
+    }
     @JsonNaming(value = SnakeCaseStrategy.class)
     @Valid
     public record InnerShopOpen(

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
@@ -61,6 +61,8 @@ public record AdminModifyShopRequest(
     String name,
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
+    @NotNull
+    @Size(min = 7, max = 7)
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
@@ -62,7 +62,7 @@ public record AdminModifyShopRequest(
 
     @Schema(description = "요일별 휴무 여부 및 장사 시간", requiredMode = NOT_REQUIRED)
     @NotNull
-    @Size(min = 7, max = 7)
+    @Size(min = 7, max = 7, message = "7개의 요일의 운영시간을 모두 입력해주세요.")
     List<InnerShopOpen> open,
 
     @Schema(description = "계좌 이체 가능 여부", example = "true", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueIdValidator.java
@@ -14,6 +14,9 @@ public class UniqueIdValidator implements ConstraintValidator<UniqueId, List<Int
 
     @Override
     public boolean isValid(List<Integer> elements, ConstraintValidatorContext context) {
+        if (elements == null) {
+            elements = List.of();
+        }
         return elements.stream().distinct().count() == elements.size();
     }
 }

--- a/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/UniqueUrlsValidator.java
@@ -14,6 +14,9 @@ public class UniqueUrlsValidator implements ConstraintValidator<UniqueUrl, List<
 
     @Override
     public boolean isValid(List<String> elements, ConstraintValidatorContext context) {
+        if (elements == null) {
+            elements = List.of();
+        }
         return elements.stream().distinct().count() == elements.size();
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #634
- close #632  

# 🚀 작업 내용

1. imageUrls가 null일 경우 `@UniqueUrl`커스텀 어노테이션에서 null예외가 발생하는 것을 확인하여 DTO의 생성자에 null일경우 빈 리스트로 초기화 해주는 로직을 추가하였습니다.

# 💬 리뷰 중점사항
