### PR TITLE
fix : timetableLecture class_time 데이터 형식 TEXT로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
@@ -34,7 +34,6 @@ public record TimetableLectureCreateRequest(
         String classTitle,
 
         @Schema(description = "강의 시간", example = "[210, 211]", requiredMode = REQUIRED)
-        @Size(max = 100, message = "강의 시간의 최대 글자는 100글자입니다.")
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "도서관", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.domain.timetable.dto.TimetableUpdateRequest;
 import in.koreatech.koin.domain.timetable.model.Lecture;
-import in.koreatech.koin.domain.timetableV2.dto.TimetableLectureUpdateRequest;
 import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,6 +14,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -38,8 +38,8 @@ public class TimetableLecture extends BaseEntity {
     @Column(name = "class_title", length = 100)
     private String classTitle;
 
-    @Size(max = 100)
-    @Column(name = "class_time", length = 100)
+    @Lob
+    @Column(name = "class_time")
     private String classTime;
 
     @Size(max = 30)

--- a/src/main/resources/db/migration/V66__modify_column_timetable_lecture_text.sql
+++ b/src/main/resources/db/migration/V66__modify_column_timetable_lecture_text.sql
@@ -1,0 +1,2 @@
+ALTER TABLE timetable_lecture
+    MODIFY COLUMN class_time TEXT;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #935 

# 🚀 작업 내용

1. TimetableLecture의 class_time 컬럼의 데이터 형식을 TEXT로 변경했습니다.
- 많은 데이터를 넣는 과정에서 VARCHAR(255)의 크기가 작아서 생기는 오류가 있어서 데이터 형식을 수정했습니다.


# 💬 리뷰 중점사항
빠리 빠리