### PR TITLE
fix : 생협 운영시간 정보에 학기 필드 semester 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopShopResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopShopResponse.java
@@ -19,6 +19,9 @@ public record AdminCoopShopResponse(
     @Schema(example = "세탁소", description = "생협 매장 이름", requiredMode = REQUIRED)
     String name,
 
+    @Schema(example = "하계방학", description = "운영 학기", requiredMode = REQUIRED)
+    String semester,
+
     @Schema(description = "요일별 생협 매장 운영시간")
     List<InnerCoopOpens> opens,
 
@@ -36,6 +39,7 @@ public record AdminCoopShopResponse(
         return new AdminCoopShopResponse(
             coopShop.getId(),
             coopShop.getName(),
+            coopShop.getSemester(),
             coopShop.getCoopOpens().stream()
                 .map(InnerCoopOpens::from)
                 .toList(),

--- a/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
@@ -19,6 +19,9 @@ public record CoopShopResponse(
     @Schema(example = "세탁소", description = "생협 매장 이름", requiredMode = REQUIRED)
     String name,
 
+    @Schema(example = "하계방학", description = "운영 학기", requiredMode = REQUIRED)
+    String semester,
+
     @Schema(description = "요일별 생협 매장 운영시간")
     List<InnerCoopOpens> opens,
 
@@ -36,6 +39,7 @@ public record CoopShopResponse(
         return new CoopShopResponse(
             coopShop.getId(),
             coopShop.getName(),
+            coopShop.getSemester(),
             coopShop.getCoopOpens().stream()
                 .map(InnerCoopOpens::from)
                 .toList(),

--- a/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShop.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShop.java
@@ -34,6 +34,10 @@ public class CoopShop extends BaseEntity {
     private String name;
 
     @NotNull
+    @Column(name = "semester", nullable = false)
+    private String semester;
+
+    @NotNull
     @Column(name = "phone", nullable = false)
     private String phone;
 
@@ -54,11 +58,13 @@ public class CoopShop extends BaseEntity {
     @Builder
     private CoopShop(
         String name,
+        String semester,
         String phone,
         String location,
         String remarks
     ) {
         this.name = name;
+        this.semester = semester;
         this.phone = phone;
         this.location = location;
         this.remarks = remarks;

--- a/src/main/resources/db/migration/V31__add_coopshop_semester.sql
+++ b/src/main/resources/db/migration/V31__add_coopshop_semester.sql
@@ -1,0 +1,2 @@
+alter table coop_shop
+    add column semester varchar(50) not null	comment "운영 학기";

--- a/src/test/java/in/koreatech/koin/acceptance/CoopShopTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CoopShopTest.java
@@ -48,6 +48,7 @@ class CoopShopTest extends AcceptanceTest {
                         {
                             "id": 1,
                             "name": "학생식당",
+                            "semester" : "하계방학",
                             "opens": [
                                 {
                                     "day_of_week": "평일",
@@ -81,6 +82,7 @@ class CoopShopTest extends AcceptanceTest {
                         {
                             "id": 2,
                             "name": "세탁소",
+                            "semester" : "학기",
                             "opens": [
                                 {
                                     "day_of_week": "평일",
@@ -120,6 +122,7 @@ class CoopShopTest extends AcceptanceTest {
                     {
                         "id": 1,
                         "name": "학생식당",
+                        "semester" : "하계방학",
                         "opens": [
                             {
                                 "day_of_week": "평일",

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopTest.java
@@ -67,6 +67,7 @@ class AdminCoopShopTest extends AcceptanceTest {
                              {
                                  "id": 1,
                                  "name": "학생식당",
+                                 "semester": "하계방학",
                                  "opens": [
                                      {
                                          "day_of_week": "평일",
@@ -100,6 +101,7 @@ class AdminCoopShopTest extends AcceptanceTest {
                              {
                                  "id": 2,
                                  "name": "세탁소",
+                                 "semester": "학기",
                                  "opens": [
                                      {
                                          "day_of_week": "평일",
@@ -141,6 +143,7 @@ class AdminCoopShopTest extends AcceptanceTest {
                     {
                         "id": 2,
                         "name": "세탁소",
+                        "semester": "학기",
                         "opens": [
                             {
                                 "day_of_week": "평일",

--- a/src/test/java/in/koreatech/koin/fixture/CoopShopFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/CoopShopFixture.java
@@ -22,6 +22,7 @@ public class CoopShopFixture {
         var coopShop = coopShopRepository.save(
             CoopShop.builder()
                 .name("학생식당")
+                .semester("하계방학")
                 .location("학생회관 1층")
                 .phone("041-000-0000")
                 .remarks("공휴일 휴무")
@@ -66,6 +67,7 @@ public class CoopShopFixture {
         var coopShop = coopShopRepository.save(
             CoopShop.builder()
                 .name("세탁소")
+                .semester("학기")
                 .location("학생회관 2층")
                 .phone("041-000-0000")
                 .remarks("연중무휴")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 생협 운영시간에 학기 정보(semester)가 추가되었습니다.
    - `coop_shop` 테이블에 `semester` 칼럼 추가
    - {"semester" : "하계방학"} 과 같은 형태로 들어갑니다.

# 💬 리뷰 중점사항
