### PR TITLE
hotfix : 학생 회원가입 전화번호 입력 값 Swagger에 맞춰 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -77,7 +77,7 @@ public record StudentRegisterRequest(
     String studentNumber,
 
     @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.")
     String phoneNumber
 ) {
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #694 

# 🚀 작업 내용

1. Swagger 형식에 맞도록 Requset를 수정했습니다. (11자리 형식에서, 3-4-4 형식 추가)
<img width="591" alt="image" src="https://github.com/user-attachments/assets/b71df29b-62e8-4122-8889-bd3b0d0b582e">

# 💬 리뷰 중점사항
저번 로그인 로직 수정하면서 전화번호를 통일하겠다! 하고 수정했던 내용인데, Swagger에 반영이 안 되어 있었습니다. 다시 전화번호 형식을 2가지 받도록 했고, 학생 측에서도 전화번호 회원가입도 의견이 나옴에 따라 이 사항도 한 번 논의해봐야 할 것 같습니다.
브랜치를 잘못 파서 PR을 더 날려버렸네요 죄송합니당😢 