### PR TITLE
fix: 코인 게시글은 인기 게시글에 포함되지 않는 쿼리 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -100,15 +100,22 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     }
 
     @Query(value = "SELECT a.* FROM new_articles a "
-        + "JOIN new_koraetech_articles ka ON ka.article_id = a.id "
-        + "WHERE ka.registered_at > :registeredAt AND a.is_deleted = false "
-        + "ORDER BY (a.hit + ka.portal_hit) DESC, a.id DESC "
-        + "LIMIT :limit", nativeQuery = true)
-    List<Article> findAllHotArticles(@Param("registeredAt") LocalDate registeredAt, @Param("limit") int limit);
+        + "LEFT JOIN new_koreatech_articles ka ON ka.article_id = a.id "
+        + "WHERE ( "
+        + "    (ka.article_id IS NOT NULL AND ka.registered_at > :registeredAt) "
+        + "    OR (ka.article_id IS NULL AND a.created_at > :registeredAt) "
+        + ") "
+        + "AND a.is_deleted = false "
+        + "ORDER BY (a.hit + IFNULL(ka.portal_hit, 0)) DESC, a.id DESC LIMIT :limit", nativeQuery = true)
+    List<Article> findMostHitArticles(@Param("registeredAt") LocalDate registeredAt, @Param("limit") int limit);
 
     @Query(value = "SELECT a.* FROM new_articles a "
-        + "JOIN new_koreatech_articles ka ON ka.article_id = a.id "
-        + "WHERE ka.registered_at > :localDate AND a.is_deleted = false", nativeQuery = true)
-    List<Article> findAllByRegisteredAtIsAfter(LocalDate localDate);
+        + "LEFT JOIN new_koreatech_articles ka ON ka.article_id = a.id "
+        + "WHERE ( "
+        + "    (ka.article_id IS NOT NULL AND ka.registered_at > :registeredAt) "
+        + "    OR (ka.article_id IS NULL AND a.created_at > :registeredAt) "
+        + ") "
+        + "AND a.is_deleted = false ", nativeQuery = true)
+    List<Article> findAllByRegisteredAtIsAfter(LocalDate registeredAt);
 
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -103,7 +103,7 @@ public class ArticleService {
             .map(articleRepository::getById)
             .collect(Collectors.toList());
         if (cacheList.size() < HOT_ARTICLE_LIMIT) {
-            List<Article> highestHitArticles = articleRepository.findAllHotArticles(
+            List<Article> highestHitArticles = articleRepository.findMostHitArticles(
                 LocalDate.now(clock).minusDays(HOT_ARTICLE_BEFORE_DAYS), HOT_ARTICLE_LIMIT);
             cacheList.addAll(highestHitArticles);
             return cacheList.stream().limit(HOT_ARTICLE_LIMIT)


### PR DESCRIPTION
# 🔥 연관 이슈


# 🚀 작업 내용

1. 쿼리 오류를 수정해서 인기게시글에 코인 게시글도 반영되도록 했습니다.

# 💬 리뷰 중점사항
