### PR TITLE
refactor: 모든 상점 조회시 필터 유효성 검사 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/dto/CreateReviewRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/CreateReviewRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.global.validation.UniqueUrl;
@@ -18,7 +19,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record CreateReviewRequest(
     @Schema(example = "4", description = "리뷰의 별점", requiredMode = REQUIRED)
     @NotNull
@@ -27,7 +28,6 @@ public record CreateReviewRequest(
     Integer rating,
 
     @Schema(example = "정말 맛있어요~!", description = "리뷰 내용", requiredMode = REQUIRED)
-    @NotBlank
     String content,
 
     @Schema(example = """
@@ -43,7 +43,7 @@ public record CreateReviewRequest(
     @JsonCreator
     public CreateReviewRequest(
         @JsonProperty("rating") @NotNull @Min(1) @Max(5) Integer rating,
-        @JsonProperty("content") @NotBlank String content,
+        @JsonProperty("content") String content,
         @JsonProperty("image_urls") List<String> imageUrls,
         @JsonProperty("menu_names") List<String> menuNames
     ) {

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyReviewRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyReviewRequest.java
@@ -27,7 +27,6 @@ public record ModifyReviewRequest(
     Integer rating,
 
     @Schema(example = "정말 맛있어요~!", description = "리뷰 내용", requiredMode = REQUIRED)
-    @NotBlank
     String content,
 
     @Schema(example = """
@@ -43,7 +42,7 @@ public record ModifyReviewRequest(
     @JsonCreator
     public ModifyReviewRequest(
         @JsonProperty("rating") @NotNull @Min(1) @Max(5) Integer rating,
-        @JsonProperty("content") @NotBlank String content,
+        @JsonProperty("content") String content,
         @JsonProperty("image_urls") List<String> imageUrls,
         @JsonProperty("menu_names") List<String> menuNames
     ) {

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewReportRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewReportRequest.java
@@ -2,20 +2,31 @@ package in.koreatech.koin.domain.shop.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.util.List;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ShopReviewReportRequest (
-    @Schema(example = "기타", description = "신고 제목", requiredMode = REQUIRED)
-    @NotBlank(message = "신고 제목은 필수입니다.")
-    String title,
-
-    @Schema(example = "이 글은 논란이 될수도 있겠는데요~?", description = "신고 내용", requiredMode = REQUIRED)
-    @NotBlank(message = "신고 내용은 필수입니다.")
-    String content
+    @Schema(description = "신고내용 리스트", requiredMode = REQUIRED)
+    @NotNull
+    @Valid
+    List<InnerShopReviewReport> reports
 ){
+    public static record InnerShopReviewReport(
+        @Schema(example = "기타", description = "신고 제목", requiredMode = REQUIRED)
+        @NotBlank(message = "신고 제목은 필수입니다.")
+        String title,
+
+        @Schema(example = "이 글은 논란이 될수도 있겠는데요~?", description = "신고 내용", requiredMode = REQUIRED)
+        @NotBlank(message = "신고 내용은 필수입니다.")
+        String content
+    ) {
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
@@ -1,12 +1,10 @@
 package in.koreatech.koin.domain.shop.dto;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
+
 import in.koreatech.koin.domain.shop.model.Shop;
-import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteria.java
@@ -1,11 +1,15 @@
 package in.koreatech.koin.domain.shop.dto;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
-
 import in.koreatech.koin.domain.shop.model.Shop;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+import lombok.Getter;
 
+@Getter
 public enum ShopsFilterCriteria {
 
     OPEN("OPEN"),
@@ -16,10 +20,6 @@ public enum ShopsFilterCriteria {
 
     ShopsFilterCriteria(String value) {
         this.value = value;
-    }
-
-    public String getValue() {
-        return value;
     }
 
     public Predicate<Shop> getCondition(LocalDateTime now) {

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteriaConverter.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteriaConverter.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+@Component
+public class ShopsFilterCriteriaConverter implements Converter<String, ShopsFilterCriteria> {
+
+    @Override
+    public ShopsFilterCriteria convert(String source) {
+        return Arrays.stream(ShopsFilterCriteria.values())
+            .filter(criteria -> criteria.name().equalsIgnoreCase(source))
+            .findFirst()
+            .orElseThrow(() -> KoinIllegalArgumentException.withDetail("잘못된 FILTER 입니다."));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteriaConverter.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsFilterCriteriaConverter.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.shop.dto;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
@@ -16,6 +15,6 @@ public class ShopsFilterCriteriaConverter implements Converter<String, ShopsFilt
         return Arrays.stream(ShopsFilterCriteria.values())
             .filter(criteria -> criteria.name().equalsIgnoreCase(source))
             .findFirst()
-            .orElseThrow(() -> KoinIllegalArgumentException.withDetail("잘못된 FILTER 입니다."));
+            .orElse(null);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -33,7 +33,6 @@ public class ShopReview extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(nullable = false)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -33,6 +33,7 @@ public class ShopReview extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(name = "content")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.service;
 
+import static in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest.*;
 import static in.koreatech.koin.domain.shop.model.ReportStatus.UNHANDLED;
 
 import java.util.HashMap;
@@ -123,15 +124,17 @@ public class ShopReviewService {
     ) {
         Student student = studentRepository.getById(studentId);
         ShopReview shopReview = shopReviewRepository.getAllByIdAndShopIdAndIsDeleted(reviewId, shopId);
-        shopReviewReportRepository.save(
-            ShopReviewReport.builder()
-                .userId(student)
-                .review(shopReview)
-                .title(shopReviewReportRequest.title())
-                .reportStatus(UNHANDLED)
-                .content(shopReviewReportRequest.content())
-                .build()
-        );
+        for (InnerShopReviewReport shopReviewReport: shopReviewReportRequest.reports()) {
+            shopReviewReportRepository.save(
+                ShopReviewReport.builder()
+                    .userId(student)
+                    .review(shopReview)
+                    .title(shopReviewReport.title())
+                    .reportStatus(UNHANDLED)
+                    .content(shopReviewReport.content())
+                    .build()
+            );
+        }
     }
 
     public ShopReviewReportCategoryResponse getReviewReportCategories() {

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -33,6 +33,7 @@ import in.koreatech.koin.domain.shop.repository.MenuRepository;
 import in.koreatech.koin.domain.shop.repository.ShopCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.ShopRepository;
 import in.koreatech.koin.domain.shop.repository.redis.ShopsRedisRepository;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -114,6 +115,9 @@ public class ShopService {
     }
 
     public ShopsResponseV2 getShopsV2(ShopsSortCriteria sortBy, List<ShopsFilterCriteria> shopsFilterCriterias) {
+        if (shopsFilterCriterias.contains(null)) {
+            throw KoinIllegalArgumentException.withDetail("유효하지 않은 필터입니다.");
+        }
         List<Shop> shops = shopRepository.findAll();
         LocalDateTime now = LocalDateTime.now(clock);
         List<ShopsResponseV2.InnerShopResponse> innerShopResponses = shops.stream()

--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import in.koreatech.koin.domain.bus.controller.BusStationEnumConverter;
 import in.koreatech.koin.domain.bus.controller.BusTypeEnumConverter;
+import in.koreatech.koin.domain.shop.dto.ShopsFilterCriteriaConverter;
 import in.koreatech.koin.global.auth.AuthArgumentResolver;
 import in.koreatech.koin.global.auth.ExtractAuthenticationInterceptor;
 import in.koreatech.koin.global.auth.UserIdArgumentResolver;
@@ -62,6 +63,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addConverter(new BusStationEnumConverter());
         registry.addConverter(new ImageUploadDomainEnumConverter());
         registry.addConverter(new NotificationSubscribeTypeConverter());
+        registry.addConverter(new ShopsFilterCriteriaConverter());
     }
 
     @Override

--- a/src/main/resources/db/migration/V40__alter_review_content_nullable_.sql
+++ b/src/main/resources/db/migration/V40__alter_review_content_nullable_.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `shop_review_reports` MODIFY `content` text NULL;

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -455,8 +455,16 @@ class ShopReviewApiTest extends AcceptanceTest {
             .header("Authorization", "Bearer " + token_준호)
             .body("""
                 {
-                    "title": "기타",
-                    "content": "적절치 못한 리뷰인 것 같습니다."
+                  "reports": [
+                    {
+                      "title": "기타",
+                      "content": "적절치 못한 리뷰인 것 같습니다."
+                    },
+                    {
+                      "title": "스팸",
+                      "content": "광고가 포함된 리뷰입니다."
+                    }
+                  ]
                 }
                 """)
             .when()
@@ -468,13 +476,17 @@ class ShopReviewApiTest extends AcceptanceTest {
             .extract();
 
         transactionTemplate.executeWithoutResult(status -> {
-            Optional<ShopReviewReport> shopReviewReport = shopReviewReportRepository.findById(1);
+            Optional<ShopReviewReport> shopReviewReport1 = shopReviewReportRepository.findById(1);
+            Optional<ShopReviewReport> shopReviewReport2 = shopReviewReportRepository.findById(2);
             assertSoftly(
                 softly -> {
-                    softly.assertThat(shopReviewReport.isPresent()).isTrue();
-                    softly.assertThat(shopReviewReport.get().getTitle()).isEqualTo("기타");
-                    softly.assertThat(shopReviewReport.get().getContent()).isEqualTo("적절치 못한 리뷰인 것 같습니다.");
-                    softly.assertThat(shopReviewReport.get().getReportStatus()).isEqualTo(UNHANDLED);
+                    softly.assertThat(shopReviewReport1.isPresent()).isTrue();
+                    softly.assertThat(shopReviewReport1.get().getTitle()).isEqualTo("기타");
+                    softly.assertThat(shopReviewReport1.get().getContent()).isEqualTo("적절치 못한 리뷰인 것 같습니다.");
+                    softly.assertThat(shopReviewReport1.get().getReportStatus()).isEqualTo(UNHANDLED);
+                    softly.assertThat(shopReviewReport2.get().getTitle()).isEqualTo("스팸");
+                    softly.assertThat(shopReviewReport2.get().getContent()).isEqualTo("광고가 포함된 리뷰입니다.");
+                    softly.assertThat(shopReviewReport2.get().getReportStatus()).isEqualTo(UNHANDLED);
                 }
             );
         });


### PR DESCRIPTION
# 🔥 연관 이슈

- close #742
- close #749 
- close #750

# 🚀 작업 내용

1. 모든 상점 조회시 필터값에 유효성 검사를 추가했습니다.
2. 리뷰 작성시 내용이 null이 될 수 있게 변경했습니다.(기획에 맞도록 변경)
3. 리뷰 신고 내역을 여러개 선택할 수 있도록 변경했습니다.

# 💬 리뷰 중점사항
