### PR TITLE
refactor: 인기 게시글 조회 내부 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.community.article.dto.ArticleHotKeywordResponse;
@@ -22,8 +23,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "(Normal) Community: 커뮤니티", description = "커뮤니티 정보를 관리한다")
-public interface CommunityApi {
+@Tag(name = "(Normal) Articles: 게시글", description = "게시글 정보를 관리한다")
+@RequestMapping("/articles")
+public interface ArticleApi {
 
     @ApiResponses(
         value = {
@@ -32,7 +34,7 @@ public interface CommunityApi {
         }
     )
     @Operation(summary = "게시글 단건 조회")
-    @GetMapping("/articles/{id}")
+    @GetMapping("/{id}")
     ResponseEntity<ArticleResponse> getArticle(
         @RequestParam(required = false) Integer boardId,
         @Parameter(in = PATH) @PathVariable("id") Integer articleId
@@ -45,7 +47,7 @@ public interface CommunityApi {
         }
     )
     @Operation(summary = "게시글 목록 조회")
-    @GetMapping("/articles")
+    @GetMapping("")
     ResponseEntity<ArticlesResponse> getArticles(
         @RequestParam Integer boardId,
         @RequestParam(required = false) Integer page,
@@ -59,7 +61,7 @@ public interface CommunityApi {
         }
     )
     @Operation(summary = "인기 게시글 목록 조회")
-    @GetMapping("/articles/hot")
+    @GetMapping("/hot")
     ResponseEntity<List<HotArticleItemResponse>> getHotArticles();
 
     @ApiResponses(
@@ -69,7 +71,7 @@ public interface CommunityApi {
         }
     )
     @Operation(summary = "게시글 검색")
-    @GetMapping("/articles/search")
+    @GetMapping("/search")
     ResponseEntity<ArticlesResponse> searchArticles(
         @RequestParam String query,
         @RequestParam(required = false) Integer boardId,
@@ -84,7 +86,7 @@ public interface CommunityApi {
         }
     )
     @Operation(summary = "많이 검색되는 키워드(검색 화면)")
-    @GetMapping("/articles/hot/keyword")
+    @GetMapping("/hot/keyword")
     ResponseEntity<ArticleHotKeywordResponse> getArticlesHotKeyword(
         @RequestParam Integer count
     );

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -13,23 +13,23 @@ import in.koreatech.koin.domain.community.article.dto.ArticleHotKeywordResponse;
 import in.koreatech.koin.domain.community.article.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.article.dto.ArticlesResponse;
 import in.koreatech.koin.domain.community.article.dto.HotArticleItemResponse;
-import in.koreatech.koin.domain.community.article.service.CommunityService;
+import in.koreatech.koin.domain.community.article.service.ArticleService;
 import in.koreatech.koin.global.ipaddress.IpAddress;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/articles")
-public class CommunityController implements CommunityApi {
+public class ArticleController implements ArticleApi {
 
-    private final CommunityService communityService;
+    private final ArticleService articleService;
 
     @GetMapping("/{id}")
     public ResponseEntity<ArticleResponse> getArticle(
         @RequestParam(required = false) Integer boardId,
         @PathVariable("id") Integer articleId
     ) {
-        ArticleResponse foundArticle = communityService.getArticle(boardId, articleId);
+        ArticleResponse foundArticle = articleService.getArticle(boardId, articleId);
         return ResponseEntity.ok().body(foundArticle);
     }
 
@@ -39,13 +39,13 @@ public class CommunityController implements CommunityApi {
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit
     ) {
-        ArticlesResponse foundArticles = communityService.getArticles(boardId, page, limit);
+        ArticlesResponse foundArticles = articleService.getArticles(boardId, page, limit);
         return ResponseEntity.ok().body(foundArticles);
     }
 
     @GetMapping("/hot")
     public ResponseEntity<List<HotArticleItemResponse>> getHotArticles() {
-        List<HotArticleItemResponse> hotArticles = communityService.getHotArticles();
+        List<HotArticleItemResponse> hotArticles = articleService.getHotArticles();
         return ResponseEntity.ok().body(hotArticles);
     }
 
@@ -57,7 +57,7 @@ public class CommunityController implements CommunityApi {
         @RequestParam(required = false) Integer limit,
         @IpAddress String ipAddress
     ) {
-        ArticlesResponse foundArticles = communityService.searchArticles(query, boardId, page, limit, ipAddress);
+        ArticlesResponse foundArticles = articleService.searchArticles(query, boardId, page, limit, ipAddress);
         return ResponseEntity.ok().body(foundArticles);
     }
 
@@ -65,7 +65,7 @@ public class CommunityController implements CommunityApi {
     public ResponseEntity<ArticleHotKeywordResponse> getArticlesHotKeyword(
         @RequestParam Integer count
     ) {
-        ArticleHotKeywordResponse response = communityService.getArticlesHotKeyword(count);
+        ArticleHotKeywordResponse response = articleService.getArticlesHotKeyword(count);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleResponse.java
@@ -58,7 +58,7 @@ public record ArticleResponse(
             article.getTitle(),
             article.getContent(),
             article.getAuthor(),
-            article.getHit(),
+            article.getTotalHit(),
             article.getAttachments().stream()
                 .map(InnerArticleAttachmentResponse::from)
                 .toList(),

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticlesResponse.java
@@ -77,7 +77,7 @@ public record ArticlesResponse(
                 article.getBoard().getId(),
                 article.getTitle(),
                 article.getAuthor(),
-                article.getHit(),
+                article.getTotalHit(),
                 article.getRegisteredAt(),
                 article.getUpdatedAt()
             );

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/HotArticleItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/HotArticleItemResponse.java
@@ -43,7 +43,7 @@ public record HotArticleItemResponse(
             article.getBoard().getId(),
             article.getTitle(),
             article.getAuthor(),
-            article.getHit(),
+            article.getTotalHit(),
             article.getRegisteredAt(),
             article.getUpdatedAt()
         );

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -101,6 +101,10 @@ public class Article extends BaseEntity {
         koinHit++;
     }
 
+    public int getHit() {
+        return hit + koinHit;
+    }
+
     public void setPrevNextArticles(Article prev, Article next) {
         if (prev != null) {
             prevId = prev.getId();

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -107,7 +107,7 @@ public class Article extends BaseEntity {
         koinHit++;
     }
 
-    public int getHit() {
+    public int getTotalHit() {
         return hit + koinHit;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/redis/ArticleHit.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/redis/ArticleHit.java
@@ -1,0 +1,31 @@
+package in.koreatech.koin.domain.community.article.model.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import in.koreatech.koin.domain.community.article.model.Article;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("articleHit")
+public class ArticleHit {
+
+    @Id
+    private Integer id;
+
+    private Integer hit;
+
+    @Builder
+    private ArticleHit(Integer id, Integer hit) {
+        this.id = id;
+        this.hit = hit;
+    }
+
+    public static ArticleHit from(Article article) {
+        return ArticleHit.builder()
+            .id(article.getId())
+            .hit(article.getHit())
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/redis/ArticleHit.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/redis/ArticleHit.java
@@ -25,7 +25,7 @@ public class ArticleHit {
     public static ArticleHit from(Article article) {
         return ArticleHit.builder()
             .id(article.getId())
-            .hit(article.getHit())
+            .hit(article.getTotalHit())
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.community.article.repository;
 
 import static in.koreatech.koin.domain.community.article.service.ArticleService.NOTICE_BOARD_ID;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,4 +76,11 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         }
         return findNextArticle(article.getId(), board.getId()).orElse(null);
     }
+
+    @Query(value = "SELECT * FROM koreatech_articles a WHERE a.registered_at > :registeredAt "
+        + "ORDER BY (a.hit + a.koin_hit) DESC, a.registered_at DESC, a.id DESC "
+        + "LIMIT :limit", nativeQuery = true)
+    List<Article> findAllHotArticles(@Param("registeredAt") LocalDate registeredAt, @Param("limit") int limit);
+
+    List<Article> findAllByRegisteredAtIsAfter(LocalDate localDate);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.community.article.repository;
 
-import static in.koreatech.koin.domain.community.article.service.CommunityService.NOTICE_BOARD_ID;
+import static in.koreatech.koin.domain.community.article.service.ArticleService.NOTICE_BOARD_ID;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/redis/ArticleHitRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/redis/ArticleHitRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.community.article.repository.redis;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+import in.koreatech.koin.domain.community.article.model.redis.ArticleHit;
+
+public interface ArticleHitRepository extends CrudRepository<ArticleHit, Integer> {
+
+    List<ArticleHit> findAll();
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/redis/HotArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/redis/HotArticleRepository.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.community.article.repository.redis;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class HotArticleRepository {
+
+    public static final String REDIS_KEY = "hotArticles";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void saveArticlesWithHitToRedis(Map<Integer, Integer> articlesWithHit, int limit) {
+        List<Integer> sortedArticles = articlesWithHit.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+            .limit(limit)
+            .map(Map.Entry::getKey)
+            .toList();
+        ListOperations<String, Object> listOps = redisTemplate.opsForList();
+        redisTemplate.delete(REDIS_KEY);
+        for (Integer articleId : sortedArticles) {
+            listOps.rightPush(REDIS_KEY, articleId);
+        }
+    }
+
+    public List<Integer> getHotArticles(int limit) {
+        ListOperations<String, Object> listOps = redisTemplate.opsForList();
+        List<Object> cache = listOps.range(REDIS_KEY, 0, -1);
+        if (cache == null) {
+            return List.of();
+        }
+        return cache.stream()
+            .map(Integer.class::cast)
+            .limit(limit)
+            .toList();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleScheduler.java
@@ -3,7 +3,7 @@ package in.koreatech.koin.domain.community.article.scheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import in.koreatech.koin.domain.community.article.service.CommunityService;
+import in.koreatech.koin.domain.community.article.service.ArticleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,12 +12,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ArticleScheduler {
 
-    private final CommunityService communityService;
+    private final ArticleService articleService;
 
     @Scheduled(cron = "0 0 0/6 * * *")
     public void resetOldKeywordsAndIpMaps() {
         try {
-            communityService.resetWeightsAndCounts();
+            articleService.resetWeightsAndCounts();
         } catch (Exception e) {
             log.error("많이 검색한 키워드 초기화 중에 오류가 발생했습니다.", e);
         }

--- a/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleScheduler.java
@@ -14,6 +14,15 @@ public class ArticleScheduler {
 
     private final ArticleService articleService;
 
+    @Scheduled(cron = "0 0 6 * * *")
+    public void updateHotArticles() {
+        try {
+            articleService.updateHotArticles();
+        } catch (Exception e) {
+            log.error("인기 게시글 업데이트 중에 오류가 발생했습니다.", e);
+        }
+    }
+
     @Scheduled(cron = "0 0 0/6 * * *")
     public void resetOldKeywordsAndIpMaps() {
         try {

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -243,10 +243,10 @@ public class ArticleService {
                 .filter(articleHit -> articleHit.getId().equals(article.getId()))
                 .findAny();
             int beforeArticleHit = cache.isPresent() ? cache.get().getHit() : 0;
-            if (article.getHit() - beforeArticleHit <= 0) {
+            if (article.getTotalHit() - beforeArticleHit <= 0) {
                 continue;
             }
-            articlesIdWithHit.put(article.getId(), article.getHit() - beforeArticleHit);
+            articlesIdWithHit.put(article.getId(), article.getTotalHit() - beforeArticleHit);
         }
         hotArticleRepository.saveArticlesWithHitToRedis(articlesIdWithHit, HOT_ARTICLE_LIMIT);
     }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CommunityService {
+public class ArticleService {
 
     public static final int NOTICE_BOARD_ID = 4;
     private static final int HOT_ARTICLE_LIMIT = 10;

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.article.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -56,6 +57,7 @@ public class ArticleService {
     private final ArticleSearchKeywordRepository articleSearchKeywordRepository;
     private final ArticleHitRepository articleHitRepository;
     private final HotArticleRepository hotArticleRepository;
+    private final Clock clock;
 
     @Transactional
     public ArticleResponse getArticle(Integer boardId, Integer articleId) {
@@ -99,7 +101,7 @@ public class ArticleService {
             .collect(Collectors.toList());
         if (cacheList.size() < HOT_ARTICLE_LIMIT) {
             List<Article> highestHitArticles = articleRepository.findAllHotArticles(
-                LocalDate.now().minusDays(HOT_ARTICLE_BEFORE_DAYS), HOT_ARTICLE_LIMIT);
+                LocalDate.now(clock).minusDays(HOT_ARTICLE_BEFORE_DAYS), HOT_ARTICLE_LIMIT);
             cacheList.addAll(highestHitArticles);
             return cacheList.stream().limit(HOT_ARTICLE_LIMIT)
                 .map(HotArticleItemResponse::from)
@@ -234,7 +236,7 @@ public class ArticleService {
         List<ArticleHit> articleHits = articleHitRepository.findAll();
         articleHitRepository.deleteAll();
         List<Article> allArticles =
-            articleRepository.findAllByRegisteredAtIsAfter(LocalDate.now().minusDays(HOT_ARTICLE_BEFORE_DAYS));
+            articleRepository.findAllByRegisteredAtIsAfter(LocalDate.now(clock).minusDays(HOT_ARTICLE_BEFORE_DAYS));
         articleHitRepository.saveAll(allArticles.stream().map(ArticleHit::from).toList());
 
         Map<Integer, Integer> articlesIdWithHit = new HashMap<>();

--- a/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
@@ -25,7 +25,7 @@ import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
 
 @SuppressWarnings("NonAsciiCharacters")
-class CommunityApiTest extends AcceptanceTest {
+class ArticleApiTest extends AcceptanceTest {
 
     @Autowired
     private ArticleRepository articleRepository;

--- a/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
@@ -8,13 +8,11 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.config.FixedDate;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.Board;
 import in.koreatech.koin.domain.community.article.model.Comment;
@@ -87,7 +85,7 @@ class ArticleApiTest extends AcceptanceTest {
                     "title": "자유 글의 제목입니다",
                     "content": "<p>내용</p>",
                     "author": "작성자1",
-                    "hit": 1,
+                    "hit": 3,
                     "attachments": [
                         {
                             "id": 1,
@@ -129,7 +127,7 @@ class ArticleApiTest extends AcceptanceTest {
                             "board_id": 1,
                             "title": "자유 글2의 제목입니다",
                             "author": "작성자2",
-                            "hit": 1,
+                            "hit": 2,
                             "registered_at": "2024-01-15",
                             "updated_at": "2024-01-15 12:00:00"
                         },
@@ -138,7 +136,7 @@ class ArticleApiTest extends AcceptanceTest {
                             "board_id": 1,
                             "title": "자유 글의 제목입니다",
                             "author": "작성자1",
-                            "hit": 1,
+                            "hit": 2,
                             "registered_at": "2024-01-15",
                             "updated_at": "2024-01-15 12:00:00"
                         }
@@ -315,7 +313,7 @@ class ArticleApiTest extends AcceptanceTest {
                             "board_id": 1,
                             "title": "자유 글의 제목입니다",
                             "author": "작성자1",
-                            "hit": 1,
+                            "hit": 2,
                             "registered_at": "2024-01-15",
                             "updated_at": "2024-01-15 12:00:00"
                         }
@@ -352,7 +350,7 @@ class ArticleApiTest extends AcceptanceTest {
                                "board_id": 1,
                                "title": "자유 글의 제목입니다",
                                "author": "작성자1",
-                               "hit": 1,
+                               "hit": 2,
                                "registered_at": "2024-01-15",
                                "updated_at": "2024-01-15 12:00:00"
                            }
@@ -366,6 +364,7 @@ class ArticleApiTest extends AcceptanceTest {
     }
 
     @Test
+    @FixedDate(year = 2024, month = 1, day = 20)
     @DisplayName("인기많은 게시글 목록을 조회한다.")
     void getHotArticles() {
         // given
@@ -429,7 +428,7 @@ class ArticleApiTest extends AcceptanceTest {
                         "board_id": 1,
                         "title": "자유 글2의 제목입니다",
                         "author": "작성자2",
-                        "hit": 1,
+                        "hit": 2,
                         "registered_at": "2024-01-15",
                         "updated_at": "2024-01-15 12:00:00"
                     },
@@ -438,7 +437,7 @@ class ArticleApiTest extends AcceptanceTest {
                         "board_id": 1,
                         "title": "자유 글의 제목입니다",
                         "author": "작성자1",
-                        "hit": 1,
+                        "hit": 2,
                         "registered_at": "2024-01-15",
                         "updated_at": "2024-01-15 12:00:00"
                     }
@@ -468,7 +467,7 @@ class ArticleApiTest extends AcceptanceTest {
                                "board_id": 1,
                                "title": "자유 글2의 제목입니다",
                                "author": "작성자2",
-                               "hit": 1,
+                               "hit": 2,
                                "registered_at": "2024-01-15",
                                "updated_at": "2024-01-15 12:00:00"
                            },
@@ -477,7 +476,7 @@ class ArticleApiTest extends AcceptanceTest {
                                "board_id": 1,
                                "title": "자유 글의 제목입니다",
                                "author": "작성자1",
-                               "hit": 1,
+                               "hit": 2,
                                "registered_at": "2024-01-15",
                                "updated_at": "2024-01-15 12:00:00"
                            }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #776 

# 🚀 작업 내용

1. Article 관련 클래스명이 Community로 남아있는 부분이 있어 수정했습니다.

## 내부 로직
1. 매일 6시에 최근 1달간 업로드된 모든 게시글의 조회수를 기록한다.
2. 전날 6시와 오늘 6시 사이에 조회수가 많이 올라온 게시글을 인기 게시글로 지정한다.
    1. 조회수 상승량에 대해 내림차순으로 정렬한다.
    2. 내일 6시 전까지는 반영하지 않고 대기하기 때문에 이 결과를 기록해두고 추후 요청이 오면 그대로 반환한다.
    3. 조회수 차이가 없는 게시글은 인기 게시글에서 제외한다.
        1. 여기서 여러 문제가 파생되지만 3번 로직으로 해결된다.
        2. 단, 4번과 같은 현상이 일어날 수 있다.
3. 인기 게시글 조회 시 지정된 인기 게시글 수가 10개 미만이라면 가장 높은 조회수를 가진 게시글들을 뒤에 이어붙여 반환한다.
    1. 최근 1달간 업로드된 모든 게시글 중 조회수가 높은 순으로 정렬한다.
    2. 이걸 인기 게시글 뒤에 덧붙여 반환한다.
    3. ex) 인기게시글이 3개뿐이라면 -> 조회수 높은 게시글 7개를 뒤에 붙여 반환한다.
4. 조회수가 높은 게시글보다 조회수가 오른 게시글이 우선순위를 가지기 때문에, 조회수만 보면 자연스럽지 않은 상황이 연출될 수 있습니다.
    1. 극단적인 예시를 들어보면, 모든 게시글의 조회수가 어제와 그대로인 상황에서 하나의 게시글만 조회수가 1 올랐다면 아래와 같은 응답이 반환됩니다.

```
[
  {
    "hit": 1, <- 1위
  },
  {
    "hit": 7777, <- 2위
  },
  {
    "hit": 1650, <- 3위
  },
  {
    "hit": 1242, <- 4위
  },
  ...
]
```

# 💬 리뷰 중점사항

현재는 API 호출 수에 따라 koin_hit가 매번 증가하도록 해두었습니다(제한 x). 이 부분은 수정이 필요하지만 추후 AB테스트가 머지되면 클라이언트 기기를 구분할 수 있는 기능이 생기기 때문에 그 때 돌아오겠습니다.