### PR TITLE
refactor : 품절 알림 여부 판단 시 생협 API 운영시간을 참조하도록 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopShopResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopShopResponse.java
@@ -3,8 +3,10 @@ package in.koreatech.koin.admin.coopShop.dto;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.coopshop.model.CoopOpen;
@@ -32,7 +34,11 @@ public record AdminCoopShopResponse(
     String location,
 
     @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
-    String remarks
+    String remarks,
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Schema(example = "2024-06-26", description = "학식 운영시간 업데이트 날짜", requiredMode = REQUIRED)
+    LocalDateTime updatedAt
 ) {
 
     public static AdminCoopShopResponse from(CoopShop coopShop) {
@@ -45,7 +51,8 @@ public record AdminCoopShopResponse(
                 .toList(),
             coopShop.getPhone(),
             coopShop.getLocation(),
-            coopShop.getRemarks()
+            coopShop.getRemarks(),
+            coopShop.getUpdatedAt()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -47,12 +47,12 @@ public class CoopService {
     @Transactional
     public void changeSoldOut(SoldOutRequest soldOutRequest) {
         Dining dining = diningRepository.getById(soldOutRequest.menuId());
-        LocalDateTime now = LocalDateTime.now(clock);
-        boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType().getDiningName());
 
         if (soldOutRequest.soldOut()) {
+            LocalDateTime now = LocalDateTime.now(clock);
             dining.setSoldOut(now);
-            if (diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty() && isOpened) {
+            boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType());
+            if (isOpened && diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty()) {
                 eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getPlace(), dining.getType()));
             }
         } else {

--- a/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
@@ -3,8 +3,10 @@ package in.koreatech.koin.domain.coopshop.dto;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.coopshop.model.CoopOpen;
@@ -32,7 +34,11 @@ public record CoopShopResponse(
     String location,
 
     @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
-    String remarks
+    String remarks,
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Schema(example = "2024-06-26", description = "학식 운영시간 업데이트 날짜", requiredMode = REQUIRED)
+    LocalDateTime updatedAt
 ) {
 
     public static CoopShopResponse from(CoopShop coopShop) {
@@ -45,7 +51,8 @@ public record CoopShopResponse(
                 .toList(),
             coopShop.getPhone(),
             coopShop.getLocation(),
-            coopShop.getRemarks()
+            coopShop.getRemarks(),
+            coopShop.getUpdatedAt()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/coopshop/exception/CoopOpenNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/exception/CoopOpenNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.coopshop.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class CoopOpenNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "해당 운영 시간이 존재하지 않습니다.";
+
+    public CoopOpenNotFoundException(String message) {
+        super(message);
+    }
+
+    public CoopOpenNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static CoopOpenNotFoundException withDetail(String detail) {
+        return new CoopOpenNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShopType.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopShopType.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.coopshop.model;
+
+import java.util.Arrays;
+
+import in.koreatech.koin.domain.coopshop.exception.CoopShopNotFoundException;
+import lombok.Getter;
+
+@Getter
+public enum CoopShopType {
+    CAFETERIA("학생식당");
+
+    private final String name;
+
+    CoopShopType(String name) {
+        this.name = name;
+    }
+
+    public CoopShopType from(String name) {
+        return Arrays.stream(CoopShopType.values())
+            .filter(coopShop -> coopShop.name().equals(name))
+            .findAny()
+            .orElseThrow(() -> new CoopShopNotFoundException(name));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coopshop/repository/CoopOpenRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/repository/CoopOpenRepository.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.coopshop.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.coopshop.exception.CoopOpenNotFoundException;
+import in.koreatech.koin.domain.coopshop.model.CoopOpen;
+import in.koreatech.koin.domain.coopshop.model.CoopShop;
+
+public interface CoopOpenRepository extends Repository<CoopOpen, Integer> {
+
+    Optional<CoopOpen> findByCoopShopAndTypeAndDayOfWeek(CoopShop coopShop, String type, String dayOfWeek);
+
+    default CoopOpen getByCoopShopAndTypeAndDayOfWeek(CoopShop coopShop, String type, String dayOfWeek) {
+        return findByCoopShopAndTypeAndDayOfWeek(coopShop, type, dayOfWeek)
+            .orElseThrow(() -> CoopOpenNotFoundException.withDetail(
+                String.format("coopShop: %s, type: %s, day of week: %s", coopShop, type, dayOfWeek)
+            ));
+    }
+
+}

--- a/src/main/java/in/koreatech/koin/domain/coopshop/repository/CoopShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/repository/CoopShopRepository.java
@@ -18,8 +18,15 @@ public interface CoopShopRepository extends Repository<CoopShop, Integer> {
 
     Optional<CoopShop> findById(Integer id);
 
+    Optional<CoopShop> findByName(String name);
+
     default CoopShop getById(Integer id) {
         return findById(id)
-            .orElseThrow(() -> CoopShopNotFoundException.withDetail("coop_id : " + id));
+            .orElseThrow(() -> CoopShopNotFoundException.withDetail("coopShopId : " + id));
+    }
+
+    default CoopShop getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> CoopShopNotFoundException.withDetail("coopShopType : " + name));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coopshop/service/CoopShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/service/CoopShopService.java
@@ -1,11 +1,19 @@
 package in.koreatech.koin.domain.coopshop.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import in.koreatech.koin.domain.coopshop.dto.CoopShopResponse;
+import in.koreatech.koin.domain.coopshop.model.CoopOpen;
 import in.koreatech.koin.domain.coopshop.model.CoopShop;
+import in.koreatech.koin.domain.coopshop.model.CoopShopType;
+import in.koreatech.koin.domain.coopshop.repository.CoopOpenRepository;
 import in.koreatech.koin.domain.coopshop.repository.CoopShopRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class CoopShopService {
 
     private final CoopShopRepository coopShopRepository;
+    private final CoopOpenRepository coopOpenRepository;
 
     public List<CoopShopResponse> getCoopShops() {
         return coopShopRepository.findAllByIsDeletedFalse().stream()
@@ -24,5 +33,22 @@ public class CoopShopService {
     public CoopShopResponse getCoopShop(Integer id) {
         CoopShop coopShop = coopShopRepository.getById(id);
         return CoopShopResponse.from(coopShop);
+    }
+
+    public boolean getIsOpened(LocalDateTime now, CoopShopType coopShopType, String type) {
+        try {
+            String todayType =
+                (now.getDayOfWeek() == DayOfWeek.SATURDAY || now.getDayOfWeek() == DayOfWeek.SUNDAY) ? "주말" : "평일";
+            CoopShop coopShop = coopShopRepository.getByName(coopShopType.getName());
+            CoopOpen open = coopOpenRepository.getByCoopShopAndTypeAndDayOfWeek(coopShop, type, todayType);
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+            LocalDateTime openTime = LocalTime.parse(open.getOpenTime(), formatter).atDate(now.toLocalDate());
+            LocalDateTime closeTime = LocalTime.parse(open.getCloseTime(), formatter).atDate(now.toLocalDate());
+
+            return (!now.isBefore(openTime) && !now.isAfter(closeTime));
+        } catch (DateTimeParseException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coopshop/service/CoopShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/service/CoopShopService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.coopshop.model.CoopShop;
 import in.koreatech.koin.domain.coopshop.model.CoopShopType;
 import in.koreatech.koin.domain.coopshop.repository.CoopOpenRepository;
 import in.koreatech.koin.domain.coopshop.repository.CoopShopRepository;
+import in.koreatech.koin.domain.dining.model.DiningType;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -35,12 +36,13 @@ public class CoopShopService {
         return CoopShopResponse.from(coopShop);
     }
 
-    public boolean getIsOpened(LocalDateTime now, CoopShopType coopShopType, String type) {
+    public boolean getIsOpened(LocalDateTime now, CoopShopType coopShopType, DiningType type) {
         try {
             String todayType =
                 (now.getDayOfWeek() == DayOfWeek.SATURDAY || now.getDayOfWeek() == DayOfWeek.SUNDAY) ? "주말" : "평일";
             CoopShop coopShop = coopShopRepository.getByName(coopShopType.getName());
-            CoopOpen open = coopOpenRepository.getByCoopShopAndTypeAndDayOfWeek(coopShop, type, todayType);
+            CoopOpen open = coopOpenRepository
+                .getByCoopShopAndTypeAndDayOfWeek(coopShop, type.getDiningName(), todayType);
 
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
             LocalDateTime openTime = LocalTime.parse(open.getOpenTime(), formatter).atDate(now.toLocalDate());

--- a/src/test/java/in/koreatech/koin/acceptance/CoopShopTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CoopShopTest.java
@@ -77,7 +77,8 @@ class CoopShopTest extends AcceptanceTest {
                             ],
                             "phone": "041-000-0000",
                             "location": "학생회관 1층",
-                            "remarks": "공휴일 휴무"
+                            "remarks": "공휴일 휴무",
+                            "updated_at" : "2024-01-15"
                         },
                         {
                             "id": 2,
@@ -99,7 +100,8 @@ class CoopShopTest extends AcceptanceTest {
                             ],
                             "phone": "041-000-0000",
                             "location": "학생회관 2층",
-                            "remarks": "연중무휴"
+                            "remarks": "연중무휴",
+                            "updated_at" : "2024-01-15"
                         }
                     ]
                     """
@@ -151,7 +153,8 @@ class CoopShopTest extends AcceptanceTest {
                         ],
                         "phone": "041-000-0000",
                         "location": "학생회관 1층",
-                        "remarks": "공휴일 휴무"
+                        "remarks": "공휴일 휴무",
+                        "updated_at" : "2024-01-15"
                     }
                     """
             );

--- a/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
@@ -17,9 +17,11 @@ import org.springframework.http.HttpStatus;
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
 import in.koreatech.koin.domain.coop.repository.DiningSoldOutCacheRepository;
+import in.koreatech.koin.domain.coopshop.model.CoopShop;
 import in.koreatech.koin.domain.dining.model.Dining;
 import in.koreatech.koin.domain.dining.repository.DiningRepository;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.CoopShopFixture;
 import in.koreatech.koin.fixture.DiningFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
@@ -41,11 +43,15 @@ class DiningApiTest extends AcceptanceTest {
     @Autowired
     private DiningFixture diningFixture;
 
+    @Autowired
+    private CoopShopFixture coopShopFixture;
+
     private Dining A코너_점심;
     private User coop_준기;
     private String token_준기;
     private User owner_현수;
     private String token_현수;
+    private CoopShop 학생식당;
 
     @BeforeEach
     void setUp() {
@@ -54,6 +60,7 @@ class DiningApiTest extends AcceptanceTest {
         owner_현수 = userFixture.현수_사장님().getUser();
         token_현수 = userFixture.getToken(owner_현수);
         A코너_점심 = diningFixture.A코스_점심(LocalDate.parse("2024-01-15"));
+        학생식당 = coopShopFixture.학생식당();
     }
 
     @Test
@@ -242,6 +249,7 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -264,6 +272,7 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -287,6 +296,7 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
@@ -251,7 +251,6 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -274,7 +273,6 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -298,7 +296,6 @@ class DiningApiTest extends AcceptanceTest {
             .when()
             .patch("/coop/dining/soldout")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopTest.java
@@ -96,7 +96,8 @@ class AdminCoopShopTest extends AcceptanceTest {
                                  ],
                                  "phone": "041-000-0000",
                                  "location": "학생회관 1층",
-                                 "remarks": "공휴일 휴무"
+                                 "remarks": "공휴일 휴무",
+                                 "updated_at" : "2024-01-15"
                              },
                              {
                                  "id": 2,
@@ -118,7 +119,8 @@ class AdminCoopShopTest extends AcceptanceTest {
                                  ],
                                  "phone": "041-000-0000",
                                  "location": "학생회관 2층",
-                                 "remarks": "연중무휴"
+                                 "remarks": "연중무휴",
+                                 "updated_at" : "2024-01-15"
                              }
                          ]
                      }
@@ -160,7 +162,8 @@ class AdminCoopShopTest extends AcceptanceTest {
                         ],
                         "phone": "041-000-0000",
                         "location": "학생회관 2층",
-                        "remarks": "연중무휴"
+                        "remarks": "연중무휴",
+                        "updated_at" : "2024-01-15"
                     }
                     """
             );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #571 

# 🚀 작업 내용

1. 품절 알림 여부 판단 시 `DiningType` Enum을 참조하는 것에서 생협 API의 운영시간을 참조하는 것으로 수정하였습니다.
2. 생협 API의 `coopShopResponse`에 `updated_at` 필드가 추가되었습니다.

# 💬 리뷰 중점사항
