### PR TITLE
fix : fcm 알림의 버전 분리

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
@@ -27,7 +27,7 @@ public class TestController implements TestApi {
         @RequestParam(required = false) MobileAppPath mobileAppPath,
         @RequestParam(required = false) String url
     ) {
-        fcmClient.sendMessage(
+        fcmClient.sendMessageV2(
             deviceToken,
             title,
             body,

--- a/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
@@ -39,7 +39,37 @@ public class FcmClient {
         log.info("call FcmClient sendMessage: title: {}, content: {}", title, content);
 
         ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type);
-        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, path, schemeUri, type);
+        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, path, type);
+
+        Message message = Message.builder()
+            .setToken(targetDeviceToken)
+            .setApnsConfig(apnsConfig)
+            .setAndroidConfig(androidConfig).build();
+        try {
+            String result = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM 알림 전송 성공: {}", result);
+        } catch (Exception e) {
+            log.warn("FCM 알림 전송 실패", e);
+        }
+    }
+
+    @Async
+    public void sendMessageV2(
+        String targetDeviceToken,
+        String title,
+        String content,
+        String imageUrl,
+        MobileAppPath path,
+        String schemeUri,
+        String type
+    ) {
+        if (targetDeviceToken == null) {
+            return;
+        }
+        log.info("call FcmClient sendMessageV2: title: {}, content: {}", title, content);
+
+        ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type);
+        AndroidConfig androidConfig = generateAndroidConfigV2(title, content, imageUrl, schemeUri, type);
 
         Message message = Message.builder()
             .setToken(targetDeviceToken)
@@ -92,7 +122,6 @@ public class FcmClient {
         String content,
         String imageUrl,
         MobileAppPath path,
-        String schemeUri,
         String type
     ) {
         AndroidNotification androidNotification = AndroidNotification.builder()
@@ -102,6 +131,20 @@ public class FcmClient {
             .setClickAction(path != null ? path.getAndroid() : null)
             .build();
 
+        return AndroidConfig.builder()
+            .setNotification(androidNotification)
+            .putData("type", type != null ? type : "")
+            .setPriority(HIGH)
+            .build();
+    }
+
+    private AndroidConfig generateAndroidConfigV2(
+        String title,
+        String content,
+        String imageUrl,
+        String schemeUri,
+        String type
+    ) {
         Map<String, String> androidNotificationV2 = new HashMap<>();
         androidNotificationV2.put("title", title != null ? title : "");
         androidNotificationV2.put("content", content != null ? content : "");
@@ -110,7 +153,6 @@ public class FcmClient {
         androidNotificationV2.put("type", type != null ? type : "");
 
         return AndroidConfig.builder()
-            .setNotification(androidNotification)
             .putAllData(androidNotificationV2)
             .setPriority(HIGH)
             .build();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. notification과 data 두 페이로드에 대한 메시지 생성을 분리했습니다.
    - fcm은 notification과 data를 선택적으로 처리하는 것이 불가능하여 필요한 정보만 전송해야 한다고 합니다.
    - 안드로이드의 경우 구버전은 notification을 통해, 신버전은 data를 통해 알림을 처리할 예정입니다.

# 💬 리뷰 중점사항
#### FCM의 페이로드(Notification, Data) 내용 정리
- **공통**
	- 받을 대상(`device token`)과 내용(`title`,` message` 등) 전달
- **Notification 페이로드**
	- FCM에서 자동으로 휴대폰 상단바에 알림을 띄워 줌(코인 앱에서의 처리가 아닌 fcm이 알림을 띄움)
	- Andriod, iOS 둘 다 백그라운드(앱이 꺼져있는 상황), 포그라운드(앱 활성화 중)에서 모두 알림 띄우기 가능
	- Android
		- 알림 클릭을 통한 어플 접속 가능
		- 대신 딥링크(특정 상점의 페이지 등)까지는 불가능
	- iOS
		- 알림 클릭을 통해 딥링크까지 접속 가능
- **data 페이로드**
	- FCM에서 데이터 처리 관련 내용을 전달해 줌
	- 자동으로 알림을 띄워주지는 않기 때문에 코인 앱 자체에서 알림을 띄우도록 data를 이용한 처리가 필요함
	- Android
		- 백그라운드, 포그라운드 모두 데이터 처리 가능
		- data를 통해 커스텀 알림(클릭 시 딥링크 접속, 알림 문구 수정 등) 가능
	- iOS
		- 백그라운드에서는 data 페이로드 처리 불가능
		- 그래서 notification 페이로드와 함께 활용해야 함