### PR TITLE
fix: 어드민 공지 조회 API 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/notice/dto/AdminNoticeResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/dto/AdminNoticeResponse.java
@@ -36,7 +36,7 @@ public record AdminNoticeResponse(
     public static AdminNoticeResponse from(Article article) {
         return new AdminNoticeResponse(
             article.getId(),
-            article.getKoinArticle().getUser().getName(),
+            article.getAuthor(),
             article.getTitle(),
             article.getContent(),
             article.getCreatedAt(),

--- a/src/main/java/in/koreatech/koin/admin/notice/dto/AdminNoticesResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/dto/AdminNoticesResponse.java
@@ -15,7 +15,7 @@ import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.global.model.Criteria;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record AdminNoticesResponse (
+public record AdminNoticesResponse(
     @Schema(description = "공지사항 목록")
     List<InnerAdminNoticeResponse> notices,
 
@@ -63,13 +63,13 @@ public record AdminNoticesResponse (
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
     ) {
 
-        public static InnerAdminNoticeResponse from(Article noticeArticle) {
+        public static InnerAdminNoticeResponse from(Article article) {
             return new InnerAdminNoticeResponse(
-                noticeArticle.getId(),
-                noticeArticle.getTitle(),
-                noticeArticle.getKoinArticle().getUser().getName(),
-                noticeArticle.getCreatedAt(),
-                noticeArticle.getUpdatedAt()
+                article.getId(),
+                article.getTitle(),
+                article.getAuthor(),
+                article.getCreatedAt(),
+                article.getUpdatedAt()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/admin/notice/repository/AdminKoinArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/repository/AdminKoinArticleRepository.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.admin.notice.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.article.model.KoinArticle;
+
+public interface AdminKoinArticleRepository extends Repository<KoinArticle, Integer> {
+
+    @Query(value = "SELECT * FROM new_koin_articles WHERE article_id = :noticeId", nativeQuery = true)
+    Optional<KoinArticle> findByArticleId(Integer noticeId);
+}

--- a/src/main/java/in/koreatech/koin/admin/notice/repository/AdminKoreatechArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/repository/AdminKoreatechArticleRepository.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.admin.notice.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.community.article.model.KoreatechArticle;
+
+public interface AdminKoreatechArticleRepository extends Repository<KoreatechArticle, Integer> {
+
+    @Query(value = "SELECT * FROM new_koreatech_articles WHERE article_id = :noticeId", nativeQuery = true)
+    Optional<KoreatechArticle> findByArticleId(Integer noticeId);
+}

--- a/src/main/java/in/koreatech/koin/admin/notice/repository/AdminNoticeRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/repository/AdminNoticeRepository.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.admin.notice.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundException;
+import in.koreatech.koin.domain.community.article.model.Article;
+
+public interface AdminNoticeRepository extends Repository<Article, Integer> {
+
+    void save(Article article);
+
+    Optional<Article> findByIdAndIsDeleted(Integer noticeId, boolean isDeleted);
+
+    @Query(value = "SELECT * FROM new_articles WHERE id = :noticeId", nativeQuery = true)
+    Optional<Article> findNoticeById(@Param("noticeId") Integer noticeId);
+
+    @Query(value = "SELECT * FROM new_articles WHERE board_id = :boardId AND is_deleted = :isDeleted", nativeQuery = true)
+    Page<Article> findAllByBoardIdAndIsDeleted(@Param("boardId") Integer boardId, @Param("isDeleted") boolean isDeleted, Pageable pageable);
+
+    @Query(value = "SELECT COUNT(*) FROM new_articles WHERE is_deleted = :isDeleted AND board_id = :boardId", nativeQuery = true)
+    Integer countAllByIsDeletedAndBoardId(@Param("isDeleted") boolean isDeleted, @Param("boardId") Integer boardId);
+
+    default Article getNoticeById(Integer noticeId) {
+        return findNoticeById(noticeId).orElseThrow(
+            () -> ArticleNotFoundException.withDetail("articleId: " + noticeId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/notice/service/AdminNoticeService.java
+++ b/src/main/java/in/koreatech/koin/admin/notice/service/AdminNoticeService.java
@@ -13,10 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.admin.notice.dto.AdminNoticeRequest;
 import in.koreatech.koin.admin.notice.dto.AdminNoticeResponse;
 import in.koreatech.koin.admin.notice.dto.AdminNoticesResponse;
+import in.koreatech.koin.admin.notice.repository.AdminKoinArticleRepository;
+import in.koreatech.koin.admin.notice.repository.AdminKoreatechArticleRepository;
+import in.koreatech.koin.admin.notice.repository.AdminNoticeRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.Board;
-import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.article.repository.BoardRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.model.Criteria;
@@ -27,39 +29,50 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AdminNoticeService {
 
-    private final ArticleRepository articleRepository;
+    private final AdminNoticeRepository adminNoticeRepository;
     private final AdminUserRepository adminUserRepository;
     private final BoardRepository boardRepository;
 
     private static final Sort NOTICES_SORT = Sort.by(
         Sort.Order.desc("id")
     );
+    private final AdminKoinArticleRepository adminKoinArticleRepository;
+    private final AdminKoreatechArticleRepository adminKoreatechArticleRepository;
 
     @Transactional
     public void createNotice(AdminNoticeRequest request, Integer adminUserId) {
         Board adminNoticeBoard = boardRepository.getById(KOIN_ADMIN_NOTICE_BOARD_ID);
         User adminUser = adminUserRepository.getById(adminUserId);
         Article adminNoticeArticle = Article.createKoinNoticeArticleByAdmin(request, adminNoticeBoard, adminUser);
-        articleRepository.save(adminNoticeArticle);
+        adminNoticeRepository.save(adminNoticeArticle);
     }
 
     public AdminNoticesResponse getNotices(Integer page, Integer limit, Boolean isDeleted) {
-        Integer total = articleRepository.countAllByIsDeletedAndBoardId(isDeleted, KOIN_ADMIN_NOTICE_BOARD_ID);
+        Integer total = adminNoticeRepository.countAllByIsDeletedAndBoardId(isDeleted, KOIN_ADMIN_NOTICE_BOARD_ID);
         Criteria criteria = Criteria.of(page, limit, total);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), NOTICES_SORT);
-        Page<Article> result = articleRepository.findAllByBoardIdAndIsDeleted(KOIN_ADMIN_NOTICE_BOARD_ID, isDeleted, pageRequest);
-
+        Page<Article> result = adminNoticeRepository.findAllByBoardIdAndIsDeleted(KOIN_ADMIN_NOTICE_BOARD_ID, isDeleted,
+            pageRequest);
+        result.forEach(this::setAuthorName);
         return AdminNoticesResponse.of(result, criteria);
     }
 
+    private void setAuthorName(Article article) {
+        adminKoinArticleRepository.findByArticleId(article.getId())
+            .ifPresent(koinArticle -> article.setAuthor(koinArticle.getUser().getName()));
+        adminKoreatechArticleRepository.findByArticleId(article.getId())
+            .ifPresent(koreatechArticle -> article.setAuthor(koreatechArticle.getAuthor()));
+    }
+
     public AdminNoticeResponse getNotice(Integer noticeId) {
-        Article noticeArticle = articleRepository.getAdminNoticeArticleById(noticeId);
-        return AdminNoticeResponse.from(noticeArticle);
+        Article article = adminNoticeRepository.getNoticeById(noticeId);
+        setAuthorName(article);
+        return AdminNoticeResponse.from(article);
     }
 
     @Transactional
     public void deleteNotice(Integer noticeId) {
-        Optional<Article> foundArticle = articleRepository.findById(noticeId);
+        Optional<Article> foundArticle = adminNoticeRepository.findByIdAndIsDeleted(noticeId, false);
         if (foundArticle.isEmpty()) {
             return;
         }
@@ -68,7 +81,7 @@ public class AdminNoticeService {
 
     @Transactional
     public void updateNotice(Integer noticeId, AdminNoticeRequest request) {
-        Article notice = articleRepository.getById(noticeId);
+        Article notice = adminNoticeRepository.getNoticeById(noticeId);
         notice.updateKoinAdminArticle(request.title(), request.content());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -24,6 +24,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
@@ -86,6 +88,9 @@ public class Article extends BaseEntity {
     @Transient
     private Integer nextId;
 
+    @Transient
+    private String author;
+
     public void increaseKoinHit() {
         this.hit++;
     }
@@ -106,17 +111,29 @@ public class Article extends BaseEntity {
         }
     }
 
-    public String getAuthor() {
-        if (this.koreatechArticle != null || this.koinArticle == null) {
-            return this.koreatechArticle.getAuthor();
-        } else if (Objects.equals(this.board.getId(), KOIN_ADMIN_NOTICE_BOARD_ID)) {
-            return ADMIN_NOTICE_AUTHOR;
-        } else {
-            if (Objects.equals(this.koinArticle.getUser(), null)) {
-                return "탈퇴한 사용자";
-            }
-            return this.koinArticle.getUser().getName();
+    @PostPersist
+    @PostLoad
+    public void updateAuthor() {
+        if (koreatechArticle == null && koinArticle == null) {
+            return;
         }
+        if (koreatechArticle != null) {
+            author = koreatechArticle.getAuthor();
+            return;
+        }
+        if (Objects.equals(board.getId(), KOIN_ADMIN_NOTICE_BOARD_ID)) {
+            author = ADMIN_NOTICE_AUTHOR;
+            return;
+        }
+        if (Objects.equals(koinArticle.getUser(), null)) {
+            author = "탈퇴한 사용자";
+            return;
+        }
+        author = koinArticle.getUser().getName();
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
     }
 
     public LocalDate getRegisteredAt() {

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -25,25 +25,13 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Optional<Article> findById(Integer articleId);
 
-    @Query(value = "SELECT * FROM new_articles "
-        + "WHERE id = :noticeId", nativeQuery = true)
-    Optional<Article> findAdminNoticeArticleById(@Param("noticeId") Integer noticeId);
-
     List<Article> findAll(Pageable pageable);
 
     Page<Article> findAllByBoardId(Integer boardId, PageRequest pageRequest);
 
-    @Query(value = "SELECT * FROM new_articles WHERE board_id = :boardId AND is_deleted = :isDeleted", nativeQuery = true)
-    Page<Article> findAllByBoardIdAndIsDeleted(@Param("boardId") Integer boardId, @Param("isDeleted") boolean isDeleted, Pageable pageable);
-
     default Article getById(Integer articleId) {
         return findById(articleId).orElseThrow(
             () -> ArticleNotFoundException.withDetail("articleId: " + articleId));
-    }
-
-    default Article getAdminNoticeArticleById(Integer noticeId) {
-        return findAdminNoticeArticleById(noticeId).orElseThrow(
-            () -> ArticleNotFoundException.withDetail("articleId: " + noticeId));
     }
 
     @Query(
@@ -119,8 +107,5 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         + "JOIN new_articles a ON ka.article_id = a.id "
         + "WHERE ka.registered_at > :localDate", nativeQuery = true)
     List<Article> findAllByRegisteredAtIsAfter(LocalDate localDate);
-
-    @Query(value = "SELECT COUNT(*) FROM new_articles WHERE is_deleted = :isDeleted AND board_id = :boardId", nativeQuery = true)
-    Integer countAllByIsDeletedAndBoardId(@Param("isDeleted") boolean isDeleted, @Param("boardId") Integer boardId);
 
 }


### PR DESCRIPTION

# 🚀 작업 내용

1. 어드민 페이지에서 코인 공지 (단건, 리스트) 조회 시 소프트딜리트된 대상이 검색 대상에 포함되면 NPE가 발생하는 문제를 해결했습니다.

# 💬 리뷰 중점사항
