### PR TITLE
feat : GET /semesters/check 반환값 내림차순 변경 & 학생 회원가입 전화번호 형식 hotfix develop 적용

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/SemesterCheckResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/SemesterCheckResponse.java
@@ -15,7 +15,7 @@ public record SemesterCheckResponse(
     Integer userId,
 
     @Schema(description = "유저 학기", example = """
-        ["20192", "20201"]
+        ["20202", "20201"]
         """, requiredMode = REQUIRED)
     List<String> semesters
 ) {

--- a/src/main/java/in/koreatech/koin/domain/timetable/service/SemesterService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/service/SemesterService.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetable.service;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -27,10 +28,11 @@ public class SemesterService {
     }
 
     public SemesterCheckResponse getStudentSemesters(Integer userId) {
-        List<TimetableFrame> timeTableFrames = timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(userId);
-        List<String> semesters = timeTableFrames.stream()
-            .map(timeTableFrame -> timeTableFrame.getSemester().getSemester())
+        List<TimetableFrame> timetableFrames = timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(userId);
+        List<String> semesters = timetableFrames.stream()
+            .map(timetableFrame -> timetableFrame.getSemester().getSemester())
             .distinct()
+            .sorted(Comparator.reverseOrder())
             .toList();
         return SemesterCheckResponse.of(userId, semesters);
     }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -77,7 +77,7 @@ public record StudentRegisterRequest(
     String studentNumber,
 
     @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.")
     String phoneNumber
 ) {
 

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -335,8 +335,8 @@ class TimetableApiTest extends AcceptanceTest {
                 {
                     "user_id": 1,
                     "semesters": [
-                      "20192",
-                      "20201"
+                      "20201",
+                      "20192"
                     ]
                 }
                 """


### PR DESCRIPTION
# 🔥 연관 이슈

- close #704 

# 🚀 작업 내용

1. GET /semesters/check의 학기 반환값을 오름차순 -> 내림차순으로 변경했습니다.
2. hotfix로 적용하였던 학생 회원가입 전화번호 표현식 변경사항을 develop에도 적용했습니다. (3 - 4 - 4 + 11자리 가능)

# 💬 리뷰 중점사항
<img width="552" alt="image" src="https://github.com/user-attachments/assets/23640916-becf-455e-80b7-51285c95166b">

프론트엔드 도훈님의 요청으로 학기의 반환값을 내림차순으로 변경했습니다. 
추가적으로 hotfix로 적용하였던 학생 회원가입 전화번호 표현식을 develop에도 적용했습니다.
잘 부탁드립니다~ :D 