### PR TITLE
refactor: 승인이 안된 사장님이 로그인할시 403반환한다

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -52,6 +52,7 @@ import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
 import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
 import in.koreatech.koin.global.domain.email.form.OwnerRegistrationData;
 import in.koreatech.koin.global.domain.email.service.MailService;
@@ -94,7 +95,7 @@ public class OwnerService {
         }
 
         if (!user.isAuthed()) {
-            throw new KoinIllegalArgumentException("미인증 상태입니다. 인증을 진행해주세요.");
+            throw new AuthorizationException("미인증 상태입니다. 인증을 진행해주세요.");
         }
 
         String accessToken = jwtProvider.createToken(user);

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -81,6 +81,29 @@ class OwnerApiTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("관리자가 승인하지 않은 사장님이 로그인을 진행한다")
+    void unAuthOwnerLogin() {
+        Owner owner = userFixture.철수_사장님();
+        String phoneNumber = owner.getAccount();
+        String password = "1234";
+
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "account" : "%s",
+                  "password" : "%s"
+                }
+                """.formatted(phoneNumber, password))
+            .when()
+            .post("/owner/login")
+            .then()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .extract();
+    }
+
+    @Test
     @DisplayName("로그인된 사장님 정보를 조회한다.")
     void getOwner() {
         // given


### PR DESCRIPTION
# 🔥 연관 이슈

- close #712 

# 🚀 작업 내용

1.  승인이 안된 사장님이 로그인을 할 시 400을 반환하던 것을 403을 반환하도록 변경하였습니다.
2. 관리자가 승인하지 않은 사장님이 로그인을 진행하는 경우 테스트코드를 추가하였습니다.

# 💬 리뷰 중점사항
