### PR TITLE
fix: PUT/timetables/lecture 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
@@ -16,109 +16,111 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableLectureResponse(
-        @Schema(description = "시간표 프레임 id", example = "1")
-        Integer timetableFrameId,
+    @Schema(description = "시간표 프레임 id", example = "1")
+    Integer timetableFrameId,
 
-        @Schema(description = "시간표 상세정보")
-        List<InnerTimetableLectureResponse> timetable,
+    @Schema(description = "시간표 상세정보")
+    List<InnerTimetableLectureResponse> timetable,
 
-        @Schema(description = "해당 학기 학점", example = "21")
-        Integer grades,
+    @Schema(description = "해당 학기 학점", example = "21")
+    Integer grades,
 
-        @Schema(description = "전체 학기 학점", example = "121")
-        Integer totalGrades
+    @Schema(description = "전체 학기 학점", example = "121")
+    Integer totalGrades
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimetableLectureResponse(
-            @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
-            Integer id,
+        @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
 
-            @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
-            Integer lectureId,
+        @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
+        Integer lectureId,
 
-            @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
-            String regularNumber,
+        @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
+        String regularNumber,
 
-            @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
-            String code,
+        @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
+        String code,
 
-            @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
-            String designScore,
+        @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
+        String designScore,
 
-            @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
-            List<Integer> classTime,
+        @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
+        List<Integer> classTime,
 
-            @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
-            String classPlace,
+        @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
+        String classPlace,
 
-            @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
-            String memo,
+        @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
+        String memo,
 
-            @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
-            String grades,
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
+        String grades,
 
-            @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
-            String classTitle,
+        @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
+        String classTitle,
 
-            @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
-            String lectureClass,
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        String lectureClass,
 
-            @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
-            String target,
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        String target,
 
-            @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
-            String professor,
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        String professor,
 
-            @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
-            String department
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        String department
     ) {
 
-        public static List<InnerTimetableLectureResponse> from(List<TimetableLecture> timetableLectures) {
+        public static List<InnerTimetableLectureResponse> from(
+            List<TimetableLecture> timetableLectures) {
             List<InnerTimetableLectureResponse> timetableLectureList = new ArrayList<>();
 
             for (TimetableLecture timetableLecture : timetableLectures) {
                 InnerTimetableLectureResponse response;
                 if (timetableLecture.getLecture() == null) {
                     response = new InnerTimetableLectureResponse(
-                            timetableLecture.getId(),
-                            null,
-                            null,
-                            null,
-                            null,
-                            parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
-                            timetableLecture.getClassPlace(),
-                            timetableLecture.getMemo(),
-                            timetableLecture.getGrades(),
-                            timetableLecture.getClassTitle(),
-                            null,
-                            null,
-                            timetableLecture.getProfessor(),
-                            null
+                        timetableLecture.getId(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
+                        timetableLecture.getClassPlace(),
+                        timetableLecture.getMemo(),
+                        timetableLecture.getGrades(),
+                        timetableLecture.getClassTitle(),
+                        null,
+                        null,
+                        timetableLecture.getProfessor(),
+                        null
                     );
                 } else {
                     response = new InnerTimetableLectureResponse(
-                            timetableLecture.getId(),
-                            timetableLecture.getLecture().getId(),
-                            timetableLecture.getLecture().getRegularNumber(),
-                            timetableLecture.getLecture().getCode(),
-                            timetableLecture.getLecture().getDesignScore(),
-                            timetableLecture.getClassTime() == null
-                                    ? parseIntegerClassTimesFromString(timetableLecture.getLecture().getClassTime())
-                                    : parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
-                            timetableLecture.getClassPlace(),
-                            timetableLecture.getMemo(),
-                            timetableLecture.getGrades() == null
-                                    ? timetableLecture.getLecture().getGrades()
-                                    : timetableLecture.getGrades(),
-                            timetableLecture.getClassTitle() == null
-                                    ? timetableLecture.getLecture().getName()
-                                    : timetableLecture.getClassTitle(),
-                            timetableLecture.getLecture().getLectureClass(),
-                            timetableLecture.getLecture().getTarget(),
-                            timetableLecture.getProfessor() == null
-                                    ? timetableLecture.getLecture().getProfessor()
-                                    : timetableLecture.getProfessor(),
-                            timetableLecture.getLecture().getDepartment()
+                        timetableLecture.getId(),
+                        timetableLecture.getLecture().getId(),
+                        timetableLecture.getLecture().getRegularNumber(),
+                        timetableLecture.getLecture().getCode(),
+                        timetableLecture.getLecture().getDesignScore(),
+                        timetableLecture.getClassTime() == null
+                            ? parseIntegerClassTimesFromString(
+                            timetableLecture.getLecture().getClassTime())
+                            : parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
+                        timetableLecture.getClassPlace(),
+                        timetableLecture.getMemo(),
+                        timetableLecture.getGrades() == null
+                            ? timetableLecture.getLecture().getGrades()
+                            : timetableLecture.getGrades(),
+                        timetableLecture.getClassTitle() == null
+                            ? timetableLecture.getLecture().getName()
+                            : timetableLecture.getClassTitle(),
+                        timetableLecture.getLecture().getLectureClass(),
+                        timetableLecture.getLecture().getTarget(),
+                        timetableLecture.getProfessor() == null
+                            ? timetableLecture.getLecture().getProfessor()
+                            : timetableLecture.getProfessor(),
+                        timetableLecture.getLecture().getDepartment()
                     );
                 }
                 timetableLectureList.add(response);
@@ -127,22 +129,25 @@ public record TimetableLectureResponse(
         }
     }
 
-    public static TimetableLectureResponse of(Integer timetableFrameId, List<TimetableLecture> timetableLectures,
-                                              Integer grades, Integer totalGrades) {
-        return new TimetableLectureResponse(timetableFrameId, InnerTimetableLectureResponse.from(timetableLectures),
-                grades, totalGrades);
+    public static TimetableLectureResponse of(Integer timetableFrameId,
+        List<TimetableLecture> timetableLectures,
+        Integer grades, Integer totalGrades) {
+        return new TimetableLectureResponse(timetableFrameId,
+            InnerTimetableLectureResponse.from(timetableLectures),
+            grades, totalGrades);
     }
 
     private static final int INITIAL_BRACE_INDEX = 1;
 
     private static List<Integer> parseIntegerClassTimesFromString(String classTime) {
-        String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX, classTime.length() - 1);
+        String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX,
+            classTime.length() - 1);
 
         if (!classTimeWithoutBrackets.isEmpty()) {
             return Arrays.stream(classTimeWithoutBrackets.split(","))
-                    .map(String::strip)
-                    .map(Integer::parseInt)
-                    .toList();
+                .map(String::strip)
+                .map(Integer::parseInt)
+                .toList();
         } else {
             return Collections.emptyList();
         }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
@@ -16,61 +16,61 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableLectureResponse(
-    @Schema(description = "시간표 프레임 id", example = "1")
-    Integer timetableFrameId,
+        @Schema(description = "시간표 프레임 id", example = "1")
+        Integer timetableFrameId,
 
-    @Schema(description = "시간표 상세정보")
-    List<InnerTimetableLectureResponse> timetable,
+        @Schema(description = "시간표 상세정보")
+        List<InnerTimetableLectureResponse> timetable,
 
-    @Schema(description = "해당 학기 학점", example = "21")
-    Integer grades,
+        @Schema(description = "해당 학기 학점", example = "21")
+        Integer grades,
 
-    @Schema(description = "전체 학기 학점", example = "121")
-    Integer totalGrades
+        @Schema(description = "전체 학기 학점", example = "121")
+        Integer totalGrades
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimetableLectureResponse(
-        @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
-        Integer id,
+            @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
+            Integer id,
 
-        @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
-        Integer lectureId,
+            @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
+            Integer lectureId,
 
-        @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
-        String regularNumber,
+            @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
+            String regularNumber,
 
-        @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
-        String code,
+            @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
+            String code,
 
-        @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
-        String designScore,
+            @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
+            String designScore,
 
-        @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
-        List<Integer> classTime,
+            @Schema(description = "강의(커스텀) 시간", example = "[204, 205, 206, 207, 302, 303]", requiredMode = REQUIRED)
+            List<Integer> classTime,
 
-        @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
-        String classPlace,
+            @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
+            String classPlace,
 
-        @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
-        String memo,
+            @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
+            String memo,
 
-        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
-        String grades,
+            @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
+            String grades,
 
-        @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
-        String classTitle,
+            @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
+            String classTitle,
 
-        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
-        String lectureClass,
+            @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
+            String lectureClass,
 
-        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
-        String target,
+            @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+            String target,
 
-        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
-        String professor,
+            @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+            String professor,
 
-        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
-        String department
+            @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+            String department
     ) {
 
         public static List<InnerTimetableLectureResponse> from(List<TimetableLecture> timetableLectures) {
@@ -80,37 +80,45 @@ public record TimetableLectureResponse(
                 InnerTimetableLectureResponse response;
                 if (timetableLecture.getLecture() == null) {
                     response = new InnerTimetableLectureResponse(
-                        timetableLecture.getId(),
-                        null,
-                        null,
-                        null,
-                        null,
-                        parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
-                        timetableLecture.getClassPlace(),
-                        timetableLecture.getMemo(),
-                        timetableLecture.getGrades(),
-                        timetableLecture.getClassTitle(),
-                        null,
-                        null,
-                        timetableLecture.getProfessor(),
-                        null
+                            timetableLecture.getId(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
+                            timetableLecture.getClassPlace(),
+                            timetableLecture.getMemo(),
+                            timetableLecture.getGrades(),
+                            timetableLecture.getClassTitle(),
+                            null,
+                            null,
+                            timetableLecture.getProfessor(),
+                            null
                     );
                 } else {
                     response = new InnerTimetableLectureResponse(
-                        timetableLecture.getId(),
-                        timetableLecture.getLecture().getId(),
-                        timetableLecture.getLecture().getRegularNumber(),
-                        timetableLecture.getLecture().getCode(),
-                        timetableLecture.getLecture().getDesignScore(),
-                        parseIntegerClassTimesFromString(timetableLecture.getLecture().getClassTime()),
-                        timetableLecture.getClassPlace(),
-                        timetableLecture.getMemo(),
-                        timetableLecture.getLecture().getGrades(),
-                        timetableLecture.getLecture().getName(),
-                        timetableLecture.getLecture().getLectureClass(),
-                        timetableLecture.getLecture().getTarget(),
-                        timetableLecture.getLecture().getProfessor(),
-                        timetableLecture.getLecture().getDepartment()
+                            timetableLecture.getId(),
+                            timetableLecture.getLecture().getId(),
+                            timetableLecture.getLecture().getRegularNumber(),
+                            timetableLecture.getLecture().getCode(),
+                            timetableLecture.getLecture().getDesignScore(),
+                            timetableLecture.getClassTime() == null
+                                    ? parseIntegerClassTimesFromString(timetableLecture.getLecture().getClassTime())
+                                    : parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
+                            timetableLecture.getClassPlace(),
+                            timetableLecture.getMemo(),
+                            timetableLecture.getGrades() == null
+                                    ? timetableLecture.getLecture().getGrades()
+                                    : timetableLecture.getGrades(),
+                            timetableLecture.getClassTitle() == null
+                                    ? timetableLecture.getLecture().getName()
+                                    : timetableLecture.getClassTitle(),
+                            timetableLecture.getLecture().getLectureClass(),
+                            timetableLecture.getLecture().getTarget(),
+                            timetableLecture.getProfessor() == null
+                                    ? timetableLecture.getLecture().getProfessor()
+                                    : timetableLecture.getProfessor(),
+                            timetableLecture.getLecture().getDepartment()
                     );
                 }
                 timetableLectureList.add(response);
@@ -120,9 +128,9 @@ public record TimetableLectureResponse(
     }
 
     public static TimetableLectureResponse of(Integer timetableFrameId, List<TimetableLecture> timetableLectures,
-        Integer grades, Integer totalGrades) {
+                                              Integer grades, Integer totalGrades) {
         return new TimetableLectureResponse(timetableFrameId, InnerTimetableLectureResponse.from(timetableLectures),
-            grades, totalGrades);
+                grades, totalGrades);
     }
 
     private static final int INITIAL_BRACE_INDEX = 1;
@@ -132,9 +140,9 @@ public record TimetableLectureResponse(
 
         if (!classTimeWithoutBrackets.isEmpty()) {
             return Arrays.stream(classTimeWithoutBrackets.split(","))
-                .map(String::strip)
-                .map(Integer::parseInt)
-                .toList();
+                    .map(String::strip)
+                    .map(Integer::parseInt)
+                    .toList();
         } else {
             return Collections.emptyList();
         }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -108,7 +109,7 @@ public record TimetableLectureResponse(
                             : parseIntegerClassTimesFromString(timetableLecture.getClassTime()),
                         timetableLecture.getClassPlace(),
                         timetableLecture.getMemo(),
-                        timetableLecture.getGrades() == null
+                        Objects.equals(timetableLecture.getGrades(), "0")
                             ? timetableLecture.getLecture().getGrades()
                             : timetableLecture.getGrades(),
                         timetableLecture.getClassTitle() == null

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureResponse.java
@@ -73,8 +73,7 @@ public record TimetableLectureResponse(
         String department
     ) {
 
-        public static List<InnerTimetableLectureResponse> from(
-            List<TimetableLecture> timetableLectures) {
+        public static List<InnerTimetableLectureResponse> from(List<TimetableLecture> timetableLectures) {
             List<InnerTimetableLectureResponse> timetableLectureList = new ArrayList<>();
 
             for (TimetableLecture timetableLecture : timetableLectures) {
@@ -129,19 +128,16 @@ public record TimetableLectureResponse(
         }
     }
 
-    public static TimetableLectureResponse of(Integer timetableFrameId,
-        List<TimetableLecture> timetableLectures,
+    public static TimetableLectureResponse of(Integer timetableFrameId, List<TimetableLecture> timetableLectures,
         Integer grades, Integer totalGrades) {
-        return new TimetableLectureResponse(timetableFrameId,
-            InnerTimetableLectureResponse.from(timetableLectures),
+        return new TimetableLectureResponse(timetableFrameId, InnerTimetableLectureResponse.from(timetableLectures),
             grades, totalGrades);
     }
 
     private static final int INITIAL_BRACE_INDEX = 1;
 
     private static List<Integer> parseIntegerClassTimesFromString(String classTime) {
-        String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX,
-            classTime.length() - 1);
+        String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX, classTime.length() - 1);
 
         if (!classTimeWithoutBrackets.isEmpty()) {
             return Arrays.stream(classTimeWithoutBrackets.split(","))

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -44,15 +44,12 @@ public class TimetableServiceV2 {
     private final SemesterRepositoryV2 semesterRepositoryV2;
 
     @Transactional
-    public TimetableFrameResponse createTimetablesFrame(Integer userId,
-        TimetableFrameCreateRequest request) {
+    public TimetableFrameResponse createTimetablesFrame(Integer userId, TimetableFrameCreateRequest request) {
         Semester semester = semesterRepositoryV2.getBySemester(request.semester());
         User user = userRepository.getById(userId);
-        int currentFrameCount = timetableFrameRepositoryV2.countByUserIdAndSemesterId(userId,
-            semester.getId());
+        int currentFrameCount = timetableFrameRepositoryV2.countByUserIdAndSemesterId(userId, semester.getId());
         boolean isMain = (currentFrameCount == 0);
-        String name = (request.timetableName() != null) ? request.timetableName() :
-            "시간표" + (currentFrameCount + 1);
+        String name = (request.timetableName() != null) ? request.timetableName() : "시간표" + (currentFrameCount + 1);
         TimetableFrame timetableFrame = request.toTimetablesFrame(user, semester, name, isMain);
         TimetableFrame savedTimetableFrame = timetableFrameRepositoryV2.save(timetableFrame);
         return TimetableFrameResponse.from(savedTimetableFrame);
@@ -71,15 +68,13 @@ public class TimetableServiceV2 {
                 throw new KoinIllegalArgumentException("메인 시간표는 필수입니다.");
             }
         }
-        timeTableFrame.updateTimetableFrame(semester, timetableFrameUpdateRequest.timetableName(),
-            isMain);
+        timeTableFrame.updateTimetableFrame(semester, timetableFrameUpdateRequest.timetableName(), isMain);
         return TimetableFrameUpdateResponse.from(timeTableFrame);
     }
 
     public List<TimetableFrameResponse> getTimetablesFrame(Integer userId, String semesterRequest) {
         Semester semester = semesterRepositoryV2.getBySemester(semesterRequest);
-        return timetableFrameRepositoryV2.findAllByUserIdAndSemesterId(userId, semester.getId())
-            .stream()
+        return timetableFrameRepositoryV2.findAllByUserIdAndSemesterId(userId, semester.getId()).stream()
             .map(TimetableFrameResponse::from)
             .toList();
     }
@@ -94,8 +89,7 @@ public class TimetableServiceV2 {
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
                 timetableFrameRepositoryV2.
-                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId,
-                        frame.getSemester().getId());
+                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
             }
@@ -103,10 +97,8 @@ public class TimetableServiceV2 {
     }
 
     @Transactional
-    public TimetableLectureResponse createTimetableLectures(Integer userId,
-        TimetableLectureCreateRequest request) {
-        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(
-            request.timetableFrameId());
+    public TimetableLectureResponse createTimetableLectures(Integer userId, TimetableLectureCreateRequest request) {
+        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
         if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }
@@ -114,8 +106,7 @@ public class TimetableServiceV2 {
         for (InnerTimeTableLectureRequest timetableLectureRequest : request.timetableLecture()) {
             Lecture lecture = timetableLectureRequest.lectureId() == null ?
                 null : lectureRepositoryV2.getLectureById(timetableLectureRequest.lectureId());
-            TimetableLecture timetableLecture = timetableLectureRequest.toTimetableLecture(
-                timetableFrame, lecture);
+            TimetableLecture timetableLecture = timetableLectureRequest.toTimetableLecture(timetableFrame, lecture);
             timetableLectureRepositoryV2.save(timetableLecture);
         }
 
@@ -125,10 +116,8 @@ public class TimetableServiceV2 {
     }
 
     @Transactional
-    public TimetableLectureResponse updateTimetablesLectures(Integer userId,
-        TimetableLectureUpdateRequest request) {
-        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(
-            request.timetableFrameId());
+    public TimetableLectureResponse updateTimetablesLectures(Integer userId, TimetableLectureUpdateRequest request) {
+        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
         if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }
@@ -160,8 +149,7 @@ public class TimetableServiceV2 {
 
     @Transactional
     public void deleteTimetableLecture(Integer userId, Integer timetableLectureId) {
-        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(
-            timetableLectureId);
+        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetableLectureId);
         TimetableFrame frame = timetableLecture.getTimetableFrame();
         if (!Objects.equals(frame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
@@ -185,8 +173,7 @@ public class TimetableServiceV2 {
                 timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
         }
 
-        return TimetableLectureResponse.of(timetableFrame.getId(), timetableLectures, grades,
-            totalGrades);
+        return TimetableLectureResponse.of(timetableFrame.getId(), timetableLectures, grades, totalGrades);
     }
 
     private int calculateGrades(List<TimetableLecture> timetableLectures) {
@@ -202,8 +189,7 @@ public class TimetableServiceV2 {
     }
 
     private void cancelMainTimetable(Integer userId, Integer semesterId) {
-        TimetableFrame mainTimetableFrame = timetableFrameRepositoryV2.getMainTimetableByUserIdAndSemesterId(
-            userId,
+        TimetableFrame mainTimetableFrame = timetableFrameRepositoryV2.getMainTimetableByUserIdAndSemesterId(userId,
             semesterId);
         mainTimetableFrame.cancelMain();
     }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -56,7 +56,7 @@ public class TimetableServiceV2 {
 
     @Transactional
     public TimetableFrameUpdateResponse updateTimetableFrame(Integer timetableFrameId,
-        TimetableFrameUpdateRequest timetableFrameUpdateRequest, Integer userId) {
+                                                             TimetableFrameUpdateRequest timetableFrameUpdateRequest, Integer userId) {
         TimetableFrame timeTableFrame = timetableFrameRepositoryV2.getById(timetableFrameId);
         Semester semester = timeTableFrame.getSemester();
         boolean isMain = timetableFrameUpdateRequest.isMain();
@@ -74,8 +74,8 @@ public class TimetableServiceV2 {
     public List<TimetableFrameResponse> getTimetablesFrame(Integer userId, String semesterRequest) {
         Semester semester = semesterRepositoryV2.getBySemester(semesterRequest);
         return timetableFrameRepositoryV2.findAllByUserIdAndSemesterId(userId, semester.getId()).stream()
-            .map(TimetableFrameResponse::from)
-            .toList();
+                .map(TimetableFrameResponse::from)
+                .toList();
     }
 
     @Transactional
@@ -87,8 +87,8 @@ public class TimetableServiceV2 {
         timetableFrameRepositoryV2.deleteById(frameId);
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
-                timetableFrameRepositoryV2.
-                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
+                    timetableFrameRepositoryV2.
+                            findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
             }
@@ -104,13 +104,13 @@ public class TimetableServiceV2 {
 
         for (InnerTimeTableLectureRequest timetableLectureRequest : request.timetableLecture()) {
             Lecture lecture = timetableLectureRequest.lectureId() == null ?
-                null : lectureRepositoryV2.getLectureById(timetableLectureRequest.lectureId());
+                    null : lectureRepositoryV2.getLectureById(timetableLectureRequest.lectureId());
             TimetableLecture timetableLecture = timetableLectureRequest.toTimetableLecture(timetableFrame, lecture);
             timetableLectureRepositoryV2.save(timetableLecture);
         }
 
         List<TimetableLecture> timetableLectures = timetableLectureRepositoryV2.findAllByTimetableFrameId(
-            timetableFrame.getId());
+                timetableFrame.getId());
         return getTimetableLectureResponse(userId, timetableFrame, timetableLectures);
     }
 
@@ -123,15 +123,13 @@ public class TimetableServiceV2 {
 
         for (InnerTimetableLectureRequest timetableRequest : request.timetableLecture()) {
             TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetableRequest.id());
-            if (timetableRequest.lectureId() == null) {
-                timetableLecture.update(
+            timetableLecture.update(
                     timetableRequest.classTitle(),
                     timetableRequest.classTime().toString(),
                     timetableRequest.classPlace(),
                     timetableRequest.professor(),
                     timetableRequest.grades(),
                     timetableRequest.memo());
-            }
         }
         List<TimetableLecture> timetableLectures = timetableFrame.getTimetableLectures();
         return getTimetableLectureResponse(userId, timetableFrame, timetableLectures);
@@ -158,7 +156,7 @@ public class TimetableServiceV2 {
     }
 
     private TimetableLectureResponse getTimetableLectureResponse(Integer userId, TimetableFrame timetableFrame,
-        List<TimetableLecture> timetableLectures) {
+                                                                 List<TimetableLecture> timetableLectures) {
         int grades = 0;
         int totalGrades = 0;
 
@@ -168,7 +166,7 @@ public class TimetableServiceV2 {
 
         for (TimetableFrame timetableFrames : timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(userId)) {
             totalGrades += calculateGrades(
-                timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
+                    timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
         }
 
         return TimetableLectureResponse.of(timetableFrame.getId(), timetableLectures, grades, totalGrades);
@@ -176,19 +174,19 @@ public class TimetableServiceV2 {
 
     private int calculateGrades(List<TimetableLecture> timetableLectures) {
         return timetableLectures.stream()
-            .mapToInt(lecture -> {
-                if (lecture.getLecture() != null) {
-                    return Integer.parseInt(lecture.getLecture().getGrades());
-                } else {
-                    return Integer.parseInt(lecture.getGrades());
-                }
-            })
-            .sum();
+                .mapToInt(lecture -> {
+                    if (lecture.getLecture() != null) {
+                        return Integer.parseInt(lecture.getLecture().getGrades());
+                    } else {
+                        return Integer.parseInt(lecture.getGrades());
+                    }
+                })
+                .sum();
     }
 
     private void cancelMainTimetable(Integer userId, Integer semesterId) {
         TimetableFrame mainTimetableFrame = timetableFrameRepositoryV2.getMainTimetableByUserIdAndSemesterId(userId,
-            semesterId);
+                semesterId);
         mainTimetableFrame.cancelMain();
     }
 
@@ -196,7 +194,7 @@ public class TimetableServiceV2 {
     public void deleteAllTimetablesFrame(Integer userId, String semester) {
         User user = userRepository.findById(userId).get();
         Semester userSemester = semesterRepositoryV2.findBySemester(semester)
-            .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
+                .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
         timetableFrameRepositoryV2.deleteAllByUserAndSemester(user, userSemester);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -157,8 +156,7 @@ public class TimetableServiceV2 {
         timetableLectureRepositoryV2.deleteById(timetableLectureId);
     }
 
-    private TimetableLectureResponse getTimetableLectureResponse(Integer userId,
-        TimetableFrame timetableFrame,
+    private TimetableLectureResponse getTimetableLectureResponse(Integer userId, TimetableFrame timetableFrame,
         List<TimetableLecture> timetableLectures) {
         int grades = 0;
         int totalGrades = 0;
@@ -167,8 +165,7 @@ public class TimetableServiceV2 {
             grades = calculateGrades(timetableLectures);
         }
 
-        for (TimetableFrame timetableFrames : timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(
-            userId)) {
+        for (TimetableFrame timetableFrames : timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(userId)) {
             totalGrades += calculateGrades(
                 timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
         }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -122,8 +122,7 @@ public class TimetableServiceV2 {
         }
 
         for (InnerTimetableLectureRequest timetableRequest : request.timetableLecture()) {
-            TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(
-                timetableRequest.id());
+            TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetableRequest.id());
             timetableLecture.update(
                 timetableRequest.classTitle(),
                 timetableRequest.classTime().toString(),

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,12 +44,15 @@ public class TimetableServiceV2 {
     private final SemesterRepositoryV2 semesterRepositoryV2;
 
     @Transactional
-    public TimetableFrameResponse createTimetablesFrame(Integer userId, TimetableFrameCreateRequest request) {
+    public TimetableFrameResponse createTimetablesFrame(Integer userId,
+        TimetableFrameCreateRequest request) {
         Semester semester = semesterRepositoryV2.getBySemester(request.semester());
         User user = userRepository.getById(userId);
-        int currentFrameCount = timetableFrameRepositoryV2.countByUserIdAndSemesterId(userId, semester.getId());
+        int currentFrameCount = timetableFrameRepositoryV2.countByUserIdAndSemesterId(userId,
+            semester.getId());
         boolean isMain = (currentFrameCount == 0);
-        String name = (request.timetableName() != null) ? request.timetableName() : "시간표" + (currentFrameCount + 1);
+        String name = (request.timetableName() != null) ? request.timetableName() :
+            "시간표" + (currentFrameCount + 1);
         TimetableFrame timetableFrame = request.toTimetablesFrame(user, semester, name, isMain);
         TimetableFrame savedTimetableFrame = timetableFrameRepositoryV2.save(timetableFrame);
         return TimetableFrameResponse.from(savedTimetableFrame);
@@ -56,7 +60,7 @@ public class TimetableServiceV2 {
 
     @Transactional
     public TimetableFrameUpdateResponse updateTimetableFrame(Integer timetableFrameId,
-                                                             TimetableFrameUpdateRequest timetableFrameUpdateRequest, Integer userId) {
+        TimetableFrameUpdateRequest timetableFrameUpdateRequest, Integer userId) {
         TimetableFrame timeTableFrame = timetableFrameRepositoryV2.getById(timetableFrameId);
         Semester semester = timeTableFrame.getSemester();
         boolean isMain = timetableFrameUpdateRequest.isMain();
@@ -67,15 +71,17 @@ public class TimetableServiceV2 {
                 throw new KoinIllegalArgumentException("메인 시간표는 필수입니다.");
             }
         }
-        timeTableFrame.updateTimetableFrame(semester, timetableFrameUpdateRequest.timetableName(), isMain);
+        timeTableFrame.updateTimetableFrame(semester, timetableFrameUpdateRequest.timetableName(),
+            isMain);
         return TimetableFrameUpdateResponse.from(timeTableFrame);
     }
 
     public List<TimetableFrameResponse> getTimetablesFrame(Integer userId, String semesterRequest) {
         Semester semester = semesterRepositoryV2.getBySemester(semesterRequest);
-        return timetableFrameRepositoryV2.findAllByUserIdAndSemesterId(userId, semester.getId()).stream()
-                .map(TimetableFrameResponse::from)
-                .toList();
+        return timetableFrameRepositoryV2.findAllByUserIdAndSemesterId(userId, semester.getId())
+            .stream()
+            .map(TimetableFrameResponse::from)
+            .toList();
     }
 
     @Transactional
@@ -87,8 +93,9 @@ public class TimetableServiceV2 {
         timetableFrameRepositoryV2.deleteById(frameId);
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
-                    timetableFrameRepositoryV2.
-                            findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
+                timetableFrameRepositoryV2.
+                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId,
+                        frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
             }
@@ -96,40 +103,46 @@ public class TimetableServiceV2 {
     }
 
     @Transactional
-    public TimetableLectureResponse createTimetableLectures(Integer userId, TimetableLectureCreateRequest request) {
-        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
+    public TimetableLectureResponse createTimetableLectures(Integer userId,
+        TimetableLectureCreateRequest request) {
+        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(
+            request.timetableFrameId());
         if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }
 
         for (InnerTimeTableLectureRequest timetableLectureRequest : request.timetableLecture()) {
             Lecture lecture = timetableLectureRequest.lectureId() == null ?
-                    null : lectureRepositoryV2.getLectureById(timetableLectureRequest.lectureId());
-            TimetableLecture timetableLecture = timetableLectureRequest.toTimetableLecture(timetableFrame, lecture);
+                null : lectureRepositoryV2.getLectureById(timetableLectureRequest.lectureId());
+            TimetableLecture timetableLecture = timetableLectureRequest.toTimetableLecture(
+                timetableFrame, lecture);
             timetableLectureRepositoryV2.save(timetableLecture);
         }
 
         List<TimetableLecture> timetableLectures = timetableLectureRepositoryV2.findAllByTimetableFrameId(
-                timetableFrame.getId());
+            timetableFrame.getId());
         return getTimetableLectureResponse(userId, timetableFrame, timetableLectures);
     }
 
     @Transactional
-    public TimetableLectureResponse updateTimetablesLectures(Integer userId, TimetableLectureUpdateRequest request) {
-        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
+    public TimetableLectureResponse updateTimetablesLectures(Integer userId,
+        TimetableLectureUpdateRequest request) {
+        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(
+            request.timetableFrameId());
         if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
         }
 
         for (InnerTimetableLectureRequest timetableRequest : request.timetableLecture()) {
-            TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetableRequest.id());
+            TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(
+                timetableRequest.id());
             timetableLecture.update(
-                    timetableRequest.classTitle(),
-                    timetableRequest.classTime().toString(),
-                    timetableRequest.classPlace(),
-                    timetableRequest.professor(),
-                    timetableRequest.grades(),
-                    timetableRequest.memo());
+                timetableRequest.classTitle(),
+                timetableRequest.classTime().toString(),
+                timetableRequest.classPlace(),
+                timetableRequest.professor(),
+                timetableRequest.grades(),
+                timetableRequest.memo());
         }
         List<TimetableLecture> timetableLectures = timetableFrame.getTimetableLectures();
         return getTimetableLectureResponse(userId, timetableFrame, timetableLectures);
@@ -147,7 +160,8 @@ public class TimetableServiceV2 {
 
     @Transactional
     public void deleteTimetableLecture(Integer userId, Integer timetableLectureId) {
-        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetableLectureId);
+        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(
+            timetableLectureId);
         TimetableFrame frame = timetableLecture.getTimetableFrame();
         if (!Objects.equals(frame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);
@@ -155,8 +169,9 @@ public class TimetableServiceV2 {
         timetableLectureRepositoryV2.deleteById(timetableLectureId);
     }
 
-    private TimetableLectureResponse getTimetableLectureResponse(Integer userId, TimetableFrame timetableFrame,
-                                                                 List<TimetableLecture> timetableLectures) {
+    private TimetableLectureResponse getTimetableLectureResponse(Integer userId,
+        TimetableFrame timetableFrame,
+        List<TimetableLecture> timetableLectures) {
         int grades = 0;
         int totalGrades = 0;
 
@@ -164,29 +179,32 @@ public class TimetableServiceV2 {
             grades = calculateGrades(timetableLectures);
         }
 
-        for (TimetableFrame timetableFrames : timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(userId)) {
+        for (TimetableFrame timetableFrames : timetableFrameRepositoryV2.findByUserIdAndIsMainTrue(
+            userId)) {
             totalGrades += calculateGrades(
-                    timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
+                timetableLectureRepositoryV2.findAllByTimetableFrameId(timetableFrames.getId()));
         }
 
-        return TimetableLectureResponse.of(timetableFrame.getId(), timetableLectures, grades, totalGrades);
+        return TimetableLectureResponse.of(timetableFrame.getId(), timetableLectures, grades,
+            totalGrades);
     }
 
     private int calculateGrades(List<TimetableLecture> timetableLectures) {
         return timetableLectures.stream()
-                .mapToInt(lecture -> {
-                    if (lecture.getLecture() != null) {
-                        return Integer.parseInt(lecture.getLecture().getGrades());
-                    } else {
-                        return Integer.parseInt(lecture.getGrades());
-                    }
-                })
-                .sum();
+            .mapToInt(lecture -> {
+                if (lecture.getLecture() != null) {
+                    return Integer.parseInt(lecture.getLecture().getGrades());
+                } else {
+                    return Integer.parseInt(lecture.getGrades());
+                }
+            })
+            .sum();
     }
 
     private void cancelMainTimetable(Integer userId, Integer semesterId) {
-        TimetableFrame mainTimetableFrame = timetableFrameRepositoryV2.getMainTimetableByUserIdAndSemesterId(userId,
-                semesterId);
+        TimetableFrame mainTimetableFrame = timetableFrameRepositoryV2.getMainTimetableByUserIdAndSemesterId(
+            userId,
+            semesterId);
         mainTimetableFrame.cancelMain();
     }
 
@@ -194,7 +212,7 @@ public class TimetableServiceV2 {
     public void deleteAllTimetablesFrame(Integer userId, String semester) {
         User user = userRepository.findById(userId).get();
         Semester userSemester = semesterRepositoryV2.findBySemester(semester)
-                .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
+            .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
         timetableFrameRepositoryV2.deleteAllByUserAndSemester(user, userSemester);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #961

# 🚀 작업 내용

timetable_lecture에 lecture_id가 있을때 lecture정보만 반환시켜주며 수정로직을 만들지 않았기때문에, 정규시간표를 수정하려할때 classTime, grades, classTitle, professor데이터가 수정이 안되고 변경된 데이터로 반환이 안되는 오류가 존재합니다.

그렇기때문에 lecture_id가 있어도 데이터가 수정될 수 있게 변경했으며, response 반환 로직에서 timetable_lecture에 데이터가 null값이라면 lecture의 정보를 반환시켜주고, null값이 아니라면 timetable_lecture 데이터를 반환시켜주게 변경했습니다.

정상 작동된 스웨거 모습
![image](https://github.com/user-attachments/assets/0bacb176-1047-4fb4-938c-05b98adf9762)
![image](https://github.com/user-attachments/assets/bfc3937a-8347-4567-a445-0f570ec92f29)


# 💬 리뷰 중점사항
