### PR TITLE
fix : coopshop 기존 데이터가 없는 로컬에서도 동작하도록 flyway 쿼리 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopSemesterResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopSemesterResponse.java
@@ -31,6 +31,10 @@ public record AdminCoopSemesterResponse(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate toDate,
 
+    @Schema(description = "업데이트 일자", example = "2024-09-01 14:02:48", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime updatedAt,
+
     @Schema(description = "생협 매장 정보 리스트", requiredMode = REQUIRED)
     List<InnerCoopShop> coopShops
 ) {
@@ -40,6 +44,7 @@ public record AdminCoopSemesterResponse(
             coopSemester.getSemester(),
             coopSemester.getFromDate(),
             coopSemester.getToDate(),
+            coopSemester.getUpdatedAt(),
             coopSemester.getCoopShops().stream().map(InnerCoopShop::from).toList()
         );
     }
@@ -62,11 +67,7 @@ public record AdminCoopSemesterResponse(
         String location,
 
         @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
-        String remarks,
-
-        @JsonFormat(pattern = "yyyy-MM-dd")
-        @Schema(example = "2024-06-26", description = "학식 운영시간 업데이트 날짜", requiredMode = REQUIRED)
-        LocalDateTime updatedAt
+        String remarks
     ) {
 
         public static InnerCoopShop from(CoopShop coopShop) {
@@ -78,8 +79,7 @@ public record AdminCoopSemesterResponse(
                     .toList(),
                 coopShop.getPhone(),
                 coopShop.getLocation(),
-                coopShop.getRemarks(),
-                coopShop.getUpdatedAt()
+                coopShop.getRemarks()
             );
         }
 

--- a/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopSemestersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/coopShop/dto/AdminCoopSemestersResponse.java
@@ -4,10 +4,12 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.coopshop.model.CoopSemester;
@@ -35,10 +37,23 @@ public record AdminCoopSemestersResponse(
 
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerSemester(
+        @Schema(description = "학기 고유 id", example = "1", requiredMode = REQUIRED)
         Integer id,
+
+        @Schema(description = "학기", example = "24-2학기", requiredMode = REQUIRED)
         String semester,
+
+        @Schema(description = "학기 기간 시작일", example = "2024-09-02", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate fromDate,
-        LocalDate toDate
+
+        @Schema(description = "학기 기간 마감일", example = "2024-12-20", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate toDate,
+
+        @Schema(description = "업데이트 일자", example = "2024-09-01 14:02:48", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime updatedAt
     ) {
 
         public static InnerSemester from(CoopSemester coopSemester) {
@@ -46,7 +61,8 @@ public record AdminCoopSemestersResponse(
                 coopSemester.getId(),
                 coopSemester.getSemester(),
                 coopSemester.getFromDate(),
-                coopSemester.getToDate()
+                coopSemester.getToDate(),
+                coopSemester.getUpdatedAt()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopsResponse.java
@@ -28,6 +28,10 @@ public record CoopShopsResponse(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate toDate,
 
+    @Schema(description = "업데이트 일자", example = "2024-09-02 14:02:48", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime updatedAt,
+
     @Schema(example = "하계방학", description = "운영 학기", requiredMode = REQUIRED)
     List<InnerCoopShop> coopShops
 ) {
@@ -37,6 +41,7 @@ public record CoopShopsResponse(
             coopSemester.getSemester(),
             coopSemester.getFromDate(),
             coopSemester.getToDate(),
+            coopSemester.getUpdatedAt(),
             coopSemester.getCoopShops().stream()
                 .map(InnerCoopShop::from)
                 .toList()
@@ -61,11 +66,7 @@ public record CoopShopsResponse(
         String location,
 
         @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
-        String remarks,
-
-        @JsonFormat(pattern = "yyyy-MM-dd")
-        @Schema(example = "2024-06-26", description = "학식 운영시간 업데이트 날짜", requiredMode = REQUIRED)
-        LocalDateTime updatedAt
+        String remarks
     ) {
 
         public static InnerCoopShop from(CoopShop coopShop) {
@@ -77,8 +78,7 @@ public record CoopShopsResponse(
                     .toList(),
                 coopShop.getPhone(),
                 coopShop.getLocation(),
-                coopShop.getRemarks(),
-                coopShop.getUpdatedAt()
+                coopShop.getRemarks()
             );
         }
 

--- a/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
+++ b/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
@@ -6,52 +6,34 @@ insert into `coop_semester` (`semester`, `from_date`, `to_date`, `is_applied`)
 values ('24-2학기', '2024-09-02', '2024-12-20', 1);
 
 INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('복지관식당', '041-560-1778', '복지관 2층', '능수관', 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), '점심', 'WEEKDAYS', '11:40', '13:30'),
-       (last_insert_id(), '점심', 'WEEKEND', '미운영', '미운영');
+VALUES ('복지관식당', '041-560-1778', '복지관 2층', '능수관', 1),
+       ('대즐', '041-560-1779', '복지관 1층', '배달 서비스, 공·일요일 미운영', 1),
+       ('서점', '041-560-1756', '복지관 1층', '점심시간 12:00 - 13:00', 1),
+       ('세탁소', '041-552-1489', '학생회관 2층', NULL, 1),
+       ('복사실', '041-560-1093', '학생회관 2층', '점심시간 11:30 - 12:30', 1),
+       ('복지관 참빛관 편의점', '041-560-1093', '복지관 1층, 참빛관 1층', '복지관 임시운영 별도공지', 1),
+       ('미용실', '041-560-1769', '학생회관 1층', '예약제운영', 1),
+       ('오락실', '041-560-1472', '학생회관 1층', NULL, 1);
 
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('대즐', '041-560-1779', '복지관 1층', '배달 서비스, 공·일요일 미운영', 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '08:30', '21:00'),
-       (last_insert_id(), NULL, 'SATURDAY', '11:00', '18:00');
+SET @FIRST_ID = LAST_INSERT_ID();
 
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('서점', '041-560-1756', '복지관 1층', '점심시간 12:00 - 13:00', 1);
 INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '09:00', '18:00'),
-       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
-
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('세탁소', '041-552-1489', '학생회관 2층', NULL, 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '11:30', '18:00'),
-       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
-
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('복사실', '041-560-1093', '학생회관 2층', '점심시간 11:30 - 12:30', 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '08:30', '18:00'),
-       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
-
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('복지관 참빛관 편의점', '041-560-1093', '복지관 1층, 참빛관 1층', '복지관 임시운영 별도공지', 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '24시간', '24시간'),
-       (last_insert_id(), NULL, 'WEEKEND', '24시간', '24시간');
-
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('미용실', '041-560-1769', '학생회관 1층', '예약제운영', 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '09:30', '17:00'),
-       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
-
-INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-VALUES ('오락실', '041-560-1472', '학생회관 1층', NULL, 1);
-INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), NULL, 'WEEKDAYS', '24시간', '24시간'),
-       (last_insert_id(), NULL, 'WEEKEND', '24시간', '24시간');
+VALUES (@FIRST_ID, '점심', 'WEEKDAYS', '11:40', '13:30'),
+       (@FIRST_ID, '점심', 'WEEKEND', '미운영', '미운영'),
+       (@FIRST_ID + 1, NULL, 'WEEKDAYS', '08:30', '21:00'),
+       (@FIRST_ID + 1, NULL, 'SATURDAY', '11:00', '18:00'),
+       (@FIRST_ID + 2, NULL, 'WEEKDAYS', '09:00', '18:00'),
+       (@FIRST_ID + 2, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@FIRST_ID + 3, NULL, 'WEEKDAYS', '11:30', '18:00'),
+       (@FIRST_ID + 3, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@FIRST_ID + 4, NULL, 'WEEKDAYS', '08:30', '18:00'),
+       (@FIRST_ID + 4, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@FIRST_ID + 5, NULL, 'WEEKDAYS', '24시간', '24시간'),
+       (@FIRST_ID + 5, NULL, 'WEEKEND', '24시간', '24시간'),
+       (@FIRST_ID + 6, NULL, 'WEEKDAYS', '09:30', '17:00'),
+       (@FIRST_ID + 6, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@FIRST_ID + 7, NULL, 'WEEKDAYS', '24시간', '24시간'),
+       (@FIRST_ID + 7, NULL, 'WEEKEND', '24시간', '24시간');
 
 UPDATE coop_shop
 SET semester_id = 1

--- a/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
+++ b/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
@@ -50,8 +50,8 @@ VALUES (last_insert_id(), NULL, 'WEEKDAYS', '09:30', '17:00'),
 INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
 VALUES ('오락실', '041-560-1472', '학생회관 1층', NULL, 1);
 INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-VALUES (last_insert_id(), 'NULL', 'WEEKDAYS', '24시간', '24시간'),
-       (last_insert_id(), 'NULL', 'WEEKEND', '24시간', '24시간');
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '24시간', '24시간'),
+       (last_insert_id(), NULL, 'WEEKEND', '24시간', '24시간');
 
 UPDATE coop_shop
 SET semester_id = 1

--- a/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
+++ b/src/main/resources/db/migration/V77__insert_coop_shop_semester.sql
@@ -1,40 +1,68 @@
+ALTER TABLE coop_semester AUTO_INCREMENT = 1;
+ALTER TABLE coop_shop AUTO_INCREMENT = 2;
+ALTER TABLE coop_opens AUTO_INCREMENT = 7;
+
 insert into `coop_semester` (`semester`, `from_date`, `to_date`, `is_applied`)
 values ('24-2학기', '2024-09-02', '2024-12-20', 1);
 
 INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
-    VALUES
-    ('복지관식당', '041-560-1778', 'NULL', '능수관', 1),
-    ('대즐', '041-560-1779', '복지관 1층', '배달 서비스, 공·일요일 미운영', 1),
-    ('서점', '041-560-1756', '복지관 1층', '점심시간 12:00 - 13:00', 1),
-    ('세탁소', '041-552-1489', '학생회관 2층', 'NULL', 1),
-    ('복사실', '041-560-1093', '학생회관 2층', '점심시간 11:30 - 12:30', 1),
-    ('복지관 참빛관 편의점', '041-560-1093', '복지관 1층, 참빛관 1층', '복지관 임시운영 별도공지', 1),
-    ('미용실', '041-560-1769', '학생회관 1층', '예약제운영', 1),
-    ('오락실', '041-560-1472', '학생회관 1층', 'NULL', 1);
-
-update `coop_shop` set `semester_id` = 1 where `id` = 1;
-update `coop_opens` set `day_of_week` = 'WEEKDAYS' where `id` = 1;
-update `coop_opens` set `day_of_week` = 'WEEKDAYS' where `id` = 2;
-update `coop_opens` set `day_of_week` = 'WEEKDAYS' where `id` = 3;
-update `coop_opens` set `day_of_week` = 'WEEKEND' where `id` = 4;
-update `coop_opens` set `day_of_week` = 'WEEKEND' where `id` = 5;
-update `coop_opens` set `day_of_week` = 'WEEKEND' where `id` = 6;
-
+VALUES ('복지관식당', '041-560-1778', '복지관 2층', '능수관', 1);
 INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
-    VALUES
-    (2, '점심', 'WEEKDAYS', '11:40', '13:30'),
-    (2, '점심', 'WEEKEND', '미운영', '미운영'),
-    (3, 'NULL', 'WEEKDAYS', '08:30', '21:00'),
-    (3, 'NULL', 'SATURDAY', '11:00', '18:00'),
-    (4, 'NULL', 'WEEKDAYS', '09:00', '18:00'),
-    (4, 'NULL', 'WEEKEND', '휴점', '휴점'),
-    (5, 'NULL', 'WEEKDAYS', '11:30', '18:00'),
-    (5, 'NULL', 'WEEKEND', '휴점', '휴점'),
-    (6, 'NULL', 'WEEKDAYS', '08:30', '18:00'),
-    (6, 'NULL', 'WEEKEND', '휴점', '휴점'),
-    (7, 'NULL', 'WEEKDAYS', '24시간', '24시간'),
-    (7, 'NULL', 'WEEKEND', '24시간', '24시간'),
-    (8, 'NULL', 'WEEKDAYS', '09:30', '17:00'),
-    (8, 'NULL', 'WEEKEND', '휴점', '휴점'),
-    (9, 'NULL', 'WEEKDAYS', '24시간', '24시간'),
-    (9, 'NULL', 'WEEKEND', '24시간', '24시간');
+VALUES (last_insert_id(), '점심', 'WEEKDAYS', '11:40', '13:30'),
+       (last_insert_id(), '점심', 'WEEKEND', '미운영', '미운영');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('대즐', '041-560-1779', '복지관 1층', '배달 서비스, 공·일요일 미운영', 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '08:30', '21:00'),
+       (last_insert_id(), NULL, 'SATURDAY', '11:00', '18:00');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('서점', '041-560-1756', '복지관 1층', '점심시간 12:00 - 13:00', 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '09:00', '18:00'),
+       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('세탁소', '041-552-1489', '학생회관 2층', NULL, 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '11:30', '18:00'),
+       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('복사실', '041-560-1093', '학생회관 2층', '점심시간 11:30 - 12:30', 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '08:30', '18:00'),
+       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('복지관 참빛관 편의점', '041-560-1093', '복지관 1층, 참빛관 1층', '복지관 임시운영 별도공지', 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '24시간', '24시간'),
+       (last_insert_id(), NULL, 'WEEKEND', '24시간', '24시간');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('미용실', '041-560-1769', '학생회관 1층', '예약제운영', 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), NULL, 'WEEKDAYS', '09:30', '17:00'),
+       (last_insert_id(), NULL, 'WEEKEND', '휴점', '휴점');
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('오락실', '041-560-1472', '학생회관 1층', NULL, 1);
+INSERT INTO coop_opens (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (last_insert_id(), 'NULL', 'WEEKDAYS', '24시간', '24시간'),
+       (last_insert_id(), 'NULL', 'WEEKEND', '24시간', '24시간');
+
+UPDATE coop_shop
+SET semester_id = 1
+WHERE name = '학생식당';
+
+UPDATE coop_opens
+SET day_of_week = 'WEEKDAYS'
+WHERE coop_shop_id = 1
+  AND day_of_week = '평일';
+
+UPDATE coop_opens
+SET day_of_week = 'WEEKEND'
+WHERE coop_shop_id = 1
+  AND day_of_week = '주말';

--- a/src/test/java/in/koreatech/koin/acceptance/CoopShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/CoopShopApiTest.java
@@ -44,6 +44,7 @@ class CoopShopApiTest extends AcceptanceTest {
                         "semester": "23-2학기",
                         "from_date": "2023-09-02",
                         "to_date": "2023-12-20",
+                        "updated_at" : "2024-01-15 12:00:00",
                         "coop_shops": [
                             {
                                 "id": 1,
@@ -58,8 +59,7 @@ class CoopShopApiTest extends AcceptanceTest {
                                 ],
                                 "phone": "041-000-0000",
                                 "location": "학생회관 1층",
-                                "remarks": "공휴일 휴무",
-                                "updated_at" : "2024-01-15"
+                                "remarks": "공휴일 휴무"
                             },
                             {
                                 "id": 2,
@@ -67,8 +67,7 @@ class CoopShopApiTest extends AcceptanceTest {
                                 "opens": [],
                                 "phone": "041-000-0000",
                                 "location": "학생회관 2층",
-                                "remarks": "연중무휴",
-                                "updated_at" : "2024-01-15"
+                                "remarks": "연중무휴"
                             }
                         ]
                     }
@@ -116,6 +115,7 @@ class CoopShopApiTest extends AcceptanceTest {
                         "semester": "23-겨울학기",
                         "from_date": "2023-12-21",
                         "to_date": "2024-02-28",
+                        "updated_at" : "2024-01-15 12:00:00",
                         "coop_shops": [
                             {
                                 "id": 3,
@@ -130,8 +130,7 @@ class CoopShopApiTest extends AcceptanceTest {
                         ],
                                 "phone": "041-000-0000",
                                 "location": "학생회관 2층",
-                                "remarks": "연중무휴",
-                                "updated_at" : "2024-01-15"
+                                "remarks": "연중무휴"
                             }
                         ]
                     }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminCoopShopApiTest.java
@@ -62,12 +62,14 @@ class AdminCoopShopApiTest extends AcceptanceTest {
                                  "semester": "23-2학기",
                                  "from_date": "2023-09-02",
                                  "to_date": "2023-12-20",
+                                 "updated_at" : "2024-01-15 12:00:00"
                              },
                              {
                                  "id": 2,
                                  "semester": "23-겨울학기",
                                  "from_date": "2023-12-21",
                                  "to_date": "2024-02-28",
+                                 "updated_at" : "2024-01-15 12:00:00"
                              }
                          ]
                      }
@@ -87,6 +89,7 @@ class AdminCoopShopApiTest extends AcceptanceTest {
                         "semester": "23-2학기",
                         "from_date": "2023-09-02",
                         "to_date": "2023-12-20",
+                        "updated_at" : "2024-01-15 12:00:00",
                         "coop_shops": [
                             {
                                 "id": 1,
@@ -101,8 +104,7 @@ class AdminCoopShopApiTest extends AcceptanceTest {
                                 ],
                                 "phone": "041-000-0000",
                                 "location": "학생회관 1층",
-                                "remarks": "공휴일 휴무",
-                                "updated_at" : "2024-01-15"
+                                "remarks": "공휴일 휴무"
                             },
                             {
                                 "id": 2,
@@ -110,8 +112,7 @@ class AdminCoopShopApiTest extends AcceptanceTest {
                                 "opens": [],
                                 "phone": "041-000-0000",
                                 "location": "학생회관 2층",
-                                "remarks": "연중무휴",
-                                "updated_at" : "2024-01-15"
+                                "remarks": "연중무휴"
                             }
                         ]
                     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. `coopshop`에 기존 데이터가 없는 로컬에서도 동작하도록 flyway 쿼리를 수정하였습니다.
    - 초기에 직접 DB에 `coopshop` 정보를 추가하면서 로컬과의 `auto_increment` `시작 id`가 차이가 나 발생하는 오류를 수정하였습니다.

# 💬 리뷰 중점사항
