### PR TITLE
fix: 이모지 어노테이션 검증 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/EmojiValidator.java
@@ -20,6 +20,9 @@ public class EmojiValidator implements ConstraintValidator<NotEmoji, String> {
 
     @Override
     public boolean isValid(String field, ConstraintValidatorContext constraintValidatorContext) {
+        if (field == null) {
+            return true;
+        }
         Matcher emojiMatcher = EMOJI_PATTERN.matcher(field);
         if (emojiMatcher.find()) {
             return false;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #666 

# 🚀 작업 내용

1. 이모지 검증하는 어노테이션이 null값을 허용하지 않아서 오류가 발생하여 null값을 허용했습니다.

# 💬 리뷰 중점사항
