### PR TITLE
refactor: refreshToken 기간 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserToken.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @RedisHash("refreshToken")
 public class UserToken {
 
-    private static final long REFRESH_TOKEN_EXPIRE_DAY = 14L;
+    private static final long REFRESH_TOKEN_EXPIRE_DAY = 90L;
 
     @Id
     private Integer id;


### PR DESCRIPTION

# 🚀 작업 내용

1. refresh token 기간을 2주에서 3개월로 변경하였습니다.

# 💬 리뷰 중점사항
- 3개월로 변경한 이유
  - 사용자들이 방학 기간 동안 코인을 잘 사용하지 않음 -> 방학이 끝난 후 다시 들어오면 로그인이 풀림
  -> 방학이 끝나도 로그인이 풀리지 않도록 방학 기간인 3개월로 변경