### PR TITLE
fix: searchkeyword 엔티티 컬럼 타입 명시

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeyword.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeyword.java
@@ -35,7 +35,7 @@ public class ArticleSearchKeyword extends BaseEntity {
     @Column(nullable = false)
     private double weight;
 
-    @Column(name = "last_searched_at")
+    @Column(name = "last_searched_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime lastSearchedAt;
 
     @Column(name = "total_searches", nullable = false)

--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -565,11 +565,11 @@ class CommunityApiTest extends AcceptanceTest {
         JsonAssertions.assertThat(response).isEqualTo("""
                 {
                   "keywords": [
-                    "검색어8",
-                    "검색어7",
-                    "검색어6",
+                    "검색어4",
                     "검색어5",
-                    "검색어4"
+                    "검색어6",
+                    "검색어7",
+                    "검색어8"
                   ]
                 }
             """);


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. db에 timestamp, 엔티티는 localdatetime으로 되어 있는데 인식을 못해서 columndefinition으로 타입을 명시해줬습니다.

# 💬 리뷰 중점사항
