### PR TITLE
fix: timetable dto에서 유효성 검사 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
@@ -30,18 +30,23 @@ public record TimetableLectureCreateRequest(
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimeTableLectureRequest(
         @Schema(description = "강의 이름", example = "기상분석", requiredMode = REQUIRED)
+        @Size(max = 100, message = "강의 이름의 최대 글자는 100글자입니다.")
         String classTitle,
 
         @Schema(description = "강의 시간", example = "[210, 211]", requiredMode = REQUIRED)
+        @Size(max = 100, message = "강의 시간의 최대 글자는 100글자입니다.")
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "도서관", requiredMode = NOT_REQUIRED)
+        @Size(max = 30, message = "강의 징소의 최대 글자는 30글자입니다.")
         String classPlace,
 
         @Schema(description = "교수명", example = "이강환", requiredMode = NOT_REQUIRED)
+        @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 
         @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
+        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다.")
         String grades,
 
         @Schema(description = "메모", example = "메모메모", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
@@ -38,7 +38,7 @@ public record TimetableLectureCreateRequest(
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "도서관", requiredMode = NOT_REQUIRED)
-        @Size(max = 30, message = "강의 징소의 최대 글자는 30글자입니다.")
+        @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
         @Schema(description = "교수명", example = "이강환", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
@@ -33,18 +33,23 @@ public record TimetableLectureUpdateRequest(
         Integer lectureId,
 
         @Schema(description = "강의 이름", example = "운영체제", requiredMode = NOT_REQUIRED)
+        @Size(max = 100, message = "강의 이름의 최대 글자는 100글자입니다.")
         String classTitle,
 
         @Schema(description = "강의 시간", example = "[210, 211]", requiredMode = NOT_REQUIRED)
+        @Size(max = 100, message = "강의 시간의 최대 글자는 100글자입니다.")
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "null", requiredMode = NOT_REQUIRED)
+        @Size(max = 30, message = "강의 징소의 최대 글자는 30글자입니다.")
         String classPlace,
 
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 
         @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
+        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다.")
         String grades,
 
         @Schema(name = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
@@ -41,7 +41,7 @@ public record TimetableLectureUpdateRequest(
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "null", requiredMode = NOT_REQUIRED)
-        @Size(max = 30, message = "강의 징소의 최대 글자는 30글자입니다.")
+        @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
         @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
@@ -50,7 +50,7 @@ public class TimetableLecture extends BaseEntity {
     @Column(name = "professor", length = 30)
     private String professor;
 
-    @Size(max = 255)
+    @Size(max = 2)
     @NotNull
     @Column(name = "grades", nullable = false)
     private String grades = "0";


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. entity에서의 길이 제한을 충족시키지 못한 문제로 dto에서 유효성 검사를 할 수 있게 size 어노테이션를 추가했습니다.

# 💬 리뷰 중점사항
