### PR TITLE
feat: 리뷰작성, 리뷰신고 모니터링을 위한 슬랙으로 알림 발송

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReviewEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReviewEventListener.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.domain.shop.model;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin.global.domain.slack.SlackClient;
+import in.koreatech.koin.global.domain.slack.model.SlackNotificationFactory;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class ReviewEventListener {
+
+    private final SlackClient slackClient;
+    private final SlackNotificationFactory slackNotificationFactory;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onReviewRegister(ReviewRegisterEvent event) {
+        var notification = slackNotificationFactory.generateReviewRegisterNotification(
+            event.shop(),
+            event.content(),
+            event.rating()
+        );
+        slackClient.sendMessage(notification);
+    }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onReviewReportRegister(ReviewReportEvent event) {
+        var notification = slackNotificationFactory.generateReviewReportNotification(event.shop());
+        slackClient.sendMessage(notification);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReviewRegisterEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReviewRegisterEvent.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.shop.model;
+
+public record ReviewRegisterEvent(
+    String shop,
+    String content,
+    Integer rating
+) {
+    public static ReviewRegisterEvent from(ShopReview shopReview) {
+        return new ReviewRegisterEvent(
+            shopReview.getShop().getName(),
+            shopReview.getContent(),
+            shopReview.getRating()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReviewRegisterEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReviewRegisterEvent.java
@@ -5,6 +5,7 @@ public record ReviewRegisterEvent(
     String content,
     Integer rating
 ) {
+
     public static ReviewRegisterEvent from(ShopReview shopReview) {
         return new ReviewRegisterEvent(
             shopReview.getShop().getName(),

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReviewReportEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReviewReportEvent.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin.domain.shop.model;
+
+public record ReviewReportEvent(
+    String shop
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/ReviewReportEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/ReviewReportEvent.java
@@ -3,4 +3,5 @@ package in.koreatech.koin.domain.shop.model;
 public record ReviewReportEvent(
     String shop
 ) {
+
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,8 @@ import in.koreatech.koin.domain.shop.dto.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.ShopReviewResponse;
 import in.koreatech.koin.domain.shop.dto.ShopReviewsResponse;
 import in.koreatech.koin.domain.shop.exception.ReviewNotFoundException;
+import in.koreatech.koin.domain.shop.model.ReviewRegisterEvent;
+import in.koreatech.koin.domain.shop.model.ReviewReportEvent;
 import in.koreatech.koin.domain.shop.model.Shop;
 import in.koreatech.koin.domain.shop.model.ShopReview;
 import in.koreatech.koin.domain.shop.model.ShopReviewImage;
@@ -53,6 +56,7 @@ public class ShopReviewService {
     private final ShopReviewReportRepository shopReviewReportRepository;
     private final ShopReviewReportCategoryRepository shopReviewReportCategoryRepository;
     private final StudentRepository studentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final EntityManager entityManager;
 
@@ -101,6 +105,7 @@ public class ShopReviewService {
                 .menuName(menuName)
                 .build());
         }
+        eventPublisher.publishEvent(ReviewRegisterEvent.from(savedShopReview));
     }
 
     @Transactional
@@ -146,6 +151,7 @@ public class ShopReviewService {
                     .build()
             );
         }
+        eventPublisher.publishEvent(new ReviewReportEvent(shopReview.getShop().getName()));
     }
 
     public ShopReviewReportCategoryResponse getReviewReportCategories() {

--- a/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
@@ -11,15 +11,18 @@ public class SlackNotificationFactory {
     private static final String MARKDOWN_ADMIN_PAGE_URL_FORMAT = "<%s|Admin page 바로가기>";
 
     private final String adminPageUrl;
+    private final String adminReviewPageUrl;
     private final String ownerEventNotificationUrl;
     private final String eventNotificationUrl;
 
     public SlackNotificationFactory(
         @Value("${koin.admin.url}") String adminPageUrl,
+        @Value("${koin.admin.url}") String adminReviewPageUrl,
         @Value("${slack.koin_event_notify_url}") String eventNotificationUrl,
         @Value("${slack.koin_owner_event_notify_url}") String ownerEventNotificationUrl
     ) {
         this.adminPageUrl = adminPageUrl;
+        this.adminReviewPageUrl = adminReviewPageUrl;
         this.eventNotificationUrl = eventNotificationUrl;
         this.ownerEventNotificationUrl = ownerEventNotificationUrl;
     }
@@ -133,6 +136,55 @@ public class SlackNotificationFactory {
             .text(String.format("""
                 `%s(%s)님이 탈퇴하셨습니다.`
                 """, email, userType.getDescription())
+            )
+            .build();
+    }
+
+    /**
+     * 상점 리뷰 등록 알림
+     */
+    public SlackNotification generateReviewRegisterNotification(
+        String shop,
+        String content,
+        Integer rating
+    ) {
+        return SlackNotification.builder()
+            .slackUrl(eventNotificationUrl)
+            .text(String.format("""
+                `%s에 새로운 리뷰가 등록되었습니다.`
+                내용: `%s`
+                별점: `%d`
+                %s
+                """,
+                shop,
+                content,
+                rating,
+                String.format(
+                    MARKDOWN_ADMIN_PAGE_URL_FORMAT,
+                    adminReviewPageUrl
+                ))
+            )
+            .build();
+    }
+
+    /**
+     * 상점 리뷰 신고 알림
+     */
+    public SlackNotification generateReviewReportNotification(
+        String shop
+    ) {
+        return SlackNotification.builder()
+            .slackUrl(eventNotificationUrl)
+            .text(String.format("""
+                `%s의 리뷰가 신고되었습니다.`
+                `신고를 처리해주세요!!`
+                %s
+                """,
+                shop,
+                String.format(
+                    MARKDOWN_ADMIN_PAGE_URL_FORMAT,
+                    adminReviewPageUrl
+                ))
             )
             .build();
     }

--- a/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
@@ -16,8 +16,8 @@ public class SlackNotificationFactory {
     private final String eventNotificationUrl;
 
     public SlackNotificationFactory(
-        @Value("${koin.admin.url}") String adminPageUrl,
-        @Value("${koin.admin.url}") String adminReviewPageUrl,
+        @Value("${koin.admin.shop.url}") String adminPageUrl,
+        @Value("${koin.admin.review.url}") String adminReviewPageUrl,
         @Value("${slack.koin_event_notify_url}") String eventNotificationUrl,
         @Value("${slack.koin_owner_event_notify_url}") String ownerEventNotificationUrl
     ) {

--- a/src/test/java/in/koreatech/koin/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/AcceptanceTest.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.config.TestTimeConfig;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordEventListener;
 import in.koreatech.koin.domain.coop.model.CoopEventListener;
 import in.koreatech.koin.domain.owner.model.OwnerEventListener;
+import in.koreatech.koin.domain.shop.model.ReviewEventListener;
 import in.koreatech.koin.domain.shop.model.ShopEventListener;
 import in.koreatech.koin.domain.user.model.StudentEventListener;
 import in.koreatech.koin.util.TestCircuitBreakerClient;
@@ -45,6 +46,9 @@ public abstract class AcceptanceTest {
 
     @MockBean
     protected OwnerEventListener ownerEventListener;
+
+    @MockBean
+    protected ReviewEventListener reviewEventListener;
 
     @MockBean
     protected StudentEventListener studentEventListener;

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.acceptance;
 import static in.koreatech.koin.domain.shop.model.ReportStatus.DISMISSED;
 import static in.koreatech.koin.domain.shop.model.ReportStatus.UNHANDLED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
 
@@ -128,6 +130,7 @@ class ShopReviewApiTest extends AcceptanceTest {
                         .isEqualTo("https://static.koreatech.in/example.png");
                     softly.assertThat(shopReview.getMenus().get(0).getMenuName()).isEqualTo("치킨");
                     softly.assertThat(shopReview.getMenus().get(1).getMenuName()).isEqualTo("피자");
+                    verify(reviewEventListener).onReviewRegister(any());
                 }
             );
         });
@@ -195,6 +198,7 @@ class ShopReviewApiTest extends AcceptanceTest {
                         .isEqualTo("https://static.koreatech.in/example.png");
                     softly.assertThat(shopReview.getMenus().get(0).getMenuName()).isEqualTo("치킨");
                     softly.assertThat(shopReview.getMenus().get(1).getMenuName()).isEqualTo("피자");
+                    verify(reviewEventListener).onReviewRegister(any());
                 }
             );
         });
@@ -581,6 +585,7 @@ class ShopReviewApiTest extends AcceptanceTest {
                     softly.assertThat(shopReviewReport2.get().getTitle()).isEqualTo("스팸");
                     softly.assertThat(shopReviewReport2.get().getContent()).isEqualTo("광고가 포함된 리뷰입니다.");
                     softly.assertThat(shopReviewReport2.get().getReportStatus()).isEqualTo(UNHANDLED);
+                    verify(reviewEventListener).onReviewReportRegister(any());
                 }
             );
         });

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -61,7 +61,10 @@ s3:
 
 koin:
   admin:
-    url: https://admin-url-path.com
+    shop:
+      url: https://admin-url-path.com
+    review:
+      url: https://admin-url-path.com
 
 cors:
   allowedOrigins:


### PR DESCRIPTION
# 🔥 연관 이슈

- close #851 

# 🚀 작업 내용

1. 리뷰작성, 리뷰신고시 `코인_이벤트알림`채널에 알림이 가도록 작성하였습니다.
2. 이벤트가 발생했는지 테스트코드도 추가해줬습니다.

# 💬 리뷰 중점사항
