### PR TITLE
refactor: 공지사항 알림 api admin만 호출 할 수 있게 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -84,6 +85,7 @@ public interface KeywordApi {
     @Operation(summary = "키워드 알림 전송", hidden = true)
     @PostMapping("/notification")
     ResponseEntity<Void> pushKeywordNotification(
-        @Valid @RequestBody KeywordNotificationRequest request
+        @Valid @RequestBody KeywordNotificationRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -63,7 +64,8 @@ public class KeywordController implements KeywordApi{
 
     @PostMapping("/notification")
     public ResponseEntity<Void> pushKeywordNotification(
-        @Valid @RequestBody KeywordNotificationRequest request
+        @Valid @RequestBody KeywordNotificationRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
     ) {
         keywordService.sendKeywordNotification(request);
         return ResponseEntity.ok().build();

--- a/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
@@ -27,6 +27,7 @@ import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepos
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import in.koreatech.koin.domain.user.model.Student;
+import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.ArticleFixture;
 import in.koreatech.koin.fixture.BoardFixture;
 import in.koreatech.koin.fixture.KeywordFixture;
@@ -59,13 +60,17 @@ public class KeywordApiTest extends AcceptanceTest {
     private ArticleFixture articleFixture;
 
     private Student 준호_학생;
+    private User 관리자;
     private String token;
+    private String adminToken;
 
     @BeforeAll
     void setup() {
         clear();
         준호_학생 = userFixture.준호_학생();
+        관리자 = userFixture.코인_운영자();
         token = userFixture.getToken(준호_학생.getUser());
+        adminToken = userFixture.getToken(관리자);
     }
 
     @Test
@@ -226,7 +231,7 @@ public class KeywordApiTest extends AcceptanceTest {
 
         mockMvc.perform(
                 post("/articles/keyword/notification")
-                    .header("Authorization", "Bearer " + token)
+                    .header("Authorization", "Bearer " + adminToken)
                     .content("""
                     {
                         "update_notification": %s
@@ -262,7 +267,7 @@ public class KeywordApiTest extends AcceptanceTest {
                         "update_notification": %s
                     }
                     """.formatted(articleIds.toString()))
-                    .header("Authorization", "Bearer " + token)
+                    .header("Authorization", "Bearer " + adminToken)
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk());


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 권한 설정을 해줬습니다.

# 💬 리뷰 중점사항
늦게 올려서 죄송합니다ㅠ
별도의 새로운 role을 만들지 그냥 admin으로 할 지 의견 한번 씩 주시면 감사하겠습니다.

이 pr은 batch의 다음 [pr]( https://github.com/BCSDLab/KOIN_BATCH/pull/138)과 연결됩니다.