### PR TITLE
refactor: User팀 안 쓰는 컬럼 삭제 - authToken, authExpriedAt 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -82,14 +82,6 @@ public class User extends BaseEntity {
     private boolean isDeleted = false;
 
     @Size(max = 255)
-    @Column(name = "auth_token")
-    private String authToken;
-
-    @Convert(converter = LocalDateTimeAttributeConverter.class)
-    @Column(name = "auth_expired_at", columnDefinition = "TIMESTAMP")
-    private LocalDateTime authExpiredAt;
-
-    @Size(max = 255)
     @Column(name = "reset_token")
     private String resetToken;
 
@@ -113,8 +105,6 @@ public class User extends BaseEntity {
         LocalDateTime lastLoggedAt,
         String profileImageUrl,
         Boolean isDeleted,
-        String authToken,
-        LocalDateTime authExpiredAt,
         String resetToken,
         LocalDateTime resetExpiredAt,
         String deviceToken
@@ -130,8 +120,6 @@ public class User extends BaseEntity {
         this.lastLoggedAt = lastLoggedAt;
         this.profileImageUrl = profileImageUrl;
         this.isDeleted = isDeleted;
-        this.authToken = authToken;
-        this.authExpiredAt = authExpiredAt;
         this.resetToken = resetToken;
         this.resetExpiredAt = resetExpiredAt;
         this.deviceToken = deviceToken;

--- a/src/main/java/in/koreatech/koin/domain/user/model/redis/StudentTemporaryStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/redis/StudentTemporaryStatus.java
@@ -73,7 +73,6 @@ public class StudentTemporaryStatus {
                 .isAuthed(true)
                 .isDeleted(false)
                 .userType(UserType.STUDENT)
-                .authToken(authToken)
                 .build();
 
         return Student.builder()

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -23,8 +23,6 @@ public interface UserRepository extends Repository<User, Integer> {
 
     Optional<User> findByNickname(String nickname);
 
-    Optional<User> findByAuthToken(String authToken);
-
     Optional<User> findAllByResetToken(String resetToken);
 
     default User getByEmail(String email) {

--- a/src/main/resources/db/migration/V42__delete_users_auth_token_auth_expried_at.sql
+++ b/src/main/resources/db/migration/V42__delete_users_auth_token_auth_expried_at.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+DROP COLUMN auth_token,
+DROP COLUMN auth_expired_at;

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -350,8 +350,6 @@ public final class UserFixture {
         private LocalDateTime lastLoggedAt;
         private String profileImageUrl;
         private Boolean isDeleted;
-        private String authToken;
-        private LocalDateTime authExpiredAt;
         private String resetToken;
         private LocalDateTime resetExpiredAt;
         private String deviceToken;
@@ -411,16 +409,6 @@ public final class UserFixture {
             return this;
         }
 
-        public UserFixtureBuilder authToken(String authToken) {
-            this.authToken = authToken;
-            return this;
-        }
-
-        public UserFixtureBuilder authExpiredAt(LocalDateTime authExpiredAt) {
-            this.authExpiredAt = authExpiredAt;
-            return this;
-        }
-
         public UserFixtureBuilder resetToken(String resetToken) {
             this.resetToken = resetToken;
             return this;
@@ -440,14 +428,12 @@ public final class UserFixture {
             return userRepository.save(
                 User.builder()
                     .phoneNumber(phoneNumber)
-                    .authExpiredAt(authExpiredAt)
                     .deviceToken(deviceToken)
                     .lastLoggedAt(lastLoggedAt)
                     .isAuthed(isAuthed)
                     .resetExpiredAt(resetExpiredAt)
                     .resetToken(resetToken)
                     .nickname(nickname)
-                    .authToken(authToken)
                     .isDeleted(isDeleted)
                     .email(email)
                     .profileImageUrl(profileImageUrl)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #738 

# 🚀 작업 내용

- authToken, authExpriedAt 제거
회원가입 때 저장하는 authToken을 redis에서 관리하도록 하였기 때문에 users 테이블과 User Domain에서 삭제하였습니다.

# 💬 리뷰 중점사항
