### PR TITLE
fix : 시간표 프레임 삭제 동시성

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -18,6 +18,11 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
 
     Optional<TimetableFrame> findById(Integer id);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM TimetableFrame t WHERE t.id = :id")
+    Optional<TimetableFrame> findByIdWithLock(@Param("id") Integer id);
+
+
     List<TimetableFrame> findByUserIdAndIsMainTrue(Integer userId);
 
     Optional<TimetableFrame> findByUserIdAndSemesterIdAndIsMainTrue(Integer userId, Integer semesterId);
@@ -25,6 +30,11 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
     default TimetableFrame getById(Integer id) {
         return findById(id)
             .orElseThrow(() -> TimetableNotFoundException.withDetail("id: " + id));
+    }
+
+    default TimetableFrame getByIdWithLock(Integer id) {
+        return findByIdWithLock(id)
+                .orElseThrow(() -> TimetableNotFoundException.withDetail("id: " + id));
     }
 
     default TimetableFrame getMainTimetableByUserIdAndSemesterId(Integer userId, Integer semesterId) {

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -74,7 +74,7 @@ public class TimetableServiceV2 {
 
     @Transactional
     public void deleteTimetablesFrame(Integer userId, Integer frameId) {
-        TimetableFrame frame = timetableFrameRepositoryV2.getById(frameId);
+        TimetableFrame frame = timetableFrameRepositoryV2.getByIdWithLock(frameId);
         if (!Objects.equals(frame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #730

# 🚀 작업 내용

![image](https://github.com/user-attachments/assets/0661ca5a-5f57-42bb-92fe-d06882edfcb9)
findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc()메서드에 베타락을 걸어도 여전히 위와같은 2개의 트랜잭션이 동시에 접근되는 상황에서 여전히 동시성 에러가 발생되고 있습니다. 이유는 사진과 같이 findById는 여전히 해당 레코드를 공유하여 접근하기 때문에 충돌이 발생합니다.

그래서 findById메서드 또한 베타락을 걸어서 다른 트랜잭션에서 findById 사용할때 해당 레코드에 동시에 접근하는 것을 막게 수정했습니다.

# 💬 리뷰 중점사항
