### PR TITLE
refactor: 많이 조회하는 키워드 테이블 제약 조건 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeyword.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeyword.java
@@ -57,7 +57,6 @@ public class ArticleSearchKeyword extends BaseEntity {
 
     public void resetWeight() {
         this.weight = 1.0;
-        this.lastSearchedAt = LocalDateTime.now();
     }
 
     public void incrementTotalSearch() {

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeywordIpMap.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleSearchKeywordIpMap.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,7 +20,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "article_search_keyword_ip_map", indexes = {
-    @Index(name = "idx_ip_address", columnList = "ipAddress")
+    @Index(name = "idx_ip_address", columnList = "ipAddress")}, uniqueConstraints = {
+    @UniqueConstraint(name = "ux_keyword_ip", columnNames = {"keyword_id", "ipAddress"})
 })
 @NoArgsConstructor(access = PROTECTED)
 public class ArticleSearchKeywordIpMap extends BaseEntity {

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleSearchKeywordIpMapRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleSearchKeywordIpMapRepository.java
@@ -15,5 +15,5 @@ public interface ArticleSearchKeywordIpMapRepository extends Repository<ArticleS
 
     Optional<ArticleSearchKeywordIpMap> findByArticleSearchKeywordAndIpAddress(ArticleSearchKeyword keyword, String ipAddress);
 
-    List<ArticleSearchKeywordIpMap> findByCreatedAtBetween(LocalDateTime fiveHoursThirtyMinutesAgo, LocalDateTime now);
+    List<ArticleSearchKeywordIpMap> findByUpdatedAtBetween(LocalDateTime before, LocalDateTime now);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleSearchKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleSearchKeywordRepository.java
@@ -31,5 +31,5 @@ public interface ArticleSearchKeywordRepository extends Repository<ArticleSearch
         """)
     List<String> findTopKeywordsByLatest(Pageable pageable);
 
-    List<ArticleSearchKeyword> findByCreatedAtBetween(LocalDateTime startTime, LocalDateTime endTime);
+    List<ArticleSearchKeyword> findByUpdatedAtBetween(LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -211,8 +211,6 @@ public class ArticleService {
         if (map.getSearchCount() <= 10) {
             keyword.updateWeight(keyword.getWeight() + additionalWeight);
         }
-
-        keyword.updateWeight(keyword.getWeight() + additionalWeight);
         articleSearchKeywordRepository.save(keyword);
     }
 
@@ -221,9 +219,9 @@ public class ArticleService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime before = now.minusHours(6).minusMinutes(30);
 
-        List<ArticleSearchKeyword> keywordsToUpdate = articleSearchKeywordRepository.findByCreatedAtBetween(
+        List<ArticleSearchKeyword> keywordsToUpdate = articleSearchKeywordRepository.findByUpdatedAtBetween(
             before, now);
-        List<ArticleSearchKeywordIpMap> ipMapsToUpdate = articleSearchKeywordIpMapRepository.findByCreatedAtBetween(
+        List<ArticleSearchKeywordIpMap> ipMapsToUpdate = articleSearchKeywordIpMapRepository.findByUpdatedAtBetween(
             before, now);
 
         for (ArticleSearchKeyword keyword : keywordsToUpdate) {

--- a/src/main/resources/db/migration/V60__alter_search_keywords_and_ip_map_unique_cascade.sql
+++ b/src/main/resources/db/migration/V60__alter_search_keywords_and_ip_map_unique_cascade.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `article_search_keywords`
+    MODIFY COLUMN `keyword` VARCHAR(255) NOT NULL UNIQUE;
+
+ALTER TABLE article_search_keyword_ip_map
+    ADD CONSTRAINT unique_keyword_ip UNIQUE (keyword_id, ip_address),
+    ADD CONSTRAINT fk_keyword_id
+    FOREIGN KEY (keyword_id)
+    REFERENCES article_search_keywords (id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용
![image](https://github.com/user-attachments/assets/36b6a2fe-1fba-44bc-911b-a557bb7fe1a8)
1. 동시에 요청이 여러개가 들어올 때 중복 검사를 하지 못하고 두 개 이상이 저장 되는 것을 방지하기 위해 db에 unique 속성을 추가했습니다.
2. 삭제 할 일이 사실상 없지만 cascade를 건 이유는 혹시나 모르게 삭제 할 일이 생길 경우 db의 참조 무결성을 보장하기 위해서 안전장치 용도로 걸었습니다.

# 💬 리뷰 중점사항
원래 동시성 제어 어노테이션이랑 같이 처리 할 생각이였는데 생각보다 동시성 제어 작업이 길어진 점과.. 따로 올리는 것이 낫겠다는 생각이 들어서 급히 올립니다.
