### PR TITLE
feat: 게시글 조회 api 응답 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -1,23 +1,19 @@
 package in.koreatech.koin.domain.community.dto;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.community.model.Article;
-import in.koreatech.koin.domain.community.model.Board;
-import in.koreatech.koin.domain.community.model.Comment;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record ArticleResponse(
+
     @Schema(description = "게시글 고유 ID", example = "1", requiredMode = REQUIRED)
     Integer id,
 
@@ -33,31 +29,13 @@ public record ArticleResponse(
     @Schema(description = "작성자 닉네임", example = "닉네임", requiredMode = REQUIRED)
     String nickname,
 
-    @Schema(description = "해결 여부", example = "false", requiredMode = REQUIRED)
-    boolean isSolved,
-
-    @Schema(description = "공지 여부", example = "false", requiredMode = REQUIRED)
-    boolean isNotice,
-
-    @Schema(description = "내용 요약", example = "내용 요약", requiredMode = NOT_REQUIRED)
-    @JsonProperty("contentSummary") String contentSummary,
-
     @Schema(description = "조회수", example = "1", requiredMode = REQUIRED)
     int hit,
 
-    @Schema(description = "댓글 수", example = "1", requiredMode = REQUIRED)
-    int commentCount,
-
-    @Schema(description = "게시판 정보", requiredMode = REQUIRED)
-    InnerBoardResponse board,
-
-    @Schema(description = "댓글 목록", requiredMode = NOT_REQUIRED)
-    List<InnerCommentResponse> comments,
-
-    @Schema(description = "생성 일자", example = "2023-01-04 12:00:01")
+    @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
 
-    @Schema(description = "수정 일자", example = "2023-01-04 12:00:01")
+    @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
 ) {
 
@@ -68,126 +46,9 @@ public record ArticleResponse(
             article.getTitle(),
             article.getContent(),
             article.getNickname(),
-            article.isSolved(),
-            article.isNotice(),
-            article.getContentSummary(),
             article.getHit(),
-            article.getCommentCount(),
-            InnerBoardResponse.from(article.getBoard()),
-            article.getComment().stream().map(InnerCommentResponse::from).toList(),
             article.getCreatedAt(),
             article.getUpdatedAt()
         );
-    }
-
-    @JsonNaming(value = SnakeCaseStrategy.class)
-    private record InnerBoardResponse(
-        @Schema(description = "게시판 고유 ID", example = "1", requiredMode = REQUIRED)
-        Integer id,
-
-        @Schema(description = "게시판 태그", example = "tag", requiredMode = REQUIRED)
-        String tag,
-
-        @Schema(description = "게시판 이름", example = "게시판 이름", requiredMode = REQUIRED)
-        String name,
-
-        @Schema(description = "익명 여부", example = "false", requiredMode = REQUIRED)
-        boolean isAnonymous,
-
-        @Schema(description = "게시글 수", example = "1", requiredMode = REQUIRED)
-        int articleCount,
-
-        @Schema(description = "삭제 여부", example = "false", requiredMode = REQUIRED)
-        boolean isDeleted,
-
-        @Schema(description = "공지 여부", example = "false", requiredMode = REQUIRED)
-        boolean isNotice,
-
-        @Schema(description = "부모 게시판 고유 ID", example = "1", requiredMode = NOT_REQUIRED)
-        Integer parentId,
-
-        @Schema(description = "순서", example = "1", requiredMode = REQUIRED)
-        int seq,
-
-        @Schema(description = "하위 게시판 목록", requiredMode = NOT_REQUIRED)
-        List<InnerBoardResponse> children,
-
-        @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt,
-
-        @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime updatedAt
-    ) {
-
-        public static InnerBoardResponse from(Board board) {
-            return new InnerBoardResponse(
-                board.getId(),
-                board.getTag(),
-                board.getName(),
-                board.getIsAnonymous(),
-                board.getArticleCount(),
-                board.isDeleted(),
-                board.isNotice(),
-                board.getParentId(),
-                board.getSeq(),
-                board.getChildren().isEmpty()
-                    ? null : board.getChildren().stream().map(InnerBoardResponse::from).toList(),
-                board.getCreatedAt(),
-                board.getUpdatedAt()
-            );
-        }
-    }
-
-    @JsonNaming(value = SnakeCaseStrategy.class)
-    private record InnerCommentResponse(
-        @Schema(description = "댓글 고유 ID", example = "1", requiredMode = NOT_REQUIRED)
-        Integer id,
-
-        @Schema(description = "게시글 고유 ID", example = "1", requiredMode = REQUIRED)
-        Integer articleId,
-
-        @Schema(description = "내용", example = "내용", requiredMode = REQUIRED)
-        String content,
-
-        @Schema(description = "작성자 고유 ID", example = "1", requiredMode = REQUIRED)
-        Integer userId,
-
-        @Schema(description = "작성자 닉네임", example = "닉네임", requiredMode = REQUIRED)
-        String nickname,
-
-        @Schema(description = "삭제 여부", example = "false", requiredMode = REQUIRED)
-        boolean isDeleted,
-
-        @Schema(description = "수정 권한", example = "false", requiredMode = REQUIRED)
-        @JsonProperty("grantEdit")
-        boolean grantEdit,
-
-        @Schema(description = "삭제 권한", example = "false", requiredMode = REQUIRED)
-        @JsonProperty("grantDelete")
-        boolean grantDelete,
-
-        @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
-
-        @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
-    ) {
-
-        public static InnerCommentResponse from(Comment comment) {
-            return new InnerCommentResponse(
-                comment.getId(),
-                comment.getArticle().getId(),
-                comment.getContent(),
-                comment.getUserId(),
-                comment.getNickname(),
-                comment.getIsDeleted(),
-                comment.isGrantEdit(),
-                comment.isGrantDelete(),
-                comment.getCreatedAt(),
-                comment.getUpdatedAt()
-            );
-        }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -1,38 +1,46 @@
 package in.koreatech.koin.domain.community.dto;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.community.model.Article;
-import in.koreatech.koin.domain.community.model.Board;
+import in.koreatech.koin.global.model.Criteria;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ArticlesResponse(
-    @Schema(description = "게시글 목록", requiredMode = NOT_REQUIRED)
+    @Schema(description = "게시글 목록")
     List<InnerArticleResponse> articles,
 
-    @Schema(description = "게시판 정보", requiredMode = REQUIRED)
-    InnerBoardResponse board,
+    @Schema(description = "총 게시글 수", example = "57", requiredMode = REQUIRED)
+    Long totalCount,
 
-    @Schema(description = "총 페이지 수", example = "1", requiredMode = REQUIRED)
-    long totalPage
+    @Schema(description = "현재 페이지에 포함된 게시글 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "총 페이지 수", example = "6", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "2", requiredMode = REQUIRED)
+    Integer currentPage
 ) {
 
-    public static ArticlesResponse of(List<Article> articles, Board board, Long totalPage) {
+    public static ArticlesResponse of(Page<Article> pagedResult, Criteria criteria) {
         return new ArticlesResponse(
-            articles.stream()
+            pagedResult.stream()
                 .map(InnerArticleResponse::from)
                 .toList(),
-            InnerBoardResponse.from(board),
-            totalPage
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
         );
     }
 
@@ -51,50 +59,17 @@ public record ArticlesResponse(
         @Schema(description = "내용", example = "내용", requiredMode = REQUIRED)
         String content,
 
-        @Schema(description = "작성자 고유 ID", example = "1", requiredMode = REQUIRED)
-        int userId,
-
         @Schema(description = "작성자 닉네임", example = "닉네임", requiredMode = REQUIRED)
         String nickname,
 
         @Schema(description = "조회수", example = "1", requiredMode = REQUIRED)
         int hit,
 
-        @Schema(description = "IP 주소", example = "123.12.1.3")
-        String ip,
-
-        @Schema(description = "해결 여부", example = "false")
-        boolean isSolved,
-
-        @Schema(description = "삭제 여부", example = "false")
-        boolean isDeleted,
-
-        @Schema(description = "댓글 수", example = "1")
-        int commentCount,
-
-        @Schema(description = "메타 정보", example = "메타 정보", requiredMode = NOT_REQUIRED)
-        String meta,
-
-        @Schema(description = "공지 여부", example = "false", requiredMode = REQUIRED)
-        boolean isNotice,
-
-        @Schema(description = "공지 게시글 고유 ID", example = "1", requiredMode = NOT_REQUIRED)
-        Integer noticeArticleId,
-
-        @Schema(description = "요약", example = "요약", requiredMode = NOT_REQUIRED)
-        String summary,
-
         @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
 
         @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime updatedAt,
-
-        @Schema(description = "내용 요약", example = "내용 요약", requiredMode = NOT_REQUIRED)
-        @JsonProperty("contentSummary")
-        String contentSummary
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
     ) {
 
         public static InnerArticleResponse from(Article article) {
@@ -103,82 +78,10 @@ public record ArticlesResponse(
                 article.getBoard().getId(),
                 article.getTitle(),
                 article.getContent(),
-                article.getUser().getId(),
                 article.getNickname(),
                 article.getHit(),
-                article.getIp(),
-                article.isSolved(),
-                article.isDeleted(),
-                article.getCommentCount(),
-                article.getMeta(),
-                article.isNotice(),
-                article.getNoticeArticleId(),
-                article.getSummary(),
                 article.getCreatedAt(),
-                article.getUpdatedAt(),
-                article.getContentSummary()
-            );
-        }
-    }
-
-    @JsonNaming(value = SnakeCaseStrategy.class)
-    public record InnerBoardResponse(
-        @Schema(description = "게시판 고유 ID", example = "1", requiredMode = REQUIRED)
-        Integer id,
-
-        @Schema(description = "게시판 태그", example = "notice", requiredMode = NOT_REQUIRED)
-        String tag,
-
-        @Schema(description = "게시판 명", example = "공지사항", requiredMode = REQUIRED)
-        String name,
-
-        @Schema(description = "익명 여부", example = "false", requiredMode = REQUIRED)
-        boolean isAnonymous,
-
-        @Schema(description = "게시글 수", example = "1", requiredMode = REQUIRED)
-        int articleCount,
-
-        @Schema(description = "삭제 여부", example = "false", requiredMode = REQUIRED)
-        boolean isDeleted,
-
-        @Schema(description = "공지 여부", example = "false", requiredMode = REQUIRED)
-        boolean isNotice,
-
-        @Schema(description = "부모 게시판 고유 ID", example = "1", requiredMode = NOT_REQUIRED)
-        Integer parentId,
-
-        @Schema(description = "순서", example = "1", requiredMode = REQUIRED)
-        int seq,
-
-        @Schema(description = "하위 게시판 목록", requiredMode = NOT_REQUIRED)
-        List<InnerBoardResponse> children,
-
-        @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt,
-
-        @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime updatedAt
-    ) {
-
-        public static InnerBoardResponse from(Board board) {
-            return new InnerBoardResponse(
-                board.getId(),
-                board.getTag(),
-                board.getName(),
-                board.getIsAnonymous(),
-                board.getArticleCount(),
-                board.isDeleted(),
-                board.isNotice(),
-                board.getParentId(),
-                board.getSeq(),
-                board.getChildren().isEmpty()
-                    ? null : board.getChildren().stream()
-                    .map(InnerBoardResponse::from)
-                    .toList(),
-                board.getCreatedAt(),
-                board.getUpdatedAt()
+                article.getUpdatedAt()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/community/dto/HotArticleItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/HotArticleItemResponse.java
@@ -1,13 +1,11 @@
 package in.koreatech.koin.domain.community.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.community.model.Article;
@@ -15,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record HotArticleItemResponse(
+
     @Schema(description = "게시글 고유 ID", example = "1", requiredMode = REQUIRED)
     Integer id,
 
@@ -24,19 +23,17 @@ public record HotArticleItemResponse(
     @Schema(description = "제목", example = "제목", requiredMode = REQUIRED)
     String title,
 
-    @Schema(description = "내용 요약", example = "내용 요약", requiredMode = NOT_REQUIRED)
-    @JsonProperty("contentSummary")
-    String contentSummary,
-
-    @Schema(description = "댓글 수", example = "1", requiredMode = REQUIRED)
-    Byte commentCount,
+    @Schema(description = "작성자 닉네임", example = "닉네임", requiredMode = REQUIRED)
+    String nickname,
 
     @Schema(description = "조회수", example = "1", requiredMode = REQUIRED)
     Integer hit,
 
     @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    LocalDateTime createdAt
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+
+    @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
 ) {
 
     public static HotArticleItemResponse from(Article article) {
@@ -44,10 +41,10 @@ public record HotArticleItemResponse(
             article.getId(),
             article.getBoard().getId(),
             article.getTitle(),
-            article.getContentSummary(),
-            article.getCommentCount(),
+            article.getNickname(),
             article.getHit(),
-            article.getCreatedAt()
+            article.getCreatedAt(),
+            article.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -16,4 +16,6 @@ public interface BoardRepository extends Repository<Board, Integer> {
         return findById(boardId).orElseThrow(
             () -> ArticleNotFoundException.withDetail("boardId: " + boardId));
     }
+
+    Long countBy();
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -72,17 +72,18 @@ public class CommunityService {
     }
 
     public ArticlesResponse getArticles(Integer boardId, Integer page, Integer limit) {
-        Criteria criteria = Criteria.of(page, limit);
+        Long total = boardRepository.countBy();
+        Criteria criteria = Criteria.of(page, limit, total.intValue());
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
 
         if (board.isNotice() && board.getTag().equals(BoardTag.공지사항.getTag())) {
             Page<Article> articles = articleRepository.findByIsNotice(true, pageRequest);
-            return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
+            return ArticlesResponse.of(articles, criteria);
         }
 
         Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
-        return ArticlesResponse.of(articles.getContent(), board, (long)articles.getTotalPages());
+        return ArticlesResponse.of(articles, criteria);
     }
 
     public List<HotArticleItemResponse> getHotArticles() {

--- a/src/main/java/in/koreatech/koin/global/model/Criteria.java
+++ b/src/main/java/in/koreatech/koin/global/model/Criteria.java
@@ -21,7 +21,8 @@ public class Criteria {
     }
 
     public static Criteria of(Integer page, Integer limit, Integer total) {
-        return new Criteria(validateAndCalculatePage(page, limit, total), validateAndCalculateLimit(limit));
+        int validatedLimit = validateAndCalculateLimit(limit);
+        return new Criteria(validateAndCalculatePage(page, validatedLimit, total), validatedLimit);
     }
 
     public enum Sort {

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -70,7 +70,6 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/{articleId}", article1.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -113,7 +112,6 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/{articleId}", article1.getId())
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -144,7 +142,6 @@ class CommunityApiTest extends AcceptanceTest {
             .param("limit", 10)
             .get("/articles")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -395,7 +392,6 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/hot/list")
             .then()
-            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -70,50 +70,19 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/{articleId}", article1.getId())
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
         JsonAssertions.assertThat(response.asPrettyString())
             .isEqualTo("""
                 {
-                    "contentSummary": "내용",
                     "id": 1,
                     "board_id": 1,
                     "title": "자유 글의 제목입니다",
                     "content": "<p>내용</p>",
                     "nickname": "준호",
-                    "is_solved": false,
-                    "is_notice": false,
                     "hit": 1,
-                    "comment_count": 0,
-                    "board": {
-                        "id": 1,
-                        "tag": "FA001",
-                        "name": "자유게시판",
-                        "is_anonymous": false,
-                        "article_count": 0,
-                        "is_deleted": false,
-                        "is_notice": false,
-                        "parent_id": null,
-                        "seq": 1,
-                        "children": null,
-                        "created_at": "2024-01-15 12:00:00",
-                        "updated_at": "2024-01-15 12:00:00"
-                    },
-                    "comments": [
-                        {
-                            "grantEdit": false,
-                            "grantDelete": false,
-                            "id": 1,
-                            "article_id": 1,
-                            "content": "댓글",
-                            "user_id": 1,
-                            "nickname": "BCSD",
-                            "is_deleted": false,
-                            "created_at": "2024-01-15 12:00:00",
-                            "updated_at": "2024-01-15 12:00:00"
-                        }
-                    ],
                     "created_at": "2024-01-15 12:00:00",
                     "updated_at": "2024-01-15 12:00:00"
                 }
@@ -144,50 +113,19 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/{articleId}", article1.getId())
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
         JsonAssertions.assertThat(response.asPrettyString())
             .isEqualTo("""
                 {
-                    "contentSummary": "내용",
                     "id": 1,
                     "board_id": 1,
                     "title": "자유 글의 제목입니다",
                     "content": "<p>내용</p>",
                     "nickname": "준호",
-                    "is_solved": false,
-                    "is_notice": false,
                     "hit": 2,
-                    "comment_count": 0,
-                    "board": {
-                        "id": 1,
-                        "tag": "FA001",
-                        "name": "자유게시판",
-                        "is_anonymous": false,
-                        "article_count": 0,
-                        "is_deleted": false,
-                        "is_notice": false,
-                        "parent_id": null,
-                        "seq": 1,
-                        "children": null,
-                        "created_at": "2024-01-15 12:00:00",
-                        "updated_at": "2024-01-15 12:00:00"
-                    },
-                    "comments": [
-                        {
-                            "grantEdit": true,
-                            "grantDelete": true,
-                            "id": 1,
-                            "article_id": 1,
-                            "content": "댓글",
-                            "user_id": 1,
-                            "nickname": "BCSD",
-                            "is_deleted": false,
-                            "created_at": "2024-01-15 12:00:00",
-                            "updated_at": "2024-01-15 12:00:00"
-                        }
-                    ],
                     "created_at": "2024-01-15 12:00:00",
                     "updated_at": "2024-01-15 12:00:00"
                 }
@@ -206,6 +144,7 @@ class CommunityApiTest extends AcceptanceTest {
             .param("limit", 10)
             .get("/articles")
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -214,61 +153,30 @@ class CommunityApiTest extends AcceptanceTest {
                 {
                     "articles": [
                         {
-                            "contentSummary": "내용222",
                             "id": 2,
                             "board_id": 1,
                             "title": "자유 글2의 제목입니다",
                             "content": "<p>내용222</p>",
-                            "user_id": 1,
                             "nickname": "준호",
                             "hit": 1,
-                            "ip": "127.0.0.1",
-                            "is_solved": false,
-                            "is_deleted": false,
-                            "comment_count": 0,
-                            "meta": null,
-                            "is_notice": false,
-                            "notice_article_id": null,
-                            "summary": null,
                             "created_at": "2024-01-15 12:00:00",
                             "updated_at": "2024-01-15 12:00:00"
                         },
                         {
-                            "contentSummary": "내용",
                             "id": 1,
                             "board_id": 1,
                             "title": "자유 글의 제목입니다",
                             "content": "<p>내용</p>",
-                            "user_id": 1,
                             "nickname": "준호",
                             "hit": 1,
-                            "ip": "123.21.234.321",
-                            "is_solved": false,
-                            "is_deleted": false,
-                            "comment_count": 0,
-                            "meta": null,
-                            "is_notice": false,
-                            "notice_article_id": null,
-                            "summary": null,
                             "created_at": "2024-01-15 12:00:00",
                             "updated_at": "2024-01-15 12:00:00"
                         }
                     ],
-                    "board": {
-                        "id": 1,
-                        "tag": "FA001",
-                        "name": "자유게시판",
-                        "is_anonymous": false,
-                        "article_count": 0,
-                        "is_deleted": false,
-                        "is_notice": false,
-                        "parent_id": null,
-                        "seq": 1,
-                        "children": null,
-                        "created_at": "2024-01-15 12:00:00",
-                        "updated_at": "2024-01-15 12:00:00"
-                    },
-                    "totalPage": 1
+                    "totalCount": 2,
+                    "currentCount": 2,
+                    "totalPage": 1,
+                    "currentPage": 1
                 }
                 """);
     }
@@ -421,7 +329,7 @@ class CommunityApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("게시글들을 페이지네이션하여 조회한다. - 요청된 페이지에 게시글이 존재하지 않으면 빈 게시글 배열을 반환한다.")
+    @DisplayName("게시글들을 페이지네이션하여 조회한다. - 최대 페이지를 초과한 요청이 들어오면 마지막 페이지를 반환한다.")
     void getArticlesByPagination_overMaxPageNotFound() {
         // when then
         var response = RestAssured
@@ -435,7 +343,27 @@ class CommunityApiTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract();
 
-        assertThat(response.jsonPath().getList("articles")).isEmpty();
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                   {
+                       "articles": [
+                           {
+                               "id": 2,
+                               "board_id": 1,
+                               "title": "자유 글2의 제목입니다",
+                               "content": "<p>내용222</p>",
+                               "nickname": "준호",
+                               "hit": 1,
+                               "created_at": "2024-01-15 12:00:00",
+                               "updated_at": "2024-01-15 12:00:00"
+                           }
+                       ],
+                       "totalCount": 2,
+                       "currentCount": 1,
+                       "totalPage": 2,
+                       "currentPage": 1
+                   }
+                """);
     }
 
     @Test
@@ -467,6 +395,7 @@ class CommunityApiTest extends AcceptanceTest {
             .when()
             .get("/articles/hot/list")
             .then()
+            .log().all()
             .statusCode(HttpStatus.OK.value())
             .extract();
 
@@ -474,51 +403,51 @@ class CommunityApiTest extends AcceptanceTest {
             .isEqualTo("""
                 [
                     {
-                        "contentSummary": "내용",
                         "id": 5,
                         "board_id": 1,
                         "title": "Article 7",
-                        "comment_count": 2,
+                        "nickname": "BCSD",
                         "hit": 7,
-                        "created_at": "2024-01-15 12:00:00"
+                        "created_at": "2024-01-15 12:00:00",
+                        "updated_at": "2024-01-15 12:00:00"
                     },
                     {
-                        "contentSummary": "내용",
                         "id": 4,
                         "board_id": 1,
                         "title": "Article 6",
-                        "comment_count": 2,
+                        "nickname": "BCSD",
                         "hit": 6,
-                        "created_at": "2024-01-15 12:00:00"
+                        "created_at": "2024-01-15 12:00:00",
+                        "updated_at": "2024-01-15 12:00:00"
                     },
                     {
-                        "contentSummary": "내용",
                         "id": 3,
                         "board_id": 1,
                         "title": "Article 5",
-                        "comment_count": 2,
+                        "nickname": "BCSD",
                         "hit": 5,
-                        "created_at": "2024-01-15 12:00:00"
+                        "created_at": "2024-01-15 12:00:00",
+                        "updated_at": "2024-01-15 12:00:00"
                     },
                     {
-                        "contentSummary": "내용222",
                         "id": 2,
                         "board_id": 1,
                         "title": "자유 글2의 제목입니다",
-                        "comment_count": 0,
+                        "nickname": "준호",
                         "hit": 1,
-                        "created_at": "2024-01-15 12:00:00"
+                        "created_at": "2024-01-15 12:00:00",
+                        "updated_at": "2024-01-15 12:00:00"
                     },
                     {
-                        "contentSummary": "내용",
                         "id": 1,
                         "board_id": 1,
                         "title": "자유 글의 제목입니다",
-                        "comment_count": 0,
+                        "nickname": "준호",
                         "hit": 1,
-                        "created_at": "2024-01-15 12:00:00"
+                        "created_at": "2024-01-15 12:00:00",
+                        "updated_at": "2024-01-15 12:00:00"
                     }
                 ]
-                    """);
+                """);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #774 

# 🚀 작업 내용

1. 게시글 조회 API를 변경된 명세에 맞게 수정했습니다.
2. 인기있는 게시글 조회 API는 내부 로직은 그대로 두고 명세만 수정했습니다.
    1. 로직 수정은 8월 안으로 마무리해서 올리겠습니다.
3. Criteria 클래스 생성자에 limit에 대해 validate가 누락되어있길래 추가했습니다. 
    1. 사이드이펙트가 없..을 거라고 믿습니다.
    2. 기존 코드 보니까 이 부분에 막혀서 호출단에서 한 번 더 validate한 부분은 있던데 언제 한번 청소해야할 것 같아요

# 💬 리뷰 중점사항
