### PR TITLE
fix: DELETE/timetable 동시성 에러

### DIFF
--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -584,4 +584,45 @@ class TimetableApiTest extends AcceptanceTest {
 
         assertThat(timetableRepository.findById(2)).isNotPresent();
     }
+
+    @Test
+    @DisplayName("시간표 삭제 동시성 예외 적절하게 처리하는지 테스트한다.")
+    void deleteTimetableConcurrency() throws InterruptedException {
+        User user = userFixture.준호_학생().getUser();
+        String token = userFixture.getToken(user);
+        Semester semester = semesterFixture.semester("20192");
+
+        Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
+        Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
+
+        timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+
+        List<Response> responseList = new ArrayList<>();
+        Runnable deleteTask = () -> {
+            Response response = RestAssured
+                    .given()
+                    .header("Authorization", "Bearer " + token)
+                    .when()
+                    .param("id", 2)
+                    .delete("/timetable");
+            responseList.add(response);
+            latch.countDown();
+        };
+
+        executor.submit(deleteTask);
+        executor.submit(deleteTask);
+
+        latch.await();
+
+        boolean hasConflict = responseList.stream()
+                .anyMatch(response -> response.getStatusCode() == 409);
+
+        assertThat(hasConflict).isTrue();
+        assertThat(timetableRepository.findById(2)).isNotPresent();
+
+        executor.shutdown();
+    }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,12 @@ import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @SuppressWarnings("NonAsciiCharacters")
 class TimetableApiTest extends AcceptanceTest {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #741

# 🚀 작업 내용

DELETE/timetable API 동시 호출과정에서 ObjectOptimisticLockingFailureException 에러가 발생했습니다.

- ObjectOptimisticLockingFailureException란?
JPA에서 매핑된 객체에 대한 낙관적 잠금 위반에 대해 발생한 예외를 말합니다. 즉, DB단이 아닌 어플리케이션의 JPA 영속성단에서 레코드를 수정하기 전에 다른 트랜잭션이 해당 레코드를 수정했는지를 확인하고 발생시킵니다.

트랜잭션A : 조회 -> 삭제
트랜잭션B : 조회 -> 삭제

현재 위와같은 삭제API가 동시에 호출되면서 트랜잭션 충돌이 발생하여 JPA에서 ObjectOptimisticLockingFailureException 예외가 발생되었습니다.

해결방안1 - 조회메서드에 비관적락을 건다.
조회메서드에 비관적락을 걸게되면 예외가 발생하지 않고 간단하게 처리됩니다. 하지만 해당 레코드에 많은 트랜잭션의 접근이 발생시 지연이 발생합니다.

해결방안2 - try-catch문으로 예외처리한다.
만약 현재 단순 조회->삭제 로직에서 조회메서드에 락을 걸게된다면 얻는 이익은 예외가 발생 안한다뿐입니다. 그렇기때문에 예외를 발생시키지 않기위해 성능저하를 감수하는것은 올바르지 못한 방향이라 생각이 들었기에, try-catch문을 통해 단순 요청이 빠르다는 정보를 클라이언트에게 넘겨줍니다.

그래서 현재 상황에서 최적의 방안은 해결방안2라고 생각이들어 try-catch문으로 해결했습니다.

# 💬 리뷰 중점사항
