### PR TITLE
fix : coopShop 조회 시 모든 CoopOpen이 즉시 조회되도록 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopOpen.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopOpen.java
@@ -26,7 +26,7 @@ public class CoopOpen {
     @GeneratedValue(strategy = IDENTITY)
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coop_id", referencedColumnName = "id", nullable = false)
     private CoopShop coopShop;
 

--- a/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShop.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShop.java
@@ -10,6 +10,7 @@ import java.util.List;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
@@ -52,7 +53,8 @@ public class CoopShop extends BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
-    @OneToMany(mappedBy = "coopShop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    @OneToMany(mappedBy = "coopShop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE},
+        fetch = FetchType.EAGER)
     private List<CoopOpen> coopOpens = new ArrayList<>();
 
     @Builder


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. CoopShop 조회 시 모든 CoopOpen이 조회되도록 `Lazy`에서 `Eager`로 수정하였습니다.
    - CoopShop을 통한 CoopOpen 조회는 OneToMany에 적용해야 하는데 ManyToOne에 잘못 적용해서 다시 올립니다.

# 💬 리뷰 중점사항
