### PR TITLE
fix: 많이 검색한 키워드 추천 api 테스트 응답 값 순서에 상관 없도록 수정

### DIFF
--- a/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CommunityApiTest.java
@@ -8,8 +8,11 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.community.article.model.Article;
@@ -560,18 +563,8 @@ class CommunityApiTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract()
-            .asPrettyString();
+            .asString();
 
-        JsonAssertions.assertThat(response).isEqualTo("""
-                {
-                  "keywords": [
-                    "검색어4",
-                    "검색어5",
-                    "검색어6",
-                    "검색어7",
-                    "검색어8"
-                  ]
-                }
-            """);
+        assertThat(response).contains("검색어4", "검색어5", "검색어6", "검색어7", "검색어8");
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 테스트 응답 값을 순서에 상관 없이 검사 할 수 있도록 수정 했습니다.

# 💬 리뷰 중점사항
