### PR TITLE
hotfix: 모든 상점 조회시 삭제된 리뷰는 통계에 포함 안되도록 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
@@ -43,6 +43,7 @@ public class ShopCustomRepository {
             .on(eventArticle.startDate.loe(now)
                 .and(eventArticle.endDate.goe(now)))
             .leftJoin(shop.reviews, shopReview)
+            .on(shopReview.isDeleted.eq(false))
             .groupBy(shop.id)
             .fetch();
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #924

# 🚀 작업 내용

1. 모든 상점 조회시 삭제된 리뷰가 통계에 포함되지 않도록 변경하였습니다.

# 💬 리뷰 중점사항
