### PR TITLE
refactor: Swagger 한글 Example value 영어로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
@@ -16,27 +16,27 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableLectureResponse(
-    @Schema(name = "시간표 프레임 id", example = "1")
+    @Schema(description = "시간표 프레임 id", example = "1")
     Integer timetableFrameId,
 
-    @Schema(name = "시간표 상세정보")
+    @Schema(description = "시간표 상세정보")
     List<InnerTimetableLectureResponse> timetable,
 
-    @Schema(name = "해당 학기 학점", example = "21")
+    @Schema(description = "해당 학기 학점", example = "21")
     Integer grades,
 
-    @Schema(name = "전체 학기 학점", example = "121")
+    @Schema(description = "전체 학기 학점", example = "121")
     Integer totalGrades
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimetableLectureResponse(
-        @Schema(name = "시간표 id", example = "1", requiredMode = REQUIRED)
+        @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
         Integer id,
 
-        @Schema(name = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
+        @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
         String regularNumber,
 
-        @Schema(name = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
+        @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
         String code,
 
         @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
@@ -45,28 +45,28 @@ public record TimetableLectureResponse(
         @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
         List<Integer> classTime,
 
-        @Schema(description = "강의 장소", example = "2 공학관", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
         String classPlace,
 
         @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
         String memo,
 
-        @Schema(name = "학점", example = "3", requiredMode = REQUIRED)
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
         String grades,
 
-        @Schema(name = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
+        @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
         String classTitle,
 
-        @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
         String lectureClass,
 
-        @Schema(name = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
         String target,
 
-        @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(name = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
         String department
     ) {
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
@@ -44,7 +44,7 @@ public record TimetableLectureUpdateRequest(
         @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
-        @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 
@@ -52,7 +52,7 @@ public record TimetableLectureUpdateRequest(
         @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다.")
         String grades,
 
-        @Schema(name = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
+        @Schema(description = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #908 

# 🚀 작업 내용

1. 한글로 출력되고 있던 Example Value를 영어로 수정했습니다.
-> description 대신 name을 사용하는 부분이 있어서 통일시켰습니다.

# 💬 리뷰 중점사항
간단한 수정사항이라 잔디 채우러 오셔도 됩니당