### PR TITLE
feat: 학기 반환 순서 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/SemesterCheckResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/SemesterCheckResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.timetable.model.Semester;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -20,10 +21,12 @@ public record SemesterCheckResponse(
     List<String> semesters
 ) {
 
-    public static SemesterCheckResponse of(Integer userId, List<String> semesters) {
+    public static SemesterCheckResponse of(Integer userId, List<Semester> semesters) {
         return new SemesterCheckResponse(
             userId,
-            semesters
+            semesters.stream()
+                .map(Semester::getSemester)
+                .toList()
         );
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -204,10 +204,13 @@ class TimetableApiTest extends AcceptanceTest {
     @Test
     @DisplayName("모든 학기를 조회한다.")
     void findAllSemesters() {
-        semesterFixture.semester("20221");
-        semesterFixture.semester("20222");
+        semesterFixture.semester("20241");
+        semesterFixture.semester("20242");
+        semesterFixture.semester("2024-여름");
         semesterFixture.semester("20231");
         semesterFixture.semester("20232");
+        semesterFixture.semester("2023-여름");
+        semesterFixture.semester("2023-겨울");
 
         var response = RestAssured
             .given()
@@ -221,20 +224,32 @@ class TimetableApiTest extends AcceptanceTest {
             .isEqualTo("""
                 [
                     {
-                        "id": 4,
-                        "semester": "20232"
+                        "id": 2,
+                        "semester": "20242"
                     },
                     {
                         "id": 3,
-                        "semester": "20231"
-                    },
-                    {
-                        "id": 2,
-                        "semester": "20222"
+                        "semester": "2024-여름"
                     },
                     {
                         "id": 1,
-                        "semester": "20221"
+                        "semester": "20241"
+                    },
+                    {
+                        "id": 7,
+                        "semester": "2023-겨울"
+                    },
+                    {
+                        "id": 5,
+                        "semester": "20232"
+                    },
+                    {
+                        "id": 6,
+                        "semester": "2023-여름"
+                    },
+                    {
+                        "id": 4,
+                        "semester": "20231"
                     }
                 ]
                 """);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #818

# 🚀 작업 내용

1. 클라이언트의 요청에따라 GET/semesters와 GET/semesters/check에 대한 학기 반환값을 '겨울-2-여름-1'과 같은 순으로 변경했습니다.

![image](https://github.com/user-attachments/assets/360e0e0f-6c6a-4b3b-b62b-59e8b6217c58)

# 💬 리뷰 중점사항
