### PR TITLE
feat: 게시글 조회 응답 필드 추가 및 로직 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityApi.java
@@ -43,6 +43,7 @@ public interface CommunityApi {
     @GetMapping("/articles/{id}")
     ResponseEntity<ArticleResponse> getArticle(
         @UserId Integer userId,
+        @RequestParam(required = false) Integer boardId,
         @Parameter(in = PATH) @PathVariable("id") Integer articleId,
         @IpAddress String ipAddress
     );

--- a/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/controller/CommunityController.java
@@ -34,10 +34,11 @@ public class CommunityController implements CommunityApi {
     @GetMapping("/articles/{id}")
     public ResponseEntity<ArticleResponse> getArticle(
         @UserId Integer userId,
+        @RequestParam(required = false) Integer boardId,
         @PathVariable("id") Integer articleId,
         @IpAddress String ipAddress
     ) {
-        ArticleResponse foundArticle = communityService.getArticle(userId, articleId, ipAddress);
+        ArticleResponse foundArticle = communityService.getArticle(userId, boardId, articleId, ipAddress);
         return ResponseEntity.ok().body(foundArticle);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/dto/ArticleResponse.java
@@ -14,10 +14,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonNaming(SnakeCaseStrategy.class)
 public record ArticleResponse(
 
-    @Schema(description = "게시글 고유 ID", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "게시글 고유 ID", example = "2", requiredMode = REQUIRED)
     Integer id,
 
-    @Schema(description = "게시판 고유 ID", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "게시판 고유 ID", example = "4", requiredMode = REQUIRED)
     Integer boardId,
 
     @Schema(description = "제목", example = "제목", requiredMode = REQUIRED)
@@ -30,7 +30,13 @@ public record ArticleResponse(
     String nickname,
 
     @Schema(description = "조회수", example = "1", requiredMode = REQUIRED)
-    int hit,
+    Integer hit,
+
+    @Schema(description = "이전 게시글 ID", example = "1")
+    Integer prevId,
+
+    @Schema(description = "다음 게시글 ID", example = "3")
+    Integer nextId,
 
     @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
@@ -47,6 +53,8 @@ public record ArticleResponse(
             article.getContent(),
             article.getNickname(),
             article.getHit(),
+            article.getPrevId(),
+            article.getNextId(),
             article.getCreatedAt(),
             article.getUpdatedAt()
         );

--- a/src/main/java/in/koreatech/koin/domain/community/exception/ArticleBoardMisMatchException.java
+++ b/src/main/java/in/koreatech/koin/domain/community/exception/ArticleBoardMisMatchException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.community.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class ArticleBoardMisMatchException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "게시판 정보와 게시글 정보가 일치하지 않습니다.";
+
+    public ArticleBoardMisMatchException(String message) {
+        super(message);
+    }
+
+    public ArticleBoardMisMatchException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ArticleBoardMisMatchException withDetail(String detail) {
+        return new ArticleBoardMisMatchException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/exception/BoardNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/community/exception/BoardNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.community.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class BoardNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "게시판이 존재하지 않습니다.";
+
+    public BoardNotFoundException(String message) {
+        super(message);
+    }
+
+    public BoardNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static BoardNotFoundException withDetail(String detail) {
+        return new BoardNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/model/Article.java
@@ -105,6 +105,12 @@ public class Article extends BaseEntity {
     @Transient
     private String contentSummary;
 
+    @Transient
+    private Integer prevId;
+
+    @Transient
+    private Integer nextId;
+
     @PostPersist
     @PostLoad
     public void updateContentSummary() {
@@ -122,6 +128,15 @@ public class Article extends BaseEntity {
 
     public void increaseHit() {
         hit++;
+    }
+
+    public void setPrevNextArticles(Article prev, Article next) {
+        if (prev != null) {
+            prevId = prev.getId();
+        }
+        if (next != null) {
+            nextId = next.getId();
+        }
     }
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/repository/BoardRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
-import in.koreatech.koin.domain.community.exception.ArticleNotFoundException;
+import in.koreatech.koin.domain.community.exception.BoardNotFoundException;
 import in.koreatech.koin.domain.community.model.Board;
 
 public interface BoardRepository extends Repository<Board, Integer> {
@@ -14,6 +14,6 @@ public interface BoardRepository extends Repository<Board, Integer> {
 
     default Board getById(Integer boardId) {
         return findById(boardId).orElseThrow(
-            () -> ArticleNotFoundException.withDetail("boardId: " + boardId));
+            () -> BoardNotFoundException.withDetail("boardId: " + boardId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/service/CommunityService.java
@@ -24,7 +24,6 @@ import in.koreatech.koin.domain.community.model.ArticleKeyword;
 import in.koreatech.koin.domain.community.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.model.ArticleViewLog;
 import in.koreatech.koin.domain.community.model.Board;
-import in.koreatech.koin.domain.community.model.BoardTag;
 import in.koreatech.koin.domain.community.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.repository.ArticleKeywordUserMapRepository;
 import in.koreatech.koin.domain.community.repository.ArticleRepository;
@@ -41,7 +40,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class CommunityService {
 
-    private static final int NOTICE_BOARD_ID = 4;
+    public static final int NOTICE_BOARD_ID = 4;
+
     private static final int HOT_ARTICLE_LIMIT = 10;
     private static final Sort ARTICLES_SORT = Sort.by(Sort.Direction.DESC, "id");
 
@@ -105,12 +105,10 @@ public class CommunityService {
         Criteria criteria = Criteria.of(page, limit, total.intValue());
         Board board = boardRepository.getById(boardId);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
-
-        if (isFullNoticeBoard(board)) {
-            Page<Article> articles = articleRepository.findAllByIsNotice(true, pageRequest);
+        if (boardId == NOTICE_BOARD_ID) {
+            Page<Article> articles = articleRepository.findAllByBoardIsNoticeIsTrue(pageRequest);
             return ArticlesResponse.of(articles, criteria);
         }
-
         Page<Article> articles = articleRepository.findAllByBoardId(boardId, pageRequest);
         return ArticlesResponse.of(articles, criteria);
     }
@@ -129,16 +127,12 @@ public class CommunityService {
         Page<Article> articles;
         if (boardId == null) {
             articles = articleRepository.findAllByTitleContaining(query, pageRequest);
-        } else if (isFullNoticeBoard(boardRepository.getById(boardId))) {
-            articles = articleRepository.findAllByIsNoticeAndTitleContaining(true, query, pageRequest);
+        } else if (boardId == NOTICE_BOARD_ID) {
+            articles = articleRepository.findAllByBoardIsNoticeIsTrueAndTitleContaining(query, pageRequest);
         } else {
             articles = articleRepository.findAllByBoardIdAndTitleContaining(boardId, query, pageRequest);
         }
         return ArticlesResponse.of(articles, criteria);
-    }
-
-    private boolean isFullNoticeBoard(Board board) {
-        return board.isNotice() && Objects.equals(board.getTag(), BoardTag.공지사항.getTag());
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -92,6 +92,8 @@ class CommunityApiTest extends AcceptanceTest {
                     "content": "<p>내용</p>",
                     "nickname": "준호",
                     "hit": 1,
+                    "prev_id": null,
+                    "next_id": 2,
                     "created_at": "2024-01-15 12:00:00",
                     "updated_at": "2024-01-15 12:00:00"
                 }
@@ -134,6 +136,8 @@ class CommunityApiTest extends AcceptanceTest {
                     "content": "<p>내용</p>",
                     "nickname": "준호",
                     "hit": 2,
+                    "prev_id": null,
+                    "next_id": 2,
                     "created_at": "2024-01-15 12:00:00",
                     "updated_at": "2024-01-15 12:00:00"
                 }


### PR DESCRIPTION
# 🔥 연관 이슈


# 🚀 작업 내용

1. GET /article/{id} 응답에 `prev_id`, `next_id`를 추가하여 이전글/다음글 기능을 사용할 수 있게 했습니다.
2. article.isNotice를 기반으로 공지글 여부를 판단하던 기존 로직을 article.board.isNotice를 기반으로 판단하도록 수정했습니다.

# 💬 리뷰 중점사항
