### PR TITLE
feat: 리뷰 조회 API 응답에 신고 여부 필드 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -189,8 +189,7 @@ public interface ShopApi {
     @GetMapping("/shops/{shopId}/reviews/{reviewId}")
     ResponseEntity<ShopReviewResponse> getReview(
         @Parameter(in = PATH) @PathVariable Integer shopId,
-        @Parameter(in = PATH) @PathVariable Integer reviewId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Parameter(in = PATH) @PathVariable Integer reviewId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -195,10 +195,9 @@ public class ShopController implements ShopApi {
     @GetMapping("/shops/{shopId}/reviews/{reviewId}")
     public ResponseEntity<ShopReviewResponse> getReview(
         @Parameter(in = PATH) @PathVariable Integer shopId,
-        @Parameter(in = PATH) @PathVariable Integer reviewId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Parameter(in = PATH) @PathVariable Integer reviewId
     ) {
-        ShopReviewResponse shopReviewResponse = shopReviewService.getReviewByReviewId(shopId, reviewId, studentId);
+        ShopReviewResponse shopReviewResponse = shopReviewService.getReviewByReviewId(shopId, reviewId);
         return ResponseEntity.ok(shopReviewResponse);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/CreateReviewRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/CreateReviewRequest.java
@@ -7,15 +7,14 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -38,6 +37,7 @@ public record CreateReviewRequest(
     List<String> imageUrls,
 
     @Schema(example = "[\"치킨\", \"피자\"]", description = "메뉴 이름", requiredMode = REQUIRED)
+    @NotBlankElement(message = "빈 요소가 존재합니다.")
     List<String> menuNames
 ) {
     @JsonCreator

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyReviewRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyReviewRequest.java
@@ -10,11 +10,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueUrl;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -37,6 +37,7 @@ public record ModifyReviewRequest(
     List<String> imageUrls,
 
     @Schema(example = "[\"치킨\", \"피자\"]", description = "메뉴 이름", requiredMode = REQUIRED)
+    @NotBlankElement(message = "빈 요소가 존재합니다.")
     List<String> menuNames
 ) {
     @JsonCreator

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopReviewsResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.shop.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
@@ -87,6 +88,9 @@ public record ShopReviewsResponse(
         @Schema(example = "false", description = "수정된 적 있는 리뷰인지", requiredMode = REQUIRED)
         boolean isModified,
 
+        @Schema(example = "true", description = "신고 여부", requiredMode = REQUIRED)
+        boolean isReported,
+
         @JsonFormat(pattern = "yyyy-MM-dd")
         @Schema(example = "2024-03-01", description = "리뷰 작성일", requiredMode = REQUIRED)
         LocalDateTime createdAt
@@ -97,6 +101,9 @@ public record ShopReviewsResponse(
             if (nickName == null) {
                 nickName = review.getReviewer().getAnonymousNickname();
             }
+            boolean isReported = review.getReports().stream()
+                .filter(it -> it.getReportStatus() != DISMISSED)
+                .count() > 0;
             return new InnerReviewResponse(
                 review.getId(),
                 review.getRating(),
@@ -106,6 +113,7 @@ public record ShopReviewsResponse(
                 review.getMenus().stream().map(ShopReviewMenu::getMenuName).toList(),
                 Objects.equals(review.getReviewer().getId(), userId),
                 !review.getCreatedAt().equals(review.getUpdatedAt()),
+                isReported,
                 review.getCreatedAt()
             );
         }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ShopsResponseV2.java
@@ -10,10 +10,8 @@ import java.util.List;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.dto.ShopResponse.InnerShopOpen;
-import in.koreatech.koin.domain.shop.model.ReportStatus;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopReview;
-import in.koreatech.koin.domain.shop.model.ShopReviewReport;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -89,20 +87,14 @@ public record ShopsResponseV2(
                 isEvent,
                 isOpen,
                 Math.round(shop.getReviews().stream()
-                    .filter(review -> notContainsUnhandledReport(review.getReports()))
                     .filter(review -> !review.isDeleted())
                     .mapToInt(ShopReview::getRating)
                     .average()
                     .orElse(0.0) * 10) / 10.0,
                 shop.getReviews().stream()
-                    .filter(review -> notContainsUnhandledReport(review.getReports()))
                     .filter(review -> !review.isDeleted())
                     .count()
             );
-        }
-
-        private static boolean notContainsUnhandledReport(List<ShopReviewReport> reports) {
-            return reports.stream().noneMatch(report -> report.getReportStatus().equals(ReportStatus.UNHANDLED));
         }
 
         public static Comparator<InnerShopResponse> getComparator(ShopsSortCriteria shopsSortCriteria) {

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/ShopReviewRepository.java
@@ -6,12 +6,10 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.shop.exception.ReviewNotFoundException;
 import in.koreatech.koin.domain.shop.model.ShopReview;
-import io.lettuce.core.dynamic.annotation.Param;
 
 public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
 
@@ -31,67 +29,13 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
             .orElseThrow(() -> ReviewNotFoundException.withDetail(String.format("reviewId: %s", reviewId)));
     }
 
-    @Query("""
-           SELECT sr FROM ShopReview sr 
-           WHERE sr.shop.id = :shopId 
-           AND sr.isDeleted = false
-           AND sr.reviewer.id = :studentId
-           AND NOT EXISTS (
-               SELECT r FROM ShopReviewReport r 
-               WHERE r.review.id = sr.id 
-               AND r.reportStatus != 'DISMISSED'
-           )
-           """)
-    List<ShopReview> findAllMyReviewsByShopIdNotContainReportedAndIsDeletedFalse(
-        @Param("shopId") Integer shopId,
-        @Param("studentId") Integer studentId,
-        Sort sort
-    );
+    List<ShopReview> findByShopIdAndReviewerIdAndIsDeletedFalse(Integer shopId, Integer studentId, Sort sort);
 
-    @Query("""
-           SELECT sr FROM ShopReview sr 
-           WHERE sr.shop.id = :shopId 
-           AND sr.isDeleted = false
-           AND NOT EXISTS (
-               SELECT r FROM ShopReviewReport r 
-               WHERE r.review.id = sr.id 
-               AND r.reportStatus != 'DISMISSED'
-           )
-           """)
-    Page<ShopReview> findAllByShopIdNotContainReportedAndIsDeletedFalse(
-        @Param("shopId") Integer shopId,
-        Pageable pageable
-    );
+    Page<ShopReview> findByShopIdAndIsDeletedFalse(Integer shopId, Pageable pageable);
 
-    @Query("""
-       SELECT COUNT(sr) FROM ShopReview sr 
-       WHERE sr.shop.id = :shopId
-       AND sr.isDeleted = false 
-       AND NOT EXISTS (
-           SELECT r FROM ShopReviewReport r 
-           WHERE r.review.id = sr.id 
-           AND r.reportStatus != 'DISMISSED'
-       )
-       """)
-    Integer countByShopIdNotContainReportedAndIsDeletedFalse(
-        @Param("shopId") Integer shopId
-        );
+    Integer countByShopIdAndIsDeletedFalse(Integer shopId);
 
-    @Query("""
-           SELECT COUNT(sr) FROM ShopReview sr 
-           WHERE sr.shop.id = :shopId 
-           AND sr.isDeleted = false
-           AND NOT EXISTS (
-               SELECT r FROM ShopReviewReport r 
-               WHERE r.review.id = sr.id 
-               AND r.reportStatus != 'DISMISSED'
-               )
-           AND sr.rating = :rating
-           """)
-    Integer countReviewRatingNotContainReportedAndIsDeletedFalse(
-        @Param("shopId") Integer shopId,
-        @Param("rating") Integer rating
-    );
+    Integer countByShopIdAndRatingAndIsDeletedFalse(Integer shopId, Integer rating);
 
     Optional<ShopReview> findById(Integer reviewId);
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -56,7 +56,13 @@ public class ShopReviewService {
 
     private final EntityManager entityManager;
 
-    public ShopReviewsResponse getReviewsByShopId(Integer shopId, Integer userId, Integer page, Integer limit, ReviewsSortCriteria sortBy) {
+    public ShopReviewsResponse getReviewsByShopId(
+        Integer shopId,
+        Integer userId,
+        Integer page,
+        Integer limit,
+        ReviewsSortCriteria sortBy
+    ) {
         Integer total = shopReviewRepository.countByShopIdAndIsDeletedFalse(shopId);
         Criteria criteria = Criteria.of(page, limit, total);
         PageRequest pageRequest = PageRequest.of(

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -162,11 +162,9 @@ public class ShopReviewService {
         return ratings;
     }
 
-    public ShopReviewResponse getReviewByReviewId(Integer shopId, Integer reviewId, Integer studentId) {
+    public ShopReviewResponse getReviewByReviewId(Integer shopId, Integer reviewId) {
         ShopReview shopReview = shopReviewRepository.getByIdAndIsDeleted(reviewId);
-        if (!Objects.equals(shopReview.getShop().getId(), shopId) ||
-            !Objects.equals(shopReview.getReviewer().getId(), studentId)
-        ) {
+        if (!Objects.equals(shopReview.getShop().getId(), shopId)) {
             throw ReviewNotFoundException.withDetail("해당 상점의 리뷰가 아닙니다.");
         }
         return ShopReviewResponse.from(shopReview);

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -57,14 +57,14 @@ public class ShopReviewService {
     private final EntityManager entityManager;
 
     public ShopReviewsResponse getReviewsByShopId(Integer shopId, Integer userId, Integer page, Integer limit, ReviewsSortCriteria sortBy) {
-        Integer total = shopReviewRepository.countByShopIdNotContainReportedAndIsDeletedFalse(shopId);
+        Integer total = shopReviewRepository.countByShopIdAndIsDeletedFalse(shopId);
         Criteria criteria = Criteria.of(page, limit, total);
         PageRequest pageRequest = PageRequest.of(
             criteria.getPage(),
             criteria.getLimit(),
             sortBy.getSort()
         );
-        Page<ShopReview> result = shopReviewRepository.findAllByShopIdNotContainReportedAndIsDeletedFalse(
+        Page<ShopReview> result = shopReviewRepository.findByShopIdAndIsDeletedFalse(
             shopId,
             pageRequest
         );
@@ -156,7 +156,7 @@ public class ShopReviewService {
             5, 0
         ));
         for (Integer rating : ratings.keySet()) {
-            Integer count = shopReviewRepository.countReviewRatingNotContainReportedAndIsDeletedFalse(shopId, rating);
+            Integer count = shopReviewRepository.countByShopIdAndRatingAndIsDeletedFalse(shopId, rating);
             ratings.put(rating, count);
         }
         return ratings;
@@ -171,7 +171,7 @@ public class ShopReviewService {
     }
 
     public ShopMyReviewsResponse getMyReviewsByShopId(Integer shopId, Integer studentId, ReviewsSortCriteria sortBy) {
-        List<ShopReview> reviews = shopReviewRepository.findAllMyReviewsByShopIdNotContainReportedAndIsDeletedFalse(
+        List<ShopReview> reviews = shopReviewRepository.findByShopIdAndReviewerIdAndIsDeletedFalse(
             shopId,
             studentId,
             sortBy.getSort()

--- a/src/main/java/in/koreatech/koin/global/validation/NotBlankElement.java
+++ b/src/main/java/in/koreatech/koin/global/validation/NotBlankElement.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.global.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = NotBlankElementValidator.class)
+@Target({FIELD, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+public @interface NotBlankElement {
+
+    String message() default "빈 요소가 존재합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/in/koreatech/koin/global/validation/NotBlankElementValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/NotBlankElementValidator.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.global.validation;
+
+import java.util.List;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotBlankElementValidator implements ConstraintValidator<NotBlankElement, List<String>> {
+
+    @Override
+    public void initialize(NotBlankElement constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> elements, ConstraintValidatorContext context) {
+        if (elements == null) {
+            elements = List.of();
+        }
+        return elements.stream().noneMatch(it -> it == null || it.isBlank());
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -1322,7 +1322,7 @@ class ShopApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 신고됐지만_아직_처리되지_않은_리뷰는_무시된_상태로_모든_상점을_조회한다() {
+    void 신고된_리뷰의_내용도_반영해서_모든_상점을_조회한다() {
         // given
         Shop 배달_안되는_신전_떡볶이 = shopFixture.배달_안되는_신전_떡볶이(owner);
         ShopReview 리뷰_4점 = shopReviewFixture.리뷰_4점(익명_학생, 배달_안되는_신전_떡볶이);
@@ -1430,8 +1430,8 @@ class ShopApiTest extends AcceptanceTest {
                             "phone": "010-7788-9900",
                             "is_event": false,
                             "is_open": %s,
-                            "average_rate": 0.0,
-                            "review_count": 0
+                            "average_rate": 4.0,
+                            "review_count": 1
                         }
                     ]
                 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #799
- close #800
- close #801 

# 🚀 작업 내용

1. 리뷰 조회 API 응답에 신고 여부 필드를 추가하였습니다.(이에 따른 테스트 코드 수정)
2. 리뷰 추가, 수정시 메뉴명에 공란을 넣을 수 없도록 예외처리 하였습니다.
    - `@NotBlankElement`어노테이션을 만들어서 예외처리 하였습니다.
    - 이와 관련된 테스트코드 추가하였습니다.
3. 리뷰 조회 API의 응답에 신고된 리뷰도 포함되도록 변경하였습니다.
4. 모든 상점 조회 API에 신고된 리뷰의 내용도 반영하도록 변경하였습니다.

# 💬 리뷰 중점사항
