### PR TITLE
fix : 생협 운영시간 학기에서 "중" 삭제

### DIFF
--- a/src/main/resources/db/migration/V52__update_coopshop_semester_typo.sql
+++ b/src/main/resources/db/migration/V52__update_coopshop_semester_typo.sql
@@ -1,0 +1,2 @@
+UPDATE coop_shop
+    SET semester = "학기" WHERE id = 1;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. "학기 중"에서 "중"은 클라이언트에서 띄워주는 글자라서 삭제하였습니다.

# 💬 리뷰 중점사항
