### PR TITLE
hotfix: isOpen로직 query dsl에서 기존 방식으로 원복

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopsResponse.java
@@ -36,7 +36,7 @@ public record ShopsResponse(
                     return InnerShopResponse.from(
                         it,
                         shopEventMap.get(it.getId()).durationEvent(),
-                        shopEventMap.get(it.getId()).isOpen()
+                        it.isOpen(now)
                     );
                 })
                 .sorted(Comparator.comparing(InnerShopResponse::isOpen, Comparator.reverseOrder()))

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopsResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopsResponseV2.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,8 @@ public record ShopsResponseV2(
         List<Shop> shops,
         Map<Integer, ShopInfoV2> shopInfoMap,
         ShopsSortCriteria sortBy,
-        List<ShopsFilterCriteria> shopsFilterCriterias
+        List<ShopsFilterCriteria> shopsFilterCriterias,
+        LocalDateTime now
     ) {
         List<InnerShopResponse> innerShopResponses = shops.stream()
             .map(it -> {
@@ -35,7 +37,7 @@ public record ShopsResponseV2(
                 return InnerShopResponse.from(
                     it,
                     shopInfo.durationEvent(),
-                    shopInfo.isOpen(),
+                    it.isOpen(now),
                     shopInfo.averageRate(),
                     shopInfo.reviewCount()
                 );

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
@@ -2,26 +2,20 @@ package in.koreatech.koin.domain.shop.repository.shop.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ExpressionUtils;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import in.koreatech.koin.domain.shop.model.article.QEventArticle;
 import in.koreatech.koin.domain.shop.model.review.QShopReview;
 import in.koreatech.koin.domain.shop.model.shop.QShop;
-import in.koreatech.koin.domain.shop.model.shop.QShopOpen;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -34,14 +28,6 @@ public class ShopCustomRepository {
         QShop shop = QShop.shop;
         QEventArticle eventArticle = QEventArticle.eventArticle;
         QShopReview shopReview = QShopReview.shopReview;
-        QShopOpen shopOpen = QShopOpen.shopOpen;
-
-        BooleanExpression isOpenSubQuery = JPAExpressions
-            .selectOne()
-            .from(shopOpen)
-            .where(shopOpen.shop.id.eq(shop.id)
-                .and(openCondition(shopOpen.shop.id, now)))
-            .exists();
 
         List<Tuple> results = queryFactory
             .select(
@@ -51,8 +37,7 @@ public class ShopCustomRepository {
                     Expressions.numberTemplate(Double.class, "ROUND(COALESCE({0}, 0), 1)", shopReview.rating.avg()),
                     "averageRate"
                 ),
-                shopReview.id.count().as("reviewCount"),
-                ExpressionUtils.as(isOpenSubQuery, "isOpen") // 서브쿼리 결과를 "isOpen" 필드로 추가
+                shopReview.id.count().as("reviewCount")
             )
             .from(shop)
             .leftJoin(shop.eventArticles, eventArticle)
@@ -69,8 +54,7 @@ public class ShopCustomRepository {
             ShopInfoV2 shopResult = new ShopInfoV2(
                 result.get(1, Boolean.class),
                 result.get(2, Double.class),
-                result.get(3, Long.class),
-                result.get(4, Boolean.class)
+                result.get(3, Long.class)
             );
             map.put(result.get(0, Integer.class), shopResult);
         }
@@ -80,20 +64,11 @@ public class ShopCustomRepository {
     public Map<Integer, ShopInfoV1> findAllShopEvent(LocalDateTime now) {
         QShop shop = QShop.shop;
         QEventArticle eventArticle = QEventArticle.eventArticle;
-        QShopOpen shopOpen = QShopOpen.shopOpen;
-
-        BooleanExpression isOpenSubQuery = JPAExpressions
-            .selectOne()
-            .from(shopOpen)
-            .where(shopOpen.shop.id.eq(shop.id)
-                .and(openCondition(shopOpen.shop.id, now)))
-            .exists();
 
         List<Tuple> results = queryFactory
             .select(
                 shop.id,
-                ExpressionUtils.as(eventArticle.id.count().gt(0L), "isEventActive"),
-                ExpressionUtils.as(isOpenSubQuery, "isOpen")
+                ExpressionUtils.as(eventArticle.id.count().gt(0L), "isEventActive")
             )
             .from(shop)
             .leftJoin(shop.eventArticles, eventArticle)
@@ -106,40 +81,10 @@ public class ShopCustomRepository {
 
         for (Tuple result : results) {
             ShopInfoV1 shopResult = new ShopInfoV1(
-                result.get(1, Boolean.class),
-                result.get(2, Boolean.class)
+                result.get(1, Boolean.class)
             );
             shopEventMap.put(result.get(0, Integer.class), shopResult);
         }
         return shopEventMap;
-    }
-
-    private BooleanBuilder openCondition(NumberPath<Integer> shopId, LocalDateTime now) {
-        QShopOpen shopOpen = QShopOpen.shopOpen;
-        LocalTime currentTime = now.toLocalTime();
-        LocalDateTime yesterday = now.minusDays(1);
-
-        BooleanBuilder whereCondition = new BooleanBuilder();
-
-        // 조건 1: 오늘의 요일과 시간이 open_time과 close_time 사이에 있는지 확인
-        whereCondition.or(
-            shopOpen.dayOfWeek.eq(now.getDayOfWeek().name()) // 오늘의 요일을 문자열로 비교
-                .and(shopOpen.openTime.loe(currentTime)) // openTime <= 현재 시간
-                .and(shopOpen.closeTime.goe(currentTime) // closeTime >= 현재 시간
-                    .or(shopOpen.openTime.goe(shopOpen.closeTime) // openTime >= closeTime (영업 시간이 다음날로 넘어가는 경우)
-                        .and(shopOpen.closeTime.goe(currentTime)))) // closeTime >= 현재 시간
-        );
-
-        // 조건 2: 어제의 요일과 시간이 open_time과 close_time 사이에 있는지 확인
-        whereCondition.or(
-            shopOpen.dayOfWeek.eq(yesterday.getDayOfWeek().name()) // 어제의 요일을 문자열로 비교
-                .and(shopOpen.openTime.loe(currentTime)) // openTime <= 현재 시간
-                .and(shopOpen.closeTime.goe(currentTime) // closeTime >= 현재 시간
-                    .or(shopOpen.openTime.goe(shopOpen.closeTime) // openTime >= closeTime (영업 시간이 다음날로 넘어가는 경우)
-                        .and(shopOpen.closeTime.goe(currentTime)))) // closeTime >= 현재 시간
-        );
-
-        // shop_id가 특정 값인 조건
-        return whereCondition.and(shopOpen.shop.id.eq(shopId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopInfoV1.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopInfoV1.java
@@ -1,8 +1,7 @@
 package in.koreatech.koin.domain.shop.repository.shop.dto;
 
 public record ShopInfoV1(
-    Boolean durationEvent,
-    Boolean isOpen
+    Boolean durationEvent
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopInfoV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopInfoV2.java
@@ -3,8 +3,7 @@ package in.koreatech.koin.domain.shop.repository.shop.dto;
 public record ShopInfoV2(
     Boolean durationEvent,
     Double averageRate,
-    Long reviewCount,
-    Boolean isOpen
+    Long reviewCount
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -109,6 +109,6 @@ public class ShopService {
         List<Shop> shops = shopRepository.findAll();
         LocalDateTime now = LocalDateTime.now(clock);
         Map<Integer, ShopInfoV2> shopInfoMap = shopCustomRepository.findAllShopInfo(now);
-        return ShopsResponseV2.from(shops, shopInfoMap, sortBy, shopsFilterCriterias);
+        return ShopsResponseV2.from(shops, shopInfoMap, sortBy, shopsFilterCriterias, now);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -965,4 +965,56 @@ class ShopApiTest extends AcceptanceTest {
                 """, 마슬랜_영업여부, 신전_떡볶이_영업여부)));
     }
 
+    @Test
+    void _24시간_운영중인_상점은_is_open은_true이다() throws Exception {
+        Shop 영업중인_티바 = shopFixture._24시간_영업중인_티바(owner);
+        shopReviewFixture.리뷰_4점(익명_학생, 영업중인_티바);
+
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+        shopReviewFixture.리뷰_4점(익명_학생, 마슬랜);
+        // 2024-01-15 12:00 월요일 기준
+        boolean 마슬랜_영업여부 = true;
+        boolean 티바_영업여부 = true;
+        mockMvc.perform(
+                get("/v2/shops")
+                    .queryParam("sorter", "COUNT")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json(String.format("""
+                {
+                    "count": 2,
+                    "shops": [
+                        {
+                        "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 1,
+                            "name": "마슬랜 치킨",
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7574-1212",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 2
+                        },{
+                            "category_ids": [
+                               \s
+                            ],
+                            "delivery": true,
+                            "id": 2,
+                            "name": "티바",
+                            "pay_bank": true,
+                            "pay_card": true,
+                            "phone": "010-7788-9900",
+                            "is_event": false,
+                            "is_open": %s,
+                            "average_rate": 4.0,
+                            "review_count": 1
+                        }
+                    ]
+                }
+                """, 티바_영업여부, 마슬랜_영업여부)));
+    }
 }

--- a/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
@@ -398,6 +398,94 @@ public final class ShopFixture {
         return shopRepository.save(shop);
     }
 
+    public Shop _24시간_영업중인_티바(Owner owner) {
+        var shop = shopRepository.save(
+            Shop.builder()
+                .owner(owner)
+                .name("티바")
+                .internalName("티바")
+                .chosung("티")
+                .phone("010-7788-9900")
+                .address("천안시 동남구 병천면 1600 신전떡볶이")
+                .description("신전떡볶이입니다.")
+                .delivery(true)
+                .deliveryPrice(2000)
+                .payCard(true)
+                .payBank(true)
+                .isDeleted(false)
+                .isEvent(false)
+                .remarks("비고")
+                .hit(0)
+                .build()
+        );
+        shop.getShopImages().addAll(
+            List.of(
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전.png")
+                    .build(),
+                ShopImage.builder()
+                    .shop(shop)
+                    .imageUrl("https://test-image.com/신전2.png")
+                    .build()
+            )
+        );
+        shop.getShopOpens().addAll(
+            List.of(
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SUNDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("MONDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("TUESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("WEDNESDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("THURSDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("FRIDAY")
+                    .build(),
+                ShopOpen.builder()
+                    .openTime(LocalTime.of(0, 0))
+                    .closeTime(LocalTime.of(0, 0))
+                    .shop(shop)
+                    .closed(false)
+                    .dayOfWeek("SATURDAY")
+                    .build()
+            )
+        );
+        return shopRepository.save(shop);
+    }
+
     public ShopFixtureBuilder builder() {
         return new ShopFixtureBuilder();
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #943 

# 🚀 작업 내용

1. api응답시간을 최적화 하기 위해서 query dsl을 이용하였는데, 로직상 문제가 있어서 기존 방식으로 원복합니다.

# 💬 리뷰 중점사항
