### PR TITLE
fix: 리뷰 신고 변경 API의 dto필드 NotBlank에서 NotNull로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopReviewReportStatusRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopReviewReportStatusRequest.java
@@ -4,14 +4,15 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import in.koreatech.koin.domain.shop.model.ReportStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record AdminModifyShopReviewReportStatusRequest(
     @Schema(description = "신고 상태", example = "DISMISSED", requiredMode = REQUIRED)
-    @NotBlank(message = "변경하려는 상태는 필수입니다.")
+    @NotNull(message = "변경하려는 상태는 필수입니다.")
     ReportStatus reportStatus
 ) {
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #820

# 🚀 작업 내용

1. enum에 `@NotBlank`어노테이션을 이용해서 발생한 문제였습니다.
2. `@NotNull`어노테이션으로 변경해줬습니다.

# 💬 리뷰 중점사항
