### PR TITLE
fix: not main, main 시간표 프레임 동시 삭제 문제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.timetableV2.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +12,7 @@ import in.koreatech.koin.domain.timetable.exception.TimetableNotFoundException;
 import in.koreatech.koin.domain.timetableV2.exception.TimetableFrameNotFoundException;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.LockModeType;
 
 public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, Integer> {
 
@@ -42,6 +44,7 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
             .orElseThrow(() -> TimetableFrameNotFoundException.withDetail("userId: " + user.getId()));
     }
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     TimetableFrame findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(Integer userId, Integer semesterId);
 
     @Query(

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
@@ -478,7 +478,7 @@ public class TimetableV2ApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("isMain이 false인 frame과 ture인 frame을 동시에 삭제한다.")
+    @DisplayName("isMain이 false인 frame과 true인 frame을 동시에 삭제한다.")
     void deleteNotMainAndMainTimeTablesFrame() {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
@@ -526,6 +526,8 @@ public class TimetableV2ApiTest extends AcceptanceTest {
             latch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        } finally {
+            executorService.shutdown();
         }
 
         TimetableFrame reloadedFrame2 = timetableFrameRepositoryV2.findById(frame2.getId()).orElseThrow();


### PR DESCRIPTION
# 🚀 작업 내용
## 문제 상황
  - not main 시간표 프레임과 main 시간표 프레임을 동시에 삭제하면 에러가 남
    - main 시간표 프레임을 삭제하면 not main 시간표 프레임 중에 최근 시간표 프레임을 조회해서 main으로 바꿔야 하는데 이때 이전에 삭제 요청한게 database에 반영되지 않아 조회되는 문제가 있음

## 작업
1. not main 시간표 프레임 중에 최근 시간표 프레임을 조회하는 find문에 베타적 락을 걸었습니다.
  a. 메인 시간표 프레임을 삭제할 때만 사용하는 함수이기 때문에 성능에 큰 문제가 없을 거라 생각 했습니다.
2. not main 시간표 프레임과 main 시간표 프레임을 동시에 삭제하는 테스트 코드 작성했습니다.