### PR TITLE
Feat/684 get shops filter

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopResponse.java
@@ -80,7 +80,7 @@ public record AdminShopResponse(
         Collections.sort(shop.getMenuCategories());
         return new AdminShopResponse(
             shop.getAddress(),
-            shop.isDelivery(),
+            shop.getDelivery(),
             shop.getDeliveryPrice(),
             (shop.getDescription() == null || shop.getDescription().isBlank()) ? "-" : shop.getDescription(),
             shop.getId(),

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.domain.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +25,10 @@ import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.ShopReviewResponse;
+import in.koreatech.koin.domain.shop.dto.ShopsFilterCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopsResponse;
+import in.koreatech.koin.domain.shop.dto.ShopsResponseV2;
+import in.koreatech.koin.domain.shop.dto.ShopsSortCriteria;
 import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.auth.UserId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -233,5 +238,20 @@ public interface ShopApi {
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid ShopReviewReportRequest shopReviewReportRequest,
         @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "모든 상점 조회 V2")
+    @GetMapping("/shops/v2")
+    ResponseEntity<ShopsResponseV2> getShopsV2(
+        @RequestParam(name = "sorter", defaultValue = "NONE") ShopsSortCriteria sortBy,
+        @RequestParam(name = "filter") List<ShopsFilterCriteria> shopsFilterCriterias
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -248,7 +248,7 @@ public interface ShopApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "모든 상점 조회 V2")
+    @Operation(summary = "정렬, 필터가 있는 모든 상점 조회")
     @GetMapping("/shops/v2")
     ResponseEntity<ShopsResponseV2> getShopsV2(
         @RequestParam(name = "sorter", defaultValue = "NONE") ShopsSortCriteria sortBy,

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -166,10 +166,10 @@ public  class ShopController implements ShopApi {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/shops/V2")
+    @GetMapping("/shops/v2")
     public ResponseEntity<ShopsResponseV2> getShopsV2(
         @RequestParam(name = "sorter", defaultValue = "NONE") ShopsSortCriteria sortBy,
-        @RequestParam(name = "filter") List<ShopsFilterCriteria> shopsFilterCriterias
+        @RequestParam(name = "filter", required = false) List<ShopsFilterCriteria> shopsFilterCriterias
     ) {
         if (shopsFilterCriterias == null) {
             shopsFilterCriterias = Collections.emptyList();

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -3,6 +3,9 @@ package in.koreatech.koin.domain.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,7 +28,10 @@ import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.ShopReviewResponse;
+import in.koreatech.koin.domain.shop.dto.ShopsFilterCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopsResponse;
+import in.koreatech.koin.domain.shop.dto.ShopsResponseV2;
+import in.koreatech.koin.domain.shop.dto.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.service.ShopReviewService;
 import in.koreatech.koin.domain.shop.service.ShopService;
 import in.koreatech.koin.global.auth.Auth;
@@ -36,7 +42,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class ShopController implements ShopApi {
+public  class ShopController implements ShopApi {
 
     private final ShopService shopService;
     private final ShopReviewService shopReviewService;
@@ -158,5 +164,17 @@ public class ShopController implements ShopApi {
     ) {
         shopReviewService.reportReview(shopId, reviewId, studentId, shopReviewReportRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/shops/V2")
+    public ResponseEntity<ShopsResponseV2> getShopsV2(
+        @RequestParam(name = "sorter", defaultValue = "NONE") ShopsSortCriteria sortBy,
+        @RequestParam(name = "filter") List<ShopsFilterCriteria> shopsFilterCriterias
+    ) {
+        if (shopsFilterCriterias == null) {
+            shopsFilterCriterias = Collections.emptyList();
+        }
+        var shops = shopService.getShopsV2(sortBy, shopsFilterCriterias);
+        return ResponseEntity.ok(shops);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -134,7 +134,7 @@ public  class ShopController implements ShopApi {
         @RequestBody @Valid ModifyReviewRequest modifyReviewRequest,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
-        shopReviewService.modifyShop(modifyReviewRequest, reviewId, studentId);
+        shopReviewService.modifyReview(modifyReviewRequest, reviewId, studentId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopResponse.java
@@ -77,7 +77,7 @@ public record ShopResponse(
         Collections.sort(shop.getMenuCategories());
         return new ShopResponse(
             shop.getAddress(),
-            shop.isDelivery(),
+            shop.getDelivery(),
             shop.getDeliveryPrice(),
             (shop.getDescription() == null || shop.getDescription().isBlank()) ? "-" : shop.getDescription(),
             shop.getId(),

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
@@ -3,7 +3,7 @@ package in.koreatech.koin.domain.shop.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Predicate;
-import in.koreatech.koin.domain.shop.dto.ShopsResponseV2.InnerShopResponse;
+
 import in.koreatech.koin.domain.shop.model.Shop;
 
 public enum ShopsFilterCriteria {

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Predicate;
+import in.koreatech.koin.domain.shop.dto.ShopsResponseV2.InnerShopResponse;
+import in.koreatech.koin.domain.shop.model.Shop;
+
+public enum ShopsFilterCriteria {
+
+    OPEN("OPEN"),
+    DELIVERY("DELIVERY");
+
+    private final String value;
+
+    ShopsFilterCriteria(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Predicate<Shop> getCondition(LocalDateTime now) {
+        switch (this) {
+            case OPEN:
+                return shop -> shop.isOpen(now);
+            case DELIVERY:
+                return Shop::getDelivery;
+            default:
+                return shop -> true;
+        }
+    }
+
+    public static Predicate<Shop> createCombinedFilter(List<ShopsFilterCriteria> criteriaList, LocalDateTime now) {
+        return criteriaList.stream()
+            .map(criteria -> criteria.getCondition(now))
+            .reduce(x -> true, Predicate::and);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponse.java
@@ -63,7 +63,7 @@ public record ShopsResponse(
                 shop.getShopCategories().stream().map(shopCategoryMap ->
                     shopCategoryMap.getShopCategory().getId()
                 ).toList(),
-                shop.isDelivery(),
+                shop.getDelivery(),
                 shop.getId(),
                 shop.getName(),
                 shop.getShopOpens().stream().sorted().map(InnerShopOpen::from).toList(),

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
@@ -79,7 +79,7 @@ public record ShopsResponseV2(
                 shop.getShopCategories().stream().map(shopCategoryMap ->
                     shopCategoryMap.getShopCategory().getId()
                 ).toList(),
-                shop.isDelivery(),
+                shop.getDelivery(),
                 shop.getId(),
                 shop.getName(),
                 shop.getShopOpens().stream().sorted().map(InnerShopOpen::from).toList(),
@@ -90,7 +90,9 @@ public record ShopsResponseV2(
                 isOpen,
                 shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
-                    .mapToInt(ShopReview::getRating).average().getAsDouble(),
+                    .mapToInt(ShopReview::getRating)
+                    .average()
+                    .orElse(0.0),
                 shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
                     .count()

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
@@ -1,0 +1,110 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.dto.ShopResponse.InnerShopOpen;
+import in.koreatech.koin.domain.shop.model.ReportStatus;
+import in.koreatech.koin.domain.shop.model.Shop;
+import in.koreatech.koin.domain.shop.model.ShopReview;
+import in.koreatech.koin.domain.shop.model.ShopReviewReport;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ShopsResponseV2(
+    @Schema(example = "100", description = "상점 개수", requiredMode = REQUIRED)
+    Integer count,
+
+    @Schema(description = "상점 정보")
+    List<InnerShopResponse> shops
+) {
+
+    public static ShopsResponseV2 from(
+        List<InnerShopResponse> shops
+    ) {
+        return new ShopsResponseV2(shops.size(), shops);
+    }
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerShopResponse(
+        @Schema(example = "[1, 2, 3]", description = " 속해있는 상점 카테고리들의 고유 id 리스트", requiredMode = NOT_REQUIRED)
+        List<Integer> categoryIds,
+
+        @Schema(example = "true", description = "배달 가능 여부", requiredMode = REQUIRED)
+        boolean delivery,
+
+        @Schema(example = "1", description = "고유 id", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(example = "수신반점", description = "이름", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "요일별 휴무 여부 및 장사 시간")
+        List<InnerShopOpen> open,
+
+        @Schema(example = "true", description = "계좌 이체 가능 여부", requiredMode = REQUIRED)
+        boolean payBank,
+
+        @Schema(example = "true", description = "카드 계산 가능 여부", requiredMode = REQUIRED)
+        boolean payCard,
+
+        @Schema(example = "041-000-0000", description = "전화번호", requiredMode = NOT_REQUIRED)
+        String phone,
+
+        @Schema(example = "true", description = "삭제 여부", requiredMode = REQUIRED)
+        boolean isEvent,
+
+        @Schema(example = "true", description = "운영중 여부", requiredMode = REQUIRED)
+        boolean isOpen,
+
+        @Schema(example = "4.9", description = "평균 별점", requiredMode = REQUIRED)
+        double averageRate,
+
+        @Schema(example = "10", description = "리뷰 개수", requiredMode = REQUIRED)
+        long reviewCount
+    ) {
+
+        public static InnerShopResponse from(
+            Shop shop,
+            boolean isEvent,
+            boolean isOpen
+        ) {
+            return new InnerShopResponse(
+                shop.getShopCategories().stream().map(shopCategoryMap ->
+                    shopCategoryMap.getShopCategory().getId()
+                ).toList(),
+                shop.isDelivery(),
+                shop.getId(),
+                shop.getName(),
+                shop.getShopOpens().stream().sorted().map(InnerShopOpen::from).toList(),
+                shop.isPayBank(),
+                shop.isPayCard(),
+                shop.getPhone(),
+                isEvent,
+                isOpen,
+                shop.getReviews().stream()
+                    .filter(review -> notContainsUnhandledReport(review.getReports()))
+                    .mapToInt(ShopReview::getRating).average().getAsDouble(),
+                shop.getReviews().stream()
+                    .filter(review -> notContainsUnhandledReport(review.getReports()))
+                    .count()
+            );
+        }
+
+        private static boolean notContainsUnhandledReport(List<ShopReviewReport> reports) {
+            return reports.stream().noneMatch(report -> report.getReportStatus().equals(ReportStatus.UNHANDLED));
+        }
+
+        public static Comparator<InnerShopResponse> getComparator(ShopsSortCriteria shopsSortCriteria) {
+            return Comparator
+                .comparing(InnerShopResponse::isOpen, Comparator.reverseOrder())
+                .thenComparing(shopsSortCriteria.getComparator());
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsSortCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsSortCriteria.java
@@ -7,8 +7,8 @@ import in.koreatech.koin.domain.shop.dto.ShopsResponseV2.InnerShopResponse;
 public enum ShopsSortCriteria {
 
     NONE("NONE", (shop1, shop2) -> 0),
-    COUNT("COUNT", Comparator.comparingLong(InnerShopResponse::reviewCount)),
-    RATING("RATING", Comparator.comparingDouble(InnerShopResponse::averageRate))
+    COUNT("COUNT", Comparator.comparingLong(InnerShopResponse::reviewCount).reversed()),
+    RATING("RATING", Comparator.comparingDouble(InnerShopResponse::averageRate).reversed())
     ;
 
     private final String value;

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsSortCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsSortCriteria.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import java.util.Comparator;
+
+import in.koreatech.koin.domain.shop.dto.ShopsResponseV2.InnerShopResponse;
+
+public enum ShopsSortCriteria {
+
+    NONE("NONE", (shop1, shop2) -> 0),
+    COUNT("COUNT", Comparator.comparingLong(InnerShopResponse::reviewCount)),
+    RATING("RATING", Comparator.comparingDouble(InnerShopResponse::averageRate))
+    ;
+
+    private final String value;
+    private final Comparator<InnerShopResponse> comparator;
+
+    ShopsSortCriteria(String value, Comparator<InnerShopResponse> comparator) {
+        this.value = value;
+        this.comparator = comparator;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Comparator<InnerShopResponse> getComparator() {
+        return comparator;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReportStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReportStatus.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.shop.model;
+
+public enum ReportStatus {
+    UNHANDLED("UNHANDLED", "처리 안함"),
+    DISMISSED("DISMISSED", "무의미한 신고여서 관련 리뷰 유지"),
+    DELETED("DELETED", "유의미한 신고여서 관련 리뷰 삭제"),
+    ;
+
+    private final String value;
+    private final String description;
+
+    ReportStatus(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
@@ -75,7 +75,7 @@ public class Shop extends BaseEntity {
 
     @NotNull
     @Column(name = "delivery", nullable = false)
-    private boolean delivery = false;
+    private Boolean delivery = false;
 
     @NotNull
     @Column(name = "delivery_price", nullable = false)
@@ -119,6 +119,9 @@ public class Shop extends BaseEntity {
 
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
     private List<EventArticle> eventArticles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopReview> reviews = new ArrayList<>();
 
     @Size(max = 10)
     @Column(name = "bank", length = 10)

--- a/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/Shop.java
@@ -8,8 +8,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.hibernate.annotations.Where;
 
@@ -25,6 +27,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedSubgraph;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -39,6 +44,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "shops")
 @Where(clause = "is_deleted=0")
+@NamedEntityGraph(name = "Shop.withAll", attributeNodes = {
+    @NamedAttributeNode(value = "shopOpens"),
+    @NamedAttributeNode(value = "shopCategories", subgraph = "shopCategory1"),
+},
+    subgraphs = @NamedSubgraph(name = "shopCategory1", attributeNodes = {
+        @NamedAttributeNode("shopCategory")
+    })
+)
 public class Shop extends BaseEntity {
 
     @Id
@@ -106,7 +119,7 @@ public class Shop extends BaseEntity {
     private Integer hit;
 
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
-    private List<ShopCategoryMap> shopCategories = new ArrayList<>();
+    private Set<ShopCategoryMap> shopCategories = new HashSet<>();
 
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
     private List<ShopOpen> shopOpens = new ArrayList<>();

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -46,6 +46,9 @@ public class ShopReview extends BaseEntity {
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
     @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)
     private List<ShopReviewImage> images = new ArrayList<>();
 
@@ -90,5 +93,13 @@ public class ShopReview extends BaseEntity {
                     .build();
             this.menus.add(shopReviewImage);
         }
+    }
+
+    public void deleteReview() {
+        this.isDeleted = true;
+    }
+
+    public void cancelReview() {
+        this.isDeleted = false;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -19,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,7 +47,9 @@ public class ShopReview extends BaseEntity {
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 
-    private Boolean isDeleted;
+    @NotNull
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
 
     @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)
     private List<ShopReviewImage> images = new ArrayList<>();

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -46,7 +46,6 @@ public class ShopReview extends BaseEntity {
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 
-    @Column(nullable = false)
     private Boolean isDeleted;
 
     @OneToMany(mappedBy = "review", orphanRemoval = true, cascade = ALL, fetch = LAZY)

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReviewReport.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReviewReport.java
@@ -7,12 +7,15 @@ import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,17 +39,22 @@ public class ShopReviewReport extends BaseEntity {
     @Column(name = "content", nullable = false, length = 255)
     private String content;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 25)
+    private ReportStatus reportStatus;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private Student userId;
 
-
-
     @Builder
-    public ShopReviewReport(ShopReview review, String title, String detail, Student userId) {
+    public ShopReviewReport(ShopReview review, String title, String content, ReportStatus reportStatus,
+        Student userId) {
         this.review = review;
         this.title = title;
-        this.content = detail;
+        this.content = content;
+        this.reportStatus = reportStatus;
         this.userId = userId;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopRepository.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.shop.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.shop.exception.ShopNotFoundException;
@@ -28,5 +29,6 @@ public interface ShopRepository extends Repository<Shop, Integer> {
             .orElseThrow(() -> ShopNotFoundException.withDetail("ownerId: " + ownerId));
     }
 
+    @EntityGraph(value = "Shop.withAll", type = EntityGraph.EntityGraphType.LOAD)
     List<Shop> findAll();
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
@@ -39,28 +39,26 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
-               AND r.userId.id = :userId
+               AND r.reportStatus != in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED
            )
            """)
-    Page<ShopReview> findAllByShopIdExcludingReportedByUserAndIsDeleted(
+    Page<ShopReview> findAllByShopIdNotContainReportedAndIsDeleted(
         @Param("shopId") Integer shopId,
-        @Param("userId") Integer userId,
         @Param("isDeleted") Boolean isDeleted,
         Pageable pageable);
 
     @Query("""
-           SELECT COUNT(sr) FROM ShopReview sr 
-           WHERE sr.shop.id = :shopId
-           AND sr.isDeleted = :isDeleted 
-           AND NOT EXISTS (
-               SELECT r FROM ShopReviewReport r 
-               WHERE r.review.id = sr.id 
-               AND r.userId.id = :userId
-           )
-           """)
-    Integer countByShopIdExcludingReportedByUserAndIsDeleted(
+       SELECT COUNT(sr) FROM ShopReview sr 
+       WHERE sr.shop.id = :shopId
+       AND sr.isDeleted = :isDeleted 
+       AND NOT EXISTS (
+           SELECT r FROM ShopReviewReport r 
+           WHERE r.review.id = sr.id 
+           AND r.reportStatus != in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED
+       )
+       """)
+    Integer countByShopIdNotContainReportedAndIsDeleted(
         @Param("shopId") Integer shopId,
-        @Param("userId") Integer userId,
         @Param("isDeleted") Boolean isDeleted
         );
 
@@ -71,13 +69,14 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
-               AND r.userId.id = :userId
+               AND r.reportStatus != in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED
                )
            AND sr.rating = :rating
            """)
-    Integer countReviewRatingAndIsDeleted(
+    Integer countReviewRatingNotContainReportedAndIsDeleted(
         @Param("shopId") Integer shopId,
-        @Param("userId") Integer userId,
         @Param("isDeleted") Boolean isDeleted,
         @Param("rating") Integer rating);
+
+    Optional<ShopReview> findById(Integer reviewId);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
@@ -16,49 +16,58 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
 
     ShopReview save(ShopReview review);
 
-    List<ShopReview> findAllByShopId(Integer shopId);
+    List<ShopReview> findAllByShopIdAndIsDeleted(Integer shopId, Boolean isDeleted);
 
-    Optional<ShopReview> findById(Integer reviewId);
+    Optional<ShopReview> findByIdAndIsDeleted(Integer reviewId, Boolean isDeleted);
 
-    default ShopReview getById(Integer reviewId) {
-        return findById(reviewId)
+    default ShopReview getByIdAndIsDeleted(Integer reviewId, Boolean isDeleted) {
+        return findByIdAndIsDeleted(reviewId, isDeleted)
             .orElseThrow(() -> ReviewNotFoundException.withDetail(String.format("reviewId: %s", reviewId)));
     }
 
-    Optional<ShopReview> findAllByIdAndShopId(Integer reviewId, Integer shopId);
+    Optional<ShopReview> findAllByIdAndShopIdAndIsDeleted(Integer reviewId, Integer shopId, Boolean isDeleted);
 
-    default ShopReview getAllByIdAndShopId(Integer reviewId, Integer shopId) {
-        return findAllByIdAndShopId(reviewId, shopId)
+    default ShopReview getAllByIdAndShopIdAndIsDeleted(Integer reviewId, Integer shopId, Boolean isDeleted) {
+        return findAllByIdAndShopIdAndIsDeleted(reviewId, shopId, isDeleted)
             .orElseThrow(() -> ReviewNotFoundException.withDetail(String.format("reviewId: %s", reviewId)));
     }
-
-    void deleteById(Integer id);
 
     @Query("""
            SELECT sr FROM ShopReview sr 
            WHERE sr.shop.id = :shopId 
+           AND sr.isDeleted = :isDeleted
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
                AND r.userId.id = :userId
            )
            """)
-    Page<ShopReview> findAllByShopIdExcludingReportedByUser(@Param("shopId") Integer shopId, @Param("userId") Integer userId, Pageable pageable);
+    Page<ShopReview> findAllByShopIdExcludingReportedByUserAndIsDeleted(
+        @Param("shopId") Integer shopId,
+        @Param("userId") Integer userId,
+        @Param("isDeleted") Boolean isDeleted,
+        Pageable pageable);
 
     @Query("""
            SELECT COUNT(sr) FROM ShopReview sr 
-           WHERE sr.shop.id = :shopId 
+           WHERE sr.shop.id = :shopId
+           AND sr.isDeleted = :isDeleted 
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
                AND r.userId.id = :userId
            )
            """)
-    Integer countByShopIdExcludingReportedByUser(@Param("shopId") Integer shopId, @Param("userId") Integer userId);
+    Integer countByShopIdExcludingReportedByUserAndIsDeleted(
+        @Param("shopId") Integer shopId,
+        @Param("userId") Integer userId,
+        @Param("isDeleted") Boolean isDeleted
+        );
 
     @Query("""
            SELECT COUNT(sr) FROM ShopReview sr 
            WHERE sr.shop.id = :shopId 
+           AND sr.isDeleted = :isDeleted
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
@@ -66,5 +75,9 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
                )
            AND sr.rating = :rating
            """)
-    Integer countReviewRating(@Param("shopId") Integer shopId, @Param("userId") Integer userId, @Param("rating") Integer rating);
+    Integer countReviewRatingAndIsDeleted(
+        @Param("shopId") Integer shopId,
+        @Param("userId") Integer userId,
+        @Param("isDeleted") Boolean isDeleted,
+        @Param("rating") Integer rating);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -29,7 +29,6 @@ import in.koreatech.koin.domain.shop.repository.ShopReviewReportRepository;
 import in.koreatech.koin.domain.shop.repository.ShopReviewRepository;
 import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.domain.user.repository.StudentRepository;
-import in.koreatech.koin.global.auth.JwtProvider;
 import in.koreatech.koin.global.auth.exception.AuthenticationException;
 import in.koreatech.koin.global.model.Criteria;
 import jakarta.persistence.EntityManager;
@@ -48,29 +47,19 @@ public class ShopReviewService {
     private final ShopReviewReportCategoryRepository shopReviewReportCategoryRepository;
     private final StudentRepository studentRepository;
 
-    private final JwtProvider jwtProvider;
     private final EntityManager entityManager;
-    /*
-    TODO:
-        - 어드민 페이지
-            - 어드민이 신고된 리뷰를 확인할 수 있어야 한다.
-            - 어드민이 신고된 리뷰를 삭제할 수 있어야 한다.
-            - 어드민이 신고를 삭제할 수 있다.
-                - 신고된 리뷰 조회 api작성(어드민 권한)
-                - 신고된 리뷰 삭제 api작성(어드민 권한)
-        - 어떻게 할지 자세한건 팀에서 논의 필요
-     */
 
     public ShopReviewResponse getReviewsByShopId(Integer shopId, Integer userId, Integer page, Integer limit) {
-        Integer total = shopReviewRepository.countByShopIdExcludingReportedByUser(shopId, userId);
+        Integer total = shopReviewRepository.countByShopIdExcludingReportedByUserAndIsDeleted(shopId, userId, false);
         Criteria criteria = Criteria.of(page, limit, total);
         PageRequest pageRequest = PageRequest.of(
             criteria.getPage(),
             criteria.getLimit()
         );
-        Page<ShopReview> result = shopReviewRepository.findAllByShopIdExcludingReportedByUser(
+        Page<ShopReview> result = shopReviewRepository.findAllByShopIdExcludingReportedByUserAndIsDeleted(
             shopId,
             userId,
+            false,
             pageRequest
         );
         Map<Integer, Integer> ratings = getRating(shopId, userId);
@@ -104,16 +93,16 @@ public class ShopReviewService {
 
     @Transactional
     public void deleteReview(Integer reviewId, Integer studentId) {
-        ShopReview shopReview = shopReviewRepository.getById(reviewId);
+        ShopReview shopReview = shopReviewRepository.getByIdAndIsDeleted(reviewId, false);
         if (!Objects.equals(shopReview.getReviewer().getId(), studentId)) {
             throw AuthenticationException.withDetail("해당 유저가 작성한 리뷰가 아닙니다.");
         }
-        shopReviewRepository.deleteById(shopReview.getId());
+        shopReview.deleteReview();
     }
 
     @Transactional
     public void modifyShop(ModifyReviewRequest modifyReviewRequest, Integer reviewId, Integer studentId) {
-        ShopReview shopReview = shopReviewRepository.getById(reviewId);
+        ShopReview shopReview = shopReviewRepository.getByIdAndIsDeleted(reviewId, false);
         if (!Objects.equals(shopReview.getReviewer().getId(), studentId)) {
             throw AuthenticationException.withDetail("해당 유저가 작성한 리뷰가 아닙니다.");
         }
@@ -133,13 +122,13 @@ public class ShopReviewService {
         ShopReviewReportRequest shopReviewReportRequest
     ) {
         Student student = studentRepository.getById(studentId);
-        ShopReview shopReview = shopReviewRepository.getAllByIdAndShopId(reviewId, shopId);
+        ShopReview shopReview = shopReviewRepository.getAllByIdAndShopIdAndIsDeleted(reviewId, shopId, false);
         shopReviewReportRepository.save(
             ShopReviewReport.builder()
                 .userId(student)
                 .review(shopReview)
                 .title(shopReviewReportRequest.title())
-                .detail(shopReviewReportRequest.content())
+                .content(shopReviewReportRequest.content())
                 .build()
         );
     }
@@ -158,7 +147,7 @@ public class ShopReviewService {
             5, 0
         ));
         for (Integer rating : ratings.keySet()) {
-            Integer count = shopReviewRepository.countReviewRating(shopId, studentId, rating);
+            Integer count = shopReviewRepository.countReviewRatingAndIsDeleted(shopId, studentId, false, rating);
             ratings.put(rating, count);
         }
         return ratings;

--- a/src/main/resources/db/migration/V38__add_shop_review_soft_delete_.sql
+++ b/src/main/resources/db/migration/V38__add_shop_review_soft_delete_.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shop_reviews` ADD COLUMN `is_deleted` tinyint(1) default 0;

--- a/src/main/resources/db/migration/V39__add_shop_review_report_status_.sql
+++ b/src/main/resources/db/migration/V39__add_shop_review_report_status_.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shop_review_reports` ADD COLUMN `status` varchar(25) default 'UNHANDLED';

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,7 +109,7 @@ class OwnerShopApiTest extends AcceptanceTest {
     @DisplayName("사장님의 가게 목록을 조회한다.")
     void getOwnerShops() {
         // given
-        shopFixture.신전_떡볶이(owner_현수);
+        shopFixture.영업중이_아닌_신전_떡볶이(owner_현수);
 
         // when then
         var response = RestAssured
@@ -758,7 +759,7 @@ class OwnerShopApiTest extends AcceptanceTest {
             Shop result = shopRepository.getById(1);
             List<ShopImage> shopImages = result.getShopImages();
             List<ShopOpen> shopOpens = result.getShopOpens();
-            List<ShopCategoryMap> shopCategoryMaps = result.getShopCategories();
+            Set<ShopCategoryMap> shopCategoryMaps = result.getShopCategories();
             assertSoftly(
                 softly -> {
                     softly.assertThat(result.getAddress()).isEqualTo("충청남도 천안시 동남구 병천면 충절로 1600");
@@ -770,8 +771,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                     softly.assertThat(result.isPayCard()).isTrue();
                     softly.assertThat(result.getPhone()).isEqualTo("041-123-4567");
 
-                    softly.assertThat(shopCategoryMaps.get(0).getShopCategory().getId()).isEqualTo(1);
-                    softly.assertThat(shopCategoryMaps.get(1).getShopCategory().getId()).isEqualTo(2);
+                    softly.assertThat(shopCategoryMaps.size()).isEqualTo(2);
 
                     softly.assertThat(shopImages.get(0).getImageUrl())
                         .isEqualTo("https://fixed-shopimage.com/수정된_상점_이미지.png");

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -14,11 +14,14 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.Menu;
 import in.koreatech.koin.domain.shop.model.Shop;
+import in.koreatech.koin.domain.user.model.Student;
 import in.koreatech.koin.fixture.EventArticleFixture;
 import in.koreatech.koin.fixture.MenuCategoryFixture;
 import in.koreatech.koin.fixture.MenuFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopReviewFixture;
+import in.koreatech.koin.fixture.ShopReviewReportFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
@@ -34,6 +37,12 @@ class ShopApiTest extends AcceptanceTest {
     private ShopFixture shopFixture;
 
     @Autowired
+    private ShopReviewFixture shopReviewFixture;
+
+    @Autowired
+    private ShopReviewReportFixture shopReviewReportFixture;
+
+    @Autowired
     private MenuFixture menuFixture;
 
     @Autowired
@@ -45,20 +54,23 @@ class ShopApiTest extends AcceptanceTest {
     @Autowired
     private ShopCategoryFixture shopCategoryFixture;
 
-    private Shop shop;
+    private Shop 마슬랜;
     private Owner owner;
+
+    private Student 익명_학생;
 
     @BeforeEach
     void setUp() {
         owner = userFixture.준영_사장님();
-        shop = shopFixture.마슬랜(owner);
+        마슬랜 = shopFixture.마슬랜(owner);
+        익명_학생 = userFixture.익명_학생();
     }
 
     @Test
     @DisplayName("옵션이 하나 있는 상점의 메뉴를 조회한다.")
     void findMenuSingleOption() {
         // given
-        Menu menu = menuFixture.짜장면_단일메뉴(shop, menuCategoryFixture.메인메뉴(shop));
+        Menu menu = menuFixture.짜장면_단일메뉴(마슬랜, menuCategoryFixture.메인메뉴(마슬랜));
 
         var response = RestAssured
             .given()
@@ -95,7 +107,7 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("옵션이 여러 개 있는 상점의 메뉴를 조회한다.")
     void findMenuMultipleOption() {
         // given
-        Menu menu = menuFixture.짜장면_옵션메뉴(shop, menuCategoryFixture.메인메뉴(shop));
+        Menu menu = menuFixture.짜장면_옵션메뉴(마슬랜, menuCategoryFixture.메인메뉴(마슬랜));
 
         var response = RestAssured
             .given()
@@ -176,9 +188,9 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("상점의 메뉴 카테고리들을 조회한다.")
     void findShopMenuCategories() {
         // given
-        menuCategoryFixture.사이드메뉴(shop);
-        menuCategoryFixture.세트메뉴(shop);
-        Menu menu = menuFixture.짜장면_단일메뉴(shop, menuCategoryFixture.추천메뉴(shop));
+        menuCategoryFixture.사이드메뉴(마슬랜);
+        menuCategoryFixture.세트메뉴(마슬랜);
+        Menu menu = menuFixture.짜장면_단일메뉴(마슬랜, menuCategoryFixture.추천메뉴(마슬랜));
 
         var response = RestAssured
             .given()
@@ -214,12 +226,12 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("특정 상점 조회")
     void getShop() {
         // given
-        menuCategoryFixture.사이드메뉴(shop);
-        menuCategoryFixture.세트메뉴(shop);
+        menuCategoryFixture.사이드메뉴(마슬랜);
+        menuCategoryFixture.세트메뉴(마슬랜);
         var response = RestAssured
             .given()
             .when()
-            .get("/shops/{shopId}", shop.getId())
+            .get("/shops/{shopId}", 마슬랜.getId())
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
@@ -279,12 +291,12 @@ class ShopApiTest extends AcceptanceTest {
     @Test
     @DisplayName("특정 상점 모든 메뉴 조회")
     void getShopMenus() {
-        menuFixture.짜장면_단일메뉴(shop, menuCategoryFixture.추천메뉴(shop));
-        menuFixture.짜장면_옵션메뉴(shop, menuCategoryFixture.세트메뉴(shop));
+        menuFixture.짜장면_단일메뉴(마슬랜, menuCategoryFixture.추천메뉴(마슬랜));
+        menuFixture.짜장면_옵션메뉴(마슬랜, menuCategoryFixture.세트메뉴(마슬랜));
         var response = RestAssured
             .given()
             .when()
-            .get("/shops/{shopId}/menus", shop.getId())
+            .get("/shops/{shopId}/menus", 마슬랜.getId())
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
@@ -352,7 +364,7 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("모든 상점 조회")
     void getAllShop() {
         // given
-        shopFixture.신전_떡볶이(owner);
+        shopFixture.영업중이_아닌_신전_떡볶이(owner);
         var response = RestAssured
             .given()
             .when()
@@ -497,12 +509,12 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("특정 상점의 이벤트들을 조회한다.")
     void getShopEvents() {
         eventArticleFixture.할인_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(3),
             LocalDate.now(clock).plusDays(3)
         );
         eventArticleFixture.참여_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(3),
             LocalDate.now(clock).plusDays(3)
         );
@@ -510,7 +522,7 @@ class ShopApiTest extends AcceptanceTest {
         var response = RestAssured
             .given()
             .when()
-            .get("/shops/{shopId}/events", shop.getId())
+            .get("/shops/{shopId}/events", 마슬랜.getId())
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
@@ -554,12 +566,12 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("이벤트 진행중인 상점의 정보를 조회한다.")
     void getShopWithEvents() {
         eventArticleFixture.할인_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(3),
             LocalDate.now(clock).plusDays(3)
         );
         eventArticleFixture.참여_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(3),
             LocalDate.now(clock).plusDays(3)
         );
@@ -567,7 +579,7 @@ class ShopApiTest extends AcceptanceTest {
         var response = RestAssured
             .given()
             .when()
-            .get("/shops/{shopId}", shop.getId())
+            .get("/shops/{shopId}", 마슬랜.getId())
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract();
@@ -579,12 +591,12 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("이벤트 진행중이지 않은 상점의 정보를 조회한다.")
     void getShopWithoutEvents() {
         eventArticleFixture.할인_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).plusDays(3),
             LocalDate.now(clock).plusDays(5)
         );
         eventArticleFixture.참여_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(5),
             LocalDate.now(clock).minusDays(3)
         );
@@ -592,7 +604,7 @@ class ShopApiTest extends AcceptanceTest {
         var response = RestAssured
             .given()
             .when()
-            .get("/shops/{shopId}", shop.getId())
+            .get("/shops/{shopId}", 마슬랜.getId())
             .then()
 
             .statusCode(HttpStatus.OK.value())
@@ -605,12 +617,12 @@ class ShopApiTest extends AcceptanceTest {
     @DisplayName("이벤트 베너 조회")
     void ownerShopDeleteEvent() {
         eventArticleFixture.참여_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock),
             LocalDate.now(clock).plusDays(10)
         );
         eventArticleFixture.할인_이벤트(
-            shop,
+            마슬랜,
             LocalDate.now(clock).minusDays(10),
             LocalDate.now(clock).minusDays(1)
         );
@@ -643,5 +655,664 @@ class ShopApiTest extends AcceptanceTest {
                     ]
                 }
                 """);
+    }
+
+    @Test
+    void 리뷰_평점순으로_정렬하여_모든_상점을_조회한다() {
+        // given
+        Shop 영업중인_티바 = shopFixture.영업중인_티바(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중인_티바);
+
+        var response = RestAssured
+            .given()
+            .queryParam("sorter", "RATING")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+        boolean 티바_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 2,
+                    "shops": [
+                        {
+                            "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 2,
+                            "name": "티바",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "TUESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "WEDNESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "THURSDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SATURDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SUNDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7788-9900",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        },{
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 0.0,
+                            "review_count": 0
+                        }
+                    ]
+                }
+                """, 티바_영업여부, 마슬랜_영업여부));
+    }
+
+    @Test
+    void 리뷰_개수순으로_정렬하여_모든_상점을_조회한다() {
+        // given
+        Shop 영업중인_티바 = shopFixture.영업중인_티바(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중인_티바);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("sorter", "COUNT")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+        boolean 티바_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 2,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 2
+                        },{
+                            "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 2,
+                            "name": "티바",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "TUESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "WEDNESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "THURSDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SATURDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SUNDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7788-9900",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 티바_영업여부, 마슬랜_영업여부));
+    }
+
+    @Test
+    void 리뷰_개수가_많아도_영업중이_아니라면_정렬_우선순위가_낮은_상태로_모든_상점을_조회한다() {
+        // given
+        Shop 영업중이_아닌_신전떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중이_아닌_신전떡볶이);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중이_아닌_신전떡볶이);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("sorter", "COUNT")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 신전떡볶이_영업여부 = false;
+        boolean 마슬랜_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 2,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        },{
+                            "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 2,
+                            "name": "신전 떡볶이",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "12:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "TUESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "WEDNESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "THURSDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SATURDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SUNDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7788-9900",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 2
+                        }
+                    ]
+                }
+                """, 마슬랜_영업여부, 신전떡볶이_영업여부));
+    }
+
+    @Test
+    void 운영중인_상점만_필터하여_모든_상점을_조회한다() {
+        // given
+        Shop 영업중이_아닌_신전떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중이_아닌_신전떡볶이);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중이_아닌_신전떡볶이);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("filter", "OPEN")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 1,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 마슬랜_영업여부));
+    }
+
+    @Test
+    void 배달_가능한_상점만_필터하여_모든_상점을_조회한다() {
+        // given
+        Shop 배달_안되는_신전_떡볶이 = shopFixture.배달_안되는_신전_떡볶이(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("filter", "DELIVERY")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 1,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 마슬랜_영업여부));
+    }
+
+    @Test
+    void 배달_가능하고_영업중인_상점만_필터하여_모든_상점을_조회한다() {
+        // given
+        Shop 배달_안되는_신전_떡볶이 = shopFixture.배달_안되는_신전_떡볶이(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+
+        shopFixture.영업중이_아닌_신전_떡볶이(owner);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("filter", "DELIVERY")
+            .queryParam("filter", "OPEN")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 1,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 마슬랜_영업여부));
+    }
+
+    @Test
+    void 영업중인_상점만_필터하여_리뷰_개수_순으로_모든_상점을_조회한다() {
+        // given
+        Shop 배달_안되는_신전_떡볶이 = shopFixture.배달_안되는_신전_떡볶이(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+        shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
+
+        shopFixture.영업중이_아닌_신전_떡볶이(owner);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+
+        var response = RestAssured
+            .given()
+            .queryParam("filter", "OPEN")
+            .queryParam("sorter", "COUNT")
+            .when()
+            .get("/shops/v2")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        // 2024-01-15 12:00 월요일 기준
+        boolean 신전_떡볶이_영업여부 = true;
+        boolean 마슬랜_영업여부 = true;
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                    "count": 2,
+                    "shops": [
+                        {
+                            "category_ids": [
+                               \s
+                            ],
+                            "delivery": false,
+                            "id": 2,
+                            "name": "신전 떡볶이",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "TUESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "WEDNESDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "THURSDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SATURDAY",
+                                    "closed": false,
+                                    "open_time": "11:30",
+                                    "close_time": "21:30"
+                                },
+                                {
+                                    "day_of_week": "SUNDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7788-9900",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 2
+                        },{
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "open": [
+                                {
+                                    "day_of_week": "MONDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "21:00"
+                                },
+                                {
+                                    "day_of_week": "FRIDAY",
+                                    "closed": false,
+                                    "open_time": "00:00",
+                                    "close_time": "00:00"
+                                }
+                            ],
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 신전_떡볶이_영업여부, 마슬랜_영업여부));
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -79,10 +79,10 @@ class ShopReviewApiTest extends AcceptanceTest {
         준호_학생 = userFixture.준호_학생();
         익명_학생 = userFixture.익명_학생();
         현수_사장님 = userFixture.현수_사장님();
-        신전_떡볶이 = shopFixture.신전_떡볶이(현수_사장님);
+        신전_떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(현수_사장님);
         token_준호 = userFixture.getToken(준호_학생.getUser());
-        준호_학생_리뷰 = shopReviewFixture.리뷰(준호_학생, 신전_떡볶이);
-        익명_학생_리뷰 = shopReviewFixture.리뷰(익명_학생, 신전_떡볶이);
+        준호_학생_리뷰 = shopReviewFixture.리뷰_4점(준호_학생, 신전_떡볶이);
+        익명_학생_리뷰 = shopReviewFixture.리뷰_4점(익명_학생, 신전_떡볶이);
         신고_카테고리_1 = shopReviewReportCategoryFixture.리뷰_신고_주제에_맞지_않음();
         신고_카테고리_2 = shopReviewReportCategoryFixture.리뷰_신고_스팸();
         신고_카테고리_3 = shopReviewReportCategoryFixture.리뷰_신고_욕설();

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.acceptance;
 
+import static in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED;
+import static in.koreatech.koin.domain.shop.model.ReportStatus.UNHANDLED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.Optional;
@@ -13,6 +15,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.shop.model.ReportStatus;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopReview;
 import in.koreatech.koin.domain.shop.model.ShopReviewReport;
@@ -253,9 +256,9 @@ class ShopReviewApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 자신이 신고한 리뷰를 제외한 모든 리뷰를 조회할 수 있다.")
+    @DisplayName("신고된 리뷰를 제외한 모든 리뷰를 조회할 수 있다.")
     void getReviewWithoutReportedReviews() {
-        ShopReviewReport shopReviewReport = shopReviewReportFixture.리뷰_신고(준호_학생, 익명_학생_리뷰);
+        ShopReviewReport shopReviewReport = shopReviewReportFixture.리뷰_신고(준호_학생, 익명_학생_리뷰, UNHANDLED);
         var response = RestAssured
             .given()
             .contentType(ContentType.JSON)
@@ -471,6 +474,7 @@ class ShopReviewApiTest extends AcceptanceTest {
                     softly.assertThat(shopReviewReport.isPresent()).isTrue();
                     softly.assertThat(shopReviewReport.get().getTitle()).isEqualTo("기타");
                     softly.assertThat(shopReviewReport.get().getContent()).isEqualTo("적절치 못한 리뷰인 것 같습니다.");
+                    softly.assertThat(shopReviewReport.get().getReportStatus()).isEqualTo(UNHANDLED);
                 }
             );
         });
@@ -493,12 +497,93 @@ class ShopReviewApiTest extends AcceptanceTest {
             .extract();
 
         transactionTemplate.executeWithoutResult(status -> {
-            Optional<ShopReviewReport> shopReviewReport = shopReviewReportRepository.findById(1);
+            Optional<ShopReview> shopReview = shopReviewRepository.findById(1);
             assertSoftly(
                 softly -> {
-                    softly.assertThat(shopReviewReport.isPresent()).isFalse();
+                    softly.assertThat(shopReview.get().isDeleted()).isTrue();
                 }
             );
         });
+    }
+
+    @Test
+    void 신고가_반려된_리뷰는_포함해서_모든_리뷰를_조회한다() {
+        ShopReviewReport shopReviewReport = shopReviewReportFixture.리뷰_신고(준호_학생, 익명_학생_리뷰, DISMISSED);
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer " + token_준호)
+            .when()
+            .queryParam("limit", 10)
+            .queryParam("page", 1)
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .get("/shops/{shopId}/reviews")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                {
+                   "total_count": 2,
+                   "current_count": 2,
+                   "total_page": 1,
+                   "current_page": 1,
+                   "statistics": {
+                     "average_rating": 4.0,
+                     "ratings": {
+                       "1": 0,
+                       "2": 0,
+                       "3": 0,
+                       "4": 2,
+                       "5": 0
+                     }
+                   },
+                   "reviews": [
+                     { 
+                       "review_id": %d,
+                       "rating": %d,
+                       "nick_name": "%s",
+                       "content": "%s",
+                       "image_urls": [
+                         "%s"
+                       ],
+                       "menu_names": [
+                         "%s"
+                       ],
+                       "is_mine": true,
+                       "is_modified": false,
+                       "created_at": "2024-01-15"
+                     },{ 
+                       "review_id": %d,
+                       "rating": %d,
+                       "nick_name": "%s",
+                       "content": "%s",
+                       "image_urls": [
+                         "%s"
+                       ],
+                       "menu_names": [
+                         "%s"
+                       ],
+                       "is_mine": false,
+                       "is_modified": false,
+                       "created_at": "2024-01-15"
+                     }
+                   ]
+                 }
+                """,
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                익명_학생_리뷰.getId(),
+                익명_학생_리뷰.getRating(),
+                익명_학생_리뷰.getReviewer().getAnonymousNickname(),
+                익명_학생_리뷰.getContent(),
+                익명_학생_리뷰.getImages().get(0).getImageUrls(),
+                익명_학생_리뷰.getMenus().get(0).getMenuName())
+            );
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -117,7 +117,7 @@ class ShopReviewApiTest extends AcceptanceTest {
             .extract();
 
         transactionTemplate.executeWithoutResult(status -> {
-            ShopReview shopReview = shopReviewRepository.getById(INITIAL_REVIEW_COUNT + 1);
+            ShopReview shopReview = shopReviewRepository.getByIdAndIsDeleted(INITIAL_REVIEW_COUNT + 1, false);
             assertSoftly(
                 softly -> {
                     softly.assertThat(shopReview.getRating()).isEqualTo(4);
@@ -158,7 +158,7 @@ class ShopReviewApiTest extends AcceptanceTest {
             .extract();
 
         transactionTemplate.executeWithoutResult(status -> {
-            ShopReview shopReview = shopReviewRepository.getById(준호_학생_리뷰.getId());
+            ShopReview shopReview = shopReviewRepository.getByIdAndIsDeleted(준호_학생_리뷰.getId(), false);
             assertSoftly(
                 softly -> {
                     softly.assertThat(shopReview.getRating()).isEqualTo(3);

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopApiTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -719,7 +720,7 @@ class AdminShopApiTest extends AcceptanceTest {
             Shop result = adminShopRepository.getById(1);
             List<ShopImage> shopImages = result.getShopImages();
             List<ShopOpen> shopOpens = result.getShopOpens();
-            List<ShopCategoryMap> shopCategoryMaps = result.getShopCategories();
+            Set<ShopCategoryMap> shopCategoryMaps = result.getShopCategories();
             assertSoftly(
                 softly -> {
                     softly.assertThat(result.getAddress()).isEqualTo("충청남도 천안시 동남구 병천면 충절로 1600");
@@ -731,8 +732,7 @@ class AdminShopApiTest extends AcceptanceTest {
                     softly.assertThat(result.isPayCard()).isTrue();
                     softly.assertThat(result.getPhone()).isEqualTo("041-123-4567");
 
-                    softly.assertThat(shopCategoryMaps.get(0).getShopCategory().getId()).isEqualTo(1);
-                    softly.assertThat(shopCategoryMaps.get(1).getShopCategory().getId()).isEqualTo(2);
+                    softly.assertThat(shopCategoryMaps.size()).isEqualTo(2);
 
                     softly.assertThat(shopImages.get(0).getImageUrl())
                         .isEqualTo("https://fixed-shopimage.com/수정된_상점_이미지.png");
@@ -927,7 +927,7 @@ class AdminShopApiTest extends AcceptanceTest {
     @Test
     @DisplayName("어드민이 상점을 삭제한다.")
     void deleteShop() {
-        Shop shop = shopFixture.신전_떡볶이(owner_현수);
+        Shop shop = shopFixture.영업중이_아닌_신전_떡볶이(owner_현수);
 
         RestAssured
             .given()

--- a/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
@@ -79,7 +79,7 @@ public final class ShopFixture {
         return shopRepository.save(shop);
     }
 
-    public Shop 신전_떡볶이(Owner owner) {
+    public Shop 영업중이_아닌_신전_떡볶이(Owner owner) {
         var shop = shopRepository.save(
             Shop.builder()
                 .owner(owner)
@@ -122,6 +122,182 @@ public final class ShopFixture {
                     .build(),
                 ShopOpen.builder()
                     .openTime(LocalTime.of(12, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("MONDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("TUESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("WEDNESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("THURSDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("FRIDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SATURDAY")
+                    .build()
+            )
+        );
+        return shopRepository.save(shop);
+    }
+
+    public Shop 배달_안되는_신전_떡볶이(Owner owner) {
+        var shop = shopRepository.save(
+            Shop.builder()
+                .owner(owner)
+                .name("신전 떡볶이")
+                .internalName("신전")
+                .chosung("신")
+                .phone("010-7788-9900")
+                .address("천안시 동남구 병천면 1600 신전떡볶이")
+                .description("신전떡볶이입니다.")
+                .delivery(false)
+                .deliveryPrice(2000)
+                .payCard(true)
+                .payBank(true)
+                .isDeleted(false)
+                .isEvent(false)
+                .remarks("비고")
+                .hit(0)
+                .build()
+        );
+        shop.getShopImages().addAll(
+            List.of(
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전.png")
+                    .build(),
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전2.png")
+                    .build()
+            )
+        );
+        shop.getShopOpens().addAll(
+            List.of(
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SUNDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("MONDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("TUESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("WEDNESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("THURSDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("FRIDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
+                    .closeTime(LocalTime.of(21, 30))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SATURDAY")
+                    .build()
+            )
+        );
+        return shopRepository.save(shop);
+    }
+
+    public Shop 영업중인_티바(Owner owner) {
+        var shop = shopRepository.save(
+            Shop.builder()
+                .owner(owner)
+                .name("티바")
+                .internalName("티바")
+                .chosung("티")
+                .phone("010-7788-9900")
+                .address("천안시 동남구 병천면 1600 신전떡볶이")
+                .description("신전떡볶이입니다.")
+                .delivery(true)
+                .deliveryPrice(2000)
+                .payCard(true)
+                .payBank(true)
+                .isDeleted(false)
+                .isEvent(false)
+                .remarks("비고")
+                .hit(0)
+                .build()
+        );
+        shop.getShopImages().addAll(
+            List.of(
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전.png")
+                    .build(),
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전2.png")
+                    .build()
+            )
+        );
+        shop.getShopOpens().addAll(
+            List.of(
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SUNDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(11, 30))
                     .closeTime(LocalTime.of(21, 30))
                     .shop(shop)
                     .closed(false)

--- a/src/test/java/in/koreatech/koin/fixture/ShopReviewFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopReviewFixture.java
@@ -30,7 +30,7 @@ public final class ShopReviewFixture {
     }
 
 
-    public ShopReview 리뷰(Student student, Shop shop) {
+    public ShopReview 리뷰_4점(Student student, Shop shop) {
         ShopReview shopReview = ShopReview.builder()
             .reviewer(student)
             .content("여기 진짜 맛있어요.")

--- a/src/test/java/in/koreatech/koin/fixture/ShopReviewReportFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopReviewReportFixture.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.fixture;
 
 import org.springframework.stereotype.Component;
 
+import in.koreatech.koin.domain.shop.model.ReportStatus;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopReview;
 import in.koreatech.koin.domain.shop.model.ShopReviewImage;
@@ -24,12 +25,13 @@ public final class ShopReviewReportFixture {
         this.shopReviewReportRepository = shopReviewReportRepository;
     }
 
-    public ShopReviewReport 리뷰_신고(Student student, ShopReview shopReview) {
+    public ShopReviewReport 리뷰_신고(Student student, ShopReview shopReview, ReportStatus reportStatus) {
         return shopReviewReportRepository.save(
             ShopReviewReport.builder()
                 .review(shopReview)
                 .title("기타")
                 .content("부적절한 리뷰입니다.")
+                .reportStatus(reportStatus)
                 .userId(student)
                 .build()
         );

--- a/src/test/java/in/koreatech/koin/fixture/ShopReviewReportFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopReviewReportFixture.java
@@ -29,7 +29,7 @@ public final class ShopReviewReportFixture {
             ShopReviewReport.builder()
                 .review(shopReview)
                 .title("기타")
-                .detail("부적절한 리뷰입니다.")
+                .content("부적절한 리뷰입니다.")
                 .userId(student)
                 .build()
         );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #684 
- close #728

# 🚀 작업 내용

## 정렬, 필터 기능이 있는 모든 상점 조회 API를 작성(#684 )
1. `EntityGraph`를 이용해서 이른 로딩을 진행하였습니다.
    - 캐싱은 진행하지 않았습니다.
    - 이른 로딩을 해도 성능이 나쁘다면 캐싱을 진행하도록 하겠습니다.
2. 신고의 상태를 나타낼 필요가 있어서 `shop_review_reports`테이블에 `status`필드를 추가하였습니다.
3. `review`를 `softDelete`로 변경하였습니다.
    - 리뷰가 삭제되어도 신고 내역은 유지해야 하기 때문
4. 정렬 기준, 필터는 ENUM으로 정의했습니다.

## 리뷰 조회시 신고된 리뷰는 조회되지 않도록 변경(#728)
1. 신고의 상태가 `DISMISSED`(무의미한 신고여서 관련 리뷰를 유지하는 경우)인 경우를 제외한 모든 신고의 경우 리뷰 조회에 포함되지 않도록 하였습니다.

# 💬 리뷰 중점사항
