### PR TITLE
refactor : fcm 스킴 uri의 도메인 명 소문자 통일

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
@@ -28,7 +28,6 @@ public class ArticleKeywordEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onKeywordRequest(ArticleKeywordEvent event) {
-        String schemeUri = String.format("%s?id=%s", KEYWORD.name(), event.articleId());
         List<Notification> notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(ARTICLE_KEYWORD, null)
             .stream()
@@ -37,7 +36,7 @@ public class ArticleKeywordEventListener {
                 .anyMatch(map -> map.getUser().getId().equals(subscribe.getUser().getId())))
             .map(subscribe -> notificationFactory.generateKeywordNotification(
                 KEYWORD,
-                schemeUri,
+                event.articleId(),
                 event.keyword().getKeyword(),
                 subscribe.getUser()
             )).toList();

--- a/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/CoopEventListener.java
@@ -31,7 +31,6 @@ public class CoopEventListener {
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
         diningSoldOutCacheRepository.save(DiningSoldOutCache.from(event.place()));
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
-        String schemeUri = String.format("%s?id=%s", DINING.name(), event.id());
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(DINING_SOLD_OUT, null).stream()
             .filter(subscribe -> notificationSubscribeRepository.findByUserIdAndSubscribeTypeAndDetailType(
@@ -40,7 +39,7 @@ public class CoopEventListener {
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateSoldOutNotification(
                 DINING,
-                schemeUri,
+                event.id(),
                 event.place(),
                 subscribe.getUser()
             )).toList();
@@ -49,13 +48,12 @@ public class CoopEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onDiningImageUploadRequest(DiningImageUploadEvent event) {
-        String schemeUri = String.format("%s?id=%s", DINING.name(), event.id());
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(DINING_IMAGE_UPLOAD, null).stream()
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateDiningImageUploadNotification(
                 DINING,
-                schemeUri,
+                event.id(),
                 event.imageUrl(),
                 subscribe.getUser()
             )).toList();

--- a/src/main/java/in/koreatech/koin/domain/shop/model/event/listener/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/event/listener/ShopEventListener.java
@@ -29,14 +29,13 @@ public class ShopEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onShopEventCreate(EventArticleCreateShopEvent event) {
-        String schemeUri = String.format("%s?id=%s", SHOP.name(), event.shopId());
         List<Notification> notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(SHOP_EVENT, null)
             .stream()
             .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
             .map(subscribe -> notificationFactory.generateShopEventCreateNotification(
                 SHOP,
-                schemeUri,
+                event.shopId(),
                 event.thumbnailImage(),
                 event.shopName(),
                 event.title(),

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -78,8 +78,11 @@ public class NotificationFactory {
         );
     }
 
-    private String generateSchemeUri(MobileAppPath path, Integer id) {
-        return String.format("%s?id=%s", path.name().toLowerCase(), id);
+    private String generateSchemeUri(MobileAppPath path, Integer eventId) {
+        if (eventId == null) {
+            return path.getPath();
+        }
+        return String.format("%s?id=%d", path.getPath(), eventId);
     }
 
     private String getPostposition(String place, String firstPost, String secondPost) {

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -10,7 +10,7 @@ public class NotificationFactory {
 
     public Notification generateShopEventCreateNotification(
         MobileAppPath path,
-        String schemeUri,
+        Integer eventShopId,
         String imageUrl,
         String shopName,
         String title,
@@ -18,7 +18,7 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
-            schemeUri,
+            generateSchemeUri(path, eventShopId),
             "%s의 이벤트가 추가되었어요 🎉".formatted(shopName),
             "%s".formatted(title),
             imageUrl,
@@ -29,13 +29,13 @@ public class NotificationFactory {
 
     public Notification generateSoldOutNotification(
         MobileAppPath path,
-        String schemeUri,
+        Integer eventDiningId,
         String place,
         User target
     ) {
         return new Notification(
             path,
-            schemeUri,
+            generateSchemeUri(path, eventDiningId),
             "%s 품절됐어요 \uD83D\uDE22".formatted(getPostposition(place, "이", "가")),
             "다른 코너 메뉴도 확인해보세요",
             null,
@@ -44,21 +44,15 @@ public class NotificationFactory {
         );
     }
 
-    private String getPostposition(String place, String firstPost, String secondPost) {
-        char lastChar = place.charAt(place.length() - 1);
-        String result = (lastChar - 0xAC00) % 28 > 0 ? firstPost : secondPost;
-        return place + result;
-    }
-
     public Notification generateDiningImageUploadNotification(
         MobileAppPath path,
-        String schemeUri,
+        Integer eventDiningId,
         String imageUrl,
         User target
     ) {
         return new Notification(
             path,
-            schemeUri,
+            generateSchemeUri(path, eventDiningId),
             "식단 사진이 업로드 됐어요!",
             "사진 보러 가기 \uD83D\uDE0B",
             imageUrl,
@@ -69,18 +63,28 @@ public class NotificationFactory {
 
     public Notification generateKeywordNotification(
         MobileAppPath path,
-        String schemeUri,
+        Integer eventKeywordId,
         String keywordName,
         User target
     ) {
         return new Notification(
             path,
-            schemeUri,
+            generateSchemeUri(path, eventKeywordId),
             "공지사항이 등록됐어요!",
             "%s 공지가 등록되었습니다.".formatted(keywordName),
             null,
             NotificationType.MESSAGE,
             target
         );
+    }
+
+    private String generateSchemeUri(MobileAppPath path, Integer id) {
+        return String.format("%s?id=%s", path.name().toLowerCase(), id);
+    }
+
+    private String getPostposition(String place, String firstPost, String secondPost) {
+        char lastChar = place.charAt(place.length() - 1);
+        String result = (lastChar - 0xAC00) % 28 > 0 ? firstPost : secondPost;
+        return place + result;
     }
 }

--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
@@ -24,16 +24,16 @@ public class TestController implements TestApi {
         @RequestParam(required = false) String title,
         @RequestParam(required = false) String body,
         @RequestParam(required = false) String image,
-        @RequestParam(required = false) MobileAppPath mobileAppPath,
-        @RequestParam(required = false) String url
+        @RequestParam(defaultValue = "HOME") MobileAppPath appPath,
+        @RequestParam(required = false) String uri
     ) {
         fcmClient.sendMessage(
             deviceToken,
             title,
             body,
             image,
-            mobileAppPath,
-            url,
+            appPath,
+            uri,
             NotificationType.MESSAGE.name().toLowerCase()
         );
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/FcmClient.java
@@ -71,7 +71,7 @@ public class FcmClient {
                             .build()
                     )
                     .setSound("default")
-                    .setCategory(path != null ? path.getApple() : null)
+                    .setCategory(path != null ? path.getPath() : null)
                     .setMutableContent(true)
                     .build()
             )

--- a/src/main/java/in/koreatech/koin/global/fcm/MobileAppPath.java
+++ b/src/main/java/in/koreatech/koin/global/fcm/MobileAppPath.java
@@ -4,18 +4,16 @@ import lombok.Getter;
 
 @Getter
 public enum MobileAppPath {
-    HOME("home", "home"),
-    LOGIN("login", "login"),
-    SHOP("shop", "shop"),
-    DINING("dining", "dining"),
-    KEYWORD("keyword", "keyword")
+    HOME("home"),
+    LOGIN("login"),
+    SHOP("shop"),
+    DINING("dining"),
+    KEYWORD("keyword")
     ;
 
-    private final String android;
-    private final String apple;
+    private final String path;
 
-    MobileAppPath(String android, String apple) {
-        this.android = android;
-        this.apple = apple;
+    MobileAppPath(String path) {
+        this.path = path;
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. fcm 스킴 uri 의 도메인명을 소문자로 수정하였습니다.
    - ex: KEWORD?id=1 → keyword?id=1

# 💬 리뷰 중점사항
