### PR TITLE
task: 테스트코드 mockMvc로 변경

### DIFF
--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -1,12 +1,17 @@
 package in.koreatech.koin.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.restassured.response.Response;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.timetable.model.Lecture;
@@ -17,9 +22,7 @@ import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
 import in.koreatech.koin.fixture.UserFixture;
-import in.koreatech.koin.support.JsonAssertions;
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +31,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TimetableApiTest extends AcceptanceTest {
 
     @Autowired
@@ -46,25 +51,20 @@ class TimetableApiTest extends AcceptanceTest {
     private SemesterFixture semesterFixture;
 
     @Test
-    @DisplayName("특정 학기 강의를 조회한다")
-    void getSemesterLecture() {
+    void 특정_학기_강의를_조회한다() throws Exception {
         semesterFixture.semester("20192");
         semesterFixture.semester("20201");
         String semester = "20201";
         lectureFixture.HRD_개론(semester);
         lectureFixture.건축구조의_이해_및_실습("20192");
 
-        var response = RestAssured
-            .given()
-            .when()
-            .param("semester_date", semester)
-            .get("/lectures")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/lectures")
+                    .param("semester_date", semester)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 [
                     {
                         "id" : 1,
@@ -84,29 +84,24 @@ class TimetableApiTest extends AcceptanceTest {
                         ]
                     }
                 ]
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("특정 학기 강의들을 조회한다")
-    void getSemesterLectures() {
+    void 특정_학기_강의들을_조회한다() throws Exception {
         semesterFixture.semester("20201");
         String semester = "20201";
         lectureFixture.HRD_개론(semester);
         lectureFixture.건축구조의_이해_및_실습(semester);
         lectureFixture.재료역학(semester);
 
-        var response = RestAssured
-            .given()
-            .when()
-            .param("semester_date", semester)
-            .get("/lectures")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/lectures")
+                    .param("semester_date", semester)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 [
                     {
                         "id" : 1,
@@ -160,50 +155,41 @@ class TimetableApiTest extends AcceptanceTest {
                         ]
                     }
                 ]
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("존재하지 않는 학기를 조회하면 404")
-    void isNotSemester() {
+    void 존재하지_않는_학기를_조회하면_404() throws Exception {
         String semester = "20201";
         lectureFixture.HRD_개론(semester);
         lectureFixture.건축구조의_이해_및_실습(semester);
 
-        RestAssured
-            .given()
-            .when()
-            .param("semester_date", "20193")
-            .get("/lectures")
-            .then()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .extract();
+        mockMvc.perform(
+                get("/lectures")
+                    .param("semester_date", "20193")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("계절학기를 조회하면 빈 리스트로 반환한다.")
-    void getSeasonLecture() {
+    void 계절학기를_조회하면_빈_리스트로_반환한다() throws Exception {
         semesterFixture.semester("20241");
         semesterFixture.semester("20242");
         semesterFixture.semester("2024-여름");
         semesterFixture.semester("2024-겨울");
 
-        var Response = RestAssured
-                .given()
-                .when()
-                .param("semester_date", "2024-여름")
-                .get("/lectures")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
-
-        JsonAssertions.assertThat(Response.asPrettyString())
-                .isEqualTo("[]");
+        mockMvc.perform(
+                get("/lectures")
+                    .param("semester_date", "2024-여름")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
     }
 
     @Test
-    @DisplayName("모든 학기를 조회한다.")
-    void findAllSemesters() {
+    void 모든_학기를_조회한다() throws Exception {
         semesterFixture.semester("20241");
         semesterFixture.semester("20242");
         semesterFixture.semester("2024-여름");
@@ -212,16 +198,12 @@ class TimetableApiTest extends AcceptanceTest {
         semesterFixture.semester("2023-여름");
         semesterFixture.semester("2023-겨울");
 
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/semesters")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/semesters")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 [
                     {
                         "id": 2,
@@ -252,13 +234,11 @@ class TimetableApiTest extends AcceptanceTest {
                         "semester": "20231"
                     }
                 ]
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("시간표를 조회한다.")
-    void getTimeTables() {
-        // given
+    void 시간표를_조회한다() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
@@ -268,19 +248,14 @@ class TimetableApiTest extends AcceptanceTest {
 
         timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
 
-        // when & then
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .param("semester", semester.getSemester())
-            .get("/timetables")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo(String.format("""
+        mockMvc.perform(
+                get("/timetables")
+                    .header("Authorization", "Bearer " + token)
+                    .param("semester", semester.getSemester())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                     "semester": "20192",
                     "timetable": [
@@ -318,31 +293,23 @@ class TimetableApiTest extends AcceptanceTest {
                     "grades": 6,
                     "total_grades": 6
                 }
-                """
-            ));
+                """));
     }
 
     @Test
-    @DisplayName("시간표를 조회한다. - 시간표 프레임 없으면 생성")
-    void getTimeTablesAfterCreate() {
-        // given
+    void 시간표를_조회한다_시간표_프레임_없으면_생성() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
 
-        // when & then
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .param("semester", semester.getSemester())
-            .get("/timetables")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo(String.format("""
+        mockMvc.perform(
+                get("/timetables")
+                    .header("Authorization", "Bearer " + token)
+                    .param("semester", semester.getSemester())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                     "semester": "20192",
                     "timetable": [
@@ -350,13 +317,11 @@ class TimetableApiTest extends AcceptanceTest {
                     "grades": 0,
                     "total_grades": 0
                 }
-                """
-            ));
+                """));
     }
 
     @Test
-    @DisplayName("학생이 가진 시간표의 학기를 조회한다.")
-    void getStudentCheckSemester() {
+    void 학생이_가진_시간표의_학기를_조회한다() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester1 = semesterFixture.semester("20192");
@@ -366,18 +331,13 @@ class TimetableApiTest extends AcceptanceTest {
         timetableV2Fixture.시간표6(user, semester1, HRD_개론, null);
         timetableV2Fixture.시간표6(user, semester2, 건축구조의_이해_및_실습, null);
 
-
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/semesters/check")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/semesters/check")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                     "user_id": 1,
                     "semesters": [
@@ -385,13 +345,11 @@ class TimetableApiTest extends AcceptanceTest {
                       "20192"
                     ]
                 }
-                """
-            );
+                """));
     }
 
     @Test
-    @DisplayName("시간표를 생성한다.")
-    void createTimeTables() {
+    void 시간표를_생성한다() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
@@ -399,99 +357,92 @@ class TimetableApiTest extends AcceptanceTest {
        lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
        lectureFixture.HRD_개론(semester.getSemester());
 
-        timetableV2Fixture.시간표1(user, semester);
+       timetableV2Fixture.시간표1(user, semester);
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-            {
-              "timetable": [
-               {
-                    "regular_number": "25",
-                    "code": "ARB244",
-                    "design_score": "0",
-                    "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "건축구조의 이해 및 실습",
-                    "lecture_class": "01",
-                    "target": "디자 1 건축",
-                    "professor": "황현식",
-                    "department": "디자인ㆍ건축공학부"
-               },
-               {
-                    "regular_number": "22",
-                    "code": "BSM590",
-                    "design_score": "0",
-                    "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "컴퓨팅사고",
-                    "lecture_class": "06",
-                    "target": "기공1",
-                    "professor": "박한수,최준호",
-                    "department": "기계공학부"
-               }
-             ],
-              "semester": "20192"
-            }
-         """)
-            .when()
-            .post("/timetables")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract()
-            .response();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
-        {
-            "semester": "20192",
-            "timetable": [
+        mockMvc.perform(
+                post("/timetables")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                        {
+                            "timetable": [
+                            {
+                               "regular_number": "25",
+                               "code": "ARB244",
+                               "design_score": "0",
+                               "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
+                               "class_place": null,
+                               "memo": null,
+                               "grades": "3",
+                               "class_title": "건축구조의 이해 및 실습",
+                               "lecture_class": "01",
+                               "target": "디자 1 건축",
+                               "professor": "황현식",
+                               "department": "디자인ㆍ건축공학부"
+                            },
+                            {
+                               "regular_number": "22",
+                               "code": "BSM590",
+                               "design_score": "0",
+                               "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                               "class_place": null,
+                               "memo": null,
+                               "grades": "3",
+                               "class_title": "컴퓨팅사고",
+                               "lecture_class": "06",
+                               "target": "기공1",
+                               "professor": "박한수,최준호",
+                               "department": "기계공학부"
+                            }
+                            ],
+                            "semester": "20192"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
-                    "id": 1,
-                    "regular_number": "25",
-                    "code": "ARB244",
-                    "design_score": "0",
-                    "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "건축구조의 이해 및 실습",
-                    "lecture_class": "01",
-                    "target": "디자 1 건축",
-                    "professor": "황현식",
-                    "department": "디자인ㆍ건축공학부"
-                },
-                {
-                    "id": 2,
-                    "regular_number": "22",
-                    "code": "BSM590",
-                    "design_score": "0",
-                    "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "컴퓨팅사고",
-                    "lecture_class": "06",
-                    "target": "기공1",
-                    "professor": "박한수,최준호",
-                    "department": "기계공학부"
+                    "semester": "20192",
+                    "timetable": [
+                        {
+                            "id": 1,
+                            "regular_number": "25",
+                            "code": "ARB244",
+                            "design_score": "0",
+                            "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "건축구조의 이해 및 실습",
+                            "lecture_class": "01",
+                            "target": "디자 1 건축",
+                            "professor": "황현식",
+                            "department": "디자인ㆍ건축공학부"
+                        },
+                        {
+                            "id": 2,
+                            "regular_number": "22",
+                            "code": "BSM590",
+                            "design_score": "0",
+                            "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "컴퓨팅사고",
+                            "lecture_class": "06",
+                            "target": "기공1",
+                            "professor": "박한수,최준호",
+                            "department": "기계공학부"
+                        }
+                    ],
+                    "grades": 6,
+                    "total_grades": 6
                 }
-            ],
-            "grades": 6,
-            "total_grades": 6
-        }
-        """);
+                """));
     }
 
     @Test
-    @DisplayName("시간표를 단일 생성한다. - 전체 반환")
-    void createTimeTablesReturnAll() {
+    void 시간표를_단일_생성한다_전체_반환() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
@@ -501,115 +452,104 @@ class TimetableApiTest extends AcceptanceTest {
 
         timetableV2Fixture.시간표1(user, semester);
 
-        var response1 = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-            {
-              "timetable": [
-               {
-                    "regular_number": "25",
-                    "code": "ARB244",
-                    "design_score": "0",
-                    "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "건축구조의 이해 및 실습",
-                    "lecture_class": "01",
-                    "target": "디자 1 건축",
-                    "professor": "황현식",
-                    "department": "디자인ㆍ건축공학부"
-               }
-             ],
-              "semester": "20192"
-            }
-         """)
-            .when()
-            .post("/timetables")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract()
-            .response();
+        mockMvc.perform(
+                post("/timetables")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                        {
+                          "timetable": [
+                           {
+                                "regular_number": "25",
+                                "code": "ARB244",
+                                "design_score": "0",
+                                "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
+                                "class_place": null,
+                                "memo": null,
+                                "grades": "3",
+                                "class_title": "건축구조의 이해 및 실습",
+                                "lecture_class": "01",
+                                "target": "디자 1 건축",
+                                "professor": "황현식",
+                                "department": "디자인ㆍ건축공학부"
+                           }
+                         ],
+                          "semester": "20192"
+                        }
+                     """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
 
-        var response2 = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-            {
-              "timetable": [
-               {
-                    "regular_number": "22",
-                    "code": "BSM590",
-                    "design_score": "0",
-                    "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "컴퓨팅사고",
-                    "lecture_class": "06",
-                    "target": "기공1",
-                    "professor": "박한수,최준호",
-                    "department": "기계공학부"
-               }
-             ],
-              "semester": "20192"
-            }
-         """)
-            .when()
-            .post("/timetables")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract()
-            .response();
-
-        JsonAssertions.assertThat(response2.asPrettyString())
-            .isEqualTo("""
-        {
-            "semester": "20192",
-            "timetable": [
+        mockMvc.perform(
+                post("/timetables")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                        {
+                          "timetable": [
+                           {
+                                "regular_number": "22",
+                                "code": "BSM590",
+                                "design_score": "0",
+                                "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                                "class_place": null,
+                                "memo": null,
+                                "grades": "3",
+                                "class_title": "컴퓨팅사고",
+                                "lecture_class": "06",
+                                "target": "기공1",
+                                "professor": "박한수,최준호",
+                                "department": "기계공학부"
+                           }
+                         ],
+                          "semester": "20192"
+                        }
+                     """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
-                    "id": 1,
-                    "regular_number": "25",
-                    "code": "ARB244",
-                    "design_score": "0",
-                    "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "건축구조의 이해 및 실습",
-                    "lecture_class": "01",
-                    "target": "디자 1 건축",
-                    "professor": "황현식",
-                    "department": "디자인ㆍ건축공학부"
-                },
-                {
-                    "id": 2,
-                    "regular_number": "22",
-                    "code": "BSM590",
-                    "design_score": "0",
-                    "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
-                    "class_place": null,
-                    "memo": null,
-                    "grades": "3",
-                    "class_title": "컴퓨팅사고",
-                    "lecture_class": "06",
-                    "target": "기공1",
-                    "professor": "박한수,최준호",
-                    "department": "기계공학부"
+                    "semester": "20192",
+                    "timetable": [
+                        {
+                            "id": 1,
+                            "regular_number": "25",
+                            "code": "ARB244",
+                            "design_score": "0",
+                            "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "건축구조의 이해 및 실습",
+                            "lecture_class": "01",
+                            "target": "디자 1 건축",
+                            "professor": "황현식",
+                            "department": "디자인ㆍ건축공학부"
+                        },
+                        {
+                            "id": 2,
+                            "regular_number": "22",
+                            "code": "BSM590",
+                            "design_score": "0",
+                            "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "컴퓨팅사고",
+                            "lecture_class": "06",
+                            "target": "기공1",
+                            "professor": "박한수,최준호",
+                            "department": "기계공학부"
+                        }
+                    ],
+                    "grades": 6,
+                    "total_grades": 6
                 }
-            ],
-            "grades": 6,
-            "total_grades": 6
-        }
-        """);
+                """));
     }
 
     @Test
-    @DisplayName("시간표를 삭제한다.")
-    void deleteTimetable() {
+    void 시간표를_삭제한다() throws Exception {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
@@ -619,21 +559,20 @@ class TimetableApiTest extends AcceptanceTest {
 
         timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .param("id", 2)
-            .delete("/timetable")
-            .then()
-            .statusCode(HttpStatus.OK.value());
+        mockMvc.perform(
+                delete("/timetable")
+                    .header("Authorization", "Bearer " + token)
+                    .param("id", "2")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
 
         assertThat(timetableRepository.findById(2)).isNotPresent();
     }
 
-    @Test
-    @DisplayName("시간표 삭제 동시성 예외 적절하게 처리하는지 테스트한다.")
-    void deleteTimetableConcurrency() throws InterruptedException {
+/*    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 시간표_삭제_동시성_예외_적절하게_처리하는지_테스트한다() throws InterruptedException {
         User user = userFixture.준호_학생().getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester("20192");
@@ -670,5 +609,6 @@ class TimetableApiTest extends AcceptanceTest {
         assertThat(timetableRepository.findById(2)).isNotPresent();
 
         executor.shutdown();
-    }
+
+    }*/
 }

--- a/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TrackApiTest.java
@@ -1,19 +1,25 @@
 package in.koreatech.koin.acceptance;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.member.model.Track;
 import in.koreatech.koin.fixture.MemberFixture;
 import in.koreatech.koin.fixture.TechStackFixture;
 import in.koreatech.koin.fixture.TrackFixture;
-import in.koreatech.koin.support.JsonAssertions;
-import io.restassured.RestAssured;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TrackApiTest extends AcceptanceTest {
 
     @Autowired
@@ -26,22 +32,17 @@ class TrackApiTest extends AcceptanceTest {
     private TechStackFixture techStackFixture;
 
     @Test
-    @DisplayName("BCSDLab 트랙 정보를 조회한다")
-    void findTracks() {
+    void BCSDLab_트랙_정보를_조회한다() throws Exception {
         trackFixture.backend();
         trackFixture.frontend();
         trackFixture.ios();
 
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/tracks")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/tracks")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 [
                     {
                         "id": 1,
@@ -68,27 +69,23 @@ class TrackApiTest extends AcceptanceTest {
                         "updated_at": "2024-01-15 12:00:00"
                     }
                 ]
-                """);
+                """));
     }
 
     @Test
     @DisplayName("BCSDLab 트랙 정보 단건 조회 - 삭제된 멤버는 조회하지 않는다.")
-    void findTrackWithoutDeletedMember() {
+    void BCSDLab_트랙_정보_단건_조회_삭제된_멤버는_조회하지_않는다() throws Exception {
         Track track = trackFixture.backend();
         memberFixture.배진호(track); // 삭제된 멤버
         memberFixture.최준호(track);
         techStackFixture.java(track);
 
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/tracks/{id}", track.getId())
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/tracks/{id}", track.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                      "TrackName": "BackEnd",
                      "TechStacks": [
@@ -118,26 +115,21 @@ class TrackApiTest extends AcceptanceTest {
                          }
                      ]
                  }
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("BCSDLab 트랙 정보 단건 조회")
-    void findTrack() {
+    void BCSDLab_트랙_정보_단건_조회() throws Exception {
         Track track = trackFixture.backend();
         memberFixture.최준호(track);
         techStackFixture.java(track);
 
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/tracks/{id}", track.getId())
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/tracks/{id}", track.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                      "TrackName": "BackEnd",
                      "TechStacks": [
@@ -167,24 +159,19 @@ class TrackApiTest extends AcceptanceTest {
                          }
                      ]
                  }
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("BCSDLab 트랙 정보 단건 조회 - 트랙에 속한 멤버와 기술스택이 없을 때")
-    void findTrackWithEmptyMembersAndTechStacks() {
+    void BCSDLab_트랙_정보_단건_조회_트랙에_속한_멤버와_기술스택이_없을_때() throws Exception {
         Track track = trackFixture.frontend();
 
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/tracks/{id}", track.getId())
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/tracks/{id}", track.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                     "TrackName": "FrontEnd",
                     "TechStacks": [
@@ -194,6 +181,6 @@ class TrackApiTest extends AcceptanceTest {
                        
                     ]
                 }
-                """);
+                """));
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -1,28 +1,27 @@
 package in.koreatech.koin.acceptance;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static in.koreatech.koin.domain.user.model.UserIdentity.UNDERGRADUATE;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import in.koreatech.koin.domain.user.model.redis.StudentTemporaryStatus;
 import in.koreatech.koin.domain.user.repository.StudentRedisRepository;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -36,11 +35,10 @@ import in.koreatech.koin.domain.user.repository.StudentRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.global.auth.JwtProvider;
-import in.koreatech.koin.support.JsonAssertions;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UserApiTest extends AcceptanceTest {
 
     @Autowired
@@ -62,107 +60,87 @@ class UserApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Test
-    @DisplayName("학생이 로그인을 진행한다(구 API(/user/login))")
-    void login() {
+    void 학생이_로그인을_진행한다_구_API_user_login() throws Exception {
         Student student = userFixture.성빈_학생();
         String email = student.getUser().getEmail();
         String password = "1234";
 
-        var response = RestAssured
-            .given()
-            .contentType(ContentType.JSON)
-            .body("""
-                {
-                  "email" : "%s",
-                  "password" : "%s"
-                }
-                """.formatted(email, password))
-            .when()
-            .post("/user/login")
-            .then()
-            .statusCode(HttpStatus.CREATED.value())
-            .extract();
+        mockMvc.perform(
+                post("/user/login")
+                    .content("""
+                        {
+                          "email" : "%s",
+                          "password" : "%s"
+                        }
+                        """.formatted(email, password))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated());
     }
 
     @Test
-    @DisplayName("학생이 로그인을 진행한다(신규 API(/student/login))")
-    void studentLogin() {
+    void 학생이_로그인을_진행한다_신규_API_student_login() throws Exception {
         Student student = userFixture.성빈_학생();
         String email = student.getUser().getEmail();
         String password = "1234";
 
-        var response = RestAssured
-            .given()
-            .contentType(ContentType.JSON)
-            .body("""
-                {
-                  "email" : "%s",
-                  "password" : "%s"
-                }
-                """.formatted(email, password))
-            .when()
-            .post("/student/login")
-            .then()
-            .statusCode(HttpStatus.CREATED.value())
-            .extract();
+        mockMvc.perform(
+                post("/student/login")
+                    .content("""
+                        {
+                          "email" : "%s",
+                          "password" : "%s"
+                        }
+                        """.formatted(email, password))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated());
     }
 
     @Test
-    @DisplayName("영양사가 로그인을 진행한다")
-    void coopLogin() {
+    void 영양사가_로그인을_진행한다() throws Exception {
         Coop coop = userFixture.준기_영양사();
         String id = coop.getCoopId();
         String password = "1234";
 
-        var response = RestAssured
-            .given()
-            .contentType(ContentType.JSON)
-            .body("""
-                {
-                  "id" : "%s",
-                  "password" : "%s"
-                }
-                """.formatted(id, password))
-            .when()
-            .post("/coop/login")
-            .then()
-            .statusCode(HttpStatus.CREATED.value())
-            .extract();
+        mockMvc.perform(
+                post("/coop/login")
+                    .content("""
+                        {
+                          "id" : "%s",
+                          "password" : "%s"
+                        }
+                        """.formatted(id, password))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated());
     }
 
     @Test
-    @DisplayName("올바른 영양사 계정인지 확인한다")
-    void coopCheckMe() {
+    void 올바른_영양사_계정인지_확인한다() throws Exception {
         Coop coop = userFixture.준기_영양사();
         String token = userFixture.getToken(coop.getUser());
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/user/coop/me")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/coop/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("올바른 학생계정인지 확인한다")
-    void studentCheckMe() {
+    void 올바른_학생계정인지_확인한다() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
                 {
                     "anonymous_nickname": "익명",
                     "email": "juno@koreatech.ac.kr",
@@ -173,70 +151,72 @@ class UserApiTest extends AcceptanceTest {
                     "phone_number": "01012345678",
                     "student_number": "2019136135"
                 }
-                """);
+                """));
     }
 
     @Test
-    @DisplayName("올바른 학생계정인지 확인한다 - 토큰 정보가 올바르지 않으면  401")
-    void studentCheckMeUnAuthorized() {
+    void 올바른_학생계정인지_확인한다_토큰_정보가_올바르지_않으면_401() throws Exception {
         userFixture.준호_학생();
         String token = "invalidToken";
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.UNAUTHORIZED.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
-    @DisplayName("올바른 학생계정인지 확인한다 - 회원을 찾을 수 없으면 404")
-    void studentCheckMeNotFound() {
+    void 올바른_학생계정인지_확인한다_회원을_찾을_수_없으면_404() throws Exception {
         Student student = userFixture.준호_학생();
         String token = jwtProvider.createToken(student.getUser());
         transactionTemplate.executeWithoutResult(status ->
             studentRepository.deleteByUserId(student.getId())
         );
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다")
-    void studentUpdateMe() {
+    void 학생이_정보를_수정한다() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-                  {
-                    "gender" : 1,
-                    "major" : "기계공학부",
-                    "name" : "서정빈",
-                    "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
-                    "nickname" : "duehee",
-                    "phone_number" : "01023456789",
-                    "student_number" : "2019136136"
-                  }
-                """)
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                        {
+                          "gender" : 1,
+                          "major" : "기계공학부",
+                          "name" : "서정빈",
+                          "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
+                          "nickname" : "duehee",
+                          "phone_number" : "01023456789",
+                          "student_number" : "2019136136"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                    "anonymous_nickname": "익명",
+                    "email": "juno@koreatech.ac.kr",
+                    "gender": 1,
+                    "major": "기계공학부",
+                    "name": "서정빈",
+                    "nickname": "duehee",
+                    "phone_number": "01023456789",
+                    "student_number": "2019136136"
+                }
+            """));
 
         transactionTemplate.executeWithoutResult(status -> {
             Student result = studentRepository.getById(student.getId());
@@ -250,33 +230,17 @@ class UserApiTest extends AcceptanceTest {
                 }
             );
         });
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo("""
-                {
-                    "anonymous_nickname": "익명",
-                    "email": "juno@koreatech.ac.kr",
-                    "gender": 1,
-                    "major": "기계공학부",
-                    "name": "서정빈",
-                    "nickname": "duehee",
-                    "phone_number": "01023456789",
-                    "student_number": "2019136136"
-                }
-                """);
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다 - 학번의 형식이 맞지 않으면 400")
-    void studentUpdateMeNotValidStudentNumber() {
+    void 학생이_정보를_수정한다_학번의_형식이_맞지_않으면_400() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
                   {
                     "gender" : 0,
                     "major" : "메카트로닉스공학부",
@@ -286,24 +250,20 @@ class UserApiTest extends AcceptanceTest {
                     "student_number" : "201913613"
                   }
                 """)
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다 - 학부의 형식이 맞지 않으면 400")
-    void studentUpdateMeNotValidDepartment() {
+    void 학생이_정보를_수정한다_학부의_형식이_맞지_않으면_400() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
                   {
                     "gender" : 0,
                     "major" : "경영학과",
@@ -313,24 +273,20 @@ class UserApiTest extends AcceptanceTest {
                     "student_number" : "2019136136"
                   }
                 """)
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다 - 토큰이 올바르지 않다면 401")
-    void studentUpdateMeUnAuthorized() {
+    void 학생이_정보를_수정한다_토큰이_올바르지_않다면_401() throws Exception {
         userFixture.준호_학생();
         String token = "invalidToken";
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
                   {
                     "gender" : 0,
                     "major" : "메카트로닉스공학부",
@@ -340,27 +296,23 @@ class UserApiTest extends AcceptanceTest {
                     "student_number" : "2019136136"
                   }
                 """)
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.UNAUTHORIZED.value())
-            .extract();
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다 - 회원을 찾을 수 없다면 404")
-    void studentUpdateMeNotFound() {
+    void 학생이_정보를_수정한다_회원을_찾을_수_없다면_404() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
         transactionTemplate.executeWithoutResult(status ->
             studentRepository.deleteByUserId(student.getId())
         );
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
                   {
                     "gender" : 0,
                     "major" : "메카트로닉스공학부",
@@ -370,25 +322,21 @@ class UserApiTest extends AcceptanceTest {
                     "student_number" : "2019136136"
                   }
                 """)
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .extract();
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("학생이 정보를 수정한다 - 이미 있는 닉네임이라면 409")
-    void studentUpdateMeDuplicationNickname() {
+    void 학생이_정보를_수정한다_이미_있는_닉네임이라면_409() throws Exception {
         Student 준호 = userFixture.준호_학생();
         Student 성빈 = userFixture.성빈_학생();
         String token = userFixture.getToken(준호.getUser());
 
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body(String.format("""
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content(String.format("""
                  {
                     "gender" : 0,
                     "major" : "테스트학과",
@@ -398,128 +346,101 @@ class UserApiTest extends AcceptanceTest {
                     "student_number" : "2019136136"
                  }
                 """, 성빈.getUser().getNickname()))
-            .when()
-            .put("/user/student/me")
-            .then()
-            .statusCode(HttpStatus.CONFLICT.value())
-            .extract();
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isConflict());
     }
 
     @Test
-    @DisplayName("회원이 탈퇴한다")
-    void userWithdraw() {
+    void 회원이_탈퇴한다() throws Exception {
         Student student = userFixture.성빈_학생();
         String token = userFixture.getToken(student.getUser());
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .delete("/user")
-            .then()
-            .statusCode(HttpStatus.NO_CONTENT.value())
-            .extract();
+        mockMvc.perform(
+                delete("/user")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNoContent());
 
         assertThat(userRepository.findById(student.getId())).isNotPresent();
     }
 
     @Test
-    @DisplayName("이메일이 중복인지 확인한다")
-    void emailCheckExists() {
+    void 이메일이_중복인지_확인한다() throws Exception {
         String email = "notduplicated@koreatech.ac.kr";
 
-        RestAssured
-            .given()
-            .param("address", email)
-            .when()
-            .get("/user/check/email")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/check/email")
+                    .param("address", email)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
 
         assertThat(userRepository.findByEmail(email)).isNotPresent();
     }
 
     @Test
-    @DisplayName("이메일이 중복인지 확인한다 - 파라미터에 이메일을 포함하지 않으면 400")
-    void emailCheckExistsNull() {
-        RestAssured
-            .when()
-            .get("/user/check/email")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+    void 이메일이_중복인지_확인한다_파라미터에_이메일을_포함하지_않으면_400() throws Exception {
+        mockMvc.perform(
+                get("/user/check/email")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("이메일이 중복인지 확인한다 - 잘못된 이메일 형식이면 400")
-    void emailCheckExistsWrongFormat() {
+    void 이메일이_중복인지_확인한다_잘못된_이메일_형식이면_400() throws Exception {
         String email = "wrong email format";
 
-        RestAssured
-            .given()
-            .param("address", email)
-            .when()
-            .get("/user/check/email")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/check/email")
+                    .param("address", email)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("이메일이 중복인지 확인한다 - 중복이면 422")
-    void emailCheckExistsAlreadyExists() {
+    void 이메일이_중복인지_확인한다_중복이면_422() throws Exception {
         User user = userFixture.성빈_학생().getUser();
 
-        var response = RestAssured
-            .given()
-            .param("address", user.getEmail())
-            .when()
-            .get("/user/check/email")
-            .then()
-            .statusCode(HttpStatus.CONFLICT.value())
-            .extract();
-
-        assertThat(response.body().jsonPath().getString("message"))
-            .contains("존재하는 이메일입니다.");
+        mockMvc.perform(
+                get("/user/check/email")
+                    .param("address", user.getEmail())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("존재하는 이메일입니다."));
     }
 
     @Test
-    @DisplayName("닉네임 중복일때 상태코드 409를 반환한다.")
-    void checkDuplicationOfNicknameConflict() {
+    void 닉네임_중복일때_상태코드_409를_반환한다() throws Exception {
         User user = userFixture.성빈_학생().getUser();
 
-        var response = RestAssured
-            .given()
-            .when()
-            .param("nickname", user.getNickname())
-            .get("/user/check/nickname")
-            .then()
-            .statusCode(HttpStatus.CONFLICT.value())
-            .extract();
-
-        assertThat(response.body().jsonPath().getString("message"))
-            .contains("이미 존재하는 닉네임입니다.");
+        mockMvc.perform(
+                get("/user/check/nickname")
+                    .param("nickname", user.getNickname())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message").value("이미 존재하는 닉네임입니다."));
     }
 
     @Test
-    @DisplayName("닉네임 중복이 아닐시 상태코드 200을 반환한다.")
-    void checkDuplicationOfNickname() {
+    void 닉네임_중복이_아닐시_상태코드_200을_반환한다() throws Exception {
         User user = userFixture.성빈_학생().getUser();
 
-        RestAssured
-            .given()
-            .when()
-            .param("nickname", "철수")
-            .get("/user/check/nickname")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/check/nickname")
+                    .param("nickname", "철수")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("닉네임 제약조건 위반시 상태코드 400를 반환한다.")
-    void checkDuplicationOfNicknameBadRequest() {
+    void 닉네임_제약조건_위반시_상태코드_400를_반환한다() throws Exception {
         User user = User.builder()
             .password("1234")
             .nickname("주노")
@@ -534,28 +455,23 @@ class UserApiTest extends AcceptanceTest {
 
         userRepository.save(user);
 
-        RestAssured
-            .given()
-            .when()
-            .param("nickname", "철".repeat(11))
-            .get("/user/check/nickname")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/check/nickname")
+                    .param("nickname", "철".repeat(11))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
 
-        RestAssured
-            .given()
-            .when()
-            .param("nickname", "")
-            .get("/user/check/nickname")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract();
+        mockMvc.perform(
+                get("/user/check/nickname")
+                    .param("nickname", "")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("로그인된 사용자의 권한을 조회한다.")
-    void getAuth() {
+    void 로그인된_사용자의_권한을_조회한다() throws Exception {
         Student student = Student.builder()
             .studentNumber("2019136135")
             .anonymousNickname("익명")
@@ -579,50 +495,37 @@ class UserApiTest extends AcceptanceTest {
 
         studentRepository.save(student);
         String token = jwtProvider.createToken(student.getUser());
-
-        var response = RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .when()
-            .get("/user/auth")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
         User user = student.getUser();
 
-        assertSoftly(
-            softly -> {
-                softly.assertThat(response.body().jsonPath().getString("user_type"))
-                    .isEqualTo(user.getUserType().getValue());
-            }
-        );
+        mockMvc.perform(
+                get("/user/auth")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.user_type").value(user.getUserType().getValue()));
     }
 
     @Test
-    @DisplayName("학생 회원가입 후 학교 이메일요청 이벤트가 발생하고 Redis에 저장된다.")
-    void studentRegister() {
-        var response = RestAssured
-                .given()
-                .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@koreatech.ac.kr",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "2021136012",
-                  "phone_number": "01000000000"
-                }
-                """)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/user/student/register")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
+    void 학생_회원가입_후_학교_이메일요청_이벤트가_발생하고_Redis에_저장된다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@koreatech.ac.kr",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
 
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
@@ -630,54 +533,51 @@ class UserApiTest extends AcceptanceTest {
                 Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
 
                 assertSoftly(
-                        softly -> {
-                            softly.assertThat(student).isNotNull();
-                            softly.assertThat(student.get().getNickname()).isEqualTo("koko");
-                            softly.assertThat(student.get().getName()).isEqualTo("김철수");
-                            softly.assertThat(student.get().getPhoneNumber()).isEqualTo("01000000000");
-                            softly.assertThat(student.get().getEmail()).isEqualTo("koko123@koreatech.ac.kr");
-                            softly.assertThat(student.get().getStudentNumber()).isEqualTo("2021136012");
-                            softly.assertThat(student.get().getDepartment()).isEqualTo(Dept.COMPUTER_SCIENCE.getName());
-                            verify(studentEventListener).onStudentEmailRequest(any());
-                        }
+                    softly -> {
+                        softly.assertThat(student).isNotNull();
+                        softly.assertThat(student.get().getNickname()).isEqualTo("koko");
+                        softly.assertThat(student.get().getName()).isEqualTo("김철수");
+                        softly.assertThat(student.get().getPhoneNumber()).isEqualTo("01000000000");
+                        softly.assertThat(student.get().getEmail()).isEqualTo("koko123@koreatech.ac.kr");
+                        softly.assertThat(student.get().getStudentNumber()).isEqualTo("2021136012");
+                        softly.assertThat(student.get().getDepartment()).isEqualTo(Dept.COMPUTER_SCIENCE.getName());
+                        verify(studentEventListener).onStudentEmailRequest(any());
+                    }
                 );
             }
         });
     }
 
     @Test
-    @DisplayName("이메일 요청을 확인 후 회원가입 이벤트가 발생하고 Redis에 저장된 정보가 삭제된다.")
-    void authenticate() {
-        RestAssured
-                .given()
-                .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@koreatech.ac.kr",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "2021136012",
-                  "phone_number": "01000000000"
-                }
-                """)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/user/student/register")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
+    void 이메일_요청을_확인_후_회원가입_이벤트가_발생하고_Redis에_저장된_정보가_삭제된다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@koreatech.ac.kr",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
+
 
         Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
 
-        RestAssured
-                .given()
-                .param("auth_token", student.get().getAuthToken())
-                .when()
-                .get("/user/authenticate")
-                .then();
+        mockMvc.perform(
+                post("/user/authenticate")
+                    .param("auth_token", student.get().getAuthToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andReturn();
 
         User user = userRepository.getByEmail("koko123@koreatech.ac.kr");
         assertThat(studentRedisRepository.findById("koko123@koreatech.ac.kr")).isEmpty();
@@ -687,140 +587,123 @@ class UserApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("회원 가입 필수 파라미터를 안넣을시 400에러코드를 반환한다.")
-    void studentRegisterBadRequest() {
-        RestAssured
-            .given()
-            .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": null,
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "2021136012",
-                  "phone_number": "01000000000"
-                }
-                """)
-            .contentType(ContentType.JSON)
-            .when()
-            .post("/user/student/register")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+    void 회원_가입_필수_파라미터를_안넣을시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": null,
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("한기대 이메일이 아닐시 400에러코드를 반환한다.")
-    void studentRegisterInvalid() {
-        RestAssured
-            .given()
-            .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@gmail.com",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "2021136012",
-                  "phone_number": "01000000000"
-                }
-                """)
-            .contentType(ContentType.JSON)
-            .when()
-            .post("/user/student/register")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+    void 한기대_이메일이_아닐시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("유효한 학번의 형식이 아닐시 400에러코드를 반환한다.")
-    void studentRegisterStudentNumberInvalid() {
-        RestAssured
-            .given()
-            .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@gmail.com",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "20211360123324231",
-                  "phone_number": "01000000000"
-                }
-                """)
-            .contentType(ContentType.JSON)
-            .when()
-            .post("/user/student/register")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+    void 유효한_학번의_형식이_아닐시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "20211360123324231",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
 
-        RestAssured
-            .given()
-            .body("""
-                {
-                  "major": "컴퓨터공학부",
-                  "email": "koko123@gmail.com",
-                  "name": "김철수",
-                  "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                  "nickname": "koko",
-                  "gender": "0",
-                  "is_graduated": false,
-                  "student_number": "19911360123",
-                  "phone_number": "01000000000"
-                }
-                """)
-            .contentType(ContentType.JSON)
-            .when()
-            .post("/user/student/register")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "19911360123",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다.")
-    void userCheckPassword() {
+    void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-                  {
-                    "password": "1234"
-                  }
-                """)
-            .when()
-            .post("/user/check/password")
-            .then()
-            .statusCode(HttpStatus.OK.value());
+        mockMvc.perform(
+                post("/user/check/password")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                      {
+                        "password": "1234"
+                      }
+                    """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("사용자가 비밀번호를 통해 자신이 맞는지 인증한다. - 비밀번호가 다르면 400 반환")
-    void userCheckPasswordInvalid() {
+    void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다_비밀번호가_다르면_400_반환() throws Exception {
         Student student = userFixture.준호_학생();
         String token = userFixture.getToken(student.getUser());
 
-        RestAssured
-            .given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .body("""
-                  {
-                    "password": "1233"
-                  }
-                """)
-            .when()
-            .post("/user/check/password")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+        mockMvc.perform(
+                post("/user/check/password")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                      {
+                        "password": "123"
+                      }
+                    """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/VersionApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/VersionApiTest.java
@@ -1,26 +1,30 @@
 package in.koreatech.koin.acceptance;
 
-import org.junit.jupiter.api.DisplayName;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.version.model.Version;
 import in.koreatech.koin.domain.version.model.VersionType;
 import in.koreatech.koin.domain.version.repository.VersionRepository;
-import in.koreatech.koin.support.JsonAssertions;
-import io.restassured.RestAssured;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VersionApiTest extends AcceptanceTest {
 
     @Autowired
     private VersionRepository versionRepository;
 
     @Test
-    @DisplayName("버전 타입을 통해 버전 정보를 조회한다.")
-    void findVersionByType() {
+    void 버전_타입을_통해_버전_정보를_조회한다() throws Exception {
         Version version = versionRepository.save(
             Version.builder()
                 .version("1.0.0")
@@ -28,17 +32,12 @@ class VersionApiTest extends AcceptanceTest {
                 .build()
         );
 
-        // when then
-        var response = RestAssured
-            .given()
-            .when()
-            .get("/versions/" + version.getType())
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract();
-
-        JsonAssertions.assertThat(response.asPrettyString())
-            .isEqualTo(String.format("""
+        mockMvc.perform(
+                get("/versions/" + version.getType())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json(String.format("""
                 {
                     "id": %d,
                     "version": "1.0.0",
@@ -47,28 +46,24 @@ class VersionApiTest extends AcceptanceTest {
                     "updated_at": "2024-01-15"
                 }
                 """, version.getId()
-            ));
+            )));
     }
 
     @Test
-    @DisplayName("버전 타입을 통해 버전 정보를 조회한다. - 저장되지 않은 버전 타입을 요청한 경우 에러가 발생한다.")
-    void findVersionByTypeError() {
+    void 버전_타입을_통해_버전_정보를_조회한다_저장되지_않은_버전_타입을_요청한_경우_에러가_발생한다() throws Exception {
         VersionType failureType = VersionType.TIMETABLE;
-        RestAssured
-            .given()
-            .when()
-            .get("/versions/" + failureType.getValue())
-            .then()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .extract();
-
         String undefinedType = "undefined";
-        RestAssured
-            .given()
-            .when()
-            .get("/versions/" + undefinedType)
-            .then()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .extract();
+
+        mockMvc.perform(
+                get("/versions/" + failureType.getValue())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
+
+        mockMvc.perform(
+                get("/versions/" + undefinedType)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

-  #853 

# 🚀 작업 내용

아래 테스트 코드들을 mockMvc로 변경 & 메서드명 한글로 변경
1. Timetable
2. TimetableV2
3. Track
4. User
5. Version

# 💬 리뷰 중점사항
- UserApiTest에서 실패한 테스트
  - 이메일_요청을_확인_후_회원가입_이벤트가_발생하고_Redis에_저장된_정보가_삭제된다()
  - 학생_회원가입_후_학교_이메일요청_이벤트가_발생하고_Redis에_저장된다()

- TimetableApiTest에서 문제 있는 테스트
  - 시간표_삭제_동시성_예외_적절하게_처리하는지_테스트한다()
- TimetableV2ApiTest에서 문제 있는 테스트
  - isMain이_false인_frame과_true인_frame을_동시에_삭제한다()

시간표 테스트에서 동시성 테스트는 트랜잭션 어노테이션이 적용되면 실패하는 것 같아 적용시키지 않았습니다. 
적용시킨 테스트와 적용 안시킨 테스트를 같이 실행하면 다른 테스트들에 영향을 줘서 실패시키는 것 같습니다.
