### PR TITLE
fix: v1 시간표 조회 api에서 커스텀 시간표 조회할 때 에러 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
@@ -73,22 +73,41 @@ public record TimetableResponse(
 
         public static List<InnerTimetableResponse> from(List<TimetableLecture> timetableLectures) {
             return timetableLectures.stream()
-                .map(timeTableLecture -> new InnerTimetableResponse(
-                        timeTableLecture.getId(),
-                        timeTableLecture.getLecture().getRegularNumber(),
-                        timeTableLecture.getLecture().getCode(),
-                        timeTableLecture.getLecture().getDesignScore(),
-                        parseIntegerClassTimesFromString(timeTableLecture.getLecture().getClassTime()),
-                        timeTableLecture.getClassPlace(),
-                        timeTableLecture.getMemo(),
-                        timeTableLecture.getLecture().getGrades(),
-                        timeTableLecture.getLecture().getName(),
-                        timeTableLecture.getLecture().getLectureClass(),
-                        timeTableLecture.getLecture().getTarget(),
-                        timeTableLecture.getLecture().getProfessor(),
-                        timeTableLecture.getLecture().getDepartment()
-                    )
-                )
+                .map(timeTableLecture -> {
+                    if (timeTableLecture.getLecture() == null) {
+                        return new InnerTimetableResponse(
+                            timeTableLecture.getId(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            timeTableLecture.getClassPlace(),
+                            timeTableLecture.getMemo(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        );
+                    } else {
+                        return new InnerTimetableResponse(
+                            timeTableLecture.getId(),
+                            timeTableLecture.getLecture().getRegularNumber(),
+                            timeTableLecture.getLecture().getCode(),
+                            timeTableLecture.getLecture().getDesignScore(),
+                            parseIntegerClassTimesFromString(timeTableLecture.getLecture().getClassTime()),
+                            timeTableLecture.getClassPlace(),
+                            timeTableLecture.getMemo(),
+                            timeTableLecture.getLecture().getGrades(),
+                            timeTableLecture.getLecture().getName(),
+                            timeTableLecture.getLecture().getLectureClass(),
+                            timeTableLecture.getLecture().getTarget(),
+                            timeTableLecture.getLecture().getProfessor(),
+                            timeTableLecture.getLecture().getDepartment()
+                        );
+                    }
+                })
                 .toList();
         }
     }


### PR DESCRIPTION

# 🚀 작업 내용

1. v1 시간표 조회 api에서 커스텀 시간표 조회할 때 null 값을 필드에 넣도록 하였습니다.

# 💬 리뷰 중점사항
