### PR TITLE
fix: 상점 생성, 수정시 이미지 url의 요소가 공백인 경우 예외처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
@@ -51,7 +51,7 @@ public record OwnerShopsRequest(
         [ "https://testimage.com" ]
         """, requiredMode = REQUIRED)
     @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
-    @NotBlankElement
+    @NotBlankElement(message = "빈 요소가 존재합니다.")
     List<String> imageUrls,
 
     @Schema(description = "가게명", example = "써니 숯불 도시락", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.Shop;
+import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueId;
 import in.koreatech.koin.global.validation.UniqueUrl;
 import in.koreatech.koin.global.validation.ValidDayOfWeek;
@@ -50,6 +51,7 @@ public record OwnerShopsRequest(
         [ "https://testimage.com" ]
         """, requiredMode = REQUIRED)
     @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
+    @NotBlankElement
     List<String> imageUrls,
 
     @Schema(description = "가게명", example = "써니 숯불 도시락", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopOpen;
+import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueId;
 import in.koreatech.koin.global.validation.UniqueUrl;
 import in.koreatech.koin.global.validation.ValidDayOfWeek;
@@ -50,6 +51,7 @@ public record ModifyShopRequest(
         [ "https://static.koreatech.in/example.png" ]
         """, requiredMode = NOT_REQUIRED)
     @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
+    @NotBlankElement
     List<String> imageUrls,
 
     @Schema(example = "수신반점", description = "이름", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/ModifyShopRequest.java
@@ -51,7 +51,7 @@ public record ModifyShopRequest(
         [ "https://static.koreatech.in/example.png" ]
         """, requiredMode = NOT_REQUIRED)
     @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
-    @NotBlankElement
+    @NotBlankElement(message = "빈 요소가 존재합니다.")
     List<String> imageUrls,
 
     @Schema(example = "수신반점", description = "이름", requiredMode = REQUIRED)

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -966,4 +966,131 @@ class OwnerShopApiTest extends AcceptanceTest {
         Optional<EventArticle> modifiedEventArticle = eventArticleRepository.findById(eventArticle.getId());
         assertThat(modifiedEventArticle).isNotPresent();
     }
+
+    @Test
+    void 이미지_url의_요소가_null인_채로_상점을_수정하면_400에러가_반환된다() {
+        // given
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer " + token_현수)
+            .contentType(ContentType.JSON)
+            .body(String.format("""
+                {
+                  "address": "충청남도 천안시 동남구 병천면 충절로 1600",
+                  "category_ids": [
+                   %d, %d
+                  ],
+                  "delivery": false,
+                  "delivery_price": 1000,
+                  "description": "이번주 전 메뉴 10%% 할인 이벤트합니다.",
+                  "image_urls": [
+                    ""
+                  ],
+                  "name": "써니 숯불 도시락",
+                  "open": [
+                    {
+                      "close_time": "22:30",
+                      "closed": false,
+                      "day_of_week": "MONDAY",
+                      "open_time": "10:00"
+                    },
+                    {
+                      "close_time": "23:30",
+                      "closed": true,
+                      "day_of_week": "SUNDAY",
+                      "open_time": "11:00"
+                    }
+                  ],
+                  "pay_bank": true,
+                  "pay_card": true,
+                  "phone": "041-123-4567"
+                }
+                """, shopCategory_일반.getId(), shopCategory_치킨.getId()
+            ))
+            .when()
+            .put("/owner/shops/{id}", shop_마슬랜.getId())
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract();
+
+    }
+
+    @Test
+    void 이미지_url의_요소가_null인_채로_상점을_생성하면_400에러가_반환된다() {
+        // given
+        RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer " + token_현수)
+            .body(String.format("""
+                {
+                    "address": "대전광역시 유성구 대학로 291",
+                    "category_ids": [
+                        %d
+                    ],
+                    "delivery": true,
+                    "delivery_price": 4000,
+                    "description": "테스트 상점2입니다.",
+                    "image_urls": [
+                        "",
+                    ],
+                    
+                    "name": "테스트 상점2",
+                    "open": [
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "MONDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "TUESDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "WEDNESDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "THURSDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "FRIDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "SATURDAY",
+                            "open_time": "09:00"
+                        },
+                        {
+                            "close_time": "21:00",
+                            "closed": false,
+                            "day_of_week": "SUNDAY",
+                            "open_time": "09:00"
+                        }
+                    ],
+                    "pay_bank": true,
+                    "pay_card": true,
+                    "phone": "010-1234-5678"
+                }
+                """, shopCategory_치킨.getId())
+            )
+            .when()
+            .post("/owner/shops")
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract();
+    }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -968,7 +968,7 @@ class OwnerShopApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 이미지_url의_요소가_null인_채로_상점을_수정하면_400에러가_반환된다() {
+    void 이미지_url의_요소가_공백인_채로_상점을_수정하면_400에러가_반환된다() {
         // given
         RestAssured
             .given()
@@ -1016,7 +1016,7 @@ class OwnerShopApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 이미지_url의_요소가_null인_채로_상점을_생성하면_400에러가_반환된다() {
+    void 이미지_url의_요소가_공백인_채로_상점을_생성하면_400에러가_반환된다() {
         // given
         RestAssured
             .given()


### PR DESCRIPTION
# 🔥 연관 이슈

- close #813

# 🚀 작업 내용

1. 상점 생성, 수정시 이미지 url의 요소가 공백인 경우 예외처리 하였습니다.
2. 이전에 만들어 두었던 `@NotBlankElement`어노테이션을 활용하였습니다.

# 💬 리뷰 중점사항
