### PR TITLE
feat: 존재하지 않는 api 요청 시 커스텀 응답 반환

### DIFF
--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -183,9 +183,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpStatusCode status,
         WebRequest request
     ) {
-        log.warn("요청하신 API를 찾을 수 없습니다. " + e.getRequestURL());
+        log.warn("유효하지 않은 API 경로입니다. " + e.getRequestURL());
         requestLogging(((ServletWebRequest)request).getRequest());
-        return buildErrorResponse(HttpStatus.NOT_FOUND, "요청하신 API를 찾을 수 없습니다.");
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "유효하지 않은 API 경로입니다.");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.WebUtils;
@@ -173,6 +174,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn("클라이언트가 연결을 중단했습니다: " + e.getMessage());
         requestLogging(request);
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "클라이언트에 의해 연결이 중단되었습니다");
+    }
+
+    @Override
+    public ResponseEntity<Object> handleNoHandlerFoundException(
+        NoHandlerFoundException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        log.warn("요청하신 API를 찾을 수 없습니다. " + e.getRequestURL());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "요청하신 API를 찾을 수 없습니다.");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,11 @@ jwt:
     expiration-time: 600000 # (ms) = 10 minutes
 
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
   flyway:
     enabled: false
   jpa:


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 존재하지 않는 api를 호출할 경우 404 Not Found 응답 대신 커스텀 예외 메시지를 반환하도록 수정했습니다.

# 💬 리뷰 중점사항
코드 라인 수 자체는 굉장히 적지만 온전한 이해를 위해서는 배경지식이 필요하기 때문에 관련 블로깅 해두었으니 리뷰하기 전에 읽어보시기를 권장드립니다.
[관련 포스팅](https://velog.io/@songsunkook/%EC%A1%B4%EC%9E%AC%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94-API-%EC%9D%91%EB%8B%B5-%EC%BB%A4%EC%8A%A4%ED%85%80%ED%95%98%EA%B8%B0)

yml에 추가해야할 부분이 있기 때문에 머지되면 stage, prod 설정파일에 직접 추가해두겠습니다.