### PR TITLE
refactor: 키워드 추천 api를 비로그인 api로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
@@ -79,7 +79,6 @@ public interface KeywordApi {
     @Operation(summary = "알림 키워드 추천")
     @GetMapping("/articles/keyword/suggestions")
     ResponseEntity<ArticleKeywordsSuggestionResponse> suggestKeywords(
-        @Auth(permit = {STUDENT}) Integer userId
     );
 
     @Operation(summary = "키워드 알림 전송", hidden = true)

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
@@ -56,9 +56,8 @@ public class KeywordController implements KeywordApi{
 
     @GetMapping("/suggestions")
     public ResponseEntity<ArticleKeywordsSuggestionResponse> suggestKeywords(
-        @Auth(permit = {STUDENT}) Integer userId
     ) {
-        ArticleKeywordsSuggestionResponse response = keywordService.suggestKeywords(userId);
+        ArticleKeywordsSuggestionResponse response = keywordService.suggestKeywords();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -41,7 +41,6 @@ import lombok.RequiredArgsConstructor;
 public class KeywordService {
 
     private static final int ARTICLE_KEYWORD_LIMIT = 10;
-    private static final int ARTICLE_KEYWORD_SUGGEST_LIMIT = 5;
     private static final int KEYWORD_BATCH_SIZE = 100;
 
     private final ApplicationEventPublisher eventPublisher;
@@ -98,15 +97,11 @@ public class KeywordService {
         return ArticleKeywordsResponse.from(articleKeywordUserMaps);
     }
 
-    public ArticleKeywordsSuggestionResponse suggestKeywords(Integer userId) {
+    public ArticleKeywordsSuggestionResponse suggestKeywords() {
         List<ArticleKeywordSuggestCache> hotKeywords = articleKeywordSuggestRepository.findTop15ByOrderByCountDesc();
-        List<String> userKeywords = Optional.ofNullable(articleKeywordUserMapRepository.findAllKeywordbyUserId(userId))
-            .orElse(Collections.emptyList());
 
         List<String> suggestions = hotKeywords.stream()
             .map(ArticleKeywordSuggestCache::getKeyword)
-            .filter(keyword -> !userKeywords.contains(keyword))
-            .limit(ARTICLE_KEYWORD_SUGGEST_LIMIT)
             .collect(Collectors.toList());
 
         return ArticleKeywordsSuggestionResponse.from(suggestions);
@@ -171,7 +166,7 @@ public class KeywordService {
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
         List<ArticleKeywordResult> topKeywords = articleKeywordRepository.findTopKeywordsInLastWeek(oneWeekAgo, top15);
 
-        if(topKeywords.isEmpty()) {
+        if(topKeywords.size() < 15) {
             topKeywords = articleKeywordRepository.findTop15Keywords(top15);
         }
         List<ArticleKeywordSuggestCache> hotKeywords = topKeywords.stream()

--- a/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
@@ -204,25 +204,9 @@ public class KeywordApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 사용자가_추가_한_키워드는_제외_하고_가장_인기_있는_키워드_추천() {
+    void 가장_인기_있는_키워드_추천() {
         Student student = userFixture.준호_학생();
         String token1 = userFixture.getToken(student.getUser());
-
-        for (int i = 1; i <= 10; i++) {
-            RestAssured
-                .given()
-                .header("Authorization", "Bearer " + token1)
-                .contentType(ContentType.JSON)
-                .body("""
-                    {
-                        "keyword": "수강신청%s"
-                    }
-                    """.formatted(i))
-                .when()
-                .post("/articles/keyword")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-        }
 
         // Redis에 인기 키워드 15개 저장
         List<ArticleKeywordSuggestCache> hotKeywords = new ArrayList<>();
@@ -247,12 +231,14 @@ public class KeywordApiTest extends AcceptanceTest {
             .asPrettyString();
 
         JsonAssertions.assertThat(response).isEqualTo("""
-                {
-                  "keywords": [
-                    "수강신청11", "수강신청12", "수강신청13", "수강신청14", "수강신청15"
-                  ]
-                }
-            """);
+            {
+              "keywords": [
+                "수강신청1", "수강신청2", "수강신청3", "수강신청4", "수강신청5",
+                "수강신청6", "수강신청7", "수강신청8", "수강신청9", "수강신청10",
+                "수강신청11", "수강신청12", "수강신청13", "수강신청14", "수강신청15"
+              ]
+            }
+        """);
     }
 
     @Test


### PR DESCRIPTION
# 🔥 연관 이슈

- close #847 

# 🚀 작업 내용

1. 클라이언트의 요청으로 키워드 추천 api를 비로그인 api로 수정했습니다.
2. 레디스에 캐싱하는 로직을 최근에 사용자가 추가한 키워드가 비어 있을 때가 아니라 15개가 안될 때 전체 조회해서 가져오는 것으로 로직을 변경했습니다. 항상 키워드를 15개를 반환하게 하기 위함입니다.

# 💬 리뷰 중점사항
