### PR TITLE
refactor: 게시글 검색 속도 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -31,15 +31,29 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     default Article getById(Integer articleId) {
         return findById(articleId).orElseThrow(
-            () -> ArticleNotFoundException.withDetail(
-                "articleId: " + articleId));
+            () -> ArticleNotFoundException.withDetail("articleId: " + articleId));
     }
 
-    Page<Article> findAllByBoardIdAndTitleContaining(Integer boardId, String query, PageRequest pageRequest);
+    @Query(
+        value = "SELECT * FROM koreatech_articles WHERE board_id = :boardId AND MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        countQuery = "SELECT count(*) FROM articles WHERE board_id = :boardId AND MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        nativeQuery = true
+    )
+    Page<Article> findAllByBoardIdAndTitleContaining(@Param("boardId") Integer boardId, @Param("query") String query, Pageable pageable);
 
-    Page<Article> findAllByTitleContaining(String query, PageRequest pageRequest);
+    @Query(
+        value = "SELECT * FROM koreatech_articles WHERE MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        countQuery = "SELECT count(*) FROM articles WHERE MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        nativeQuery = true
+    )
+    Page<Article> findAllByTitleContaining(@Param("query") String query, Pageable pageable);
 
-    Page<Article> findAllByIsNoticeIsTrueAndTitleContaining(String query, PageRequest pageRequest);
+    @Query(
+        value = "SELECT * FROM koreatech_articles WHERE is_notice = true AND MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        countQuery = "SELECT count(*) FROM articles WHERE is_notice = true AND MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
+        nativeQuery = true
+    )
+    Page<Article> findAllByIsNoticeIsTrueAndTitleContaining(@Param("query") String query, Pageable pageable);
 
     Long countBy();
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -50,6 +50,10 @@ public class ArticleService {
         Sort.Order.desc("registeredAt"),
         Sort.Order.desc("id")
     );
+    private static final Sort NATIVE_ARTICLES_SORT = Sort.by(
+        Sort.Order.desc("registered_at"),
+        Sort.Order.desc("id")
+    );
 
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
@@ -118,7 +122,7 @@ public class ArticleService {
         }
 
         Criteria criteria = Criteria.of(page, limit);
-        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), NATIVE_ARTICLES_SORT);
         Page<Article> articles;
         if (boardId == null) {
             articles = articleRepository.findAllByTitleContaining(query, pageRequest);

--- a/src/main/resources/db/migration/V57__alter_articles_table_fulltext_index.sql
+++ b/src/main/resources/db/migration/V57__alter_articles_table_fulltext_index.sql
@@ -1,0 +1,1 @@
+CREATE FULLTEXT INDEX idx_fulltext_title ON koreatech_articles (title) WITH PARSER ngram;


### PR DESCRIPTION
# 🔥 연관 이슈
`

# 🚀 작업 내용

1. koreatech_articles 테이블의 title 필드에 ngram fulltext index를 적용하여 텍스트 검색 속도를 개선했습니다.

## 풀텍스트 인덱스 적용 후 검색 속도 차이
```
스테이지(초) : 로컬(초)
0.5 : 0.115 - 최근에 데이터가 많은 거(탐색 빠름)
6.7 : 0.061 - 데이터 수가 적은 거(탐색 오래걸림)
5.5 : 0.039 - 데이터가 없는 거(탐색 오래걸림)
4.6 : 0.064 - 데이터가 없는거(탐색 오래걸림)
```
**데이터가 많은 경우: 약 4.3배 빠름
데이터가 적거나 없는 경우 : 70~140배 빠름**

스테이지와 로컬을 기반으로 측정한 데이터라 스테이지에 올라가면 조금 더 느려질 수는 있습니다

fulltext index에 대해서는 정리해서 블로깅한 후 공유드리겠습니다.
ngram fulltext index는 `한국어 기반 텍스트 검색 속도를 개선하기 위한 인덱싱 방법` 정도로 봐주시면 감사하겠습니다.
fulltext index 적용을 위해서는 네이티브 쿼리를 사용해야 했기에 그렇게 진행했습니다.

# 💬 리뷰 중점사항
