### PR TITLE
fix : 안드로이드 fcm 알림 페이로드 notification → data 로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/service/NotificationService.java
@@ -43,7 +43,7 @@ public class NotificationService {
             notification.getImageUrl(),
             notification.getMobileAppPath(),
             notification.getSchemeUri(),
-            notification.getType()
+            notification.getType().toLowerCase()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
@@ -27,7 +27,7 @@ public class TestController implements TestApi {
         @RequestParam(required = false) MobileAppPath mobileAppPath,
         @RequestParam(required = false) String url
     ) {
-        fcmClient.sendMessageV2(
+        fcmClient.sendMessage(
             deviceToken,
             title,
             body,

--- a/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
@@ -39,37 +39,7 @@ public class FcmClient {
         log.info("call FcmClient sendMessage: title: {}, content: {}", title, content);
 
         ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type, schemeUri);
-        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, path, type);
-
-        Message message = Message.builder()
-            .setToken(targetDeviceToken)
-            .setApnsConfig(apnsConfig)
-            .setAndroidConfig(androidConfig).build();
-        try {
-            String result = FirebaseMessaging.getInstance().send(message);
-            log.info("FCM 알림 전송 성공: {}", result);
-        } catch (Exception e) {
-            log.warn("FCM 알림 전송 실패", e);
-        }
-    }
-
-    @Async
-    public void sendMessageV2(
-        String targetDeviceToken,
-        String title,
-        String content,
-        String imageUrl,
-        MobileAppPath path,
-        String schemeUri,
-        String type
-    ) {
-        if (targetDeviceToken == null) {
-            return;
-        }
-        log.info("call FcmClient sendMessageV2: title: {}, content: {}", title, content);
-
-        ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type, schemeUri);
-        AndroidConfig androidConfig = generateAndroidConfigV2(title, content, imageUrl, schemeUri, type);
+        AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, schemeUri, type);
 
         Message message = Message.builder()
             .setToken(targetDeviceToken)
@@ -120,27 +90,6 @@ public class FcmClient {
     }
 
     private AndroidConfig generateAndroidConfig(
-        String title,
-        String content,
-        String imageUrl,
-        MobileAppPath path,
-        String type
-    ) {
-        AndroidNotification androidNotification = AndroidNotification.builder()
-            .setTitle(title)
-            .setBody(content)
-            .setImage(imageUrl)
-            .setClickAction(path != null ? path.getAndroid() : null)
-            .build();
-
-        return AndroidConfig.builder()
-            .setNotification(androidNotification)
-            .putData("type", type != null ? type : "")
-            .setPriority(HIGH)
-            .build();
-    }
-
-    private AndroidConfig generateAndroidConfigV2(
         String title,
         String content,
         String imageUrl,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 기존에 안드로이드의 fcm 알림 페이로드 전달 방식을 notification으로 appPath를 전달하는 방식에서 data로 scheme uri를 전달하는 방식으로 수정하였습니다.
    - notification 페이로드는 firebase에서 알림창을 생성해서 띄워주기 때문에 딥링크와 같은 커스텀이 불가능합니다.
    - 그래서 딥링크(알림 클릭을 통해 구체적인 페이지 진입)를 위해 코인 어플이 자체적으로 커스텀 알림을 생성하여 띄울 수 있도록 data 페이로드를 사용하는 방식으로 수정하였습니다.
    - iOS는 notification 페이로드로도 딥링크가 가능하여 수정된 부분이 없습니다.
3. 두 방식은 하위호환성을 지키며 동시에 사용이 불가능해 기존의 방식은 삭제하였습니다.
    - 해당 pr이 배포된 이후부터는 최신 버전으로 업데이트하기 전까지 알림이 오지 않습니다.
    - 하위호환이 가능하려면 알림을 각 방법(notification, data)으로 두 번씩 발송을 해야하기 때문에, 하나의 방식(data)만 유지하고 홍보를 통해 새로운 버전으로 업데이트를 유도하기로 결정했습니다.

- 안드로이드 fcm 페이로드
    - 기존 응답
    ```
    {
	    "notification": {
		    "title": "식단 품절 알림",
		    "message": "식단이 품절되었어요ㅠ. 다른 식단 보러 가기",
		    "image_url": "~@#%#^&$$^T",
		    "click-action": "DINING"     ( ⇢  AppPath )
	    },
	    "data": {
		    "type": "message"
	    }
    }
    ```
    - 수정된 응답
    ```
    {
	    "data": {
		    "title": "식단 품절 알림",
		    "message": "식단이 품절되었어요ㅠ. 다른 식단 보러 가기",
		    "image_url": "~@#%#^&$$^T",
		    "scheme_uri": "koin://dining?id=1",
		    "type": "message"
	    }
    }
    ``` 

# 💬 리뷰 중점사항
