### PR TITLE
feat : shop_review 관련 FK 조건 CASCADE 수정

### DIFF
--- a/src/main/resources/db/migration/V34__shop_reviews_restrict_change_cascade_.sql
+++ b/src/main/resources/db/migration/V34__shop_reviews_restrict_change_cascade_.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `koin`.`shop_reviews`
+    DROP FOREIGN KEY `shop_reviews_ibfk_1`,
+    DROP FOREIGN KEY `shop_reviews_ibfk_2`;
+
+ALTER TABLE `koin`.`shop_reviews`
+    ADD CONSTRAINT `shop_reviews_ibfk_1`
+        FOREIGN KEY (`reviewer_id`)
+        REFERENCES `koin`.`users` (`id`)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT `shop_reviews_ibfk_2`
+        FOREIGN KEY (`shop_id`)
+        REFERENCES `koin`.`shops` (`id`)
+        ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V35__shop_review_reports_restrict_change_cascade_.sql
+++ b/src/main/resources/db/migration/V35__shop_review_reports_restrict_change_cascade_.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `koin`.`shop_review_reports`
+    DROP FOREIGN KEY `shop_review_reports_ibfk_1`,
+    DROP FOREIGN KEY `shop_review_reports_ibfk_2`;
+
+ALTER TABLE `koin`.`shop_review_reports`
+    ADD CONSTRAINT `shop_review_reports_ibfk_1`
+        FOREIGN KEY (`review_id`)
+        REFERENCES `koin`.`shop_reviews` (`id`)
+        ON DELETE CASCADE,
+    ADD CONSTRAINT `shop_review_reports_ibfk_2`
+        FOREIGN KEY (`user_id`)
+        REFERENCES `koin`.`users` (`id`)
+        ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V36__shop_review_images_restrict_change_cascade_.sql
+++ b/src/main/resources/db/migration/V36__shop_review_images_restrict_change_cascade_.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `koin`.`shop_review_images`
+    DROP FOREIGN KEY `shop_review_images_ibfk_1`;
+
+ALTER TABLE `koin`.`shop_review_images`
+    ADD CONSTRAINT `shop_review_images_ibfk_1`
+        FOREIGN KEY (`review_id`)
+        REFERENCES `koin`.`shop_reviews` (`id`)
+        ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V37__shop_review_menus_restrict_change_cascade_.sql
+++ b/src/main/resources/db/migration/V37__shop_review_menus_restrict_change_cascade_.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `koin`.`shop_review_menus`
+    DROP FOREIGN KEY `shop_review_menus_ibfk_1`;
+
+ALTER TABLE `koin`.`shop_review_menus`
+    ADD CONSTRAINT `shop_review_menus_ibfk_1`
+        FOREIGN KEY (`review_id`)
+        REFERENCES `koin`.`shop_reviews` (`id`)
+        ON DELETE CASCADE;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #721 

# 🚀 작업 내용

1. Shop_review 관련 FK의 제약 조건을 RESTRICT -> CASCADE로 수정했습니다.
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/dfda4420-3c9d-4087-8fa8-47ebc46f7fac">

# 💬 리뷰 중점사항
확인해보니 `user`가 `review`를 남김 -> `review`에는 `menu / image`가 포함 || 또는 리뷰 신고시 `report`에 `user_id / review_id` 포함되는 형태인데, 각 FK 관계가 RESTRICT여서 오류가 발생했습니다.
review와 관련된 4개의 테이블의 FK 조건을 CASCADE로 변경했습니다. (user / shop)
잘 부탁드려요~