### PR TITLE
feat: 리뷰 조회 API 정렬 기능 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.domain.shop.dto.CreateReviewRequest;
 import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ModifyReviewRequest;
+import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
@@ -159,6 +160,7 @@ public interface ShopApi {
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
+        @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
         @UserId Integer userId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -22,6 +22,7 @@ import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
+import in.koreatech.koin.domain.shop.dto.ShopMyReviewsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
@@ -162,6 +163,20 @@ public interface ShopApi {
         @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
         @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
         @UserId Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "자신의 리뷰 조회")
+    @GetMapping("/shops/{shopId}/reviews/me")
+    ResponseEntity<ShopMyReviewsResponse> getMyReviews(
+        @Parameter(in = PATH) @PathVariable Integer shopId,
+        @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
+        @Auth(permit = {STUDENT}) Integer studentId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
+import in.koreatech.koin.domain.shop.dto.ShopMyReviewsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
@@ -118,6 +119,16 @@ public class ShopController implements ShopApi {
     ) {
         ShopReviewsResponse reviewResponse = shopReviewService.getReviewsByShopId(shopId, userId, page, limit, sortBy);
         return ResponseEntity.ok(reviewResponse);
+    }
+
+    @GetMapping("/shops/{shopId}/reviews/me")
+    public ResponseEntity<ShopMyReviewsResponse> getMyReviews(
+        @Parameter(in = PATH) @PathVariable Integer shopId,
+        @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ShopMyReviewsResponse reviewsResponse = shopReviewService.getMyReviewsByShopId(shopId, studentId, sortBy);
+        return ResponseEntity.ok(reviewsResponse);
     }
 
     @PostMapping("/shops/{shopId}/reviews")

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -21,6 +21,7 @@ import in.koreatech.koin.domain.shop.dto.CreateReviewRequest;
 import in.koreatech.koin.domain.shop.dto.MenuCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.ModifyReviewRequest;
+import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopMenuResponse;
@@ -112,9 +113,10 @@ public class ShopController implements ShopApi {
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "50", required = false) Integer limit,
+        @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
         @UserId Integer userId
     ) {
-        ShopReviewsResponse reviewResponse = shopReviewService.getReviewsByShopId(shopId, userId, page, limit);
+        ShopReviewsResponse reviewResponse = shopReviewService.getReviewsByShopId(shopId, userId, page, limit, sortBy);
         return ResponseEntity.ok(reviewResponse);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ReviewsSortCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ReviewsSortCriteria.java
@@ -1,0 +1,28 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum ReviewsSortCriteria {
+
+    LATEST("LATEST", Sort.by(Sort.Direction.DESC, "createdAt")),
+    OLDEST("OLDEST", Sort.by(Sort.Direction.ASC, "createdAt")),
+    HIGHEST_RATING("HIGHEST_RATING", Sort.by(Sort.Direction.DESC, "rating")),
+    LOWEST_RATING("LOWEST_RATING", Sort.by(Sort.Direction.ASC, "rating")),
+    ;
+
+    private final String value;
+    private final Sort sort;
+
+    ReviewsSortCriteria(String value, Sort sort) {
+        this.value = value;
+        this.sort = sort;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Sort getSort() {
+        return sort;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMyReviewsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopMyReviewsResponse.java
@@ -1,0 +1,91 @@
+package in.koreatech.koin.domain.shop.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.ShopReview;
+import in.koreatech.koin.domain.shop.model.ShopReviewImage;
+import in.koreatech.koin.domain.shop.model.ShopReviewMenu;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ShopMyReviewsResponse(
+
+    @Schema(description = "내 리뷰 수", example = "57", requiredMode = REQUIRED)
+    Integer count,
+
+    @Schema(description = "해당 상점 자신의 리뷰", requiredMode = REQUIRED)
+    List<InnerReviewResponse> reviews
+) {
+
+    public static ShopMyReviewsResponse from(
+        List<ShopReview> shopReviews
+    ) {
+        return new ShopMyReviewsResponse(
+            shopReviews.size(),
+            shopReviews.stream()
+                .map(InnerReviewResponse::from)
+                .toList()
+        );
+    }
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerReviewResponse(
+        @Schema(example = "1", description = "리뷰 ID", requiredMode = REQUIRED)
+        int reviewId,
+
+        @Schema(example = "4", description = "별점", requiredMode = REQUIRED)
+        int rating,
+
+        @Schema(example = "익명23432423", description = "닉네임", requiredMode = REQUIRED)
+        String nickName,
+
+        @Schema(example = "맛있어요~", description = "내용", requiredMode = REQUIRED)
+        String content,
+
+        @Schema(example = """
+            [ "https://static.koreatech.in/example.png" ]
+            """, description = "이미지 URL 리스트", requiredMode = REQUIRED)
+        List<String> imageUrls,
+
+        @Schema(example = """
+            [ "피자" ]
+            """, description = "메뉴 이름 리스트", requiredMode = REQUIRED)
+        List<String> menuNames,
+
+        @Schema(example = "false", description = "로그인한 회원의 리뷰인지 여부. 비회원이라면 false", requiredMode = REQUIRED)
+        boolean isMine,
+
+        @Schema(example = "false", description = "수정된 적 있는 리뷰인지", requiredMode = REQUIRED)
+        boolean isModified,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @Schema(example = "2024-03-01", description = "리뷰 작성일", requiredMode = REQUIRED)
+        LocalDateTime createdAt
+    ) {
+
+        public static InnerReviewResponse from(ShopReview review) {
+            String nickName = review.getReviewer().getUser().getNickname();
+            if (nickName == null) {
+                nickName = review.getReviewer().getAnonymousNickname();
+            }
+            return new InnerReviewResponse(
+                review.getId(),
+                review.getRating(),
+                nickName,
+                review.getContent(),
+                review.getImages().stream().map(ShopReviewImage::getImageUrls).toList(),
+                review.getMenus().stream().map(ShopReviewMenu::getMenuName).toList(),
+                true,
+                !review.getCreatedAt().equals(review.getUpdatedAt()),
+                review.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewsResponse.java
@@ -143,7 +143,7 @@ public record ShopReviewsResponse(
                 averageRating = totalSum / totalCount;
             }
             return new InnerReviewStatisticsResponse(
-                averageRating,
+                Math.round(averageRating * 10) / 10.0,
                 ratings
             );
         }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopReview.java
@@ -61,7 +61,12 @@ public class ShopReview extends BaseEntity {
     private List<ShopReviewReport> reports = new ArrayList<>();
 
     @Builder
-    public ShopReview(String content, Integer rating, Student reviewer, Shop shop) {
+    public ShopReview(
+        String content,
+        Integer rating,
+        Student reviewer,
+        Shop shop
+    ) {
         this.content = content;
         this.rating = rating;
         this.reviewer = reviewer;
@@ -90,9 +95,9 @@ public class ShopReview extends BaseEntity {
         entityManager.flush();
         for (String menuName : menuNames) {
             ShopReviewMenu shopReviewImage = ShopReviewMenu.builder()
-                    .menuName(menuName)
-                    .review(this)
-                    .build();
+                .menuName(menuName)
+                .review(this)
+                .build();
             this.menus.add(shopReviewImage);
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
@@ -1,9 +1,11 @@
 package in.koreatech.koin.domain.shop.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
@@ -12,8 +14,6 @@ import in.koreatech.koin.domain.shop.model.ShopReview;
 import io.lettuce.core.dynamic.annotation.Param;
 
 public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
-
-    boolean NOT_DELETED = false;
 
     ShopReview save(ShopReview review);
 
@@ -35,10 +35,27 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
            SELECT sr FROM ShopReview sr 
            WHERE sr.shop.id = :shopId 
            AND sr.isDeleted = false
+           AND sr.reviewer.id = :studentId
            AND NOT EXISTS (
                SELECT r FROM ShopReviewReport r 
                WHERE r.review.id = sr.id 
-               AND r.reportStatus != in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED
+               AND r.reportStatus != 'DISMISSED'
+           )
+           """)
+    List<ShopReview> findAllMyReviewsByShopIdNotContainReportedAndIsDeletedFalse(
+        @Param("shopId") Integer shopId,
+        @Param("studentId") Integer studentId,
+        Sort sort
+    );
+
+    @Query("""
+           SELECT sr FROM ShopReview sr 
+           WHERE sr.shop.id = :shopId 
+           AND sr.isDeleted = false
+           AND NOT EXISTS (
+               SELECT r FROM ShopReviewReport r 
+               WHERE r.review.id = sr.id 
+               AND r.reportStatus != 'DISMISSED'
            )
            """)
     Page<ShopReview> findAllByShopIdNotContainReportedAndIsDeletedFalse(

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -10,13 +10,13 @@ import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.shop.dto.CreateReviewRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyReviewRequest;
 import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
+import in.koreatech.koin.domain.shop.dto.ShopMyReviewsResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.ShopReviewResponse;
@@ -170,5 +170,14 @@ public class ShopReviewService {
             throw ReviewNotFoundException.withDetail("해당 상점의 리뷰가 아닙니다.");
         }
         return ShopReviewResponse.from(shopReview);
+    }
+
+    public ShopMyReviewsResponse getMyReviewsByShopId(Integer shopId, Integer studentId, ReviewsSortCriteria sortBy) {
+        List<ShopReview> reviews = shopReviewRepository.findAllMyReviewsByShopIdNotContainReportedAndIsDeletedFalse(
+            shopId,
+            studentId,
+            sortBy.getSort()
+        );
+        return ShopMyReviewsResponse.from(reviews);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -10,11 +10,13 @@ import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.shop.dto.CreateReviewRequest;
 import in.koreatech.koin.domain.shop.dto.ModifyReviewRequest;
+import in.koreatech.koin.domain.shop.dto.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.ShopReviewResponse;
@@ -54,12 +56,13 @@ public class ShopReviewService {
 
     private final EntityManager entityManager;
 
-    public ShopReviewsResponse getReviewsByShopId(Integer shopId, Integer userId, Integer page, Integer limit) {
+    public ShopReviewsResponse getReviewsByShopId(Integer shopId, Integer userId, Integer page, Integer limit, ReviewsSortCriteria sortBy) {
         Integer total = shopReviewRepository.countByShopIdNotContainReportedAndIsDeletedFalse(shopId);
         Criteria criteria = Criteria.of(page, limit, total);
         PageRequest pageRequest = PageRequest.of(
             criteria.getPage(),
-            criteria.getLimit()
+            criteria.getLimit(),
+            sortBy.getSort()
         );
         Page<ShopReview> result = shopReviewRepository.findAllByShopIdNotContainReportedAndIsDeletedFalse(
             shopId,

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -680,4 +680,688 @@ class ShopReviewApiTest extends AcceptanceTest {
                 준호_학생_리뷰.getMenus().get(0).getMenuName())
             );
     }
+
+    @Test
+    void 최신순으로_정렬하여_리뷰를_조회한다() {
+        ShopReview 최신_리뷰_2024_08_07 = shopReviewFixture.최신_리뷰_2024_08_07(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .when()
+            .queryParam("limit", 10)
+            .queryParam("page", 1)
+            .queryParam("sorter", "LATEST")
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .get("/shops/{shopId}/reviews")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "total_count": 3,
+                       "current_count": 3,
+                       "total_page": 1,
+                       "current_page": 1,
+                       "statistics": {
+                         "average_rating": 4.0,
+                         "ratings": {
+                           "1": 0,
+                           "2": 0,
+                           "3": 0,
+                           "4": 3,
+                           "5": 0
+                         }
+                       },
+                       "reviews": [
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-08-07"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                최신_리뷰_2024_08_07.getId(),
+                최신_리뷰_2024_08_07.getRating(),
+                최신_리뷰_2024_08_07.getReviewer().getUser().getNickname(),
+                최신_리뷰_2024_08_07.getContent(),
+                최신_리뷰_2024_08_07.getImages().get(0).getImageUrls(),
+                최신_리뷰_2024_08_07.getMenus().get(0).getMenuName(),
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                익명_학생_리뷰.getId(),
+                익명_학생_리뷰.getRating(),
+                익명_학생_리뷰.getReviewer().getAnonymousNickname(),
+                익명_학생_리뷰.getContent(),
+                익명_학생_리뷰.getImages().get(0).getImageUrls(),
+                익명_학생_리뷰.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 오래된_순으로_정렬하여_리뷰를_조회한다() {
+        ShopReview 최신_리뷰_2024_08_07 = shopReviewFixture.최신_리뷰_2024_08_07(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .when()
+            .queryParam("limit", 10)
+            .queryParam("page", 1)
+            .queryParam("sorter", "OLDEST")
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .get("/shops/{shopId}/reviews")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "total_count": 3,
+                       "current_count": 3,
+                       "total_page": 1,
+                       "current_page": 1,
+                       "statistics": {
+                         "average_rating": 4.0,
+                         "ratings": {
+                           "1": 0,
+                           "2": 0,
+                           "3": 0,
+                           "4": 3,
+                           "5": 0
+                         }
+                       },
+                       "reviews": [
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-08-07"
+                         }
+                       ]
+                     }
+                    """,
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                익명_학생_리뷰.getId(),
+                익명_학생_리뷰.getRating(),
+                익명_학생_리뷰.getReviewer().getAnonymousNickname(),
+                익명_학생_리뷰.getContent(),
+                익명_학생_리뷰.getImages().get(0).getImageUrls(),
+                익명_학생_리뷰.getMenus().get(0).getMenuName(),
+                최신_리뷰_2024_08_07.getId(),
+                최신_리뷰_2024_08_07.getRating(),
+                최신_리뷰_2024_08_07.getReviewer().getUser().getNickname(),
+                최신_리뷰_2024_08_07.getContent(),
+                최신_리뷰_2024_08_07.getImages().get(0).getImageUrls(),
+                최신_리뷰_2024_08_07.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 별점이_높은_순으로_정렬하여_리뷰를_조회한다() {
+        ShopReview 리뷰_5점 = shopReviewFixture.리뷰_5점(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .when()
+            .queryParam("limit", 10)
+            .queryParam("page", 1)
+            .queryParam("sorter", "HIGHEST_RATING")
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .get("/shops/{shopId}/reviews")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "total_count": 3,
+                       "current_count": 3,
+                       "total_page": 1,
+                       "current_page": 1,
+                       "statistics": {
+                         "average_rating": 4.3,
+                         "ratings": {
+                           "1": 0,
+                           "2": 0,
+                           "3": 0,
+                           "4": 2,
+                           "5": 1
+                         }
+                       },
+                       "reviews": [
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                리뷰_5점.getId(),
+                리뷰_5점.getRating(),
+                리뷰_5점.getReviewer().getUser().getNickname(),
+                리뷰_5점.getContent(),
+                리뷰_5점.getImages().get(0).getImageUrls(),
+                리뷰_5점.getMenus().get(0).getMenuName(),
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                익명_학생_리뷰.getId(),
+                익명_학생_리뷰.getRating(),
+                익명_학생_리뷰.getReviewer().getAnonymousNickname(),
+                익명_학생_리뷰.getContent(),
+                익명_학생_리뷰.getImages().get(0).getImageUrls(),
+                익명_학생_리뷰.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 별점이_낮은_순으로_정렬하여_리뷰를_조회한다() {
+        ShopReview 리뷰_5점 = shopReviewFixture.리뷰_5점(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .when()
+            .queryParam("limit", 10)
+            .queryParam("page", 1)
+            .queryParam("sorter", "LOWEST_RATING")
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .get("/shops/{shopId}/reviews")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "total_count": 3,
+                       "current_count": 3,
+                       "total_page": 1,
+                       "current_page": 1,
+                       "statistics": {
+                         "average_rating": 4.3,
+                         "ratings": {
+                           "1": 0,
+                           "2": 0,
+                           "3": 0,
+                           "4": 2,
+                           "5": 1
+                         }
+                       },
+                       "reviews": [
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": false,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                익명_학생_리뷰.getId(),
+                익명_학생_리뷰.getRating(),
+                익명_학생_리뷰.getReviewer().getAnonymousNickname(),
+                익명_학생_리뷰.getContent(),
+                익명_학생_리뷰.getImages().get(0).getImageUrls(),
+                익명_학생_리뷰.getMenus().get(0).getMenuName(),
+                리뷰_5점.getId(),
+                리뷰_5점.getRating(),
+                리뷰_5점.getReviewer().getUser().getNickname(),
+                리뷰_5점.getContent(),
+                리뷰_5점.getImages().get(0).getImageUrls(),
+                리뷰_5점.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 자신의_리뷰를_최신순으로_조회한다() {
+        ShopReview 최신_리뷰_2024_08_07 = shopReviewFixture.최신_리뷰_2024_08_07(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token_준호)
+            .contentType(ContentType.JSON)
+            .when()
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .queryParam("sorter", "LATEST")
+            .get("/shops/{shopId}/reviews/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "count": 2,
+                       "reviews": [
+                       {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-08-07"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                최신_리뷰_2024_08_07.getId(),
+                최신_리뷰_2024_08_07.getRating(),
+                최신_리뷰_2024_08_07.getReviewer().getUser().getNickname(),
+                최신_리뷰_2024_08_07.getContent(),
+                최신_리뷰_2024_08_07.getImages().get(0).getImageUrls(),
+                최신_리뷰_2024_08_07.getMenus().get(0).getMenuName(),
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 자신의_리뷰를_오래된_순으로_조회한다() {
+        ShopReview 최신_리뷰_2024_08_07 = shopReviewFixture.최신_리뷰_2024_08_07(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token_준호)
+            .contentType(ContentType.JSON)
+            .when()
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .queryParam("sorter", "OLDEST")
+            .get("/shops/{shopId}/reviews/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "count": 2,
+                       "reviews": [
+                       {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-08-07"
+                         }
+                       ]
+                     }
+                    """,
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                최신_리뷰_2024_08_07.getId(),
+                최신_리뷰_2024_08_07.getRating(),
+                최신_리뷰_2024_08_07.getReviewer().getUser().getNickname(),
+                최신_리뷰_2024_08_07.getContent(),
+                최신_리뷰_2024_08_07.getImages().get(0).getImageUrls(),
+                최신_리뷰_2024_08_07.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 자신의_리뷰를_별점이_높은_순으로_조회한다() {
+        ShopReview 리뷰_5점 = shopReviewFixture.리뷰_5점(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token_준호)
+            .contentType(ContentType.JSON)
+            .when()
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .queryParam("sorter", "HIGHEST_RATING")
+            .get("/shops/{shopId}/reviews/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "count": 2,
+                       "reviews": [
+                       {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                리뷰_5점.getId(),
+                리뷰_5점.getRating(),
+                리뷰_5점.getReviewer().getUser().getNickname(),
+                리뷰_5점.getContent(),
+                리뷰_5점.getImages().get(0).getImageUrls(),
+                리뷰_5점.getMenus().get(0).getMenuName(),
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName())
+            );
+    }
+
+    @Test
+    void 자신의_리뷰를_별점이_낮은_순으로_조회한다() {
+        ShopReview 리뷰_5점 = shopReviewFixture.리뷰_5점(준호_학생, 신전_떡볶이);
+        var response = RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token_준호)
+            .contentType(ContentType.JSON)
+            .when()
+            .pathParam("shopId", 신전_떡볶이.getId())
+            .queryParam("sorter", "LOWEST_RATING")
+            .get("/shops/{shopId}/reviews/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo(String.format("""
+                    {
+                       "count": 2,
+                       "reviews": [
+                       {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         },
+                         {
+                           "review_id": %d,
+                           "rating": %d,
+                           "nick_name": "%s",
+                           "content": "%s",
+                           "image_urls": [
+                             "%s"
+                           ],
+                           "menu_names": [
+                             "%s"
+                           ],
+                           "is_mine": true,
+                           "is_modified": false,
+                           "created_at": "2024-01-15"
+                         }
+                       ]
+                     }
+                    """,
+                준호_학생_리뷰.getId(),
+                준호_학생_리뷰.getRating(),
+                준호_학생_리뷰.getReviewer().getUser().getNickname(),
+                준호_학생_리뷰.getContent(),
+                준호_학생_리뷰.getImages().get(0).getImageUrls(),
+                준호_학생_리뷰.getMenus().get(0).getMenuName(),
+                리뷰_5점.getId(),
+                리뷰_5점.getRating(),
+                리뷰_5점.getReviewer().getUser().getNickname(),
+                리뷰_5점.getContent(),
+                리뷰_5점.getImages().get(0).getImageUrls(),
+                리뷰_5점.getMenus().get(0).getMenuName())
+            );
+    }
 }

--- a/src/test/java/in/koreatech/koin/config/FixedDate.java
+++ b/src/test/java/in/koreatech/koin/config/FixedDate.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.config;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface FixedDate {
+    int year();
+    int month();
+    int day();
+}

--- a/src/test/java/in/koreatech/koin/config/FixedDateAspect.java
+++ b/src/test/java/in/koreatech/koin/config/FixedDateAspect.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.config;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class FixedDateAspect {
+
+    @Autowired
+    private TestTimeConfig testTimeConfig;
+
+    @Around("@annotation(fixedDate)")
+    public Object around(ProceedingJoinPoint joinPoint, FixedDate fixedDate) throws Throwable {
+        LocalDate date = LocalDate.of(fixedDate.year(), fixedDate.month(), fixedDate.day());
+        LocalDateTime fixedDateTime = date.atStartOfDay();
+        testTimeConfig.setCurrTime(fixedDateTime);
+        try {
+            return joinPoint.proceed();
+        } finally {
+            testTimeConfig.setOriginTime();
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/config/FixedDateAspect.java
+++ b/src/test/java/in/koreatech/koin/config/FixedDateAspect.java
@@ -1,10 +1,7 @@
 package in.koreatech.koin.config;
 
-import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;

--- a/src/test/java/in/koreatech/koin/config/TestTimeConfig.java
+++ b/src/test/java/in/koreatech/koin/config/TestTimeConfig.java
@@ -12,16 +12,25 @@ import org.springframework.data.auditing.DateTimeProvider;
 public class TestTimeConfig {
 
     private final LocalDateTime fixedTime = LocalDateTime.of(2024, 1, 15, 12, 0);
+    private LocalDateTime currTime = fixedTime;
+
+    public void setCurrTime(LocalDateTime localDateTime) {
+        this.currTime = localDateTime;
+    }
+
+    public void setOriginTime() {
+        this.currTime = fixedTime;
+    }
 
     @Bean
     public DateTimeProvider dateTimeProvider() {
-        return () -> Optional.of(fixedTime);
+        return () -> Optional.of(currTime);
     }
 
     @Bean
     public Clock clock() {
         return Clock.fixed(
-            fixedTime.atZone(Clock.systemDefaultZone().getZone()).toInstant(),
+            currTime.atZone(Clock.systemDefaultZone().getZone()).toInstant(),
             Clock.systemDefaultZone().getZone()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/ShopReviewFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopReviewFixture.java
@@ -1,7 +1,10 @@
 package in.koreatech.koin.fixture;
 
+import java.time.Clock;
+
 import org.springframework.stereotype.Component;
 
+import in.koreatech.koin.config.FixedDate;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopReview;
 import in.koreatech.koin.domain.shop.model.ShopReviewImage;
@@ -13,20 +16,23 @@ import in.koreatech.koin.domain.user.model.Student;
 
 @Component
 @SuppressWarnings("NonAsciiCharacters")
-public final class ShopReviewFixture {
+public class ShopReviewFixture {
 
     private final ShopReviewRepository shopReviewRepository;
     private final ShopReviewImageRepository shopReviewImageRepository;
     private final ShopReviewMenuRepository shopReviewMenuRepository;
+    private final Clock clock;
 
     public ShopReviewFixture(
         ShopReviewRepository shopReviewRepository,
         ShopReviewImageRepository shopReviewImageRepository,
-        ShopReviewMenuRepository shopReviewMenuRepository
+        ShopReviewMenuRepository shopReviewMenuRepository,
+        Clock clock
     ) {
         this.shopReviewRepository = shopReviewRepository;
         this.shopReviewImageRepository = shopReviewImageRepository;
         this.shopReviewMenuRepository = shopReviewMenuRepository;
+        this.clock = clock;
     }
 
 
@@ -35,6 +41,45 @@ public final class ShopReviewFixture {
             .reviewer(student)
             .content("여기 진짜 맛있어요.")
             .rating(4)
+            .shop(shop)
+            .build();
+        shopReview.getImages().add(ShopReviewImage.builder()
+            .imageUrls("https://static.koreatech.in/example.png")
+            .review(shopReview)
+            .build());
+        shopReview.getMenus().add(ShopReviewMenu.builder()
+            .menuName("피자")
+            .review(shopReview)
+            .build());
+        ShopReview savedShopReview = shopReviewRepository.save(shopReview);
+        return savedShopReview;
+    }
+
+    @FixedDate(year = 2024, month = 8, day = 7)
+    public ShopReview 최신_리뷰_2024_08_07(Student student, Shop shop) {
+        ShopReview shopReview = ShopReview.builder()
+            .reviewer(student)
+            .content("여기 진짜 맛있어요.")
+            .rating(4)
+            .shop(shop)
+            .build();
+        shopReview.getImages().add(ShopReviewImage.builder()
+            .imageUrls("https://static.koreatech.in/example.png")
+            .review(shopReview)
+            .build());
+        shopReview.getMenus().add(ShopReviewMenu.builder()
+            .menuName("피자")
+            .review(shopReview)
+            .build());
+        ShopReview savedShopReview = shopReviewRepository.save(shopReview);
+        return savedShopReview;
+    }
+
+    public ShopReview 리뷰_5점(Student student, Shop shop) {
+        ShopReview shopReview = ShopReview.builder()
+            .reviewer(student)
+            .content("여기 진짜 맛있어요.")
+            .rating(5)
             .shop(shop)
             .build();
         shopReview.getImages().add(ShopReviewImage.builder()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #755 
- close #754  

# 🚀 작업 내용

1. 리뷰 조회시 정렬을 할 수 있도록 API를 변경하였습니다.
2. 내가 작성한 리뷰만 모아볼 수 있도록 별도의 API를 작성하였습니다.
3. 정렬 기준 중 오래된순, 최신순이 있는데 그것을 테스트하기 위해서는 `created_at`을 특정 날짜로 지정할 수 있어야 합니다. 따라서 테스트에서만 사용하는 `@FixedDate`어노테이션을 만들었습니다.
    - 특정 메소드에 시간을 지정할 수 있습니다.
    - `@FixedDate(year = 2024, month = 8, day = 7)`이렇게 메소드 위에 붙이면 AOP를 이용해서 해당 메소드에서는 지정한 시간대로 설정하고 메소드가 끝나면 원래 시간으로 되돌립니다.

# 💬 리뷰 중점사항
테스트코드가 대부분입니다.. ㅎ
