### PR TITLE
fix: 캠퍼스팀 안 쓰는 컬럼 삭제 - 식단에 price 컬럼 추가

### DIFF
--- a/src/main/resources/db/migration/V41__add_dining_menus_price_column.sql
+++ b/src/main/resources/db/migration/V41__add_dining_menus_price_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dining_menus
+    ADD COLUMN price INT UNSIGNED;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #736 

# 🚀 작업 내용

1. 식단의 `price_card` 와 `price_cash` 칼럼을 `price`로 합쳤습니다.
    - `price_card` , `price_cash` 칼럼은 클라이언트 대응 후 삭제할 예정입니다.

# 💬 리뷰 중점사항
