### PR TITLE
fix: 게시글 조회 api redisson lock 시간 연장

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -149,7 +149,7 @@ public class ArticleService {
         return ArticleHotKeywordResponse.from(topKeywords);
     }
 
-    @ConcurrencyGuard(lockName = "searchLog", waitTime = 5, leaseTime = 3)
+    @ConcurrencyGuard(lockName = "searchLog")
     private void saveOrUpdateSearchLog(String query, String ipAddress) {
         if (query == null || query.trim().isEmpty()) {
             return;

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -113,7 +113,7 @@ public class ArticleService {
         return cacheList.stream().map(HotArticleItemResponse::from).toList();
     }
 
-    @ConcurrencyGuard(lockName = "searchLog")
+    @ConcurrencyGuard(lockName = "searchLog", waitTime = 6, leaseTime = 4)
     public ArticlesResponse searchArticles(String query, Integer boardId, Integer page, Integer limit,
         String ipAddress) {
         if (query.length() >= MAXIMUM_SEARCH_LENGTH) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -113,7 +113,7 @@ public class ArticleService {
         return cacheList.stream().map(HotArticleItemResponse::from).toList();
     }
 
-    @ConcurrencyGuard(lockName = "searchLog", waitTime = 6, leaseTime = 4)
+    @Transactional
     public ArticlesResponse searchArticles(String query, Integer boardId, Integer page, Integer limit,
         String ipAddress) {
         if (query.length() >= MAXIMUM_SEARCH_LENGTH) {
@@ -149,6 +149,7 @@ public class ArticleService {
         return ArticleHotKeywordResponse.from(topKeywords);
     }
 
+    @ConcurrencyGuard(lockName = "searchLog", waitTime = 6, leaseTime = 4)
     private void saveOrUpdateSearchLog(String query, String ipAddress) {
         if (query == null || query.trim().isEmpty()) {
             return;

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -149,7 +149,7 @@ public class ArticleService {
         return ArticleHotKeywordResponse.from(topKeywords);
     }
 
-    @ConcurrencyGuard(lockName = "searchLog", waitTime = 6, leaseTime = 4)
+    @ConcurrencyGuard(lockName = "searchLog", waitTime = 5, leaseTime = 3)
     private void saveOrUpdateSearchLog(String query, String ipAddress) {
         if (query == null || query.trim().isEmpty()) {
             return;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #969 

# 🚀 작업 내용
![image](https://github.com/user-attachments/assets/8487f779-5052-49f6-b528-f5d040f82b6c)

1. 조회 api의 redisson 락 점유 시간이 적어 에러가 발생한 것으로 판단해서 redisson 락 점유 시간을 증가시켰습니다

# 💬 리뷰 중점사항
