### PR TITLE
fix: 메인시간표 필수로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -6,6 +6,7 @@ import static in.koreatech.koin.domain.timetableV2.dto.TimetableLectureUpdateReq
 import java.util.List;
 import java.util.Objects;
 
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +61,10 @@ public class TimetableServiceV2 {
         boolean isMain = timetableFrameUpdateRequest.isMain();
         if (isMain) {
             cancelMainTimetable(userId, semester.getId());
+        } else {
+            if (timeTableFrame.isMain()) {
+                throw new KoinIllegalArgumentException("메인 시간표는 필수입니다.");
+            }
         }
         timeTableFrame.updateTimetableFrame(semester, timetableFrameUpdateRequest.name(), isMain);
         return TimetableFrameUpdateResponse.from(timeTableFrame);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #879

# 🚀 작업 내용

**1.  로직 수정**
학기에 메인시간표 1개를 필수로 두게했지만, 현재 발생한 문제는 기존 시간표 프레임 수정할때 메인시간표를 false로 변경하고 나면 메인시간표를 1개를 필수로 두어야하는 정합성에 불일치가 생겨 로직 수정했습니다.


**2. DB데이터 수정**
<img width="497" alt="image" src="https://github.com/user-attachments/assets/b736cfb3-e587-40eb-9f15-3d36debfc746">

현재 발생한 문제로 인해 stage DB에  {user_id=1020, semester_id=10}과 {user_id=1782, semester_id=11} 두개의 데이터에서 메인시간표가 존재하지 않는 정합성 불일치가 존재합니다. 

그래서 {user_id=1020, semester_id=10}에 해당하는 id=1046데이터를 is_main=1로 변경하고 {user_id=1782, semester_id=11}에 해당하는 id=2048을 is_main=1로 변경하고자합니다.


# 💬 리뷰 중점사항
