### PR TITLE
refactor : 회원가입 + 회원정보 수정 형식 일치

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 
     implementation 'org.jsoup:jsoup:1.15.3'

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // userAgent parser
+    implementation 'com.github.ua-parser:uap-java:1.4.4'
+
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestApi.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestApi.java
@@ -1,0 +1,213 @@
+package in.koreatech.koin.admin.abtest.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.admin.abtest.dto.AbtestAdminAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestCloseRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestDevicesResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestUsersResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestsResponse;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
+import in.koreatech.koin.global.useragent.UserAgent;
+import in.koreatech.koin.global.useragent.UserAgentInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RequestMapping("/abtest")
+@Tag(name = "(NORMAL, ADMIN) Abtest : AB테스트", description = "AB테스트를 관리한다.")
+public interface AbtestApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 생성")
+    @PostMapping
+    ResponseEntity<AbtestResponse> createAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid AbtestRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 수정")
+    @PutMapping("/{id}")
+    ResponseEntity<AbtestResponse> putAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId,
+        @RequestBody @Valid AbtestRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 삭제")
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> deleteAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 목록 조회")
+    @PostMapping
+    ResponseEntity<AbtestsResponse> getAbtests(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 단건 조회")
+    @PostMapping("/{id}")
+    ResponseEntity<AbtestResponse> getAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @Parameter(in = PATH) @PathVariable("id") Integer articleId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험 종료")
+    @PostMapping("/close/{id}")
+    ResponseEntity<Void> closeAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId,
+        @RequestBody @Valid AbtestCloseRequest abtestCloseRequest
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "(ADMIN) 이름으로 유저 목록 조회")
+    @GetMapping("/user")
+    ResponseEntity<AbtestUsersResponse> getUsersByName(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestParam(value = "name") String userName
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "(ADMIN) 유저 id로 디바이스 목록 조회")
+    @GetMapping("/user/{id}/device")
+    ResponseEntity<AbtestDevicesResponse> getDevicesByUserId(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable(value = "id") Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "(ADMIN) 실험군 수동 편입")
+    @PostMapping("/{id}/move")
+    ResponseEntity<Void> assignAbtestVariableByAdmin(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable(value = "id") Integer abtestId,
+        @RequestBody @Valid AbtestAdminAssignRequest abtestAdminAssignRequest
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(NORMAL) 자신의 실험군 조회")
+    @GetMapping("/me")
+    ResponseEntity<String> getMyAbtestVariable(
+        @RequestHeader("accessHistoryId") Integer accessHistoryId,
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId,
+        @RequestParam(name = "title") String title
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(NORMAL) 실험군 최초 편입")
+    @PostMapping("/assign")
+    ResponseEntity<AbtestAssignResponse> assignAbtestVariable(
+        @RequestHeader("accessHistoryId") Integer accessHistoryId,
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId,
+        @RequestBody @Valid AbtestAssignRequest abtestAssignRequest
+    );
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestController.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestController.java
@@ -1,0 +1,149 @@
+package in.koreatech.koin.admin.abtest.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.admin.abtest.dto.AbtestAdminAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestCloseRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestDevicesResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestUsersResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestsResponse;
+import in.koreatech.koin.admin.abtest.service.AbtestService;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
+import in.koreatech.koin.global.useragent.UserAgent;
+import in.koreatech.koin.global.useragent.UserAgentInfo;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/abtest")
+public class AbtestController implements AbtestApi {
+
+    private final AbtestService abtestService;
+
+    @PostMapping
+    public ResponseEntity<AbtestResponse> createAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid AbtestRequest request
+    ) {
+        AbtestResponse response = abtestService.createAbtest(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<AbtestResponse> putAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId,
+        @RequestBody @Valid AbtestRequest request
+    ) {
+        AbtestResponse response = abtestService.putAbtest(abtestId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId
+    ) {
+        abtestService.deleteAbtest(abtestId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<AbtestsResponse> getAbtests(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit
+    ) {
+        AbtestsResponse response = abtestService.getAbtests(page, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AbtestResponse> getAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @Parameter(in = PATH) @PathVariable("id") Integer abtestId
+    ) {
+        AbtestResponse response = abtestService.getAbtest(abtestId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/close/{id}")
+    public ResponseEntity<Void> closeAbtest(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable("id") Integer abtestId,
+        @RequestBody @Valid AbtestCloseRequest abtestCloseRequest
+    ) {
+        abtestService.closeAbtest(abtestId, abtestCloseRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<AbtestUsersResponse> getUsersByName(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestParam(value = "name") String userName
+    ) {
+        AbtestUsersResponse response = abtestService.getUsersByName(userName);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}/device")
+    public ResponseEntity<AbtestDevicesResponse> getDevicesByUserId(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable(value = "userId") Integer userId
+    ) {
+        AbtestDevicesResponse response = abtestService.getDevicesByUserId(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/move")
+    public ResponseEntity<Void> assignAbtestVariableByAdmin(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @PathVariable(value = "id") Integer abtestId,
+        @RequestBody @Valid AbtestAdminAssignRequest abtestAdminAssignRequest
+    ) {
+        abtestService.assignVariableByAdmin(abtestId, abtestAdminAssignRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<String> getMyAbtestVariable(
+        @RequestHeader("access_history_id") Integer accessHistoryId,
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId,
+        @RequestParam(name = "title") String title
+    ) {
+        String response = abtestService.getMyVariable(accessHistoryId, userAgentInfo, userId, title);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/assign")
+    public ResponseEntity<AbtestAssignResponse> assignAbtestVariable(
+        @RequestHeader(value = "access_history_id", required = false) Integer accessHistoryId,
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId,
+        @RequestBody @Valid AbtestAssignRequest abtestAssignRequest
+    ) {
+        AbtestAssignResponse response = abtestService.assignVariable(accessHistoryId, userAgentInfo, userId, abtestAssignRequest);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAdminAssignRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAdminAssignRequest.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestAdminAssignRequest(
+    @NotNull(message = "디바이스 ID는 필수입니다.")
+    @Schema(description = "디바이스 ID", example = "1")
+    Integer deviceId,
+
+    @NotNull(message = "테스트 변수명은 필수입니다.")
+    @Schema(description = "테스트 변수명", example = "A")
+    String variableName
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAssignRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAssignRequest.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestAssignRequest(
+    @NotNull(message = "테스트 변수명은 필수입니다.")
+    @Schema(description = "테스트 변수명", example = "dining_ui_test", requiredMode = REQUIRED)
+    String title
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAssignResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestAssignResponse.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestAssignResponse (
+    @Schema(description = "편입된 변수")
+    String variableName,
+
+    @Schema(description = "기기 식별자")
+    Integer accessHistoryId
+) {
+
+    public static AbtestAssignResponse of(AbtestVariable abtestVariable, AccessHistory accessHistory) {
+        return new AbtestAssignResponse(abtestVariable.getName(), accessHistory.getId());
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestCloseRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestCloseRequest.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestCloseRequest(
+    @NotNull(message = "승자 이름은 필수입니다.")
+    @Schema(description = "승자 이름", example = "A")
+    String winnerName
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestDevicesResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestDevicesResponse.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.abtest.model.Device;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestDevicesResponse(
+    List<InnerDeviceResponse> devices
+) {
+
+    public static AbtestDevicesResponse from(List<Device> devices) {
+        return new AbtestDevicesResponse(devices.stream().map(InnerDeviceResponse::from).toList());
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    private record InnerDeviceResponse(
+        @Schema(description = "디바이스 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "디바이스 타입", example = "mobile")
+        String type,
+
+        @Schema(description = "디바이스 모델", example = "Galaxy20")
+        String model,
+
+        @Schema(description = "마지막 접속 날짜", example = "2019-07-29", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd") LocalDate lastAccessedAt
+    ) {
+
+        public static InnerDeviceResponse from(Device device) {
+            return new InnerDeviceResponse(
+                device.getId(),
+                device.getType(),
+                device.getModel(),
+                device.getAccessHistory().getLastAccessedAt().toLocalDate());
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestRequest.java
@@ -1,0 +1,52 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestRequest(
+    @NotBlank(message = "실험명은 필수입니다.")
+    @Schema(description = "실험명", example = "식단 UI 실험", requiredMode = REQUIRED)
+    String displayTitle,
+
+    @Schema(description = "실험 생성자 이름", example = "홍길동", requiredMode = REQUIRED)
+    String creator,
+
+    @Schema(description = "팀명", example = "campus", requiredMode = REQUIRED)
+    String team,
+
+    @NotBlank(message = "실험명(변수명)은 필수입니다.")
+    @Schema(description = "실험명(변수명)", example = "dining_ui_test", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "실험 내용", example = "식단 UI 변경에 따른 사용자 변화량 조사", requiredMode = REQUIRED)
+    String description,
+
+    List<InnerVariableRequest> variables
+) {
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record InnerVariableRequest(
+
+        @NotNull(message = "실험군 편입 비율은 필수입니다.")
+        @Schema(description = "실험군 편입 비율", example = "33", requiredMode = REQUIRED)
+        Integer rate,
+
+        @NotBlank(message = "실험군 이름은 필수입니다.")
+        @Schema(description = "실험군 이름", example = "실험군 A", requiredMode = REQUIRED)
+        String displayName,
+
+        @NotBlank(message = "실험군 이름(변수명)은 필수입니다.")
+        @Schema(description = "실험군 이름(변수명)", example = "A", requiredMode = REQUIRED)
+        String name
+    ) {
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestResponse.java
@@ -1,0 +1,89 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.abtest.model.Abtest;
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestResponse(
+    @Schema(description = "실험 ID", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "실험명", example = "식단 UI 실험", requiredMode = REQUIRED)
+    String displayTitle,
+
+    @Schema(description = "실험 생성자 이름", example = "홍길동", requiredMode = REQUIRED)
+    String creator,
+
+    @Schema(description = "팀명", example = "campus", requiredMode = REQUIRED)
+    String team,
+
+    @Schema(description = "실험 생성자 이름", example = "홍길동", requiredMode = REQUIRED)
+    String status,
+
+    @Schema(description = "실험 생성자 이름", example = "홍길동", requiredMode = REQUIRED)
+    String winnerName,
+
+    @Schema(description = "실험명(변수명)", example = "dining_ui_test", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "실험 내용", example = "식단 UI 변경에 따른 사용자 변화량 조사", requiredMode = NOT_REQUIRED)
+    String description,
+
+    List<InnerVariableResponse> variables,
+
+    @Schema(description = "생성 일자", example = "2023-01-04 12:00:01")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+
+    @Schema(description = "수정 일자", example = "2023-01-04 12:00:01")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
+) {
+
+    public static AbtestResponse from(Abtest abtest) {
+        return new AbtestResponse(
+            abtest.getId(),
+            abtest.getDisplayTitle(),
+            abtest.getCreator(),
+            abtest.getTeam(),
+            abtest.getStatus().name(),
+            abtest.getWinnerName(),
+            abtest.getTitle(),
+            abtest.getDescription(),
+            abtest.getAbtestVariables().stream()
+                .map(InnerVariableResponse::from)
+                .toList(),
+            abtest.getCreatedAt(),
+            abtest.getUpdatedAt()
+        );
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    private record InnerVariableResponse(
+        @Schema(description = "실험군 편입 비율", example = "33", requiredMode = REQUIRED)
+        Integer rate,
+
+        @Schema(description = "실험군 이름", example = "실험군 A", requiredMode = REQUIRED)
+        String displayName,
+
+        @Schema(description = "실험군 이름(변수명)", example = "A", requiredMode = REQUIRED)
+        String name
+    ) {
+        public static InnerVariableResponse from(AbtestVariable abtestVariable) {
+            return new InnerVariableResponse(
+                abtestVariable.getRate(),
+                abtestVariable.getDisplayName(),
+                abtestVariable.getName()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestUsersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestUsersResponse.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestUsersResponse(
+    List<InnerUserResponse> users
+) {
+
+    public static AbtestUsersResponse from(List<User> users) {
+        return new AbtestUsersResponse(users.stream().map(InnerUserResponse::from).toList());
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    private record InnerUserResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "사용자 상세 정보(전화번호 or 이메일)", example = "010-1234-5678")
+        String detail
+    ) {
+
+        public static InnerUserResponse from(User user) {
+            if (user.getUserType().equals(UserType.OWNER)) {
+                return new InnerUserResponse(user.getId(), user.getName(), user.getPhoneNumber());
+            }
+            return new InnerUserResponse(user.getId(), user.getName(), user.getEmail());
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/AbtestsResponse.java
@@ -1,0 +1,92 @@
+package in.koreatech.koin.admin.abtest.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.abtest.model.Abtest;
+import in.koreatech.koin.global.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AbtestsResponse(
+    @Schema(description = "AB테스트 목록", required = true)
+    List<InnerAbtestResponse> tests,
+
+    @Schema(example = "85", description = "전체 실험 수", required = true)
+    Long totalCount,
+
+    @Schema(example = "10", description = "현재 페이지 실험 수", required = true)
+    Integer currentCount,
+
+    @Schema(example = "9", description = "전체 페이지 수", required = true)
+    Integer totalPage,
+
+    @Schema(example = "1", description = "현재 페이지", required = true)
+    Integer currentPage
+) {
+
+    public static AbtestsResponse of(Page<Abtest> pagedResult, Criteria criteria) {
+        return new AbtestsResponse(
+            pagedResult.stream()
+                .map(InnerAbtestResponse::from)
+                .toList(),
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
+        );
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    private record InnerAbtestResponse(
+
+        @Schema(example = "1", description = "AB테스트 고유 id", required = true)
+        Integer id,
+
+        @Schema(example = "IN_PROGRESS", description = "AB테스트 상태", required = true)
+        String status,
+
+        @Schema(example = "A", description = "승자 실험군 이름", required = true)
+        String winnerName,
+
+        @Schema(example = "송선권", description = "AB테스트 생성자", required = true)
+        String creator,
+
+        @Schema(example = "campus", description = "AB테스트 팀명", required = true)
+        String team,
+
+        @Schema(example = "식단 테스트", description = "AB테스트 제목", required = true)
+        String displayTitle,
+
+        @Schema(example = "dining_ui_test", description = "AB테스트 제목(변수명)", required = true)
+        String title,
+
+        @Schema(description = "생성 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+
+        @Schema(description = "수정 일자", example = "2023-01-04 12:00:01", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
+    ) {
+        public static InnerAbtestResponse from(Abtest abtest) {
+            return new InnerAbtestResponse(
+                abtest.getId(),
+                abtest.getStatus().name(),
+                abtest.getWinnerName(),
+                abtest.getCreator(),
+                abtest.getTeam(),
+                abtest.getDisplayTitle(),
+                abtest.getTitle(),
+                abtest.getCreatedAt(),
+                abtest.getUpdatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAlreadyExistException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAlreadyExistException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DuplicationException;
+
+public class AbtestAlreadyExistException extends DuplicationException {
+
+    private static final String DEFAULT_MESSAGE = "이미 존재하는 AB테스트입니다.";
+
+    public AbtestAlreadyExistException(String message) {
+        super(message);
+    }
+
+    public AbtestAlreadyExistException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestAlreadyExistException withDetail(String detail) {
+        return new AbtestAlreadyExistException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAssignException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAssignException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalStateException;
+
+public class AbtestAssignException extends KoinIllegalStateException {
+
+    private static final String DEFAULT_MESSAGE = "AB테스트 편입 중 오류가 발생했습니다.";
+
+    public AbtestAssignException(String message) {
+        super(message);
+    }
+
+    public AbtestAssignException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestAssignException withDetail(String detail) {
+        return new AbtestAssignException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAssignedUserException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestAssignedUserException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestAssignedUserException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "이미 편입된 사용자입니다.";
+
+    public AbtestAssignedUserException(String message) {
+        super(message);
+    }
+
+    public AbtestAssignedUserException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestAssignedUserException withDetail(String detail) {
+        return new AbtestAssignedUserException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestDuplicatedVariableException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestDuplicatedVariableException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DuplicationException;
+
+public class AbtestDuplicatedVariableException extends DuplicationException {
+
+    private static final String DEFAULT_MESSAGE = "실험군이 중복됩니다.";
+
+    public AbtestDuplicatedVariableException(String message) {
+        super(message);
+    }
+
+    public AbtestDuplicatedVariableException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestDuplicatedVariableException withDetail(String detail) {
+        return new AbtestDuplicatedVariableException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotAssignedUserException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotAssignedUserException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestNotAssignedUserException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "편입되지 않은 사용자입니다.";
+
+    public AbtestNotAssignedUserException(String message) {
+        super(message);
+    }
+
+    public AbtestNotAssignedUserException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestNotAssignedUserException withDetail(String detail) {
+        return new AbtestNotAssignedUserException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AbtestNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 Abtest입니다.";
+
+    public AbtestNotFoundException(String message) {
+        super(message);
+    }
+
+    public AbtestNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestNotFoundException withDetail(String detail) {
+        return new AbtestNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotInProgressException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotInProgressException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestNotInProgressException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "진행중이지 않은 AB테스트입니다.";
+
+    public AbtestNotInProgressException(String message) {
+        super(message);
+    }
+
+    public AbtestNotInProgressException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestNotInProgressException withDetail(String detail) {
+        return new AbtestNotInProgressException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotIncludeVariableException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestNotIncludeVariableException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestNotIncludeVariableException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "요청된 AB테스트 내에 실험군이 존재하지 않습니다.";
+
+    public AbtestNotIncludeVariableException(String message) {
+        super(message);
+    }
+
+    public AbtestNotIncludeVariableException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestNotIncludeVariableException withDetail(String detail) {
+        return new AbtestNotIncludeVariableException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestTitleIllegalArgumentException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestTitleIllegalArgumentException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestTitleIllegalArgumentException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "실험 이름이 잘못되었습니다.";
+
+    public AbtestTitleIllegalArgumentException(String message) {
+        super(message);
+    }
+
+    public AbtestTitleIllegalArgumentException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestTitleIllegalArgumentException withDetail(String detail) {
+        return new AbtestTitleIllegalArgumentException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableCountNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableCountNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AbtestVariableCountNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 AbtestVariableCount입니다.";
+
+    public AbtestVariableCountNotFoundException(String message) {
+        super(message);
+    }
+
+    public AbtestVariableCountNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestVariableCountNotFoundException withDetail(String detail) {
+        return new AbtestVariableCountNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableIllegalArgumentException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableIllegalArgumentException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
+public class AbtestVariableIllegalArgumentException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "실험군이 잘못되었습니다.";
+
+    public AbtestVariableIllegalArgumentException(String message) {
+        super(message);
+    }
+
+    public AbtestVariableIllegalArgumentException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestVariableIllegalArgumentException withDetail(String detail) {
+        return new AbtestVariableIllegalArgumentException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestVariableNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AbtestVariableNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 AbtestVariable입니다.";
+
+    public AbtestVariableNotFoundException(String message) {
+        super(message);
+    }
+
+    public AbtestVariableNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestVariableNotFoundException withDetail(String detail) {
+        return new AbtestVariableNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestWinnerNotDecidedException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AbtestWinnerNotDecidedException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.KoinIllegalStateException;
+
+public class AbtestWinnerNotDecidedException extends KoinIllegalStateException {
+
+    private static final String DEFAULT_MESSAGE = "종료되었으나 우승자가 결정되지 않은 AB테스트입니다.";
+
+    public AbtestWinnerNotDecidedException(String message) {
+        super(message);
+    }
+
+    public AbtestWinnerNotDecidedException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AbtestWinnerNotDecidedException withDetail(String detail) {
+        return new AbtestWinnerNotDecidedException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/AccessHistoryNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/AccessHistoryNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AccessHistoryNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 접속 이력입니다.";
+
+    public AccessHistoryNotFoundException(String message) {
+        super(message);
+    }
+
+    public AccessHistoryNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AccessHistoryNotFoundException withDetail(String detail) {
+        return new AccessHistoryNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/exception/DeviceNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/exception/DeviceNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.abtest.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class DeviceNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 디바이스입니다.";
+
+    public DeviceNotFoundException(String message) {
+        super(message);
+    }
+
+    public DeviceNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DeviceNotFoundException withDetail(String detail) {
+        return new DeviceNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/Abtest.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/Abtest.java
@@ -1,0 +1,241 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import in.koreatech.koin.admin.abtest.dto.AbtestRequest;
+import in.koreatech.koin.admin.abtest.exception.AbtestAssignException;
+import in.koreatech.koin.admin.abtest.exception.AbtestNotIncludeVariableException;
+import in.koreatech.koin.admin.abtest.exception.AbtestTitleIllegalArgumentException;
+import in.koreatech.koin.admin.abtest.exception.AbtestVariableIllegalArgumentException;
+import in.koreatech.koin.admin.abtest.model.redis.AbtestVariableCount;
+import in.koreatech.koin.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "abtest", schema = "koin")
+public class Abtest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "title", nullable = false, unique = true)
+    private String title;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "display_title", nullable = false)
+    private String displayTitle;
+
+    @Size(max = 255)
+    @Column(name = "description")
+    private String description;
+
+    @Size(max = 50)
+    @Column(name = "creator")
+    private String creator;
+
+    @Size(max = 50)
+    @Column(name = "team")
+    private String team;
+
+    @NotNull
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AbtestStatus status;
+
+    @OneToMany(mappedBy = "abtest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AbtestVariable> abtestVariables = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "winner_id")
+    private AbtestVariable winner;
+
+    @Builder
+    private Abtest(
+        Integer id,
+        String title,
+        String displayTitle,
+        String description,
+        String creator,
+        String team,
+        AbtestStatus status
+    ) {
+        this.id = id;
+        this.title = title;
+        this.displayTitle = displayTitle;
+        this.description = description;
+        this.creator = creator;
+        this.team = team;
+        this.status = status;
+    }
+
+    public AbtestVariable findAssignVariable(List<AbtestVariableCount> cacheCounts) {
+        // dbCount와 cacheCount를 병합하여 현재 카운트를 계산
+        Map<Integer, Integer> currentCounts = abtestVariables.stream()
+            .collect(Collectors.toMap(AbtestVariable::getId, AbtestVariable::getCount));
+
+        cacheCounts.forEach(count -> currentCounts.merge(
+            count.getVariableId(),
+            count.getCount(),
+            Integer::sum
+        ));
+
+        // 총 레코드 수 계산
+        int totalCount = currentCounts.values().stream().mapToInt(Integer::intValue).sum();
+        if (totalCount == 0) {
+            return abtestVariables.get(0);
+        }
+
+        // 각 변수의 차이 계산하여 가장 큰 차이를 갖는 변수 선택
+        int targetVariable = abtestVariables.stream()
+            .map(variable -> {
+                int currentRate = currentCounts.get(variable.getId()) * 100 / totalCount;
+                int difference = variable.getRate() - currentRate;
+                return new AbstractMap.SimpleEntry<>(variable.getId(), difference);
+            })
+            .max(Map.Entry.comparingByValue())
+            .orElseThrow(() -> AbtestAssignException.withDetail("abtest name: " + title))
+            .getKey();
+
+        // 타겟 변수 반환
+        return abtestVariables.stream()
+            .filter(variable -> variable.getId() == targetVariable)
+            .findAny()
+            .orElseThrow(() -> AbtestAssignException.withDetail("abtest name: " + title));
+    }
+
+    public void setVariables(List<AbtestRequest.InnerVariableRequest> variables, EntityManager entityManager) {
+        vaildateVariables(variables);
+        List<AbtestVariable> saved = variables.stream()
+            .map(request ->
+                AbtestVariable.builder()
+                    .abtest(this)
+                    .displayName(request.displayName())
+                    .rate(request.rate())
+                    .name(request.name())
+                    .build()
+            ).toList();
+        abtestVariables.clear();
+        entityManager.flush();
+        abtestVariables.addAll(saved);
+    }
+
+    public void update(String displayTitle, String creator, String team, String title, String description,
+        List<AbtestRequest.InnerVariableRequest> variables) {
+        if (!this.title.equals(title)) {
+            throw AbtestTitleIllegalArgumentException.withDetail("실험 title은 변경할 수 없습니다.");
+        }
+        vaildateVariables(variables);
+        validatePutVariables(this, variables);
+        updateVariables(variables);
+        this.displayTitle = displayTitle;
+        this.creator = creator;
+        this.team = team;
+        this.description = description;
+    }
+
+    private static void vaildateVariables(List<AbtestRequest.InnerVariableRequest> variables) {
+        int sum = variables.stream().mapToInt(AbtestRequest.InnerVariableRequest::rate).sum();
+        if (sum != 100) {
+            throw AbtestVariableIllegalArgumentException.withDetail("실험군 비율 합이 100이 아닙니다. rate sum: " + sum);
+        }
+
+        int distinctSize = variables.stream()
+            .map(AbtestRequest.InnerVariableRequest::name)
+            .distinct().toList().size();
+        if (distinctSize != variables.size()) {
+            throw AbtestVariableIllegalArgumentException.withDetail("실험군 간의 변수명(name)이 중복됩니다.");
+        }
+    }
+
+    private void updateVariables(List<AbtestRequest.InnerVariableRequest> requestVariables) {
+        requestVariables.forEach(requestVariable -> {
+            AbtestVariable variable = abtestVariables.stream()
+                .filter(abtestVariable -> abtestVariable.getName().equals(requestVariable.name()))
+                .findAny()
+                .orElseThrow(() -> AbtestVariableIllegalArgumentException.withDetail(
+                    "abtest name: " + title + ", variable name: " + requestVariable.name()));
+            variable.update(requestVariable.displayName(), requestVariable.rate());
+        });
+    }
+
+    private void validatePutVariables(Abtest abtest, List<AbtestRequest.InnerVariableRequest> variables) {
+        if (abtest.getAbtestVariables().size() != variables.size()) {
+            throw AbtestVariableIllegalArgumentException.withDetail("실험군 개수는 수정될 수 없습니다.");
+        }
+    }
+
+    public String getWinnerName() {
+        return winner != null ? winner.getName() : null;
+    }
+
+    public void close(String winnerName) {
+        status = AbtestStatus.CLOSED;
+        if (winnerName != null) {
+            winner = getVariableByName(winnerName);
+        }
+        abtestVariables.forEach(AbtestVariable::close);
+    }
+
+    public void assignVariableByAdmin(AccessHistory accessHistory, String variableName) {
+        resetExistVariable(accessHistory);
+        AbtestVariable variable = getVariableByName(variableName);
+        accessHistory.addVariable(variable);
+        variable.addCount(1);
+    }
+
+    public AbtestVariable getVariableByName(String variableName) {
+        return abtestVariables.stream()
+            .filter(abtestVariable -> abtestVariable.getName().equals(variableName))
+            .findAny()
+            .orElseThrow(() -> AbtestNotIncludeVariableException.withDetail(
+                "abtest name: " + title + ", winner name: " + variableName));
+    }
+
+    private void resetExistVariable(AccessHistory accessHistory) {
+        Optional<AbtestVariable> variable = findVariableByAccessHistory(accessHistory);
+        if (variable.isEmpty()) {
+            return;
+        }
+        variable.get().addCount(-1);
+        accessHistory.removeVariable(variable.get());
+    }
+
+    public Optional<AbtestVariable> findVariableByAccessHistory(AccessHistory accessHistory) {
+        return accessHistory.getAccessHistoryAbtestVariables().stream()
+            .filter(map -> map.getAccessHistory().getId().equals(accessHistory.getId()))
+            .map(AccessHistoryAbtestVariable::getVariable)
+            .findAny();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AbtestStatus.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AbtestStatus.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import lombok.Getter;
+
+@Getter
+public enum AbtestStatus {
+    IN_PROGRESS,
+    CLOSED,
+    ;
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AbtestVariable.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AbtestVariable.java
@@ -1,0 +1,90 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import in.koreatech.koin.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "abtest_variable", schema = "koin")
+public class AbtestVariable extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "abtest_id", nullable = false)
+    private Abtest abtest;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "display_name", nullable = false)
+    private String displayName;
+
+    @Column(name = "rate", nullable = false)
+    private Integer rate;
+
+    @Column(name = "count", nullable = false)
+    private Integer count = 0;
+
+    @OneToMany(mappedBy = "variable", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<AccessHistoryAbtestVariable> accessHistoryAbtestVariables = new ArrayList<>();
+
+    @Builder
+    private AbtestVariable(
+        Integer id,
+        Abtest abtest,
+        String name,
+        String displayName,
+        Integer rate,
+        Integer count
+    ) {
+        this.id = id;
+        this.abtest = abtest;
+        this.name = name;
+        this.displayName = displayName;
+        this.rate = rate;
+        this.count = count != null ? count : 0;
+    }
+
+    public void addCount(int count) {
+        this.count += count;
+    }
+
+    public void update(String displayName, Integer rate) {
+        this.displayName = displayName;
+        this.rate = rate;
+    }
+
+    public void close() {
+        accessHistoryAbtestVariables.clear();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
@@ -1,0 +1,117 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import in.koreatech.koin.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "access_history", schema = "koin")
+public class AccessHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id")
+    private Device device;
+
+    @OneToMany(mappedBy = "accessHistory", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<AccessHistoryAbtestVariable> accessHistoryAbtestVariables = new ArrayList<>();
+
+    @NotNull
+    @Column(name = "last_accessed_at", nullable = false, columnDefinition = "TIMESTAMP")
+    @CreatedDate
+    private LocalDateTime lastAccessedAt;
+
+    public Optional<AbtestVariable> findVariableByAbtestId(int abtestId) {
+        return accessHistoryAbtestVariables.stream()
+            .map(AccessHistoryAbtestVariable::getVariable)
+            .filter(abtestVariable -> abtestVariable.getAbtest().getId().equals(abtestId))
+            .findAny();
+    }
+
+    @Builder
+    private AccessHistory(
+        Integer id,
+        Device device,
+        LocalDateTime lastAccessedAt
+    ) {
+        this.id = id;
+        this.device = device;
+        this.lastAccessedAt = lastAccessedAt;
+    }
+
+    public void connectDevice(Device device) {
+        this.device = device;
+        device.setAccessHistory(this);
+    }
+
+    public void addVariable(AbtestVariable variable) {
+        accessHistoryAbtestVariables.add(AccessHistoryAbtestVariable.builder()
+            .accessHistory(this)
+            .variable(variable)
+            .build());
+    }
+
+    public List<AbtestVariable> getVariableBy(Abtest abtest) {
+        return accessHistoryAbtestVariables.stream()
+            .map(AccessHistoryAbtestVariable::getVariable)
+            .filter(abtestVariable -> abtestVariable.getAbtest().equals(abtest))
+            .toList();
+    }
+
+    public void addAbtestVariable(AbtestVariable variable) {
+        accessHistoryAbtestVariables.removeIf(map -> map.getVariable().getAbtest().equals(variable.getAbtest()));
+
+        AccessHistoryAbtestVariable saved = AccessHistoryAbtestVariable.builder()
+            .accessHistory(this)
+            .variable(variable)
+            .build();
+        accessHistoryAbtestVariables.add(saved);
+        variable.getAccessHistoryAbtestVariables().add(saved);
+    }
+
+    public boolean hasVariable(Integer variableId) {
+        return accessHistoryAbtestVariables.stream()
+            .map(AccessHistoryAbtestVariable::getVariable)
+            .anyMatch(abtestVariable -> Objects.equals(abtestVariable.getId(), variableId));
+    }
+
+    public void removeVariable(AbtestVariable variable) {
+        accessHistoryAbtestVariables.removeIf(
+            accessHistoryAbtestVariable -> accessHistoryAbtestVariable.getVariable().equals(variable)
+        );
+    }
+
+    public void updateLastAccessedAt(Clock clock) {
+        this.lastAccessedAt = LocalDateTime.now(clock);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistoryAbtestVariable.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistoryAbtestVariable.java
@@ -1,0 +1,51 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "access_history_abtest_variable", schema = "koin")
+public class AccessHistoryAbtestVariable extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "access_history_id", nullable = false)
+    private AccessHistory accessHistory;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "variable_id", nullable = false)
+    private AbtestVariable variable;
+
+    @Builder
+    private AccessHistoryAbtestVariable(
+        Integer id,
+        AccessHistory accessHistory,
+        AbtestVariable variable
+    ) {
+        this.id = id;
+        this.accessHistory = accessHistory;
+        this.variable = variable;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/Device.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/Device.java
@@ -1,0 +1,78 @@
+package in.koreatech.koin.admin.abtest.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "device", schema = "koin")
+public class Device extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @OneToOne(mappedBy = "device", cascade = CascadeType.PERSIST)
+    private AccessHistory accessHistory;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Size(max = 100)
+    @Column(name = "model", length = 100)
+    private String model;
+
+    @Size(max = 100)
+    @Column(name = "type", length = 100)
+    private String type;
+
+    @Builder
+    private Device(
+        Integer id,
+        AccessHistory accessHistory,
+        User user,
+        String model,
+        String type
+    ) {
+        this.id = id;
+        this.accessHistory = accessHistory;
+        this.user = user;
+        this.model = model;
+        this.type = type;
+    }
+
+    public void setAccessHistory(AccessHistory accessHistory) {
+        this.accessHistory = accessHistory;
+    }
+
+    public void changeUser(User user) {
+        this.user = user;
+    }
+
+    public void setModelInfo(String model, String type) {
+        this.model = model;
+        this.type = type;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/redis/AbtestVariableAssign.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/redis/AbtestVariableAssign.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.admin.abtest.model.redis;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("AbtestVariableAssign")
+public class AbtestVariableAssign {
+
+    public static final String DELIMITER = ":";
+
+    private static final long CACHE_EXPIRE_DAYS = 3L;
+
+    @Id
+    private String id;
+
+    @TimeToLive(unit = TimeUnit.DAYS)
+    private final Long expiration;
+
+    @Builder
+    private AbtestVariableAssign(String id, Long expiration) {
+        this.id = id;
+        this.expiration = expiration;
+    }
+
+    public static AbtestVariableAssign of(Integer variableId, Integer accessHistoryId) {
+        return AbtestVariableAssign.builder()
+            .id(variableId + DELIMITER + accessHistoryId)
+            .expiration(CACHE_EXPIRE_DAYS)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/redis/AbtestVariableCount.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/redis/AbtestVariableCount.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.admin.abtest.model.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("AbtestVariableCount")
+public class AbtestVariableCount {
+
+    @Id
+    private Integer variableId;
+    private Integer count;
+
+    @Builder
+    private AbtestVariableCount(Integer variableId, Integer count) {
+        this.variableId = variableId;
+        this.count = count;
+    }
+
+    public void resetCount() {
+        count = 0;
+    }
+
+    public void addCount() {
+        count += 1;
+    }
+
+    public void minusCount() {
+        count -= 1;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestRepository.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.exception.AbtestNotFoundException;
+import in.koreatech.koin.admin.abtest.model.Abtest;
+
+public interface AbtestRepository extends Repository<Abtest, Integer> {
+
+    Optional<Abtest> findById(Integer id);
+
+    Abtest save(Abtest build);
+
+    default Abtest getById(Integer id) {
+        return findById(id).orElseThrow(() ->
+            AbtestNotFoundException.withDetail("AbtestId: " + id));
+    }
+
+    Optional<Abtest> findByTitle(String title);
+
+    default Abtest getByTitle(String title) {
+        return findByTitle(title).orElseThrow(() -> AbtestNotFoundException.withDetail("Abtest Title: " + title));
+    }
+
+    Long countBy();
+
+    Page<Abtest> findAll(Pageable pageable);
+
+    void deleteById(Integer abtestId);
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableAssignRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableAssignRepository.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import static in.koreatech.koin.admin.abtest.model.redis.AbtestVariableAssign.DELIMITER;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.model.redis.AbtestVariableAssign;
+
+public interface AbtestVariableAssignRepository extends Repository<AbtestVariableAssign, String> {
+
+    AbtestVariableAssign save(AbtestVariableAssign abtestVariableAssign);
+
+    Optional<AbtestVariableAssign> findById(String id);
+
+    void deleteById(String id);
+
+    default Optional<AbtestVariableAssign> findByVariableIdAndAccessHistoryId(Integer variableId,
+        Integer accessHistoryId) {
+        return findById(variableId + DELIMITER + accessHistoryId);
+    }
+
+    default void deleteByVariableIdAndAccessHistoryId(Integer variableId, Integer accessHistoryId) {
+        deleteById(variableId + DELIMITER + accessHistoryId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableAssignTemplateRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableAssignTemplateRepository.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import static in.koreatech.koin.admin.abtest.model.redis.AbtestVariableAssign.DELIMITER;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AbtestVariableAssignTemplateRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void deleteAllByVariableId(Integer variableId) {
+        Set<String> keys = redisTemplate.keys("AbtestVariableAssign:" + variableId + DELIMITER + "*");
+        if (keys == null) {
+            return;
+        }
+        for (String s : keys) {
+            redisTemplate.delete(s);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableCountRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableCountRepository.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import in.koreatech.koin.admin.abtest.model.redis.AbtestVariableCount;
+
+public interface AbtestVariableCountRepository extends CrudRepository<AbtestVariableCount, Integer> {
+
+    List<AbtestVariableCount> findAll();
+
+    AbtestVariableCount save(AbtestVariableCount abtestVariableCount);
+
+    Optional<AbtestVariableCount> findById(Integer id);
+
+    default AbtestVariableCount findOrCreateIfNotExists(Integer id) {
+        return findById(id).orElseGet(() ->
+            save(AbtestVariableCount.builder()
+                .variableId(id)
+                .count(0)
+                .build())
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AbtestVariableRepository.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.exception.AbtestVariableNotFoundException;
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+
+public interface AbtestVariableRepository extends Repository<AbtestVariable, Integer> {
+
+    Optional<AbtestVariable> findById(Integer variableId);
+
+    default AbtestVariable getById(Integer variableId) {
+        return findById(variableId).orElseThrow(() ->
+            AbtestVariableNotFoundException.withDetail("AbtestVariable id: " + variableId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableCustomRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.List;
+
+public interface AccessHistoryAbtestVariableCustomRepository {
+
+    List<Integer> findIdsToMove(Integer fromVariableId, int limit);
+
+    void updateVariableIds(List<Integer> idsToUpdate, Integer toVariableId);
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableCustomRepositoryImpl.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableCustomRepositoryImpl.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import in.koreatech.koin.admin.abtest.model.QAccessHistoryAbtestVariable;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AccessHistoryAbtestVariableCustomRepositoryImpl
+    implements AccessHistoryAbtestVariableCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Integer> findIdsToMove(Integer fromVariableId, int limit) {
+        return queryFactory.select(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable.id)
+            .from(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable)
+            .where(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable.variable.id.eq(fromVariableId))
+            .limit(limit)
+            .fetch();
+    }
+
+    public void updateVariableIds(List<Integer> idsToUpdate, Integer toVariableId) {
+        queryFactory.update(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable)
+            .set(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable.variable.id, toVariableId)
+            .where(QAccessHistoryAbtestVariable.accessHistoryAbtestVariable.id.in(idsToUpdate))
+            .execute();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryAbtestVariableRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.model.AccessHistoryAbtestVariable;
+
+public interface AccessHistoryAbtestVariableRepository extends Repository<AccessHistoryAbtestVariable, Integer> {
+
+    AccessHistoryAbtestVariable save(AccessHistoryAbtestVariable accessHistoryAbtestVariable);
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryRepository.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.exception.AccessHistoryNotFoundException;
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
+
+public interface AccessHistoryRepository extends Repository<AccessHistory, Integer> {
+
+    AccessHistory save(AccessHistory accessHistory);
+
+    Optional<AccessHistory> findById(Integer id);
+
+    Optional<AccessHistory> findByDeviceId(Integer deviceId);
+
+    default AccessHistory getById(Integer accessHistoryId) {
+        return findById(accessHistoryId).orElseThrow(() ->
+            AccessHistoryNotFoundException.withDetail("accessHistoryId: " + accessHistoryId));
+    }
+
+    default AccessHistory getByDeviceId(Integer deviceId) {
+        return findByDeviceId(deviceId).orElseThrow(() ->
+            AccessHistoryNotFoundException.withDetail("deviceId: " + deviceId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/DeviceRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/DeviceRepository.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.admin.abtest.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.abtest.exception.DeviceNotFoundException;
+import in.koreatech.koin.admin.abtest.model.Device;
+
+public interface DeviceRepository extends Repository<Device, Integer> {
+
+    Device save(Device device);
+
+    Optional<Device> findById(Integer id);
+
+    List<Device> findAllByUserId(Integer id);
+
+    default Device getById(Integer id) {
+        return findById(id).orElseThrow(() ->
+            DeviceNotFoundException.withDetail("id: " + id));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/scheduler/AbtestScheduler.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/scheduler/AbtestScheduler.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.admin.abtest.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.admin.abtest.service.AbtestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AbtestScheduler {
+
+    private final AbtestService abtestService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void syncCacheCountToDB() {
+        try {
+            abtestService.syncCacheCountToDB();
+        } catch (Exception e) {
+            log.warn("AB test 편입 수 DB 동기화 과정에서 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/service/AbtestService.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/service/AbtestService.java
@@ -1,0 +1,349 @@
+package in.koreatech.koin.admin.abtest.service;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.admin.abtest.dto.AbtestAdminAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestAssignResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestCloseRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestDevicesResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestRequest;
+import in.koreatech.koin.admin.abtest.dto.AbtestResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestUsersResponse;
+import in.koreatech.koin.admin.abtest.dto.AbtestsResponse;
+import in.koreatech.koin.admin.abtest.exception.AbtestAlreadyExistException;
+import in.koreatech.koin.admin.abtest.exception.AbtestAssignedUserException;
+import in.koreatech.koin.admin.abtest.exception.AbtestDuplicatedVariableException;
+import in.koreatech.koin.admin.abtest.exception.AbtestNotAssignedUserException;
+import in.koreatech.koin.admin.abtest.exception.AbtestNotInProgressException;
+import in.koreatech.koin.admin.abtest.exception.AbtestWinnerNotDecidedException;
+import in.koreatech.koin.admin.abtest.model.Abtest;
+import in.koreatech.koin.admin.abtest.model.AbtestStatus;
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
+import in.koreatech.koin.admin.abtest.model.Device;
+import in.koreatech.koin.admin.abtest.model.redis.AbtestVariableAssign;
+import in.koreatech.koin.admin.abtest.model.redis.AbtestVariableCount;
+import in.koreatech.koin.admin.abtest.repository.AbtestRepository;
+import in.koreatech.koin.admin.abtest.repository.AbtestVariableAssignRepository;
+import in.koreatech.koin.admin.abtest.repository.AbtestVariableAssignTemplateRepository;
+import in.koreatech.koin.admin.abtest.repository.AbtestVariableCountRepository;
+import in.koreatech.koin.admin.abtest.repository.AbtestVariableRepository;
+import in.koreatech.koin.admin.abtest.repository.AccessHistoryAbtestVariableCustomRepository;
+import in.koreatech.koin.admin.abtest.repository.AccessHistoryRepository;
+import in.koreatech.koin.admin.abtest.repository.DeviceRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.model.Criteria;
+import in.koreatech.koin.global.useragent.UserAgentInfo;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AbtestService {
+
+    private final Clock clock;
+    private final EntityManager entityManager;
+    private final AbtestVariableCountRepository abtestVariableCountRepository;
+    private final AbtestRepository abtestRepository;
+    private final AbtestVariableRepository abtestVariableRepository;
+    private final AccessHistoryRepository accessHistoryRepository;
+    private final DeviceRepository deviceRepository;
+    private final UserRepository userRepository;
+    private final AbtestVariableAssignRepository abtestVariableAssignRepository;
+    private final AbtestVariableAssignTemplateRepository abtestVariableAssignTemplateRepository;
+    private final AccessHistoryAbtestVariableCustomRepository accessHistoryAbtestVariableCustomRepository;
+
+    @Transactional
+    public AbtestResponse createAbtest(AbtestRequest request) {
+        if (abtestRepository.findByTitle(request.title()).isPresent()) {
+            throw AbtestAlreadyExistException.withDetail("title: " + request.title());
+        }
+        Abtest saved = abtestRepository.save(
+            Abtest.builder()
+                .title(request.title())
+                .displayTitle(request.displayTitle())
+                .description(request.description())
+                .creator(request.creator())
+                .team(request.team())
+                .status(AbtestStatus.IN_PROGRESS)
+                .build()
+        );
+        saved.setVariables(request.variables(), entityManager);
+        return AbtestResponse.from(saved);
+    }
+
+    @Transactional
+    public AbtestResponse putAbtest(Integer abtestId, AbtestRequest request) {
+        Abtest abtest = abtestRepository.getById(abtestId);
+        validateAbtestInProgress(abtest);
+        abtest.update(
+            request.displayTitle(),
+            request.creator(),
+            request.team(),
+            request.title(),
+            request.description(),
+            request.variables()
+        );
+        return AbtestResponse.from(abtest);
+    }
+
+
+    private void deleteVariableAssignCache(Abtest abtest) {
+        abtest.getAbtestVariables().forEach(abtestVariable ->
+            abtestVariableAssignTemplateRepository.deleteAllByVariableId(abtestVariable.getId()));
+    }
+
+    @Transactional
+    public void deleteAbtest(Integer abtestId) {
+        abtestRepository.findById(abtestId).ifPresent(saved -> {
+            syncCacheCountToDB(saved);
+            deleteCountCache(saved);
+            deleteVariableAssignCache(saved);
+            abtestRepository.deleteById(abtestId);
+        });
+    }
+
+    private void deleteCountCache(Abtest abtest) {
+        abtest.getAbtestVariables()
+            .forEach(abtestVariable -> abtestVariableCountRepository.deleteById(abtestVariable.getId()));
+    }
+
+    public AbtestsResponse getAbtests(Integer page, Integer limit) {
+        Long title = abtestRepository.countBy();
+        Criteria criteria = Criteria.of(page, limit, title.intValue());
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(),
+            Sort.by(Sort.Direction.DESC, "id"));
+        Page<Abtest> abtests = abtestRepository.findAll(pageRequest);
+        return AbtestsResponse.of(abtests, criteria);
+    }
+
+    public AbtestResponse getAbtest(Integer abtestId) {
+        return AbtestResponse.from(abtestRepository.getById(abtestId));
+    }
+
+    @Transactional
+    public void closeAbtest(Integer abtestId, AbtestCloseRequest request) {
+        Abtest abtest = abtestRepository.getById(abtestId);
+        validateAbtestInProgress(abtest);
+        abtest.close(request.winnerName());
+        syncCacheCountToDB(abtest);
+        deleteCountCache(abtest);
+        deleteVariableAssignCache(abtest);
+    }
+
+    @Transactional
+    public AbtestAssignResponse assignVariable(Integer accessHistoryId, UserAgentInfo userAgentInfo, Integer userId,
+        AbtestAssignRequest request) {
+        Abtest abtest = abtestRepository.getByTitle(request.title());
+        AccessHistory accessHistory = findOrCreateAccessHistory(accessHistoryId);
+        Optional<AbtestVariable> winnerResponse = returnWinnerIfClosed(abtest);
+        if (winnerResponse.isPresent()) {
+            return AbtestAssignResponse.of(winnerResponse.get(), accessHistory);
+        }
+        validateAssignedUser(abtest, accessHistory.getId(), userId);
+        List<AbtestVariableCount> cacheCount = loadCacheCount(abtest);
+        AbtestVariable variable = abtest.findAssignVariable(cacheCount);
+        if (userId != null) {
+            createDeviceIfNotExists(userId, userAgentInfo, accessHistory, abtest);
+        }
+        accessHistory.addAbtestVariable(variable);
+        countCacheUpdate(variable);
+        variableAssignCacheSave(variable, accessHistory.getId());
+        accessHistory.updateLastAccessedAt(clock);
+        return AbtestAssignResponse.of(variable, accessHistory);
+    }
+
+    // 기기를 다른 사용자가 사용한 이력이 있는 경우 기존 사용자의 캐시를 삭제
+    private void removeBeforeUserCache(AccessHistory accessHistory, Abtest abtest) {
+        for (AbtestVariable removeVariable : accessHistory.getVariableBy(abtest)) {
+            abtestVariableAssignRepository.deleteByVariableIdAndAccessHistoryId(removeVariable.getId(),
+                accessHistory.getId());
+            AbtestVariableCount countCache = abtestVariableCountRepository.findOrCreateIfNotExists(
+                removeVariable.getId());
+            countCache.minusCount();
+            abtestVariableCountRepository.save(countCache);
+        }
+    }
+
+    private List<AbtestVariableCount> loadCacheCount(Abtest abtest) {
+        return abtest.getAbtestVariables().stream()
+            .map(abtestVariable -> abtestVariableCountRepository.findOrCreateIfNotExists(abtestVariable.getId()))
+            .toList();
+    }
+
+    private void countCacheUpdate(AbtestVariable variable) {
+        AbtestVariableCount countCache = abtestVariableCountRepository.findOrCreateIfNotExists(variable.getId());
+        countCache.addCount();
+        abtestVariableCountRepository.save(countCache);
+    }
+
+    private void variableAssignCacheSave(AbtestVariable variable, Integer accessHistoryId) {
+        abtestVariableAssignRepository.save(AbtestVariableAssign.of(variable.getId(), accessHistoryId));
+    }
+
+    @Transactional
+    public String getMyVariable(Integer accessHistoryId, UserAgentInfo userAgentInfo, Integer userId, String title) {
+        Abtest abtest = abtestRepository.getByTitle(title);
+        AccessHistory accessHistory = accessHistoryRepository.getById(accessHistoryId);
+        syncCacheCountToDB(abtest);
+        Optional<AbtestVariable> winner = returnWinnerIfClosed(abtest);
+        if (winner.isPresent()) {
+            return winner.get().getName();
+        }
+        if (userId != null) {
+            createDeviceIfNotExists(userId, userAgentInfo, accessHistory, abtest);
+        }
+        Optional<AbtestVariable> cacheVariable = abtest.getAbtestVariables().stream()
+            .filter(abtestVariable ->
+                abtestVariableAssignRepository.findByVariableIdAndAccessHistoryId(abtestVariable.getId(),
+                    accessHistory.getId()).isPresent())
+            .findAny();
+        if (cacheVariable.isEmpty()) {
+            AbtestVariable dbVariable = accessHistory.findVariableByAbtestId(abtest.getId())
+                .orElseThrow(() -> AbtestNotAssignedUserException.withDetail("abtestId: " + abtest.getId() + ", "
+                    + "accessHistoryId: " + accessHistory.getId()));
+            abtestVariableAssignRepository.save(AbtestVariableAssign.of(dbVariable.getId(), accessHistory.getId()));
+            return dbVariable.getName();
+        }
+        accessHistory.updateLastAccessedAt(clock);
+        return cacheVariable.get().getName();
+    }
+
+    private void validateAssignedUser(Abtest abtest, Integer accessHistoryId, Integer userId) {
+        AccessHistory accessHistory = accessHistoryRepository.getById(accessHistoryId);
+        if (userId != null && accessHistory.getDevice() != null
+            && !Objects.equals(accessHistory.getDevice().getUser().getId(), userId)) {
+            return;
+        }
+        if (abtest.getAbtestVariables().stream()
+            .anyMatch(abtestVariable -> accessHistory.hasVariable(abtestVariable.getId()))) {
+            throw AbtestAssignedUserException.withDetail(
+                "abtestId: " + abtest.getId() + ", accessHistoryId: " + accessHistoryId);
+        }
+    }
+
+    @Transactional
+    public void syncCacheCountToDB() {
+        List<AbtestVariableCount> cacheCount = abtestVariableCountRepository.findAll();
+        cacheCount.removeIf(Objects::isNull);
+        cacheCount.forEach(abtestVariableCount -> {
+            Optional<AbtestVariable> variable = abtestVariableRepository.findById(abtestVariableCount.getVariableId());
+            if (variable.isEmpty()) {
+                abtestVariableCountRepository.deleteById(abtestVariableCount.getVariableId());
+                return;
+            }
+            variable.get().addCount(abtestVariableCount.getCount());
+            abtestVariableCount.resetCount();
+        });
+        abtestVariableCountRepository.saveAll(cacheCount);
+    }
+
+    public void syncCacheCountToDB(Abtest abtest) {
+        List<AbtestVariableCount> cacheCount = abtest.getAbtestVariables().stream()
+            .map(AbtestVariable::getId)
+            .map(abtestVariableCountRepository::findById)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .toList();
+        cacheCount.forEach(abtestVariableCount -> {
+            AbtestVariable variable = abtestVariableRepository.getById(abtestVariableCount.getVariableId());
+            variable.addCount(abtestVariableCount.getCount());
+            abtestVariableCount.resetCount();
+        });
+        abtestVariableCountRepository.saveAll(cacheCount);
+    }
+
+    public AbtestUsersResponse getUsersByName(String userName) {
+        return AbtestUsersResponse.from(userRepository.findAllByName(userName));
+    }
+
+    public AbtestDevicesResponse getDevicesByUserId(Integer userId) {
+        User saved = userRepository.getById(userId);
+        return AbtestDevicesResponse.from(deviceRepository.findAllByUserId(saved.getId()));
+    }
+
+    @Transactional
+    public void assignVariableByAdmin(Integer abtestId, AbtestAdminAssignRequest request) {
+        Abtest abtest = abtestRepository.getById(abtestId);
+        validateAbtestInProgress(abtest);
+        AccessHistory accessHistory = accessHistoryRepository.getByDeviceId(request.deviceId());
+        Optional<AbtestVariable> beforeVariable = abtest.findVariableByAccessHistory(accessHistory);
+        AbtestVariable afterVariable = abtest.getVariableByName(request.variableName());
+        validateDuplicatedVariables(beforeVariable, afterVariable);
+        abtest.assignVariableByAdmin(accessHistory, request.variableName());
+        beforeVariable.ifPresent(
+            abtestVariable -> abtestVariableAssignRepository.deleteByVariableIdAndAccessHistoryId(
+                abtestVariable.getId(),
+                accessHistory.getId()));
+        variableAssignCacheSave(afterVariable, accessHistory.getId());
+    }
+
+    private static void validateDuplicatedVariables(Optional<AbtestVariable> beforeVariable,
+        AbtestVariable afterVariable) {
+        if (beforeVariable.isEmpty()) {
+            return;
+        }
+        if (Objects.equals(beforeVariable.get().getId(), afterVariable.getId())) {
+            throw AbtestDuplicatedVariableException.withDetail("beforeVariable id: " + beforeVariable.get().getId()
+                + ", afterVariable id: " + afterVariable.getId());
+        }
+    }
+
+    private static void validateAbtestInProgress(Abtest abtest) {
+        if (abtest.getStatus() != AbtestStatus.IN_PROGRESS) {
+            throw AbtestNotInProgressException.withDetail("abtestId: " + abtest.getId());
+        }
+    }
+
+    private static Optional<AbtestVariable> returnWinnerIfClosed(Abtest abtest) {
+        if (abtest.getStatus() == AbtestStatus.CLOSED) {
+            if (abtest.getWinner() != null) {
+                return Optional.of(abtest.getWinner());
+            }
+            throw AbtestWinnerNotDecidedException.withDetail("abtestId: " + abtest.getId());
+        }
+        return Optional.empty();
+    }
+
+    public AccessHistory findOrCreateAccessHistory(Integer id) {
+        if (id == null) {
+            return accessHistoryRepository.save(AccessHistory.builder().build());
+        }
+        return accessHistoryRepository.getById(id);
+    }
+
+    private void createDeviceIfNotExists(Integer userId, UserAgentInfo userAgentInfo,
+        AccessHistory accessHistory, Abtest abtest) {
+        userRepository.getById(userId);
+        if (accessHistory.getDevice() == null) {
+            Device device = deviceRepository.save(
+                Device.builder()
+                    .user(userRepository.getById(userId))
+                    .model(userAgentInfo.getModel())
+                    .type(userAgentInfo.getType())
+                    .build()
+            );
+            accessHistory.connectDevice(device);
+        }
+        Device device = accessHistory.getDevice();
+        if (device.getModel() == null || device.getType() == null) {
+            device.setModelInfo(userAgentInfo.getModel(), userAgentInfo.getType());
+        }
+        if (!Objects.equals(device.getUser().getId(), userId)) {
+            device.changeUser(userRepository.getById(userId));
+            removeBeforeUserCache(accessHistory, abtest);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentRegisterRequest.java
@@ -4,21 +4,9 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import in.koreatech.koin.domain.user.model.Student;
-import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
-import in.koreatech.koin.domain.user.model.UserIdentity;
-import in.koreatech.koin.domain.user.model.UserType;
-import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -37,11 +25,11 @@ public record StudentRegisterRequest(
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
     String name,
 
-    @Schema(description = " SHA 256 해시 알고리즘으로 암호화된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = REQUIRED)
+    @Schema(description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = REQUIRED)
     @NotBlank(message = "비밀번호를 입력해주세요.")
     String password,
 
-    @Schema(description = "닉네임", example = "bbo", requiredMode = NOT_REQUIRED)
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
     @Size(max = 10, message = "닉네임은 최대 10자입니다.")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname,
@@ -54,7 +42,7 @@ public record StudentRegisterRequest(
 
     @Schema(
         description = """
-            - 전공
+            전공
             - 기계공학부
             - 컴퓨터공학부
             - 메카트로닉스공학부
@@ -69,11 +57,10 @@ public record StudentRegisterRequest(
         example = "컴퓨터공학부",
         requiredMode = REQUIRED
     )
-    @JsonProperty("major")
-    String department,
+    String major,
 
     @Schema(description = "학번", example = "2021136012", requiredMode = NOT_REQUIRED)
-    @Size(min = 10, max = 10, message = "학번은 10자여야합니다.")
+    @Pattern(regexp = "^[0-9]{10}$", message = "학번엔 10자리 숫자만 입력 가능합니다.")
     String studentNumber,
 
     @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
@@ -15,7 +15,7 @@ public record StudentUpdateRequest(
     @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
     UserGender gender,
 
-    @Schema(description = "[NOT UPDATE]신원(학생, 사장님)", example = "학생", requiredMode = NOT_REQUIRED)
+    @Schema(description = "[NOT UPDATE]신원(학생 = 0, 사장님 = 1)", example = "0", requiredMode = NOT_REQUIRED)
     Integer userIdentity,
 
     @Schema(description = "[NOT UPDATE]졸업 여부(true, false)", example = "false", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/StudentUpdateRequest.java
@@ -5,24 +5,24 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import in.koreatech.koin.global.validation.NotEmoji;
+import in.koreatech.koin.domain.user.model.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record StudentUpdateRequest
-    (
-        @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
-        Integer gender,
+public record StudentUpdateRequest(
+    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
+    UserGender gender,
 
-        @Schema(description = "[NOT UPDATE]신원(학생, 사장님)", example = "학생", requiredMode = NOT_REQUIRED)
-        Integer userIdentity,
+    @Schema(description = "[NOT UPDATE]신원(학생, 사장님)", example = "학생", requiredMode = NOT_REQUIRED)
+    Integer userIdentity,
 
-        @Schema(description = "[NOT UPDATE]졸업 여부(true, false)", example = "false", requiredMode = NOT_REQUIRED)
-        Boolean isGraduated,
+    @Schema(description = "[NOT UPDATE]졸업 여부(true, false)", example = "false", requiredMode = NOT_REQUIRED)
+    boolean isGraduated,
 
-        @Schema(description = """
+    @Schema(
+        description = """
             전공
             - 기계공학부
             - 컴퓨터공학부
@@ -33,30 +33,33 @@ public record StudentUpdateRequest
             - 화학생명공학부
             - 에너지신소재공학부
             - 산업경영학부
-            - 고용서비스정책학부
-            """, example = "컴퓨터공학부", requiredMode = NOT_REQUIRED)
-        String major,
+            - 고용서비스정책학과
+            """,
+        example = "컴퓨터공학부",
+        requiredMode = NOT_REQUIRED
+    )
+    String major,
 
-        @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
-        @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
-        String name,
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
+    String name,
 
-        @Size(message = "SHA 256 해시 알고리즘으로 암호화 된 비밀번호")
-        @Schema(description = "비밀번호", example = "a0240120305812krlakdsflsa;1235", requiredMode = NOT_REQUIRED)
-        String password,
+    @Schema(description = "SHA 256 해시 알고리즘으로 암호화 된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = NOT_REQUIRED)
+    String password,
 
-        @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
-        @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
-        String nickname,
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    @Size(max = 10, message = "닉네임은 최대 10자입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
+    String nickname,
 
-        @Schema(description = "휴대폰 번호", example = "01000000000", requiredMode = NOT_REQUIRED)
-        String phoneNumber,
+    @Schema(description = "학번", example = "2021136012", requiredMode = NOT_REQUIRED)
+    @Pattern(regexp = "^[0-9]{10}$", message = "학번엔 10자리 숫자만 입력 가능합니다.")
+    String studentNumber,
 
-        @Size(min = 10, max = 10, message = "학번은 10자여야 합니다.")
-        @Schema(description = "학번", example = "2020136065", requiredMode = NOT_REQUIRED)
-        String studentNumber
-    ) {
+    @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)
+    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.")
+    String phoneNumber
+) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Size(max = 50)
-    @Column(name = "name", length = 50, unique = true)
+    @Column(name = "name", length = 50)
     private String name;
 
     @Size(max = 20)

--- a/src/main/java/in/koreatech/koin/domain/user/model/redis/StudentTemporaryStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/redis/StudentTemporaryStatus.java
@@ -59,7 +59,7 @@ public class StudentTemporaryStatus {
 
     public static StudentTemporaryStatus of(StudentRegisterRequest request, String authToken) {
         return new StudentTemporaryStatus(request.email(), authToken, request.nickname(), request.name(), request.password(), request.gender(),
-                request.isGraduated(), request.department(), request.studentNumber(), request.phoneNumber());
+                request.isGraduated(), request.major(), request.studentNumber(), request.phoneNumber());
     }
 
     public Student toStudent(PasswordEncoder passwordEncoder) {

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -62,4 +62,6 @@ public interface UserRepository extends Repository<User, Integer> {
     List<User> findAllByDeviceTokenIsNotNull();
 
     Optional<User> findByPhoneNumber(String phoneNumber);
+
+    List<User> findAllByName(String name);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/StudentService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import in.koreatech.koin.domain.user.model.*;
 import in.koreatech.koin.domain.user.model.redis.StudentTemporaryStatus;
 import in.koreatech.koin.domain.user.repository.StudentRedisRepository;
+
 import org.joda.time.LocalDateTime;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -86,13 +87,15 @@ public class StudentService {
         User user = student.getUser();
         checkNicknameDuplication(request.nickname(), userId);
         checkDepartmentValid(request.major());
-        user.update(request.nickname(), request.name(),
-            request.phoneNumber(), UserGender.from(request.gender()));
+        updateUserDetails(user, request);
         user.updateStudentPassword(passwordEncoder, request.password());
         student.update(request.studentNumber(), request.major());
         studentRepository.save(student);
-
         return StudentUpdateResponse.from(student);
+    }
+
+    private void updateUserDetails(User user, StudentUpdateRequest request) {
+        user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());
     }
 
     public void checkNicknameDuplication(String nickname, Integer userId) {
@@ -111,7 +114,8 @@ public class StudentService {
 
     @Transactional
     public ModelAndView authenticate(AuthTokenRequest request) {
-        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findByAuthToken(request.authToken());
+        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findByAuthToken(
+            request.authToken());
 
         if (studentTemporaryStatus.isEmpty()) {
             ModelAndView modelAndView = new ModelAndView("error_config");
@@ -148,28 +152,28 @@ public class StudentService {
 
         validateDataExist(request);
         validateStudentNumber(request.studentNumber());
-        checkDepartmentValid(request.department());
+        checkDepartmentValid(request.major());
     }
 
     private void validateDataExist(StudentRegisterRequest request) {
         userRepository.findByEmail(request.email())
-                .ifPresent(user -> {
-                    throw DuplicationEmailException.withDetail("email: " + request.email());
-                });
+            .ifPresent(user -> {
+                throw DuplicationEmailException.withDetail("email: " + request.email());
+            });
         studentRedisRepository.findById(request.email())
-                .ifPresent(studentTemporaryStatus -> {
-                    throw DuplicationEmailException.withDetail("email: " + request.email());
-                });
+            .ifPresent(studentTemporaryStatus -> {
+                throw DuplicationEmailException.withDetail("email: " + request.email());
+            });
 
         if (request.nickname() != null) {
             userRepository.findByNickname(request.nickname())
-                    .ifPresent(user -> {
-                        throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
-                    });
+                .ifPresent(user -> {
+                    throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
+                });
             studentRedisRepository.findByNickname(request.nickname())
-                    .ifPresent(studentTemporaryStatus -> {
-                        throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
-                    });
+                .ifPresent(studentTemporaryStatus -> {
+                    throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
+                });
         }
     }
 

--- a/src/main/java/in/koreatech/koin/global/config/RedisConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/RedisConfig.java
@@ -13,6 +13,7 @@ import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
@@ -32,6 +33,7 @@ public class RedisConfig {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
+        template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(serializer);
         template.setConnectionFactory(connectionFactory);
         return template;

--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -21,6 +21,7 @@ import in.koreatech.koin.global.host.ServerURLArgumentResolver;
 import in.koreatech.koin.global.host.ServerURLInterceptor;
 import in.koreatech.koin.global.ipaddress.IpAddressArgumentResolver;
 import in.koreatech.koin.global.ipaddress.IpAddressInterceptor;
+import in.koreatech.koin.global.useragent.UserAgentArgumentResolver;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -33,6 +34,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final AuthArgumentResolver authArgumentResolver;
     private final IpAddressInterceptor ipAddressInterceptor;
     private final ServerURLArgumentResolver serverURLArgumentResolver;
+    private final UserAgentArgumentResolver userAgentArgumentResolver;
     private final ServerURLInterceptor serverURLInterceptor;
     private final CorsProperties corsProperties;
 
@@ -55,6 +57,7 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(ipAddressArgumentResolver);
         resolvers.add(userIdArgumentResolver);
         resolvers.add(serverURLArgumentResolver);
+        resolvers.add(userAgentArgumentResolver);
     }
 
     @Override

--- a/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/slack/model/SlackNotificationFactory.java
@@ -14,17 +14,20 @@ public class SlackNotificationFactory {
     private final String adminReviewPageUrl;
     private final String ownerEventNotificationUrl;
     private final String eventNotificationUrl;
+    private final String reviewNotificationUrl;
 
     public SlackNotificationFactory(
         @Value("${koin.admin.shop.url}") String adminPageUrl,
         @Value("${koin.admin.review.url}") String adminReviewPageUrl,
         @Value("${slack.koin_event_notify_url}") String eventNotificationUrl,
-        @Value("${slack.koin_owner_event_notify_url}") String ownerEventNotificationUrl
+        @Value("${slack.koin_owner_event_notify_url}") String ownerEventNotificationUrl,
+        @Value("${slack.koin_shop_review_notify_url}") String reviewNotificationUrl
     ) {
         this.adminPageUrl = adminPageUrl;
         this.adminReviewPageUrl = adminReviewPageUrl;
         this.eventNotificationUrl = eventNotificationUrl;
         this.ownerEventNotificationUrl = ownerEventNotificationUrl;
+        this.reviewNotificationUrl = reviewNotificationUrl;
     }
 
     /**
@@ -149,7 +152,7 @@ public class SlackNotificationFactory {
         Integer rating
     ) {
         return SlackNotification.builder()
-            .slackUrl(eventNotificationUrl)
+            .slackUrl(reviewNotificationUrl)
             .text(String.format("""
                 `%s에 새로운 리뷰가 등록되었습니다.`
                 내용: `%s`
@@ -174,7 +177,7 @@ public class SlackNotificationFactory {
         String shop
     ) {
         return SlackNotification.builder()
-            .slackUrl(eventNotificationUrl)
+            .slackUrl(reviewNotificationUrl)
             .text(String.format("""
                 `%s의 리뷰가 신고되었습니다.`
                 `신고를 처리해주세요!!`

--- a/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/koin/global/exception/ErrorResponse.java
@@ -11,10 +11,12 @@ public class ErrorResponse {
     private final int status;
     private final String message;
     private final String code;
+    private final String errorTraceId;
 
-    public ErrorResponse(int status, String message) {
+    public ErrorResponse(int status, String message, String errorTraceId) {
         this.status = status;
         this.message = message;
         this.code = "";
+        this.errorTraceId = errorTraceId;
     }
 }

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.time.DateTimeException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.catalina.connector.ClientAbortException;
@@ -230,7 +231,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpStatus httpStatus,
         String message
     ) {
-        var response = new ErrorResponse(httpStatus.value(), message);
+        String errorTraceId = UUID.randomUUID().toString();
+        log.warn("traceId: {}", errorTraceId);
+        var response = new ErrorResponse(httpStatus.value(), message, errorTraceId);
         return ResponseEntity.status(httpStatus).body(response);
     }
 

--- a/src/main/java/in/koreatech/koin/global/useragent/UserAgent.java
+++ b/src/main/java/in/koreatech/koin/global/useragent/UserAgent.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.global.useragent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface UserAgent {
+}

--- a/src/main/java/in/koreatech/koin/global/useragent/UserAgentArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/global/useragent/UserAgentArgumentResolver.java
@@ -1,0 +1,65 @@
+package in.koreatech.koin.global.useragent;
+
+import java.io.IOException;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import ua_parser.Client;
+import ua_parser.Parser;
+
+@Component
+public class UserAgentArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final Parser uaParser = new Parser();
+
+    public UserAgentArgumentResolver() throws IOException {
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserAgent.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String userAgent = webRequest.getHeader("User-Agent");
+        if (userAgent == null) {
+            return null;
+        }
+
+        Client client = uaParser.parse(userAgent);
+        String type = determineDeviceType(userAgent);
+        return UserAgentInfo.builder()
+            .model(client.device.family)
+            .type(type)
+            .build();
+    }
+
+
+    private String determineDeviceType(String userAgent) {
+        // 태블릿 기기를 나타내는 패턴 검사
+        String[] tabletIndicators = {"Tablet", "iPad"};
+        for (String indicator : tabletIndicators) {
+            if (userAgent.toLowerCase().contains(indicator.toLowerCase())) {
+                return "Tablet";
+            }
+        }
+
+        // 모바일 기기를 나타내는 패턴 검사
+        String[] mobileIndicators = {"Mobile", "Mobi", "Android", "iPhone", "Windows Phone"};
+        for (String indicator : mobileIndicators) {
+            if (userAgent.toLowerCase().contains(indicator.toLowerCase())) {
+                return "Mobile";
+            }
+        }
+
+        // 모바일과 태블릿 모두 해당하지 않으면 PC로 간주
+        return "PC";
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/useragent/UserAgentInfo.java
+++ b/src/main/java/in/koreatech/koin/global/useragent/UserAgentInfo.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.global.useragent;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserAgentInfo {
+
+    private String model;
+    private String type;
+
+    @Builder
+    private UserAgentInfo(String model, String type) {
+        this.model = model;
+        this.type = type;
+    }
+}

--- a/src/main/resources/db/migration/V55__add_abtest_tables.sql
+++ b/src/main/resources/db/migration/V55__add_abtest_tables.sql
@@ -1,0 +1,61 @@
+CREATE TABLE `device`
+(
+    `id`               int unsigned NOT NULL AUTO_INCREMENT,
+    `user_id`          int unsigned NOT NULL,
+    `model`            varchar(100)       DEFAULT NULL,
+    `type`               varchar(100)       DEFAULT NULL,
+    `created_at`       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `access_history`
+(
+    `id`          int unsigned NOT NULL AUTO_INCREMENT,
+    `device_id`   int unsigned DEFAULT NULL,
+    `last_accessed_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_at`  timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `abtest_variable`
+(
+    `id`           int unsigned NOT NULL AUTO_INCREMENT,
+    `abtest_id`    int unsigned NOT NULL,
+    `name`         varchar(255) NOT NULL,
+    `display_name` varchar(255) NOT NULL,
+    `rate`         int unsigned NOT NULL,
+    `count`        int NOT NULL DEFAULT '0',
+    `created_at`   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`   timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `access_history_abtest_variable`
+(
+    `id`                int unsigned NOT NULL AUTO_INCREMENT,
+    `access_history_id` int unsigned NOT NULL,
+    `variable_id`       int unsigned NOT NULL,
+    `created_at`        timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`        timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `abtest`
+(
+    `id`            int unsigned NOT NULL AUTO_INCREMENT,
+    `title`         varchar(255) NOT NULL,
+    `display_title` varchar(255) NOT NULL,
+    `description`   varchar(255)          DEFAULT NULL,
+    `creator`       varchar(50)           DEFAULT NULL,
+    `team`          varchar(50)           DEFAULT NULL,
+    `winner_id`     int unsigned DEFAULT NULL,
+    `status`        varchar(50)  NOT NULL DEFAULT 'IN_PROGRESS',
+    `created_at`    timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`    timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    constraint title_UNIQUE
+        unique (`title`)
+);
+

--- a/src/main/resources/db/migration/V56__add_abtest_tables_fk.sql
+++ b/src/main/resources/db/migration/V56__add_abtest_tables_fk.sql
@@ -1,0 +1,58 @@
+ALTER TABLE `koin`.`device`
+    ADD INDEX `FK_DEVICE_ON_USER_ID_idx` (`user_id` ASC) VISIBLE;
+;
+ALTER TABLE `koin`.`device`
+    ADD CONSTRAINT `FK_DEVICE_ON_USER_ID`
+        FOREIGN KEY (`user_id`)
+            REFERENCES `koin`.`users` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION;
+
+ALTER TABLE `koin`.`access_history`
+    ADD INDEX `FK_ACCESS_HISTORY_ON_DEVICE_ID_idx` (`device_id` ASC) VISIBLE;
+
+ALTER TABLE `koin`.`access_history`
+    ADD CONSTRAINT `FK_ACCESS_HISTORY_ON_DEVICE_ID`
+        FOREIGN KEY (`device_id`)
+            REFERENCES `koin`.`device` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION;
+
+
+ALTER TABLE `koin`.`access_history_abtest_variable`
+    ADD INDEX `FK_ACCESS_HISTORY_ABTEST_VARIABLE_ON_ACCESS_HISTORY_ID_idx` (`access_history_id` ASC) VISIBLE,
+ADD INDEX `FK_ACCESS_HISTORY_ABTEST_VARIABLE_ON_ACCESS_VARIABLE_ID_idx` (`variable_id` ASC) VISIBLE;
+;
+ALTER TABLE `koin`.`access_history_abtest_variable`
+    ADD CONSTRAINT `FK_ACCESS_HISTORY_ABTEST_VARIABLE_ON_ACCESS_HISTORY_ID`
+        FOREIGN KEY (`access_history_id`)
+            REFERENCES `koin`.`access_history` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION,
+ADD CONSTRAINT `FK_ACCESS_HISTORY_ABTEST_VARIABLE_ON_ACCESS_VARIABLE_ID`
+  FOREIGN KEY (`variable_id`)
+  REFERENCES `koin`.`abtest_variable` (`id`)
+  ON DELETE NO ACTION
+  ON UPDATE NO ACTION;
+
+
+ALTER TABLE `koin`.`abtest_variable`
+    ADD INDEX `FK_ABTEST_VARIABLE_ON_ABTEST_ID_idx` (`abtest_id` ASC) VISIBLE;
+;
+ALTER TABLE `koin`.`abtest_variable`
+    ADD CONSTRAINT `FK_ABTEST_VARIABLE_ON_ABTEST_ID`
+        FOREIGN KEY (`abtest_id`)
+            REFERENCES `koin`.`abtest` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION;
+
+
+ALTER TABLE `koin`.`abtest`
+    ADD INDEX `FK_ABTEST_ON_WINNER_ID_idx` (`winner_id` ASC) VISIBLE;
+;
+ALTER TABLE `koin`.`abtest`
+    ADD CONSTRAINT `FK_ABTEST_ON_WINNER_ID`
+        FOREIGN KEY (`winner_id`)
+            REFERENCES `koin`.`abtest_variable` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION;

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -50,5 +50,10 @@
         <level>ERROR</level>
       </filter>
     </appender>
+
+    <root level="info">
+      <appender-ref ref="console"/>
+      <appender-ref ref="FILE"/>
+    </root>
   </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -25,6 +25,11 @@
     <conversionRule conversionWord="clr"
       converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+      <file>logs/app.log</file>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
       <encoder>
         <pattern>${consoleLogPattern}</pattern>
@@ -45,68 +50,5 @@
         <level>ERROR</level>
       </filter>
     </appender>
-
-    <root level="info">
-      <appender-ref ref="ASYNC_SLACK"/>
-      <appender-ref ref="console"/>
-    </root>
-  </springProfile>
-
-  <springProfile name="dev">
-    <property name="infoLogPath" value="logs/info"/>
-    <property name="errorLogPath" value="logs/error"/>
-    <property name="fileNamePattern" value="%d{yyyy-MM-dd}_%i.log"/>
-
-    <appender name="info-warn-error-appender"
-      class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${infoLogPath}/info.log</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <maxHistory>7</maxHistory>
-        <maxFileSize>1GB</maxFileSize>
-        <totalSizeCap>2GB</totalSizeCap>
-        <fileNamePattern>${infoLogPath}/${fileNamePattern}</fileNamePattern>
-      </rollingPolicy>
-      <encoder>
-        <pattern>${defaultLogPattern}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>INFO</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>NEUTRAL</onMismatch>
-      </filter>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>WARN</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>NEUTRAL</onMismatch>
-      </filter>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>ERROR</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-    </appender>
-
-    <appender name="error-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${errorLogPath}/error.log</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <maxHistory>7</maxHistory>
-        <maxFileSize>1GB</maxFileSize>
-        <totalSizeCap>2GB</totalSizeCap>
-        <fileNamePattern>${errorLogPath}/${fileNamePattern}</fileNamePattern>
-      </rollingPolicy>
-      <encoder>
-        <pattern>${defaultLogPattern}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>ERROR</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-    </appender>
-
-    <root level="info">
-      <appender-ref ref="info-warn-error-appender"/>
-      <appender-ref ref="error-appender"/>
-    </root>
   </springProfile>
 </configuration>

--- a/src/test/java/in/koreatech/koin/acceptance/AbtestApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/AbtestApiTest.java
@@ -1,0 +1,543 @@
+package in.koreatech.koin.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.admin.abtest.model.Abtest;
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+import in.koreatech.koin.admin.abtest.model.AccessHistoryAbtestVariable;
+import in.koreatech.koin.admin.abtest.model.Device;
+import in.koreatech.koin.admin.abtest.repository.AbtestRepository;
+import in.koreatech.koin.admin.abtest.repository.DeviceRepository;
+import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.AbtestFixture;
+import in.koreatech.koin.fixture.DeviceFixture;
+import in.koreatech.koin.fixture.UserFixture;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AbtestApiTest extends AcceptanceTest {
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private AbtestFixture abtestFixture;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Autowired
+    private DeviceFixture deviceFixture;
+
+    @Autowired
+    private AbtestRepository abtestRepository;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    private User admin;
+    private String adminToken;
+
+    @BeforeAll
+    void setUp() {
+        clear();
+        admin = userFixture.코인_운영자();
+        adminToken = userFixture.getToken(admin);
+    }
+
+    @Test
+    void 실험을_생성한다() throws Exception {
+        mockMvc.perform(
+                post("/abtest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+                    .content("""
+                        {
+                          "display_title": "사장님 전화번호 회원가입 실험",
+                          "creator": "송선권",
+                          "team": "campus",
+                          "description": "세부설명",
+                          "status": "IN_PROGRESS",
+                          "title": "business.register.phone_number",
+                          "variables": [
+                            {
+                              "rate": 33,
+                              "display_name": "실험군 A",
+                              "name": "A"
+                            },
+                            {
+                              "rate": 33,
+                              "display_name": "실험군 B",
+                              "name": "B"
+                            },
+                            {
+                              "rate": 34,
+                              "display_name": "실험군 C",
+                              "name": "C"
+                            }
+                          ]
+                        }
+                        """)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "id": 1,
+                  "display_title": "사장님 전화번호 회원가입 실험",
+                  "creator": "송선권",
+                  "team": "campus",
+                  "description": "세부설명",
+                  "title": "business.register.phone_number",
+                  "status": "IN_PROGRESS",
+                  "winner_name": null,
+                  "variables": [
+                    {
+                      "rate": 33,
+                      "display_name": "실험군 A",
+                      "name": "A"
+                    },
+                    {
+                      "rate": 33,
+                      "display_name": "실험군 B",
+                      "name": "B"
+                    },
+                    {
+                      "rate": 34,
+                      "display_name": "실험군 C",
+                      "name": "C"
+                    }
+                  ],
+                  "created_at": "2024-01-15 12:00:00",
+                  "updated_at": "2024-01-15 12:00:00"
+                }
+                """));
+    }
+
+    @Test
+    void 실험을_단건_조회한다() throws Exception {
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        mockMvc.perform(
+                get("/abtest/{id}", abtest.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "id": 1,
+                  "display_title": "식단_UI_실험",
+                  "creator": "송선권",
+                  "team": "campus",
+                  "description": "세부설명",
+                  "title": "dining_ui_test",
+                  "status": "IN_PROGRESS",
+                  "winner_name": null,
+                  "variables": [
+                    {
+                      "rate": 50,
+                      "display_name": "실험군 A",
+                      "name": "A"
+                    },
+                    {
+                      "rate": 50,
+                      "display_name": "실험군 B",
+                      "name": "B"
+                    }
+                  ],
+                  "created_at": "2024-01-15 12:00:00",
+                  "updated_at": "2024-01-15 12:00:00"
+                }
+                """));
+    }
+
+    @Test
+    void 실험_목록을_조회한다() throws Exception {
+        Abtest abtest1 = abtestFixture.식단_UI_실험();
+        Abtest abtest2 = abtestFixture.주변상점_UI_실험();
+
+        mockMvc.perform(
+                get("/abtest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "total_count": 2,
+                  "current_count": 2,
+                  "total_page": 1,
+                  "current_page": 1,
+                  "tests": [
+                    {
+                      "id": 2,
+                      "status": "IN_PROGRESS",
+                      "creator": "송선권",
+                      "team": "campus",
+                      "display_title": "주변상점_UI_실험",
+                      "title": "shop_ui_test",
+                      "winner_name": null,
+                      "created_at": "2024-01-15 12:00:00",
+                      "updated_at": "2024-01-15 12:00:00"
+                    },
+                    {
+                      "id": 1,
+                      "status": "IN_PROGRESS",
+                      "creator": "송선권",
+                      "team": "campus",
+                      "display_title": "식단_UI_실험",
+                      "title": "dining_ui_test",
+                      "winner_name": null,
+                      "created_at": "2024-01-15 12:00:00",
+                      "updated_at": "2024-01-15 12:00:00"
+                    }
+                  ]
+                }
+                """));
+    }
+
+    @Test
+    void 실험_목록을_조회한다_페이지네이션() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            abtestFixture.식단_UI_실험(i);
+        }
+
+        mockMvc.perform(
+                get("/abtest?page=2&limit=8")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "total_count": 10,
+                  "current_count": 2,
+                  "total_page": 2,
+                  "current_page": 2,
+                  "tests": [
+                    {
+                      "id": 2,
+                      "status": "IN_PROGRESS",
+                      "creator": "송선권",
+                      "team": "campus",
+                      "display_title": "식단_UI_실험",
+                      "title": "dining_ui_test1",
+                      "winner_name": null,
+                      "created_at": "2024-01-15 12:00:00",
+                      "updated_at": "2024-01-15 12:00:00"
+                    },
+                    {
+                      "id": 1,
+                      "status": "IN_PROGRESS",
+                      "creator": "송선권",
+                      "team": "campus",
+                      "display_title": "식단_UI_실험",
+                      "title": "dining_ui_test0",
+                      "winner_name": null,
+                      "created_at": "2024-01-15 12:00:00",
+                      "updated_at": "2024-01-15 12:00:00"
+                    }
+                  ]
+                }
+                """));
+    }
+
+    @Test
+    void 실험을_수정한다() throws Exception {
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        mockMvc.perform(
+                put("/abtest/{id}", abtest.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+                    .content("""
+                        {
+                          "display_title": "식단_UI_실험",
+                          "creator": "김성재",
+                          "team": "user",
+                          "title": "dining_ui_test",
+                          "description": "세부설명2",
+                          "variables": [
+                            {
+                              "rate": 10,
+                              "display_name": "실험군 A",
+                              "name": "A"
+                            },
+                            {
+                              "rate": 90,
+                              "display_name": "실험군 B",
+                              "name": "B"
+                            }
+                          ],
+                          "created_at": "2024-01-15 12:00:00",
+                          "updated_at": "2024-01-15 12:00:00"
+                        }
+                        """)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "id": 1,
+                  "display_title": "식단_UI_실험",
+                  "creator": "김성재",
+                  "team": "user",
+                  "title": "dining_ui_test",
+                  "status": "IN_PROGRESS",
+                  "description": "세부설명2",
+                  "winner_name": null,
+                  "variables": [
+                    {
+                      "rate": 10,
+                      "display_name": "실험군 A",
+                      "name": "A"
+                    },
+                    {
+                      "rate": 90,
+                      "display_name": "실험군 B",
+                      "name": "B"
+                    }
+                  ],
+                  "created_at": "2024-01-15 12:00:00",
+                  "updated_at": "2024-01-15 12:00:00"
+                }
+                """));
+    }
+
+    @Test
+    void 실험을_삭제한다() throws Exception {
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        mockMvc.perform(
+                delete("/abtest/{id}", abtest.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+            )
+            .andExpect(status().isNoContent());
+
+        assertThat(abtestRepository.findById(abtest.getId())).isNotPresent();
+    }
+
+    @Test
+    void 실험을_종료한다() throws Exception {
+        final Abtest abtest = abtestFixture.식단_UI_실험();
+        String winner = "A";
+
+        mockMvc.perform(
+                post("/abtest/close/{id}", abtest.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+                    .content(String.format("""
+                        {
+                          "winner_name": "%s"
+                        }
+                        """, winner))
+            )
+            .andExpect(status().isOk());
+
+        transactionTemplate.executeWithoutResult(status -> {
+            Abtest result = abtestRepository.getById(abtest.getId());
+            assertSoftly(
+                softly -> {
+                    softly.assertThat(result.getStatus().name()).isEqualTo("CLOSED");
+                    softly.assertThat(result.getWinner().getName()).isEqualTo(winner);
+                }
+            );
+        });
+    }
+
+    @Test
+    void 실험군_수동편입_이름으로_유저_목록을_조회한다() throws Exception {
+        Student student = userFixture.성빈_학생();
+        Owner owner = userFixture.성빈_사장님();
+
+        mockMvc.perform(
+                get("/abtest/user")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+                    .param("name", student.getUser().getName())
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "users": [
+                    {
+                    "id": 2,
+                    "name" : "박성빈",
+                    "detail": "testsungbeen@koreatech.ac.kr"
+                    },
+                    {
+                    "id": 3,
+                    "name" : "박성빈",
+                    "detail": "01098765439"
+                    }
+                  ]
+                }
+                """));
+    }
+
+    @Test
+    void 실험군_수동편입_유저_ID로_기기_목록을_조회한다() throws Exception {
+        Student student = userFixture.성빈_학생();
+        Device device1 = deviceFixture.아이폰(student.getUser().getId());
+        Device device2 = deviceFixture.갤럭시(student.getUser().getId());
+
+        mockMvc.perform(
+                get("/abtest/user/{userId}/device", student.getUser().getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                  "devices": [
+                    {
+                    "id": 1,
+                    "type": "mobile",
+                    "model" : "아이폰14",
+                    "last_accessed_at": "2024-01-15"
+                    },
+                    {
+                    "id": 2,
+                    "type": "mobile",
+                    "model" : "갤럭시24",
+                    "last_accessed_at": "2024-01-15"
+                    }
+                  ]
+                }
+                """));
+    }
+
+    @Test
+    void 특정_유저의_실험군을_수동으로_편입시킨다() throws Exception {
+        Student student = userFixture.성빈_학생();
+        Device device = deviceFixture.아이폰(student.getUser().getId());
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        mockMvc.perform(
+                post("/abtest/{id}/move", abtest.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + adminToken)
+                    .content(String.format("""
+                        {
+                          "device_id": %d,
+                          "variable_name": "A"
+                        }
+                        """, device.getId()))
+            )
+            .andExpect(status().isOk());
+
+        transactionTemplate.executeWithoutResult(status -> {
+            assertSoftly(
+                softly -> {
+                    Device result = deviceRepository.getById(device.getId());
+                    Optional<AbtestVariable> variable = result.getAccessHistory()
+                        .getAccessHistoryAbtestVariables()
+                        .stream()
+                        .map(AccessHistoryAbtestVariable::getVariable)
+                        .filter(var -> var.getAbtest().getTitle().equals(abtest.getTitle()))
+                        .findAny();
+                    softly.assertThat(variable.get().getName()).isEqualTo("A");
+                }
+            );
+        });
+    }
+
+    @Test
+    void 자신의_실험군을_조회한다() throws Exception {
+        Student student = userFixture.성빈_학생();
+        final Device device = deviceFixture.아이폰(student.getUser().getId());
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        mockMvc.perform(
+            post("/abtest/assign")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("access_history_id", device.getAccessHistory().getId())
+                .content(String.format("""
+                    {
+                      "title": "dining_ui_test"
+                    }
+                    """))
+            );
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/abtest/me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("access_history_id", device.getAccessHistory().getId())
+                    .param("title", abtest.getTitle())
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+        String responseBody = mvcResult.getResponse().getContentAsString();
+
+        transactionTemplate.executeWithoutResult(status -> {
+            assertSoftly(
+                softly -> {
+                    Device result = deviceRepository.getById(device.getId());
+                    Optional<AbtestVariable> variable = result.getAccessHistory()
+                        .getAccessHistoryAbtestVariables()
+                        .stream()
+                        .map(AccessHistoryAbtestVariable::getVariable)
+                        .filter(var -> var.getAbtest().getTitle().equals(abtest.getTitle()))
+                        .findAny();
+                    softly.assertThat(responseBody).isEqualTo(variable.get().getName());
+                }
+            );
+        });
+    }
+
+    @Test
+    void 실험군_자동_편입_실험군에_최초로_편입된다() throws Exception {
+        Student student = userFixture.성빈_학생();
+        Device device1 = deviceFixture.아이폰(student.getUser().getId());
+        Device device2 = deviceFixture.갤럭시(student.getUser().getId());
+        Abtest abtest = abtestFixture.식단_UI_실험();
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/abtest/assign")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("access_history_id", device1.getAccessHistory().getId())
+                    .content(String.format("""
+                        {
+                          "title": "dining_ui_test"
+                        }
+                        """))
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+        String responseBody = mvcResult.getResponse().getContentAsString();
+
+        MvcResult mvcResult2 = mockMvc.perform(
+                post("/abtest/assign")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("access_history_id", device2.getAccessHistory().getId())
+                    .content(String.format("""
+                        {
+                          "title": "dining_ui_test"
+                        }
+                        """))
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+        String responseBody2 = mvcResult2.getResponse().getContentAsString();
+        assertNotEquals(responseBody, responseBody2);
+    }
+}

--- a/src/test/java/in/koreatech/koin/fixture/AbtestFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/AbtestFixture.java
@@ -1,0 +1,100 @@
+package in.koreatech.koin.fixture;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.admin.abtest.model.Abtest;
+import in.koreatech.koin.admin.abtest.model.AbtestStatus;
+import in.koreatech.koin.admin.abtest.model.AbtestVariable;
+import in.koreatech.koin.admin.abtest.repository.AbtestRepository;
+
+@Component
+public final class AbtestFixture {
+
+    private final AbtestRepository abtestRepository;
+
+    public AbtestFixture(AbtestRepository abtestRepository) {
+        this.abtestRepository = abtestRepository;
+    }
+
+    public Abtest 식단_UI_실험() {
+        Abtest abtest =
+            Abtest.builder()
+                .title("dining_ui_test")
+                .displayTitle("식단_UI_실험")
+                .description("세부설명")
+                .creator("송선권")
+                .team("campus")
+                .status(AbtestStatus.IN_PROGRESS)
+                .build();
+
+        AbtestVariable abtestVariable =
+            AbtestVariable.builder()
+                .abtest(abtest)
+                .name("A")
+                .displayName("실험군 A")
+                .rate(50)
+                .count(0)
+                .build();
+
+        AbtestVariable abtestVariable2 =
+            AbtestVariable.builder()
+                .abtest(abtest)
+                .name("B")
+                .displayName("실험군 B")
+                .rate(50)
+                .count(0)
+                .build();
+
+        abtest.getAbtestVariables().addAll(List.of(abtestVariable, abtestVariable2));
+        return abtestRepository.save(abtest);
+    }
+
+    public Abtest 식단_UI_실험(int titleNumber) {
+        Abtest abtest =
+            Abtest.builder()
+                .title("dining_ui_test" + titleNumber)
+                .displayTitle("식단_UI_실험")
+                .description("세부설명")
+                .creator("송선권")
+                .team("campus")
+                .status(AbtestStatus.IN_PROGRESS)
+                .build();
+
+        AbtestVariable abtestVariable =
+            AbtestVariable.builder()
+                .abtest(abtest)
+                .name("A")
+                .displayName("실험군 A")
+                .rate(50)
+                .count(0)
+                .build();
+
+        AbtestVariable abtestVariable2 =
+            AbtestVariable.builder()
+                .abtest(abtest)
+                .name("B")
+                .displayName("실험군 B")
+                .rate(50)
+                .count(0)
+                .build();
+
+        abtest.getAbtestVariables().addAll(List.of(abtestVariable, abtestVariable2));
+        return abtestRepository.save(abtest);
+
+    }
+
+    public Abtest 주변상점_UI_실험() {
+        return abtestRepository.save(
+            Abtest.builder()
+                .title("shop_ui_test")
+                .displayTitle("주변상점_UI_실험")
+                .description("세부설명")
+                .creator("송선권")
+                .team("campus")
+                .status(AbtestStatus.IN_PROGRESS)
+                .build()
+        );
+    }
+}

--- a/src/test/java/in/koreatech/koin/fixture/DeviceFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/DeviceFixture.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.fixture;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
+import in.koreatech.koin.admin.abtest.model.Device;
+import in.koreatech.koin.admin.abtest.repository.DeviceRepository;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+
+@Component
+public class DeviceFixture {
+
+    private final DeviceRepository deviceRepository;
+    private final UserRepository userRepository;
+
+    public DeviceFixture(
+        DeviceRepository deviceRepository,
+        UserRepository userRepository
+    ) {
+        this.deviceRepository = deviceRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Device 아이폰(Integer userId) {
+        AccessHistory accessHistory = AccessHistory.builder().build();
+        Device device = Device.builder()
+            .accessHistory(accessHistory)
+            .user(userRepository.getById(userId))
+            .model("아이폰14")
+            .type("mobile")
+            .build();
+        accessHistory.connectDevice(device);
+        return deviceRepository.save(device);
+    }
+
+    public Device 갤럭시(Integer userId) {
+        AccessHistory accessHistory = AccessHistory.builder().build();
+        Device device = Device.builder()
+            .accessHistory(accessHistory)
+            .user(userRepository.getById(userId))
+            .model("갤럭시24")
+            .type("mobile")
+            .build();
+        accessHistory.connectDevice(device);
+        return deviceRepository.save(device);
+    }
+}

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -2,10 +2,7 @@ package in.koreatech.koin.fixture;
 
 import static in.koreatech.koin.domain.user.model.UserGender.MAN;
 import static in.koreatech.koin.domain.user.model.UserIdentity.UNDERGRADUATE;
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -132,8 +129,8 @@ public final class UserFixture {
                 .user(
                     User.builder()
                         .password(passwordEncoder.encode("1234"))
-                        .nickname("성빈")
-                        .name("테스트용_성빈")
+                        .nickname("빈")
+                        .name("박성빈")
                         .phoneNumber("01099411123")
                         .userType(STUDENT)
                         .gender(MAN)
@@ -144,6 +141,46 @@ public final class UserFixture {
                 )
                 .build()
         );
+    }
+
+    public Owner 성빈_사장님() {
+        User user = User.builder()
+            .password(passwordEncoder.encode("1234"))
+            .nickname("성빈")
+            .name("박성빈")
+            .phoneNumber("01098765439")
+            .userType(OWNER)
+            .gender(MAN)
+            .email("testsungbeenowner@naver.com")
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+
+        Owner owner = Owner.builder()
+            .account("01098765439")
+            .user(user)
+            .companyRegistrationNumber("723-45-67190")
+            .grantShop(true)
+            .grantEvent(true)
+            .attachments(new ArrayList<>())
+            .build();
+
+        OwnerAttachment attachment1 = OwnerAttachment.builder()
+            .url("https://test.com/성빈_사장님_인증사진_8.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        OwnerAttachment attachment2 = OwnerAttachment.builder()
+            .url("https://test.com/성빈_사장님_인증사진_9.jpg")
+            .isDeleted(false)
+            .owner(owner)
+            .build();
+
+        owner.getAttachments().add(attachment1);
+        owner.getAttachments().add(attachment2);
+
+        return ownerRepository.save(owner);
     }
 
     public Owner 현수_사장님() {
@@ -329,6 +366,15 @@ public final class UserFixture {
         return coopRepository.save(coop);
     }
 
+    public String 맥북userAgent헤더() {
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/123.45 (KHTML, like Gecko) Chrome/127.0.0"
+            + ".0 Safari/123.45, sec-fetch-dest=empty}";
+    }
+
+    public String 아이피() {
+        return "127.0.0.1";
+    }
+
     public String getToken(User user) {
         return jwtProvider.createToken(user);
     }
@@ -352,7 +398,6 @@ public final class UserFixture {
         private Boolean isDeleted;
         private String resetToken;
         private LocalDateTime resetExpiredAt;
-        private String deviceToken;
 
         public UserFixtureBuilder password(String password) {
             this.password = passwordEncoder.encode(password);
@@ -419,16 +464,10 @@ public final class UserFixture {
             return this;
         }
 
-        public UserFixtureBuilder deviceToken(String deviceToken) {
-            this.deviceToken = deviceToken;
-            return this;
-        }
-
         public User build() {
             return userRepository.save(
                 User.builder()
                     .phoneNumber(phoneNumber)
-                    .deviceToken(deviceToken)
                     .lastLoggedAt(lastLoggedAt)
                     .isAuthed(isAuthed)
                     .resetExpiredAt(resetExpiredAt)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -55,6 +55,7 @@ swagger:
 slack:
   koin_event_notify_url: https://slack-weehookurl.com
   koin_owner_event_notify_url: https://slack-weehookurl.com
+  koin_shop_review_notify_url: https://slack-weehookurl.com
   logging:
     error: https://slack-weehookurl.com
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #883 

# 🚀 작업 내용

1. 회원가입과 회원정보 수정 DTO 내의 정보에 대한 형식 일치 및 검증을 추가했습니다.
- Size로만 검증하던 학번을 Pattern을 이용하여 숫자 + 10자리로 검증하도록 했습니다.
- 전화번호를 두 DTO에서 동일하게 받을 수 있도록 수정했습니다. `(01024607469 / 010-2460-7469)`
-> 통일된 형식이 없어 둘 다 받도록 했습니다. (DB 내엔 둘 다 있습니다. || 사장님은 앞의 형식을 따르고 있는 걸로 알고 있습니다.)

2. 자잘한 코드 수정을 진행했습니다. 

# 💬 리뷰 중점사항
QA 진행 중 나왔던 이슈를 해결했습니다.
회원정보 수정이랑 회원가입의 형식을 일치시켰습니다.

궁금한 사항으로는, 이번 코드 리팩토링을 진행하면서 `is_graduated`와 `userIdentity`의 경우는 업데이트에서 NOT UPDATE 컬럼인데 유지를 해야하나, 고민이 있었습니다(기존 레거시 코드와 동일하게 마이그레이션 하는 과정에서 작성했던 코드입니다.) 추가적으로 학생 회원가입에도 `is_graduated`가 있는데, 이도 유지를 해야하나 싶습니다.

추가적으로, Service에서 다양한 검증을 진행하고 있는데, 검증단을 Service에서 따로 분리하여 유지하는 것(ex : ValidationService)에 대한 의견도 묻고 싶습니다.(SRP 위배 관련) 긴 의문사항 읽어주셔서 감사합니당 :D