### PR TITLE
refactor: 상점 조회 V2 삭제된 리뷰는 제외하도록 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
@@ -88,12 +88,12 @@ public record ShopsResponseV2(
                 shop.getPhone(),
                 isEvent,
                 isOpen,
-                shop.getReviews().stream()
+                Math.round(shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
                     .filter(review -> !review.isDeleted())
                     .mapToInt(ShopReview::getRating)
                     .average()
-                    .orElse(0.0),
+                    .orElse(0.0) * 10) / 10.0,
                 shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
                     .filter(review -> !review.isDeleted())

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
@@ -90,11 +90,13 @@ public record ShopsResponseV2(
                 isOpen,
                 shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
+                    .filter(review -> !review.isDeleted())
                     .mapToInt(ShopReview::getRating)
                     .average()
                     .orElse(0.0),
                 shop.getReviews().stream()
                     .filter(review -> notContainsUnhandledReport(review.getReports()))
+                    .filter(review -> !review.isDeleted())
                     .count()
             );
         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #761

# 🚀 작업 내용

1. 삭제된 리뷰는 제외하고 상점 정보를 구성할 수 있도록 변경하였습니다.
2. 소수점 둘째자리까지 나타내도록 수정하였습니다.

# 💬 리뷰 중점사항
