### PR TITLE
feat: 어드민 계정 분할 API 작성

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -143,6 +143,21 @@ public interface AdminUserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
+    @Operation(summary = "어드민 유저 권한 요청 허용")
+    @PutMapping("/admin/user/{id}/auth")
+    ResponseEntity<Void> allowAdminUserPermission(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
     @Operation(summary = "사장님 권한 요청 허용")
     @SecurityRequirement(name = "Jwt Authentication")
     @PutMapping("/admin/owner/{id}/authed")

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -128,6 +128,21 @@ public interface AdminUserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
+    @Operation(summary = "어드민 유저 비밀번호 변경")
+    @PutMapping("/admin/user/password")
+    ResponseEntity<Void> changeAdminPassword(
+        @RequestBody @Valid AdminPasswordChangeRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
     @Operation(summary = "사장님 권한 요청 허용")
     @SecurityRequirement(name = "Jwt Authentication")
     @PutMapping("/admin/owner/{id}/authed")

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
+import in.koreatech.koin.admin.user.dto.AdminUserResponse;
 import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
@@ -146,6 +147,21 @@ public interface AdminUserApi {
     @Operation(summary = "어드민 유저 권한 요청 허용")
     @PutMapping("/admin/user/{id}/auth")
     ResponseEntity<Void> allowAdminUserPermission(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "어드민 유저 정보 조회")
+    @GetMapping("/admin/user/{id}")
+    ResponseEntity<AdminUserResponse> getAdminUser(
         @PathVariable Integer id,
         @Auth(permit = {ADMIN}) Integer adminId
     );

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -54,7 +54,7 @@ public interface AdminUserApi {
     @Operation(summary = "학생 리스트 조회(페이지네이션)")
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/students")
-    public ResponseEntity<AdminStudentsResponse> getStudents(
+    ResponseEntity<AdminStudentsResponse> getStudents(
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit,
         @RequestParam(required = false) Boolean isAuthed,
@@ -102,7 +102,7 @@ public interface AdminUserApi {
     )
     @Operation(summary = "어드민 액세스 토큰 재발급")
     @PostMapping("/admin/user/refresh")
-    public ResponseEntity<AdminTokenRefreshResponse> refresh(
+    ResponseEntity<AdminTokenRefreshResponse> refresh(
         @RequestBody @Valid AdminTokenRefreshRequest request
     );
 

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -18,11 +18,13 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminLoginRequest;
 import in.koreatech.koin.admin.user.dto.AdminLoginResponse;
+import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
 import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
@@ -101,6 +103,21 @@ public interface AdminUserApi {
     @PostMapping("/admin/user/refresh")
     public ResponseEntity<AdminTokenRefreshResponse> refresh(
         @RequestBody @Valid AdminTokenRefreshRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "어드민 유저 생성")
+    @PostMapping("/admin/user")
+    ResponseEntity<Void> createAdminUser(
+        @RequestBody @Valid AdminUserCreateRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -23,9 +23,11 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
+import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
+import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
 import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
@@ -91,6 +93,14 @@ public class AdminUserController implements AdminUserApi{
             .body(tokenGroupResponse);
     }
 
+    @PostMapping("/admin/user")
+    public ResponseEntity<Void> createAdminUser(
+        @RequestBody @Valid AdminUserCreateRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminUserService.createAdminUser(request, adminId);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -102,6 +102,15 @@ public class AdminUserController implements AdminUserApi{
         return ResponseEntity.ok().build();
     }
 
+    @PutMapping("/admin/user/password")
+    public ResponseEntity<Void> changeAdminPassword(
+        @RequestBody @Valid AdminPasswordChangeRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminUserService.changeAdminPassword(request, adminId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(
         @PathVariable Integer id,

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -111,6 +111,15 @@ public class AdminUserController implements AdminUserApi{
         return ResponseEntity.ok().build();
     }
 
+    @PutMapping("/admin/user/{id}/auth")
+    public ResponseEntity<Void> allowAdminUserPermission(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminUserService.allowAdminUserPermission(id, adminId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/admin/users/student/{id}")
     public ResponseEntity<AdminStudentResponse> getStudent(
         @PathVariable Integer id,

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -28,6 +28,7 @@ import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
+import in.koreatech.koin.admin.user.dto.AdminUserResponse;
 import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
@@ -36,6 +37,7 @@ import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -118,6 +120,15 @@ public class AdminUserController implements AdminUserApi{
     ) {
         adminUserService.allowAdminUserPermission(id, adminId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/admin/user/{id}")
+    public ResponseEntity<AdminUserResponse> getAdminUser(
+        @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminUserResponse admin = adminUserService.getAdminUser(id);
+        return ResponseEntity.ok().body(admin);
     }
 
     @GetMapping("/admin/users/student/{id}")

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -2,9 +2,9 @@ package in.koreatech.koin.admin.user.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
-import org.springdoc.core.annotations.ParameterObject;
 import java.net.URI;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,17 +27,16 @@ import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
-import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
-import in.koreatech.koin.admin.user.dto.AdminUserResponse;
-import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshResponse;
+import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
+import in.koreatech.koin.admin.user.dto.AdminUserResponse;
+import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.service.AdminUserService;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.auth.Auth;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminPasswordChangeRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminPasswordChangeRequest.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminPasswordChangeRequest(
+    @Schema(description = "현재 비밀번호 (SHA 256 해싱된 값)", example = "password", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String oldPassword,
+
+    @Schema(description = "변경할 비밀번호 (SHA 256 해싱된 값)", example = "password", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String newPassword
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserCreateRequest.java
@@ -1,0 +1,58 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import in.koreatech.koin.admin.user.model.Admin;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AdminUserCreateRequest(
+    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
+    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    String email,
+
+    @Schema(description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password,
+
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
+    String name,
+
+    @Schema(description = "트랙 이름", example = "백엔드", requiredMode = NOT_REQUIRED)
+    @Size(max = 20, message = "트랙 이름은 20자 이내여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "트랙 이름은 한글, 영문만 사용할 수 있습니다.")
+    String trackName,
+
+    @Schema(description = "팀 이름", example = "비즈니스", requiredMode = NOT_REQUIRED)
+    @Size(max = 20, message = "팀 이름은 20자 이내여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "팀 이름은 한글, 영문만 사용할 수 있습니다.")
+    String teamName
+) {
+    public Admin toAdmin(PasswordEncoder passwordEncoder) {
+        User user = User.builder()
+            .email(email)
+            .password(passwordEncoder.encode(password))
+            .name(name)
+            .userType(ADMIN)
+            .isAuthed(false)
+            .isDeleted(false)
+            .build();
+
+        return Admin.builder()
+            .user(user)
+            .trackName(trackName)
+            .teamName(teamName)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserResponse.java
@@ -1,22 +1,64 @@
 package in.koreatech.koin.admin.user.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AdminUserResponse(
+    @Schema(description = "번호", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "이메일", example = "soundbar91@gmail.com", requiredMode = REQUIRED)
     String email,
+
+    @Schema(description = "이름", example = "신관규", requiredMode = REQUIRED)
     String name,
+
+    @Schema(description = "트랙 이름", example = "백엔드", requiredMode = REQUIRED)
     String trackName,
-    String teamName
+
+    @Schema(description = "팀 이름", example = "유저", requiredMode = REQUIRED)
+    String teamName,
+
+    @Schema(description = "인증 여부", example = "true", requiredMode = REQUIRED)
+    Boolean isAuthed,
+
+    @Schema(description = "유저 타입", example = "ADMIN", requiredMode = REQUIRED)
+    String userType,
+
+    @Schema(description = "created_at", example = "2018-09-02 21:48:14", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime createdAt,
+
+    @Schema(description = "updated_at", example = "2024-03-03 14:24:40", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime updatedAt,
+
+    @Schema(description = "last_logged_at", example = "2018-09-03 06:50:28", requiredMode = NOT_REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime lastLoggedAt
 ) {
     public static AdminUserResponse of(Admin admin) {
         User user = admin.getUser();
 
         return new AdminUserResponse(
+            user.getId(),
             user.getEmail(),
             user.getName(),
             admin.getTrackName(),
-            admin.getTeamName()
+            admin.getTeamName(),
+            user.isAuthed(),
+            user.getUserType().getValue(),
+            user.getCreatedAt(),
+            user.getUpdatedAt(),
+            user.getLastLoggedAt()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminUserResponse.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.admin.user.dto;
+
+import in.koreatech.koin.admin.user.model.Admin;
+import in.koreatech.koin.domain.user.model.User;
+
+public record AdminUserResponse(
+    String email,
+    String name,
+    String trackName,
+    String teamName
+) {
+    public static AdminUserResponse of(Admin admin) {
+        User user = admin.getUser();
+
+        return new AdminUserResponse(
+            user.getEmail(),
+            user.getName(),
+            admin.getTrackName(),
+            admin.getTeamName()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/model/Admin.java
+++ b/src/main/java/in/koreatech/koin/admin/user/model/Admin.java
@@ -1,0 +1,54 @@
+package in.koreatech.koin.admin.user.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "admins")
+@NoArgsConstructor(access = PROTECTED)
+public class Admin {
+
+    @Id
+    @Column(name = "user_id")
+    private Integer id;
+
+    @Size(max = 20)
+    @Column(name = "team_name")
+    private String teamName;
+
+    @Size(max = 20)
+    @Column(name = "track_name")
+    private String trackName;
+
+    @Column(name = "create_admin")
+    private boolean createAdmin = false;
+
+    @Column(name = "approve_admin")
+    private boolean approveAdmin = false;
+
+    @OneToOne
+    @MapsId
+    private User user;
+
+    @Builder
+    public Admin(Integer id, String teamName, String trackName, boolean createAdmin, boolean approveAdmin, User user) {
+        this.id = id;
+        this.teamName = teamName;
+        this.trackName = trackName;
+        this.createAdmin = createAdmin;
+        this.approveAdmin = approveAdmin;
+        this.user = user;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/repository/AdminRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/user/repository/AdminRepository.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.admin.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.user.model.Admin;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+
+public interface AdminRepository extends Repository<Admin, Integer> {
+    Admin save(Admin admin);
+
+    Optional<Admin> findById(Integer id);
+
+    default Admin getById(Integer adminId) {
+        return findById(adminId)
+            .orElseThrow(() -> UserNotFoundException.withDetail("adminId: " + adminId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -32,6 +32,7 @@ import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshResponse;
 import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
+import in.koreatech.koin.admin.user.dto.AdminUserResponse;
 import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.StudentsCondition;
 import in.koreatech.koin.admin.user.model.Admin;
@@ -166,6 +167,11 @@ public class AdminUserService {
         if (user.getUserType() != ADMIN)
             throw UserNotFoundException.withDetail("email" + user.getEmail());
         user.auth();
+    }
+
+    public AdminUserResponse getAdminUser(Integer id) {
+        Admin admin = adminRepository.getById(id);
+        return AdminUserResponse.of(admin);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -147,6 +147,17 @@ public class AdminUserService {
     }
 
     @Transactional
+    public void changeAdminPassword(AdminPasswordChangeRequest request, Integer adminId) {
+        Admin admin = adminRepository.getById(adminId);
+        User user = admin.getUser();
+
+        if (!passwordEncoder.matches(user.getPassword(), request.oldPassword()))
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+
+        user.updatePassword(passwordEncoder, request.newPassword());
+    }
+
+    @Transactional
     public void allowOwnerPermission(Integer id) {
         Owner owner = adminOwnerRepository.getById(id);
         owner.getUser().auth();

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -158,6 +158,17 @@ public class AdminUserService {
     }
 
     @Transactional
+    public void allowAdminUserPermission(Integer id, Integer adminId) {
+        Admin admin = adminRepository.getById(adminId);
+        if (!admin.isApproveAdmin())
+            throw new AuthorizationException("어드민 계정 승인 권한이 없습니다");
+        User user = adminRepository.getById(id).getUser();
+        if (user.getUserType() != ADMIN)
+            throw UserNotFoundException.withDetail("email" + user.getEmail());
+        user.auth();
+    }
+
+    @Transactional
     public void allowOwnerPermission(Integer id) {
         Owner owner = adminOwnerRepository.getById(id);
         owner.getUser().auth();

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -2,18 +2,16 @@ package in.koreatech.koin.admin.user.service;
 
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,16 +24,20 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
+import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminStudentUpdateResponse;
-import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.AdminStudentsResponse;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshRequest;
 import in.koreatech.koin.admin.user.dto.AdminTokenRefreshResponse;
+import in.koreatech.koin.admin.user.dto.AdminUserCreateRequest;
+import in.koreatech.koin.admin.user.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.dto.StudentsCondition;
+import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.admin.user.repository.AdminOwnerRepository;
 import in.koreatech.koin.admin.user.repository.AdminOwnerShopRedisRepository;
+import in.koreatech.koin.admin.user.repository.AdminRepository;
 import in.koreatech.koin.admin.user.repository.AdminStudentRepository;
 import in.koreatech.koin.admin.user.repository.AdminTokenRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
@@ -43,17 +45,18 @@ import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;
 import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
-import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.student.exception.StudentDepartmentNotValidException;
-import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.student.model.StudentDepartment;
+import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
 import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.auth.JwtProvider;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import in.koreatech.koin.global.model.Criteria;
 import lombok.RequiredArgsConstructor;
@@ -71,6 +74,7 @@ public class AdminUserService {
     private final AdminShopRepository adminShopRepository;
     private final PasswordEncoder passwordEncoder;
     private final AdminTokenRepository adminTokenRepository;
+    private final AdminRepository adminRepository;
 
     public AdminStudentsResponse getStudents(StudentsCondition studentsCondition) {
         Integer totalStudents = adminStudentRepository.findAllStudentCount();
@@ -129,6 +133,16 @@ public class AdminUserService {
     }
 
     @Transactional
+    public void createAdminUser(AdminUserCreateRequest request, Integer adminId) {
+        Admin admin = adminRepository.getById(adminId);
+        if (!admin.isCreateAdmin())
+            throw new AuthorizationException("어드민 계정 생성 권한이 없습니다");
+        if (adminUserRepository.findByEmail(request.email()).isPresent())
+            throw DuplicationEmailException.withDetail("email: " + request.email());
+        adminRepository.save(request.toAdmin(passwordEncoder));
+    }
+
+    @Transactional
     public void allowOwnerPermission(Integer id) {
         Owner owner = adminOwnerRepository.getById(id);
         owner.getUser().auth();
@@ -156,7 +170,7 @@ public class AdminUserService {
         validateNicknameDuplication(adminRequest.nickname(), id);
         validateDepartmentValid(adminRequest.major());
         user.update(adminRequest.nickname(), adminRequest.name(),
-                adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
+            adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
         user.updateStudentPassword(passwordEncoder, adminRequest.password());
         student.update(adminRequest.studentNumber(), adminRequest.major());
         adminStudentRepository.save(student);
@@ -174,17 +188,16 @@ public class AdminUserService {
         Page<Owner> result = getNewOwnersResultPage(ownersCondition, criteria, direction);
 
         List<OwnerIncludingShop> ownerIncludingShops = result.getContent().stream()
-                .map(owner -> {
-                    Optional<OwnerShop> ownerShop = adminOwnerShopRedisRepository.findById(owner.getId());
-                    return ownerShop
-                            .map(os -> {
-                                Shop shop = adminShopRepository.findById(os.getShopId()).orElse(null);
-                                return OwnerIncludingShop.of(owner, shop);
-                            })
-                            .orElseGet(() -> OwnerIncludingShop.of(owner, null));
-                })
-                .collect(Collectors.toList());
-
+            .map(owner -> {
+                Optional<OwnerShop> ownerShop = adminOwnerShopRedisRepository.findById(owner.getId());
+                return ownerShop
+                    .map(os -> {
+                        Shop shop = adminShopRepository.findById(os.getShopId()).orElse(null);
+                        return OwnerIncludingShop.of(owner, shop);
+                    })
+                    .orElseGet(() -> OwnerIncludingShop.of(owner, null));
+            })
+            .collect(Collectors.toList());
 
         return AdminNewOwnersResponse.of(ownerIncludingShops, result, criteria);
     }
@@ -202,9 +215,9 @@ public class AdminUserService {
     }
 
     private Page<Owner> getOwnersResultPage(OwnersCondition ownersCondition, Criteria criteria,
-                                            Sort.Direction direction) {
+        Sort.Direction direction) {
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(),
-                Sort.by(direction, "user.createdAt"));
+            Sort.by(direction, "user.createdAt"));
 
         Page<Owner> result;
 
@@ -220,9 +233,9 @@ public class AdminUserService {
     }
 
     private Page<Owner> getNewOwnersResultPage(OwnersCondition ownersCondition, Criteria criteria,
-                                               Sort.Direction direction) {
+        Sort.Direction direction) {
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(),
-                Sort.by(direction, "user.createdAt"));
+            Sort.by(direction, "user.createdAt"));
 
         Page<Owner> result;
 
@@ -237,10 +250,9 @@ public class AdminUserService {
         return result;
     }
 
-
     private void validateNicknameDuplication(String nickname, Integer userId) {
         if (nickname != null &&
-                adminUserRepository.existsByNicknameAndIdNot(nickname, userId)) {
+            adminUserRepository.existsByNicknameAndIdNot(nickname, userId)) {
             throw DuplicationNicknameException.withDetail("nickname : " + nickname);
         }
     }
@@ -255,9 +267,9 @@ public class AdminUserService {
         Owner owner = adminOwnerRepository.getById(ownerId);
 
         List<Integer> shopsId = adminShopRepository.findAllByOwnerId(ownerId)
-                .stream()
-                .map(Shop::getId)
-                .toList();
+            .stream()
+            .map(Shop::getId)
+            .toList();
 
         return AdminOwnerResponse.of(owner, shopsId);
     }

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -99,6 +99,10 @@ public class AdminUserService {
             throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
         }
 
+        if (!user.isAuthed()) {
+            throw new AuthorizationException("PL 인증 대기중입니다.");
+        }
+
         String accessToken = jwtProvider.createToken(user);
         String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
         UserToken savedtoken = adminTokenRepository.save(UserToken.create(user.getId(), refreshToken));

--- a/src/main/java/in/koreatech/koin/global/auth/AuthArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/global/auth/AuthArgumentResolver.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.global.auth;
 
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
@@ -53,6 +52,9 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
                 }
                 if (user.getUserType() == STUDENT) {
                     throw new AuthorizationException("미인증 상태입니다. 아우누리에서 인증메일을 확인해주세요");
+                }
+                if (user.getUserType() == ADMIN) {
+                    throw new AuthorizationException("PL 인증 대기중입니다.");
                 }
                 throw AuthorizationException.withDetail("userId: " + user.getId());
             }

--- a/src/main/resources/db/migration/V82__drop_admins_table.sql
+++ b/src/main/resources/db/migration/V82__drop_admins_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS admin

--- a/src/main/resources/db/migration/V83__create_admins_table.sql
+++ b/src/main/resources/db/migration/V83__create_admins_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `koin`.`admins`
+(
+    `user_id`       INT UNSIGNED NOT NULL COMMENT 'user 고유 id',
+    `team_name`     VARCHAR(20) NOT NULL COMMENT '팀 이름',
+    `track_name`    VARCHAR(20) NOT NULL COMMENT '트랙 이름',
+    `create_admin`  TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어드민 계정 생성 권한',
+    `approve_admin` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어드민 계정 승인 권한',
+    PRIMARY KEY (`user_id`),
+    CONSTRAINT FK_ADMIN_ON_USER FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #975 

# 🚀 작업 내용
[작업 문서 링크](https://www.notion.so/2-40f026dc1a6a4b95a06cbbfdebec5fa4?pvs=4)

1. 미 사용 admins 테이블을 재사용하기 위해 관련 flyway를 추가했습니다. 
![image](https://github.com/user-attachments/assets/1c787fca-793a-42ff-8e03-7d60e1b65cbc)

2. 어드민 계정 생성 API를 작성했습니다. 
a. 어드민 계정 생성 권한이 있는 유저만 어드민 계정을 생성할 수 있습니다. 

3. 어드민 계정 승인 API를 작성했습니다. 
a. 어드민 계정을 생성하면 `isAuthed=false`인 상태로 생성이 됩니다. 
b. PL 계정 혹은 관련 권한을 가지고 있는 어드민 계정에서 해당 API를 통해 인증상태를 변경해줍니다.

4. 어드민 계정 비밀번호 API를 작성했습니다. 

5. 어드민 계정 단건 정보 조회 API를 작성했습니다. 
a. 어드민 계정 목록을 조회에 대해서 논의된 사항이 없기 때문에 단건 정보 조회 API만 구현했습니다. 
b. 이후 관련 논의가 진행되면 작업 진행하겠습니다.

# 💬 리뷰 중점사항
