### PR TITLE
fix: 삭제된 게시판의 게시글 조회 시 예외 반환

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -47,8 +47,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         countQuery = "SELECT count(*) FROM new_articles WHERE board_id = :boardId AND MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",
         nativeQuery = true
     )
-    Page<Article> findAllByBoardIdAndTitleContaining(@Param("boardId") Integer boardId, @Param("query") String query,
-        Pageable pageable);
+    Page<Article> findAllByBoardIdAndTitleContaining(@Param("boardId") Integer boardId, @Param("query") String query, Pageable pageable);
 
     @Query(
         value = "SELECT * FROM new_articles WHERE MATCH(title) AGAINST(CONCAT(:query, '*') IN BOOLEAN MODE)",


### PR DESCRIPTION
# 🔥 연관 이슈
<img width="673" alt="image" src="https://github.com/user-attachments/assets/fd4b2170-e10b-4911-b71a-fd6015e7dfd2">

# 🚀 작업 내용

삭제된 게시판의 게시글 조회 시 예외를 반환하도록 수정했습니다.

# 💬 리뷰 중점사항
