### PR TITLE
feat: 게시글 검색

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
@@ -73,6 +73,7 @@ public interface CommunityApi {
     @GetMapping("/articles/search")
     ResponseEntity<ArticlesResponse> searchArticles(
         @RequestParam String query,
+        @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit
     );

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
@@ -62,4 +62,18 @@ public interface CommunityApi {
     @Operation(summary = "인기 게시글 목록 조회")
     @GetMapping("/articles/hot")
     ResponseEntity<List<HotArticleItemResponse>> getHotArticles();
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "게시글 검색")
+    @GetMapping("/articles/search")
+    ResponseEntity<ArticlesResponse> searchArticles(
+        @RequestParam String query,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit
+    );
 }

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -47,4 +47,14 @@ public class CommunityController implements CommunityApi {
         List<HotArticleItemResponse> hotArticles = communityService.getHotArticles();
         return ResponseEntity.ok().body(hotArticles);
     }
+
+    @GetMapping("/articles/search")
+    public ResponseEntity<ArticlesResponse> searchArticles(
+        @RequestParam String query,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit
+    ) {
+        ArticlesResponse foundArticles = communityService.searchArticles(query, page, limit);
+        return ResponseEntity.ok().body(foundArticles);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -51,10 +51,11 @@ public class CommunityController implements CommunityApi {
     @GetMapping("/articles/search")
     public ResponseEntity<ArticlesResponse> searchArticles(
         @RequestParam String query,
+        @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit
     ) {
-        ArticlesResponse foundArticles = communityService.searchArticles(query, page, limit);
+        ArticlesResponse foundArticles = communityService.searchArticles(query, boardId, page, limit);
         return ResponseEntity.ok().body(foundArticles);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.community.model.Article;
 import in.koreatech.koin.global.model.Criteria;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record ArticlesResponse(
     @Schema(description = "게시글 목록")
     List<InnerArticleResponse> articles,

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticlesResponse.java
@@ -57,9 +57,6 @@ public record ArticlesResponse(
         @Schema(description = "제목", example = "제목", requiredMode = REQUIRED)
         String title,
 
-        @Schema(description = "내용", example = "내용", requiredMode = REQUIRED)
-        String content,
-
         @Schema(description = "작성자 닉네임", example = "닉네임", requiredMode = REQUIRED)
         String nickname,
 
@@ -78,7 +75,6 @@ public record ArticlesResponse(
                 article.getId(),
                 article.getBoard().getId(),
                 article.getTitle(),
-                article.getContent(),
                 article.getNickname(),
                 article.getHit(),
                 article.getCreatedAt(),

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -28,4 +28,6 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             () -> ArticleNotFoundException.withDetail(
                 "articleId: " + articleId));
     }
+
+    Page<Article> findAllByTitleContaining(String query, PageRequest pageRequest);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/ArticleRepository.java
@@ -15,13 +15,13 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Article save(Article article);
 
-    Page<Article> findByIsNotice(Boolean isNotice, Pageable pageable);
+    Page<Article> findAllByIsNotice(Boolean isNotice, Pageable pageable);
 
     Optional<Article> findById(Integer articleId);
 
     List<Article> findAll(Pageable pageable);
 
-    Page<Article> findByBoardId(Integer boardId, PageRequest pageRequest);
+    Page<Article> findAllByBoardId(Integer boardId, PageRequest pageRequest);
 
     default Article getById(Integer articleId) {
         return findById(articleId).orElseThrow(
@@ -29,5 +29,9 @@ public interface ArticleRepository extends Repository<Article, Integer> {
                 "articleId: " + articleId));
     }
 
+    Page<Article> findAllByBoardIdAndTitleContaining(Integer boardId, String query, PageRequest pageRequest);
+
     Page<Article> findAllByTitleContaining(String query, PageRequest pageRequest);
+
+    Page<Article> findAllByIsNoticeAndTitleContaining(Boolean isNotice, String query, PageRequest pageRequest);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -93,4 +93,12 @@ public class CommunityService {
             .map(HotArticleItemResponse::from)
             .toList();
     }
+
+    public ArticlesResponse searchArticles(String query, Integer page, Integer limit) {
+        Long total = boardRepository.countBy(); //TODO 쿼리 기준으로 개수 세도록 변경
+        Criteria criteria = Criteria.of(page, limit, total.intValue());
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
+        Page<Article> articles = articleRepository.findByBoardId(null, pageRequest); //TODO 쿼리 기준으로 찾도록 변경
+        return ArticlesResponse.of(articles, criteria);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -95,10 +95,9 @@ public class CommunityService {
     }
 
     public ArticlesResponse searchArticles(String query, Integer page, Integer limit) {
-        Long total = boardRepository.countBy(); //TODO 쿼리 기준으로 개수 세도록 변경
-        Criteria criteria = Criteria.of(page, limit, total.intValue());
+        Criteria criteria = Criteria.of(page, limit);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-        Page<Article> articles = articleRepository.findByBoardId(null, pageRequest); //TODO 쿼리 기준으로 찾도록 변경
+        Page<Article> articles = articleRepository.findAllByTitleContaining(query, pageRequest);
         return ArticlesResponse.of(articles, criteria);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.community.service;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -77,12 +78,12 @@ public class CommunityService {
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
 
-        if (board.isNotice() && board.getTag().equals(BoardTag.공지사항.getTag())) {
-            Page<Article> articles = articleRepository.findByIsNotice(true, pageRequest);
+        if (isfullNoticeBoard(board)) {
+            Page<Article> articles = articleRepository.findAllByIsNotice(true, pageRequest);
             return ArticlesResponse.of(articles, criteria);
         }
 
-        Page<Article> articles = articleRepository.findByBoardId(boardId, pageRequest);
+        Page<Article> articles = articleRepository.findAllByBoardId(boardId, pageRequest);
         return ArticlesResponse.of(articles, criteria);
     }
 
@@ -94,10 +95,21 @@ public class CommunityService {
             .toList();
     }
 
-    public ArticlesResponse searchArticles(String query, Integer page, Integer limit) {
+    public ArticlesResponse searchArticles(String query, Integer boardId, Integer page, Integer limit) {
         Criteria criteria = Criteria.of(page, limit);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-        Page<Article> articles = articleRepository.findAllByTitleContaining(query, pageRequest);
+        Page<Article> articles;
+        if (boardId == null) {
+            articles = articleRepository.findAllByTitleContaining(query, pageRequest);
+        } else if (isfullNoticeBoard(boardRepository.getById(boardId))) {
+            articles = articleRepository.findAllByIsNoticeAndTitleContaining(true, query, pageRequest);
+        } else {
+            articles = articleRepository.findAllByBoardIdAndTitleContaining(boardId, query, pageRequest);
+        }
         return ArticlesResponse.of(articles, criteria);
+    }
+
+    private boolean isfullNoticeBoard(Board board) {
+        return board.isNotice() && Objects.equals(board.getTag(), BoardTag.공지사항.getTag());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -78,7 +78,7 @@ public class CommunityService {
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
 
-        if (isfullNoticeBoard(board)) {
+        if (isFullNoticeBoard(board)) {
             Page<Article> articles = articleRepository.findAllByIsNotice(true, pageRequest);
             return ArticlesResponse.of(articles, criteria);
         }
@@ -101,7 +101,7 @@ public class CommunityService {
         Page<Article> articles;
         if (boardId == null) {
             articles = articleRepository.findAllByTitleContaining(query, pageRequest);
-        } else if (isfullNoticeBoard(boardRepository.getById(boardId))) {
+        } else if (isFullNoticeBoard(boardRepository.getById(boardId))) {
             articles = articleRepository.findAllByIsNoticeAndTitleContaining(true, query, pageRequest);
         } else {
             articles = articleRepository.findAllByBoardIdAndTitleContaining(boardId, query, pageRequest);
@@ -109,7 +109,7 @@ public class CommunityService {
         return ArticlesResponse.of(articles, criteria);
     }
 
-    private boolean isfullNoticeBoard(Board board) {
+    private boolean isFullNoticeBoard(Board board) {
         return board.isNotice() && Objects.equals(board.getTag(), BoardTag.공지사항.getTag());
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -170,10 +170,10 @@ class CommunityApiTest extends AcceptanceTest {
                             "updated_at": "2024-01-15 12:00:00"
                         }
                     ],
-                    "totalCount": 2,
-                    "currentCount": 2,
-                    "totalPage": 1,
-                    "currentPage": 1
+                    "total_count": 2,
+                    "current_count": 2,
+                    "total_page": 1,
+                    "current_page": 1
                 }
                 """);
     }
@@ -355,10 +355,10 @@ class CommunityApiTest extends AcceptanceTest {
                                "updated_at": "2024-01-15 12:00:00"
                            }
                        ],
-                       "totalCount": 2,
-                       "currentCount": 1,
-                       "totalPage": 2,
-                       "currentPage": 1
+                       "total_count": 2,
+                       "current_count": 1,
+                       "total_page": 2,
+                       "current_page": 1
                    }
                 """);
     }

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -153,7 +153,6 @@ class CommunityApiTest extends AcceptanceTest {
                             "id": 2,
                             "board_id": 1,
                             "title": "자유 글2의 제목입니다",
-                            "content": "<p>내용222</p>",
                             "nickname": "준호",
                             "hit": 1,
                             "created_at": "2024-01-15 12:00:00",
@@ -163,7 +162,6 @@ class CommunityApiTest extends AcceptanceTest {
                             "id": 1,
                             "board_id": 1,
                             "title": "자유 글의 제목입니다",
-                            "content": "<p>내용</p>",
                             "nickname": "준호",
                             "hit": 1,
                             "created_at": "2024-01-15 12:00:00",
@@ -348,7 +346,6 @@ class CommunityApiTest extends AcceptanceTest {
                                "id": 2,
                                "board_id": 1,
                                "title": "자유 글2의 제목입니다",
-                               "content": "<p>내용222</p>",
                                "nickname": "준호",
                                "hit": 1,
                                "created_at": "2024-01-15 12:00:00",
@@ -444,6 +441,50 @@ class CommunityApiTest extends AcceptanceTest {
                         "updated_at": "2024-01-15 12:00:00"
                     }
                 ]
+                """);
+    }
+
+    @Test
+    @DisplayName("게시글을 검색한다.")
+    void searchNoticeArticles() {
+        var response = RestAssured
+            .given()
+            .when()
+            .queryParam("query", "자유")
+            .queryParam("board", 1)
+            .get("/articles/search")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract();
+
+        JsonAssertions.assertThat(response.asPrettyString())
+            .isEqualTo("""
+                   {
+                       "articles": [
+                           {
+                               "id": 2,
+                               "board_id": 1,
+                               "title": "자유 글2의 제목입니다",
+                               "nickname": "준호",
+                               "hit": 1,
+                               "created_at": "2024-01-15 12:00:00",
+                               "updated_at": "2024-01-15 12:00:00"
+                           },
+                           {
+                               "id": 1,
+                               "board_id": 1,
+                               "title": "자유 글의 제목입니다",
+                               "nickname": "준호",
+                               "hit": 1,
+                               "created_at": "2024-01-15 12:00:00",
+                               "updated_at": "2024-01-15 12:00:00"
+                           }
+                       ],
+                       "total_count": 2,
+                       "current_count": 2,
+                       "total_page": 1,
+                       "current_page": 1
+                   }
                 """);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #775

# 🚀 작업 내용

1. 게시글 검색을 간단하게 구현했습니다.
    1. 깊게 들어가기 시작하면 아주 복잡해지는데, 지금 일정도 빡빡하고 막상 조회해보니 검색이 체감될 정도로 길어지지는 않는 것 같아서 일단 이대로 진행하려고 합니다.
2. 이번에 작성한 api 응답 명세 중에 맞지 않는 부분들이 있어 수정했습니다.
    1. 목록 조회에서 content 필드 제거
    2. 페이지네이션 관련 필드 네이밍컨벤션 통일

# 💬 리뷰 중점사항
