### PR TITLE
fix: 시간표 프레임 삭제 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -78,16 +78,15 @@ public class TimetableServiceV2 {
         if (!Objects.equals(frame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }
+        timetableFrameRepositoryV2.deleteById(frameId);
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
                 timetableFrameRepositoryV2.
                     findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
-                timetableFrameRepositoryV2.save(nextMainFrame);
             }
         }
-        timetableFrameRepositoryV2.deleteById(frameId);
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #734

# 🚀 작업 내용

하나의 트랜잭션이 B레코드에 베타락을 거는 상황에서, 다른 트랜잭션이 A레코드에 베타락을걸고 B레코드에  베타락을 걸때 JPA에서 데드락으로 간주하고 cannotacquirelockexception예외를 발생시킵니다.

근데 정확히 어디에서 순환관계에 빠진 데드락 상황이 걸린진 모르겠으나, JPA에서 데드락 예외를 발생시킬만한 상황을 없애기 위해 로직순서를 변경했습니다.

# 💬 리뷰 중점사항
