### PR TITLE
feat: 계절학기 빈 리스트로 반환

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/service/TimetableService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/service/TimetableService.java
@@ -15,7 +15,6 @@ import in.koreatech.koin.domain.timetable.dto.LectureResponse;
 import in.koreatech.koin.domain.timetable.dto.TimetableCreateRequest;
 import in.koreatech.koin.domain.timetable.dto.TimetableResponse;
 import in.koreatech.koin.domain.timetable.dto.TimetableUpdateRequest;
-import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
@@ -42,10 +41,8 @@ public class TimetableService {
     private final EntityManager entityManager;
 
     public List<LectureResponse> getLecturesBySemester(String semester) {
+        semesterRepositoryV2.getBySemester(semester);
         List<Lecture> lectures = lectureRepositoryV2.findBySemester(semester);
-        if (lectures.isEmpty()) {
-            throw SemesterNotFoundException.withDetail(semester);
-        }
         return lectures.stream()
                 .map(LectureResponse::from)
                 .toList();

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -48,6 +48,8 @@ class TimetableApiTest extends AcceptanceTest {
     @Test
     @DisplayName("특정 학기 강의를 조회한다")
     void getSemesterLecture() {
+        semesterFixture.semester("20192");
+        semesterFixture.semester("20201");
         String semester = "20201";
         lectureFixture.HRD_개론(semester);
         lectureFixture.건축구조의_이해_및_실습("20192");
@@ -88,6 +90,7 @@ class TimetableApiTest extends AcceptanceTest {
     @Test
     @DisplayName("특정 학기 강의들을 조회한다")
     void getSemesterLectures() {
+        semesterFixture.semester("20201");
         String semester = "20201";
         lectureFixture.HRD_개론(semester);
         lectureFixture.건축구조의_이해_및_실습(semester);

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -178,6 +178,27 @@ class TimetableApiTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("계절학기를 조회하면 빈 리스트로 반환한다.")
+    void getSeasonLecture() {
+        semesterFixture.semester("20241");
+        semesterFixture.semester("20242");
+        semesterFixture.semester("2024-여름");
+        semesterFixture.semester("2024-겨울");
+
+        var Response = RestAssured
+                .given()
+                .when()
+                .param("semester_date", "2024-여름")
+                .get("/lectures")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        JsonAssertions.assertThat(Response.asPrettyString())
+                .isEqualTo("[]");
+    }
+
+    @Test
     @DisplayName("모든 학기를 조회한다.")
     void findAllSemesters() {
         semesterFixture.semester("20221");


### PR DESCRIPTION
# 🔥 연관 이슈

- close #763

# 🚀 작업 내용

1. 계절학기는 빈 리스트로 반환될 수 있게 로직 수정했습니다.

# 💬 리뷰 중점사항
