### PR TITLE
Fix: 이모지 검증 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -10,7 +9,7 @@ import jakarta.validation.constraints.NotBlank;
 public record StudentLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
-    @NotEmoji
+    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentLoginRequest.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 public record StudentLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
+    @NotEmoji
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
 import in.koreatech.koin.domain.user.model.UserIdentity;
 import in.koreatech.koin.domain.user.model.UserType;
+import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -29,10 +30,12 @@ public record StudentRegisterRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     @NotBlank(message = "이메일을 입력해주세요.")
+    @NotEmoji
     String email,
 
     @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
     @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
+    @NotEmoji
     String name,
 
     @Schema(description = " SHA 256 해시 알고리즘으로 암호화된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = REQUIRED)
@@ -41,6 +44,7 @@ public record StudentRegisterRequest(
 
     @Schema(description = "닉네임", example = "bbo", requiredMode = NOT_REQUIRED)
     @Size(max = 10, message = "닉네임은 최대 10자입니다.")
+    @NotEmoji
     String nickname,
 
     @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -30,7 +30,6 @@ public record StudentRegisterRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     @NotBlank(message = "이메일을 입력해주세요.")
-    @NotEmoji
     String email,
 
     @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
@@ -37,6 +38,7 @@ public record StudentUpdateRequest
 
         @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
         @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+        @NotEmoji
         String name,
 
         @Size(message = "SHA 256 해시 알고리즘으로 암호화 된 비밀번호")
@@ -45,6 +47,7 @@ public record StudentUpdateRequest
 
         @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
         @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+        @NotEmoji
         String nickname,
 
         @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -4,12 +4,13 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
-    @NotEmoji
+    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotBlank;
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
+    @NotEmoji
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -2,12 +2,14 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")
+    @NotEmoji
     String email,
 
     @Schema(

--- a/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.global.validation;
+
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+@Component
+public class EmojiValidator implements ConstraintValidator<NotEmoji, String> {
+
+    private static final Pattern EMOJI_PATTERN = Pattern.compile(
+        "[\\uD83C-\\uDBFF\\uDC00-\\uDFFF]|" +     // 서플리먼터리
+            "[\\u2600-\\u26FF]|" +                // Miscellaneous Symbols
+            "[\\u2700-\\u27BF]|" +                // Dingbats
+            "[\\u1F300-\\u1F5FF]|" +              // Miscellaneous Symbols and Pictographs
+            "[\\u1F600-\\u1F64F]|" +              // Emoticons
+            "[\\u1F680-\\u1F6FF]|" +              // Transport and Map Symbols
+            "[\\u1F700-\\u1F77F]|" +              // Alchemical Symbols
+            "[\\u1F780-\\u1F7FF]|" +              // Geometric Shapes Extended
+            "[\\u1F800-\\u1F8FF]|" +              // Supplemental Arrows-C
+            "[\\u1F900-\\u1F9FF]|" +              // Supplemental Symbols and Pictographs
+            "[\\u1FA00-\\u1FA6F]|" +              // Chess Symbols
+            "[\\u1FA70-\\u1FAFF]"                 // Symbols and Pictographs Extended-A
+    );
+
+    @Override
+    public void initialize(NotEmoji constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String field, ConstraintValidatorContext constraintValidatorContext) {
+        for (int i = 0; i < field.length(); i++) {
+            int codePoint = field.codePointAt(i);
+            if (Character.isSupplementaryCodePoint(codePoint)) {
+                i++;
+            }
+            if (isEmoji(codePoint)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isEmoji(int codePoint) {
+        return EMOJI_PATTERN.matcher(new String(Character.toChars(codePoint))).find();
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.global.validation;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Component;
@@ -10,20 +11,7 @@ import jakarta.validation.ConstraintValidatorContext;
 @Component
 public class EmojiValidator implements ConstraintValidator<NotEmoji, String> {
 
-    private static final Pattern EMOJI_PATTERN = Pattern.compile(
-        "[\\uD83C-\\uDBFF\\uDC00-\\uDFFF]|" +     // 서플리먼터리
-            "[\\u2600-\\u26FF]|" +                // Miscellaneous Symbols
-            "[\\u2700-\\u27BF]|" +                // Dingbats
-            "[\\u1F300-\\u1F5FF]|" +              // Miscellaneous Symbols and Pictographs
-            "[\\u1F600-\\u1F64F]|" +              // Emoticons
-            "[\\u1F680-\\u1F6FF]|" +              // Transport and Map Symbols
-            "[\\u1F700-\\u1F77F]|" +              // Alchemical Symbols
-            "[\\u1F780-\\u1F7FF]|" +              // Geometric Shapes Extended
-            "[\\u1F800-\\u1F8FF]|" +              // Supplemental Arrows-C
-            "[\\u1F900-\\u1F9FF]|" +              // Supplemental Symbols and Pictographs
-            "[\\u1FA00-\\u1FA6F]|" +              // Chess Symbols
-            "[\\u1FA70-\\u1FAFF]"                 // Symbols and Pictographs Extended-A
-    );
+    private static final Pattern EMOJI_PATTERN = Pattern.compile("[\\uD83C-\\uDBFF\\uDC00-\\uDFFF]+");
 
     @Override
     public void initialize(NotEmoji constraintAnnotation) {
@@ -32,14 +20,9 @@ public class EmojiValidator implements ConstraintValidator<NotEmoji, String> {
 
     @Override
     public boolean isValid(String field, ConstraintValidatorContext constraintValidatorContext) {
-        for (int i = 0; i < field.length(); i++) {
-            int codePoint = field.codePointAt(i);
-            if (Character.isSupplementaryCodePoint(codePoint)) {
-                i++;
-            }
-            if (isEmoji(codePoint)) {
-                return false;
-            }
+        Matcher emojiMatcher = EMOJI_PATTERN.matcher(field);
+        if (emojiMatcher.find()) {
+            return false;
         }
         return true;
     }

--- a/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
@@ -26,8 +26,4 @@ public class EmojiValidator implements ConstraintValidator<NotEmoji, String> {
         }
         return true;
     }
-
-    private boolean isEmoji(int codePoint) {
-        return EMOJI_PATTERN.matcher(new String(Character.toChars(codePoint))).find();
-    }
 }

--- a/src/main/java/in/koreatech/koin/global/validation/NotEmoji.java
+++ b/src/main/java/in/koreatech/koin/global/validation/NotEmoji.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.global.validation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = EmojiValidator.class)
+@Target({FIELD, PARAMETER, LOCAL_VARIABLE})
+@Retention(RUNTIME)
+public @interface NotEmoji {
+    String message() default "이모지가 허용되지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #649

# 🚀 작업 내용

1. 기존 로그인시에 이메일에 이모지를 넣어 발생한 에러는 기존에 있던 이메일 형식 검증 어노테이션을 추가했습니다.

2. 이모지 검증 어노테이션을 추가하여 닉네임이나 이름같은 필드에 이모지를 넣을시 발생할 에러를 방지했습니다.

# 💬 리뷰 중점사항
