### PR TITLE
fix : 테스트 알림 필드 required로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestApi.java
@@ -31,7 +31,8 @@ public interface TestApi {
         @Parameter(description = "알림 제목") @RequestParam String title,
         @Parameter(description = "알림 내용") @RequestParam String body,
         @Parameter(description = "이미지 url") @RequestParam String image,
-        @Parameter(description = "app path") @RequestParam MobileAppPath mobileAppPath,
+        @Parameter(description = "app path", required = true)
+        @RequestParam(defaultValue = "HOME") MobileAppPath mobileAppPath,
         @Parameter(description = "스킴 uri(ex: shop?id=1)") @RequestParam String url
     );
 

--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestApi.java
@@ -28,11 +28,11 @@ public interface TestApi {
     @GetMapping("/notification")
     ResponseEntity<Void> testSendMessage(
         @Parameter(description = "device token") @RequestParam String deviceToken,
-        @Parameter(description = "알림 제목") @RequestParam(required = false) String title,
-        @Parameter(description = "알림 내용") @RequestParam(required = false) String body,
-        @Parameter(description = "이미지 url") @RequestParam(required = false) String image,
-        @Parameter(description = "app path") @RequestParam(required = false) MobileAppPath mobileAppPath,
-        @Parameter(description = "스킴 uri(ex: shop?id=1)") @RequestParam(required = false) String url
+        @Parameter(description = "알림 제목") @RequestParam String title,
+        @Parameter(description = "알림 내용") @RequestParam String body,
+        @Parameter(description = "이미지 url") @RequestParam String image,
+        @Parameter(description = "app path") @RequestParam MobileAppPath mobileAppPath,
+        @Parameter(description = "스킴 uri(ex: shop?id=1)") @RequestParam String url
     );
 
 }

--- a/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/test/controller/TestController.java
@@ -21,11 +21,11 @@ public class TestController implements TestApi {
     @GetMapping("/notification")
     public ResponseEntity<Void> testSendMessage(
         @RequestParam String deviceToken,
-        @RequestParam(required = false) String title,
-        @RequestParam(required = false) String body,
-        @RequestParam(required = false) String image,
+        @RequestParam String title,
+        @RequestParam String body,
+        @RequestParam String image,
         @RequestParam(defaultValue = "HOME") MobileAppPath appPath,
-        @RequestParam(required = false) String uri
+        @RequestParam String uri
     ) {
         fcmClient.sendMessage(
             deviceToken,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 스웨거에서 테스트 알림 발송 시 필드 값 null 허용 여부(required)를 `false`로 수정했습니다.
    - 기존에 사용하던 `notification 페이로드`는 `null` 값이 허용되지만,
    - 새로 바꾼 `data 페이로드`는 Map 형태로 전달되기 때문에 `null`을 삽입하면 에러가 납니다.

# 💬 리뷰 중점사항
