### PR TITLE
fix: post timteable 조회 조건 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/repository/LectureRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/repository/LectureRepository.java
@@ -17,11 +17,11 @@ public interface LectureRepository extends Repository<Lecture, Integer> {
 
     Optional<Lecture> findById(Integer id);
 
-    Optional<Lecture> findBySemesterAndNameAndLectureClass(String semesterDate, String name, String classLecture);
+    Optional<Lecture> findBySemesterAndCodeAndLectureClass(String semesterDate, String code, String classLecture);
 
-    default Lecture getBySemesterAndNameAndLectureClass(String semesterDate, String name, String classLecture) {
-        return findBySemesterAndNameAndLectureClass(semesterDate, name, classLecture)
-            .orElseThrow(() -> SemesterNotFoundException.withDetail("semester: " + semesterDate + " name: " + name + " classLecture: " + classLecture));
+    default Lecture getBySemesterAndCodeAndLectureClass(String semesterDate, String code, String classLecture) {
+        return findBySemesterAndCodeAndLectureClass(semesterDate, code, classLecture)
+            .orElseThrow(() -> SemesterNotFoundException.withDetail("semester: " + semesterDate + " code: " + code + " classLecture: " + classLecture));
     }
 
     default Lecture getLectureById(Integer id) {

--- a/src/main/java/in/koreatech/koin/domain/timetable/service/TimetableService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/service/TimetableService.java
@@ -51,8 +51,8 @@ public class TimetableService {
             semester.getId());
 
         for (TimetableCreateRequest.InnerTimetableRequest timeTable : request.timetable()) {
-            Lecture lecture = lectureRepository.getBySemesterAndNameAndLectureClass(request.semester(),
-                timeTable.classTitle(), timeTable.lectureClass());
+            Lecture lecture = lectureRepository.getBySemesterAndCodeAndLectureClass(request.semester(),
+                timeTable.code(), timeTable.lectureClass());
             TimetableLecture timetableLecture = TimetableLecture.builder()
                 .classPlace(timeTable.classPlace())
                 .grades("0")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #659

# 🚀 작업 내용

1. 기존 조회 조건은 여러 개의 강의를 반환하는 경우가 있어서 post timteable api 로직 내부의 조회 조건을 변경했습니다.
(이름 -> code로 변경)

# 💬 리뷰 중점사항
