### PR TITLE
fix: 시간표 프레임 삭제 관련 에러 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -42,14 +42,7 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
             .orElseThrow(() -> TimetableFrameNotFoundException.withDetail("userId: " + user.getId()));
     }
 
-    @Query(
-        """
-        SELECT tf FROM TimetableFrame tf
-        WHERE tf.user.id = :userId
-        AND tf.semester.id = :semesterId 
-        AND tf.isMain = false ORDER BY tf.createdAt ASC
-        """)
-    TimetableFrame findFirstNonMainFrame(@Param("userId") Integer userId, @Param("semesterId") Integer semesterId);
+    TimetableFrame findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(Integer userId, Integer semesterId);
 
     @Query(
         """

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -80,7 +80,8 @@ public class TimetableServiceV2 {
         }
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
-                timetableFrameRepositoryV2.findFirstNonMainFrame(userId, frame.getSemester().getId());
+                timetableFrameRepositoryV2.
+                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
                 timetableFrameRepositoryV2.save(nextMainFrame);

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @RedisHash("refreshToken")
 public class UserToken {
 
-    private static final long REFRESH_TOKEN_EXPIRE_DAY = 90L;
+    private static final long REFRESH_TOKEN_EXPIRE_DAY = 14L;
 
     @Id
     private Integer id;

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @RedisHash("refreshToken")
 public class UserToken {
 
-    private static final long REFRESH_TOKEN_EXPIRE_DAY = 14L;
+    private static final long REFRESH_TOKEN_EXPIRE_DAY = 90L;
 
     @Id
     private Integer id;

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
@@ -173,6 +173,32 @@ public class TimetableV2ApiTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("isMain인 frame을 삭제한다 - 다른 frame이 main으로 됨")
+    void deleteMainTimeTablesFrame() {
+        User user = userFixture.준호_학생().getUser();
+        String token = userFixture.getToken(user);
+        Semester semester = semesterFixture.semester("20192");
+
+        TimetableFrame frame1 = timetableV2Fixture.시간표1(user, semester);
+        TimetableFrame frame2 = timetableV2Fixture.시간표2(user, semester);
+
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .param("id", frame1.getId())
+            .delete("/v2/timetables/frame")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+            .extract();
+
+        assertThat(timetableFrameRepositoryV2.findById(frame1.getId())).isNotPresent();
+
+        TimetableFrame reloadedFrame2 = timetableFrameRepositoryV2.findById(frame2.getId()).orElseThrow();
+        assertThat(reloadedFrame2.isMain()).isTrue();
+    }
+
+    @Test
     @DisplayName("특정 시간표 frame을 삭제한다 - 본인 삭제가 아니면 403 반환")
     void deleteTimeTablesFrameNoAuth() {
         User user1 = userFixture.준호_학생().getUser();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #705 

# 🚀 작업 내용

1.  isMain인 프레임을 삭제하면 isMain이 아닌 것 중에 가장 먼저 생성된 것이 isMain이 되도록 jpa의 힘을 빌려 로직을 짰었으나.. jpql로 바꾸게 되면서 생긴 에러 입니다.  jpql은 limit을 지원하지 않아서 limit을 지원하는 jpa로 메서드를 다시 변경했습니다.(first)

# 💬 리뷰 중점사항
