### PR TITLE
feat : fcm 알림 테스트 발송, 안드로이드의 데이터 페이로드 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
@@ -31,6 +31,7 @@ public class CoopEventListener {
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
         diningSoldOutCacheRepository.save(DiningSoldOutCache.from(event.place()));
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
+        String schemeUri = String.format("%s?id=%s", DINING.name(), event.id());
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(DINING_SOLD_OUT, null).stream()
             .filter(subscribe -> notificationSubscribeRepository.findByUserIdAndSubscribeTypeAndDetailType(
@@ -39,6 +40,7 @@ public class CoopEventListener {
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateSoldOutNotification(
                 DINING,
+                schemeUri,
                 event.place(),
                 subscribe.getUser()
             )).toList();
@@ -47,11 +49,13 @@ public class CoopEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onDiningImageUploadRequest(DiningImageUploadEvent event) {
+        String schemeUri = String.format("%s?id=%s", DINING.name(), event.id());
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(DINING_IMAGE_UPLOAD, null).stream()
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateDiningImageUploadNotification(
                 DINING,
+                schemeUri,
                 event.imageUrl(),
                 subscribe.getUser()
             )).toList();

--- a/src/main/java/in/koreatech/koin/domain/coop/model/DiningImageUploadEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/DiningImageUploadEvent.java
@@ -1,6 +1,8 @@
 package in.koreatech.koin.domain.coop.model;
 
 public record DiningImageUploadEvent(
+    int id,
     String imageUrl
 ) {
+
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/model/DiningSoldOutEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/DiningSoldOutEvent.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.coop.model;
 import in.koreatech.koin.domain.dining.model.DiningType;
 
 public record DiningSoldOutEvent(
+    int id,
     String place,
     DiningType diningType
 ) {

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -53,7 +53,7 @@ public class CoopService {
             dining.setSoldOut(now);
             boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType());
             if (isOpened && diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty()) {
-                eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getPlace(), dining.getType()));
+                eventPublisher.publishEvent(new DiningSoldOutEvent(dining.getId(), dining.getPlace(), dining.getType()));
             }
         } else {
             dining.cancelSoldOut();
@@ -70,7 +70,7 @@ public class CoopService {
         boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType());
 
         if (isOpened && !isImageExist) {
-            eventPublisher.publishEvent(new DiningImageUploadEvent(dining.getImageUrl()));
+            eventPublisher.publishEvent(new DiningImageUploadEvent(dining.getId(), dining.getImageUrl()));
         }
 
         dining.setImageUrl(imageRequest.imageUrl());

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ShopEventListener.java
@@ -29,12 +29,14 @@ public class ShopEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onShopEventCreate(EventArticleCreateShopEvent event) {
+        String schemeUri = String.format("%s?id=%s", SHOP.name(), event.shopId());
         List<Notification> notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(SHOP_EVENT, null)
             .stream()
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateShopEventCreateNotification(
                 SHOP,
+                schemeUri,
                 event.thumbnailImage(),
                 event.shopName(),
                 event.title(),

--- a/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationApi.java
@@ -16,7 +16,9 @@ import in.koreatech.koin.global.domain.notification.dto.NotificationPermitReques
 import in.koreatech.koin.global.domain.notification.dto.NotificationStatusResponse;
 import in.koreatech.koin.global.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
+import in.koreatech.koin.global.fcm.MobileAppPath;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,6 +28,26 @@ import jakarta.validation.Valid;
 
 @Tag(name = "(Normal) Notification: 알림", description = "알림 관련 API")
 public interface NotificationApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "테스트용 알림 발송")
+    @GetMapping("/notification/test")
+    ResponseEntity<Void> testSendMessage(
+        @Parameter(description = "device token") @RequestParam String deviceToken,
+        @Parameter(description = "title") @RequestParam(required = false) String title,
+        @Parameter(description = "body") @RequestParam(required = false) String body,
+        @Parameter(description = "image") @RequestParam(required = false) String image,
+        @Parameter(description = "mobile app path") @RequestParam(required = false) MobileAppPath mobileAppPath,
+        @Parameter(description = "scheme uri") @RequestParam(required = false) String url
+    );
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationController.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.global.domain.notification.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +17,8 @@ import in.koreatech.koin.global.domain.notification.dto.NotificationStatusRespon
 import in.koreatech.koin.global.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
 import in.koreatech.koin.global.domain.notification.service.NotificationService;
+import in.koreatech.koin.global.fcm.MobileAppPath;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -27,6 +27,19 @@ import lombok.RequiredArgsConstructor;
 public class NotificationController implements NotificationApi {
 
     private final NotificationService notificationService;
+
+    @GetMapping("/notification/test")
+    public ResponseEntity<Void> testSendMessage(
+        @Parameter(description = "device token") @RequestParam String deviceToken,
+        @Parameter(description = "title") @RequestParam(required = false) String title,
+        @Parameter(description = "body") @RequestParam(required = false) String body,
+        @Parameter(description = "image uri") @RequestParam(required = false) String image,
+        @Parameter(description = "mobile app path") @RequestParam(required = false) MobileAppPath mobileAppPath,
+        @Parameter(description = "scheme uri") @RequestParam(required = false) String url
+    ) {
+        notificationService.testPush(mobileAppPath, deviceToken, title, body, image, url);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/notification")
     public ResponseEntity<NotificationStatusResponse> checkNotificationStatus(

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/Notification.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/Notification.java
@@ -33,6 +33,9 @@ public class Notification extends BaseEntity {
     @Column(name = "app_path")
     private MobileAppPath mobileAppPath;
 
+    @Column(name = "scheme_uri")
+    private String schemeUri;
+
     @Column(name = "title")
     private String title;
 
@@ -55,6 +58,7 @@ public class Notification extends BaseEntity {
 
     public Notification(
         MobileAppPath appPath,
+        String schemeUri,
         String title,
         String message,
         String imageUrl,
@@ -62,6 +66,7 @@ public class Notification extends BaseEntity {
         User user
     ) {
         this.mobileAppPath = appPath;
+        this.schemeUri = schemeUri;
         this.title = title;
         this.message = message;
         this.imageUrl = imageUrl;

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -8,8 +8,28 @@ import in.koreatech.koin.global.fcm.MobileAppPath;
 @Component
 public class NotificationFactory {
 
+    public Notification generateTestNotification(
+        MobileAppPath path,
+        String schemeUri,
+        String imageUrl,
+        String title,
+        String message,
+        User target
+    ) {
+        return new Notification(
+            path,
+            schemeUri,
+            title,
+            message,
+            imageUrl,
+            NotificationType.MESSAGE,
+            target
+        );
+    }
+
     public Notification generateShopEventCreateNotification(
         MobileAppPath path,
+        String schemeUri,
         String imageUrl,
         String shopName,
         String title,
@@ -17,6 +37,7 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
+            schemeUri,
             "%s의 이벤트가 추가되었어요 🎉".formatted(shopName),
             "%s".formatted(title),
             imageUrl,
@@ -27,11 +48,13 @@ public class NotificationFactory {
 
     public Notification generateSoldOutNotification(
         MobileAppPath path,
+        String schemeUri,
         String place,
         User target
     ) {
         return new Notification(
             path,
+            schemeUri,
             "%s 품절됐어요 \uD83D\uDE22".formatted(getPostposition(place, "이", "가")),
             "다른 코너 메뉴도 확인해보세요",
             null,
@@ -40,7 +63,7 @@ public class NotificationFactory {
         );
     }
 
-    private String getPostposition(String place, String firstPost, String secondPost){
+    private String getPostposition(String place, String firstPost, String secondPost) {
         char lastChar = place.charAt(place.length() - 1);
         String result = (lastChar - 0xAC00) % 28 > 0 ? firstPost : secondPost;
         return place + result;
@@ -48,11 +71,13 @@ public class NotificationFactory {
 
     public Notification generateDiningImageUploadNotification(
         MobileAppPath path,
+        String schemeUri,
         String imageUrl,
         User target
-    ){
+    ) {
         return new Notification(
             path,
+            schemeUri,
             "식단 사진이 업로드 됐어요!",
             "사진 보러 가기 \uD83D\uDE0B",
             imageUrl,

--- a/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
@@ -13,9 +13,11 @@ import in.koreatech.koin.global.domain.notification.model.Notification;
 import in.koreatech.koin.global.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType;
+import in.koreatech.koin.global.domain.notification.model.NotificationType;
 import in.koreatech.koin.global.domain.notification.repository.NotificationRepository;
 import in.koreatech.koin.global.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.global.fcm.FcmClient;
+import in.koreatech.koin.global.fcm.MobileAppPath;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -42,7 +44,27 @@ public class NotificationService {
             notification.getMessage(),
             notification.getImageUrl(),
             notification.getMobileAppPath(),
+            notification.getSchemeUri(),
             notification.getType()
+        );
+    }
+
+    public void testPush(
+        MobileAppPath mobileAppPath,
+        String deviceToken,
+        String title,
+        String message,
+        String image,
+        String url
+    ) {
+        fcmClient.sendMessage(
+            deviceToken,
+            title,
+            message,
+            image,
+            mobileAppPath,
+            url,
+            NotificationType.MESSAGE.name().toLowerCase()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
@@ -70,7 +70,7 @@ public class FcmClient {
                             .build()
                     )
                     .setSound("default")
-                    .setCategory(path != null ? path.getApple() : "")
+                    .setCategory(path != null ? path.getApple() : null)
                     .setMutableContent(true)
                     .build()
             )
@@ -99,7 +99,7 @@ public class FcmClient {
             .setTitle(title)
             .setBody(content)
             .setImage(imageUrl)
-            .setClickAction(path != null ? path.getAndroid() : "")
+            .setClickAction(path != null ? path.getAndroid() : null)
             .build();
 
         Map<String, String> androidNotificationV2 = new HashMap<>();

--- a/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.global.fcm;
 
 import static com.google.firebase.messaging.AndroidConfig.Priority.HIGH;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.scheduling.annotation.Async;
@@ -29,6 +30,7 @@ public class FcmClient {
         String content,
         String imageUrl,
         MobileAppPath path,
+        String schemeUri,
         String type
     ) {
         if (targetDeviceToken == null) {
@@ -36,8 +38,8 @@ public class FcmClient {
         }
         log.info("call FcmClient sendMessage: title: {}, content: {}", title, content);
 
-        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, path, type);
         ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type);
+        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, path, schemeUri, type);
 
         Message message = Message.builder()
             .setToken(targetDeviceToken)
@@ -68,7 +70,7 @@ public class FcmClient {
                             .build()
                     )
                     .setSound("default")
-                    .setCategory(path.getApple())
+                    .setCategory(path != null ? path.getApple() : "")
                     .setMutableContent(true)
                     .build()
             )
@@ -90,18 +92,26 @@ public class FcmClient {
         String content,
         String imageUrl,
         MobileAppPath path,
+        String schemeUri,
         String type
     ) {
         AndroidNotification androidNotification = AndroidNotification.builder()
             .setTitle(title)
             .setBody(content)
             .setImage(imageUrl)
-            .setClickAction(path.getAndroid())
+            .setClickAction(path != null ? path.getAndroid() : "")
             .build();
+
+        Map<String, String> androidNotificationV2 = new HashMap<>();
+        androidNotificationV2.put("title", title != null ? title : "");
+        androidNotificationV2.put("content", content != null ? content : "");
+        androidNotificationV2.put("imageUrl", imageUrl != null ? imageUrl : "");
+        androidNotificationV2.put("url", "koin://" + (schemeUri != null ? schemeUri : ""));
+        androidNotificationV2.put("type", type != null ? type : "");
 
         return AndroidConfig.builder()
             .setNotification(androidNotification)
-            .putData("type", type)
+            .putAllData(androidNotificationV2)
             .setPriority(HIGH)
             .build();
     }

--- a/src/main/resources/db/migration/V43__alter_notification_add_url_column.sql
+++ b/src/main/resources/db/migration/V43__alter_notification_add_url_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification
+    ADD COLUMN scheme_uri VARCHAR(255);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. fcm 알림 테스트 발송 기능을 notification api에 추가하였습니다.
    - 식단, 상점 등에서의 이벤트 발행을 통해 알림을 테스트하는 대신 deviceToken과 본문을 직접 입력해 발송합니다.
2. 안드로이드의 세부 조작을 위해 fcm 전달 내용에 데이터 페이로드를 추가하였습니다.
    - iOS와 Android의 기존 버전은 원래대로 mobileAppPath를 포함한 notification 페이로드로 알림을 처리 합니다.
    - Android의 새 버전은 스킴uri를 포함한 data 페이로드로 알림을 처리 합니다.
    - 스킴uri는 "koin://shop?id=1" 과 같은 형태로 전달됩니다.

# 💬 리뷰 중점사항
리뷰 잘 부탁드립니다!