### PR TITLE
fix: registered_at 업데이트

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -80,7 +80,7 @@ public class Article extends BaseEntity {
     private String url;
 
     @Convert(converter = LocalDateAttributeConverter.class)
-    @Column(name = "registered_at", columnDefinition = "VARCHAR(255)", updatable = false)
+    @Column(name = "registered_at", columnDefinition = "DATETIME", updatable = false)
     private LocalDate registeredAt;
 
     @OneToMany(cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/in/koreatech/koin/global/config/LocalDateAttributeConverter.java
+++ b/src/main/java/in/koreatech/koin/global/config/LocalDateAttributeConverter.java
@@ -1,35 +1,26 @@
 package in.koreatech.koin.global.config;
 
+import java.sql.Date;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
+import java.util.Optional;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class LocalDateAttributeConverter implements AttributeConverter<LocalDate, String> {
-
-    private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
-        .appendPattern("[yyyy-MM-dd HH:mm:ss]")
-        .appendPattern("[yyyy-MM-dd]")
-        .appendPattern("[yy.MM.dd HH:mm:ss]")
-        .appendPattern("[yy.MM.dd]")
-        .toFormatter();
+public class LocalDateAttributeConverter implements AttributeConverter<LocalDate, Date> {
 
     @Override
-    public String convertToDatabaseColumn(LocalDate localDate) {
-        if (localDate == null) {
-            return null;
-        }
-        return localDate.format(formatter);
+    public Date convertToDatabaseColumn(LocalDate localDate) {
+        return Optional.ofNullable(localDate)
+            .map(Date::valueOf)
+            .orElse(null);
     }
 
     @Override
-    public LocalDate convertToEntityAttribute(String dbData) {
-        if (dbData == null) {
-            return null;
-        }
-        return LocalDate.parse(dbData, formatter);
+    public LocalDate convertToEntityAttribute(Date date) {
+        return Optional.ofNullable(date)
+            .map(Date::toLocalDate)
+            .orElse(null);
     }
 }

--- a/src/main/resources/db/migration/V51__update_koreatech_articles_registered_at.sql
+++ b/src/main/resources/db/migration/V51__update_koreatech_articles_registered_at.sql
@@ -1,0 +1,16 @@
+SET SQL_SAFE_UPDATES = 0;
+
+UPDATE koin.koreatech_articles
+SET registered_at =
+        CASE
+            WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
+                THEN DATE(STR_TO_DATE(registered_at, '%Y-%m-%d %H:%i:%s'))
+            WHEN registered_at REGEXP '^[0-9]{2}\.[0-9]{2}\.[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
+                THEN DATE(STR_TO_DATE(registered_at, '%y.%m.%d %H:%i:%s'))
+            ELSE registered_at
+            END;
+
+SET SQL_SAFE_UPDATES = 1;
+
+ALTER TABLE koin.koreatech_articles
+    MODIFY COLUMN `registered_at` DATETIME DEFAULT NULL COMMENT '등록 일자';

--- a/src/main/resources/db/migration/V53__update_koreatech_articles_registered_at.sql
+++ b/src/main/resources/db/migration/V53__update_koreatech_articles_registered_at.sql
@@ -2,15 +2,15 @@ SET SQL_SAFE_UPDATES = 0;
 
 UPDATE koin.koreatech_articles
 SET registered_at =
-        CASE
-            WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
-                THEN STR_TO_DATE(registered_at, '%Y-%m-%d %H:%i:%s')
-            WHEN registered_at REGEXP '^[0-9]{2}\.[0-9]{2}\.[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
-                THEN STR_TO_DATE(registered_at, '%y.%m.%d %H:%i:%s')
-            WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
-                THEN STR_TO_DATE(CONCAT(registered_at, ' 00:00:00'), '%Y-%m-%d %H:%i:%s')
-            ELSE registered_at
-            END;
+    CASE
+        WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
+            THEN STR_TO_DATE(registered_at, '%Y-%m-%d %H:%i:%s')
+        WHEN registered_at REGEXP '^[0-9]{2}\.[0-9]{2}\.[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
+            THEN STR_TO_DATE(registered_at, '%y.%m.%d %H:%i:%s')
+        WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+            THEN STR_TO_DATE(CONCAT(registered_at, ' 00:00:00'), '%Y-%m-%d %H:%i:%s')
+        ELSE registered_at
+        END;
 
 SET SQL_SAFE_UPDATES = 1;
 

--- a/src/main/resources/db/migration/V53__update_koreatech_articles_registered_at.sql
+++ b/src/main/resources/db/migration/V53__update_koreatech_articles_registered_at.sql
@@ -4,9 +4,11 @@ UPDATE koin.koreatech_articles
 SET registered_at =
         CASE
             WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
-                THEN DATE(STR_TO_DATE(registered_at, '%Y-%m-%d %H:%i:%s'))
+                THEN STR_TO_DATE(registered_at, '%Y-%m-%d %H:%i:%s')
             WHEN registered_at REGEXP '^[0-9]{2}\.[0-9]{2}\.[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'
-                THEN DATE(STR_TO_DATE(registered_at, '%y.%m.%d %H:%i:%s'))
+                THEN STR_TO_DATE(registered_at, '%y.%m.%d %H:%i:%s')
+            WHEN registered_at REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+                THEN STR_TO_DATE(CONCAT(registered_at, ' 00:00:00'), '%Y-%m-%d %H:%i:%s')
             ELSE registered_at
             END;
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #854 

# 🚀 작업 내용

1. `registered_at`을 `datetime`으로 수정
2. 이에 맞게 attribute converter 수정

# 💬 리뷰 중점사항
시간 날리고 날짜만 저장하도록 수정했습니다.
`yy.MM.dd HH:mm:ss` → `yyyy-MM-dd`
`yyyy-MM-dd HH:mm:ss` → `yyyy-MM-dd`

========
# 수정
시간을 저장은 하지만 사용하지 않습니다.

`yyyy-MM-dd HH:mm:ss` → `yyyy-MM-dd HH:mm:ss`
`yy.MM.dd HH:mm:ss` → `yyyy-MM-dd HH:mm:ss`
`yyyy-MM-dd` → `yyyy-MM-dd 00:00:00`