### PR TITLE
feat: 어드민 히스토리 기능 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
+++ b/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
@@ -1,0 +1,88 @@
+package in.koreatech.koin.admin.history.aop;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import in.koreatech.koin.admin.history.enums.DomainType;
+import in.koreatech.koin.admin.history.model.AdminActivityHistory;
+import in.koreatech.koin.admin.history.repository.AdminActivityHistoryRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.auth.AuthContext;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class AdminActivityHistoryAspect {
+
+    private final AuthContext authContext;
+    private final UserRepository userRepository;
+    private final AdminActivityHistoryRepository adminActivityHistoryRepository;
+    private final String regex = "^[0-9]*$";
+
+    @Pointcut("execution(* in.koreatech.koin.admin..controller.*.*(..))")
+    private void allAdminControllers() {
+    }
+
+    @Pointcut("!@annotation(org.springframework.web.bind.annotation.GetMapping)")
+    private void excludeGetMapping() {
+    }
+
+    @Pointcut("!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.adminLogin(..)) && "
+        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.logout(..)) && "
+        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.refresh(..)) && "
+        + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.assignOrGetAbtestVariable(..))")
+    private void excludeSpecificMethods() {
+    }
+
+    @AfterReturning("allAdminControllers() && excludeGetMapping() && excludeSpecificMethods()")
+    public void logAdminActivity() throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
+        String requestURI = request.getRequestURI();
+        String requestMethod = request.getMethod();
+
+        User user = userRepository.getById(authContext.getUserId());
+
+        Integer domainId = null;
+        String domainName = null;
+        getDomainIdAndName(requestURI, domainId, domainName);
+
+        ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(request);
+        String requestMessage = new String(cachingRequest.getContentAsByteArray());
+
+        adminActivityHistoryRepository.save(AdminActivityHistory.builder()
+            .domainId(domainId)
+            .user(user)
+            .requestMethod(requestMethod)
+            .domainName(domainName)
+            .requestMessage(requestMessage)
+            .build());
+    }
+
+    private void getDomainIdAndName(String requestURI, Integer domainId, String domainName) {
+        String[] split = requestURI.split("/");
+        for (int i = split.length - 1; i >= 0; i--) {
+            String segment = split[i];
+            if (EnumUtils.isValidEnumIgnoreCase(DomainType.class, segment) && domainName == null) {
+                domainName = segment.toUpperCase();
+                if (i != split.length - 1) {
+                    String index = split[i - 1];
+                    if (index.matches(regex) && domainId == null) {
+                        domainId = Integer.valueOf(index);
+                    }
+                }
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
+++ b/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
@@ -61,10 +61,10 @@ public class AdminActivityHistoryAspect {
         DomainInfo domainInfo = getDomainInfo(requestURI);
 
         adminActivityHistoryRepository.save(AdminActivityHistory.builder()
-            .domainId(domainInfo.getDomainId())
+            .domainId(domainInfo.domainId())
             .user(user)
             .requestMethod(requestMethod)
-            .domainName(domainInfo.getDomainName())
+            .domainName(domainInfo.domainName())
             .requestMessage(requestMessage)
             .build());
 
@@ -93,21 +93,6 @@ public class AdminActivityHistoryAspect {
         return new DomainInfo(domainId, domainName);
     }
 
-    private static class DomainInfo {
-        private final Integer domainId;
-        private final String domainName;
-
-        public DomainInfo(Integer domainId, String domainName) {
-            this.domainId = domainId;
-            this.domainName = domainName;
-        }
-
-        public Integer getDomainId() {
-            return domainId;
-        }
-
-        public String getDomainName() {
-            return domainName;
-        }
+    private record DomainInfo(Integer domainId, String domainName) {
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/history/controller/HistoryApi.java
+++ b/src/main/java/in/koreatech/koin/admin/history/controller/HistoryApi.java
@@ -1,0 +1,57 @@
+package in.koreatech.koin.admin.history.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.admin.history.dto.AdminHistoryResponse;
+import in.koreatech.koin.admin.history.dto.AdminHistorysResponse;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "(Admin) History: 기록", description = "관리자 기록 관련 API")
+public interface HistoryApi {
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "히스토리 리스트 조회")
+    @GetMapping("/admin/historys")
+    ResponseEntity<AdminHistorysResponse> getHistorys(
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) String requestMethod,
+        @RequestParam(required = false) String domainName,
+        @RequestParam(required = false) Integer domainId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "히스토리 단건 조회")
+    @GetMapping("/admin/history/{id}")
+    ResponseEntity<AdminHistoryResponse> getHistory(
+        @PathVariable(name = "id") Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+}

--- a/src/main/java/in/koreatech/koin/admin/history/controller/HistoryController.java
+++ b/src/main/java/in/koreatech/koin/admin/history/controller/HistoryController.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.admin.history.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.admin.history.dto.AdminHistoryResponse;
+import in.koreatech.koin.admin.history.dto.AdminHistorysCondition;
+import in.koreatech.koin.admin.history.dto.AdminHistorysResponse;
+import in.koreatech.koin.admin.history.service.HistoryService;
+import in.koreatech.koin.global.auth.Auth;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class HistoryController implements HistoryApi {
+
+    private final HistoryService historyService;
+
+    @GetMapping("/admin/historys")
+    public ResponseEntity<AdminHistorysResponse> getHistorys(
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) String requestMethod,
+        @RequestParam(required = false) String domainName,
+        @RequestParam(required = false) Integer domainId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminHistorysCondition adminHistorysCondition = new AdminHistorysCondition(page, limit, requestMethod,
+            domainName, domainId);
+        AdminHistorysResponse historys = historyService.getHistorys(adminHistorysCondition);
+        return ResponseEntity.ok(historys);
+    }
+
+    @GetMapping("/admin/history/{id}")
+    public ResponseEntity<AdminHistoryResponse> getHistory(
+        @PathVariable(name = "id") Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminHistoryResponse history = historyService.getHistory(id);
+        return ResponseEntity.ok(history);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
@@ -1,16 +1,19 @@
 package in.koreatech.koin.admin.history.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.admin.history.enums.DomainType;
 import in.koreatech.koin.admin.history.enums.HttpMethodType;
 import in.koreatech.koin.admin.history.model.AdminActivityHistory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminHistoryResponse(
     @Schema(description = "고유 id", example = "1", requiredMode = REQUIRED)
     Integer id,

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
@@ -1,0 +1,53 @@
+package in.koreatech.koin.admin.history.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import in.koreatech.koin.admin.history.model.AdminActivityHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminHistoryResponse(
+    @Schema(description = "고유 id", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "도메인 엔티티 id", example = "null", requiredMode = REQUIRED)
+    Integer domainId,
+
+    @Schema(description = "이름", example = "신관규", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "도메인 이름", example = "코인 공지", requiredMode = REQUIRED)
+    String domainName,
+
+    @Schema(description = "HTTP 요청 메소드 종류", example = "생성", requiredMode = REQUIRED)
+    String requestMethod,
+
+    @Schema(description = "HTTP 요청 메시지 바디", example = """
+        {
+            "title": "제목 예시",
+            "content": "본문 내용 예시"
+        }
+        """,
+        requiredMode = REQUIRED
+    )
+    String requestMessage,
+
+    @Schema(description = "요청 시간", example = "2019-08-16-23-01-52", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd-HH-mm-ss")
+    LocalDateTime createAt
+) {
+    public static AdminHistoryResponse from(AdminActivityHistory adminActivityHistory) {
+        return new AdminHistoryResponse(
+            adminActivityHistory.getId(),
+            adminActivityHistory.getDomainId(),
+            adminActivityHistory.getUser().getName(),
+            adminActivityHistory.getDomainName(),
+            adminActivityHistory.getRequestMethod(),
+            adminActivityHistory.getRequestMessage(),
+            adminActivityHistory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistoryResponse.java
@@ -6,6 +6,8 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import in.koreatech.koin.admin.history.enums.DomainType;
+import in.koreatech.koin.admin.history.enums.HttpMethodType;
 import in.koreatech.koin.admin.history.model.AdminActivityHistory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -44,8 +46,8 @@ public record AdminHistoryResponse(
             adminActivityHistory.getId(),
             adminActivityHistory.getDomainId(),
             adminActivityHistory.getUser().getName(),
-            adminActivityHistory.getDomainName(),
-            adminActivityHistory.getRequestMethod(),
+            DomainType.valueOf(adminActivityHistory.getDomainName()).getDescription(),
+            HttpMethodType.valueOf(adminActivityHistory.getRequestMethod()).getValue(),
             adminActivityHistory.getRequestMessage(),
             adminActivityHistory.getCreatedAt()
         );

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysCondition.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysCondition.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.admin.history.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.global.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminHistorysCondition(
+    @Schema(description = "페이지", example = "1", defaultValue = "1", requiredMode = NOT_REQUIRED)
+    Integer page,
+
+    @Schema(description = "페이지당 조회할 최대 개수", example = "10", defaultValue = "10", requiredMode = NOT_REQUIRED)
+    Integer limit,
+
+    @Schema(description = "HTTP 메소드", example = "POST", requiredMode = NOT_REQUIRED)
+    String requestMethod,
+
+    @Schema(description = "도메인 이름", example = "NOTICE", requiredMode = NOT_REQUIRED)
+    String domainName,
+
+    @Schema(description = "특정 엔티티 id", requiredMode = NOT_REQUIRED)
+    Integer domainId
+) {
+    public AdminHistorysCondition {
+        if (Objects.isNull(page)) {
+            page = Criteria.DEFAULT_PAGE;
+        }
+        if (Objects.isNull(limit)) {
+            limit = Criteria.DEFAULT_LIMIT;
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysResponse.java
@@ -1,0 +1,90 @@
+package in.koreatech.koin.admin.history.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.history.model.AdminActivityHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AdminHistorysResponse(
+    @Schema(description = "조건에 해당하는 히스토리 수", example = "10", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "조건에 해당하는 히스토리 중 현재 페이지에서 조회된 수", example = "5", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "조건에 해당하는 히스토리를 조회할 수 있는 최대 페이지", example = "2", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage,
+
+    @Schema(description = "어드민 계정 리스트", requiredMode = REQUIRED)
+    List<InnerAdminHistorysResponse> historys
+) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerAdminHistorysResponse(
+        @Schema(description = "고유 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "도메인 엔티티 id", example = "null", requiredMode = REQUIRED)
+        Integer domainId,
+
+        @Schema(description = "이름", example = "신관규", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "도메인 이름", example = "코인 공지", requiredMode = REQUIRED)
+        String domainName,
+
+        @Schema(description = "HTTP 요청 메소드 종류", example = "생성", requiredMode = REQUIRED)
+        String requestMethod,
+
+        @Schema(description = "HTTP 요청 메시지 바디", example = """
+            {
+                "title": "제목 예시",
+                "content": "본문 내용 예시"
+            }
+            """,
+            requiredMode = REQUIRED
+        )
+        String requestMessage,
+
+        @Schema(description = "요청 시간", example = "2019-08-16-23-01-52", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy-MM-dd-HH-mm-ss")
+        LocalDateTime createAt
+    ) {
+        public static InnerAdminHistorysResponse from(AdminActivityHistory adminActivityHistory) {
+            return new InnerAdminHistorysResponse(
+                adminActivityHistory.getId(),
+                adminActivityHistory.getDomainId(),
+                adminActivityHistory.getUser().getName(),
+                adminActivityHistory.getDomainName(),
+                adminActivityHistory.getRequestMethod(),
+                adminActivityHistory.getRequestMessage(),
+                adminActivityHistory.getCreatedAt()
+            );
+        }
+    }
+
+    public static AdminHistorysResponse of(Page<AdminActivityHistory> adminActivityHistoryPage) {
+        return new AdminHistorysResponse(
+            adminActivityHistoryPage.getTotalElements(),
+            adminActivityHistoryPage.getContent().size(),
+            adminActivityHistoryPage.getTotalPages(),
+            adminActivityHistoryPage.getNumber() + 1,
+            adminActivityHistoryPage.getContent().stream()
+                .map(InnerAdminHistorysResponse::from)
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/history/dto/AdminHistorysResponse.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.admin.history.enums.DomainType;
+import in.koreatech.koin.admin.history.enums.HttpMethodType;
 import in.koreatech.koin.admin.history.model.AdminActivityHistory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -68,8 +70,8 @@ public record AdminHistorysResponse(
                 adminActivityHistory.getId(),
                 adminActivityHistory.getDomainId(),
                 adminActivityHistory.getUser().getName(),
-                adminActivityHistory.getDomainName(),
-                adminActivityHistory.getRequestMethod(),
+                DomainType.valueOf(adminActivityHistory.getDomainName()).getDescription(),
+                HttpMethodType.valueOf(adminActivityHistory.getRequestMethod()).getValue(),
                 adminActivityHistory.getRequestMessage(),
                 adminActivityHistory.getCreatedAt()
             );

--- a/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
+++ b/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.admin.history.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum DomainType {
+    MEMBERS("Member", "BCSDLAB 회원"),
+    TRACKS("Track", "트랙"),
+    TECHSTACKS("TechStack", "기술 스택"),
+    NOTICE("Notice", "코인 공지"),
+    VERSION("Version", "버전관리"),
+
+    BENEFIT("Benefit", "혜택"),
+    SHOPS("Shop", "상점"),
+    REVIEWS("Review", "리뷰"),
+
+    ABTEST("Abtest", "AB 테스트"),
+
+    LANDS("Land", "복덕방"),
+    COOPSHOP("CoopShop", "생협 매장"),
+
+    USERS("User", "회원"),
+    STUDENT("Student", "학생"),
+    OWNER("Owner", "사장님"),
+    ;
+
+    private final String value;
+    private final String description;
+
+    DomainType(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
+++ b/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
@@ -10,8 +10,17 @@ public enum DomainType {
     NOTICE("Notice", "코인 공지"),
     VERSION("Version", "버전관리"),
 
+    CATEGORIES("Categories", "카테고리"),
+
     BENEFIT("Benefit", "혜택"),
+    BENEFITCATEGORIES("Benefit Categories", "혜택 카테고리"),
+
     SHOPS("Shop", "상점"),
+    SHOPSCATEGORIES("Shop Categories", "상점 카테고리"),
+
+    MENUS("Menu", "메뉴"),
+    MENUSCATEGORIES("Menu Categroies", "메뉴 카테고리"),
+
     REVIEWS("Review", "리뷰"),
 
     ABTEST("Abtest", "AB 테스트"),

--- a/src/main/java/in/koreatech/koin/admin/history/enums/HttpMethodType.java
+++ b/src/main/java/in/koreatech/koin/admin/history/enums/HttpMethodType.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.admin.history.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum HttpMethodType {
+    POST("생성"),
+    PUT("수정"),
+    DELETE("삭제"),
+    ;
+
+    private final String value;
+
+    HttpMethodType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/exception/AdminActivityHistoryNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/history/exception/AdminActivityHistoryNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.history.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class AdminActivityHistoryNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 히스토리 입니다.";
+
+    public AdminActivityHistoryNotFoundException(String message) {
+        super(message);
+    }
+
+    public AdminActivityHistoryNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AdminActivityHistoryNotFoundException withDetail(String detail) {
+        return new AdminActivityHistoryNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/model/AdminActivityHistory.java
+++ b/src/main/java/in/koreatech/koin/admin/history/model/AdminActivityHistory.java
@@ -3,11 +3,8 @@ package in.koreatech.koin.admin.history.model;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import java.time.LocalDateTime;
-
-import org.springframework.data.annotation.CreatedDate;
-
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.global.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "admins_activity_history")
 @NoArgsConstructor(access = PROTECTED)
-public class AdminActivityHistory {
+public class AdminActivityHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -47,11 +44,6 @@ public class AdminActivityHistory {
     @Column(name = "request_message", columnDefinition = "TEXT")
     private String requestMessage;
 
-    @NotNull
-    @CreatedDate
-    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
     /* TODO. admin PR 머지 되면 admin으로 바꾸기 */
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -59,12 +51,11 @@ public class AdminActivityHistory {
 
     @Builder
     public AdminActivityHistory(Integer domainId, String requestMethod, String domainName, String requestMessage,
-        LocalDateTime createdAt, User user) {
+        User user) {
         this.domainId = domainId;
         this.requestMethod = requestMethod;
         this.domainName = domainName;
         this.requestMessage = requestMessage;
-        this.createdAt = createdAt;
         this.user = user;
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/history/model/AdminActivityHistory.java
+++ b/src/main/java/in/koreatech/koin/admin/history/model/AdminActivityHistory.java
@@ -1,0 +1,70 @@
+package in.koreatech.koin.admin.history.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "admins_activity_history")
+@NoArgsConstructor(access = PROTECTED)
+public class AdminActivityHistory {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Column(name = "domain_id")
+    private Integer domainId;
+
+    @NotNull
+    @Size(max = 10)
+    @Column(name = "request_method", nullable = false, length = 10)
+    private String requestMethod;
+
+    @NotNull
+    @Size(max = 20)
+    @Column(name = "domain_name", nullable = false, length = 20)
+    private String domainName;
+
+    @Column(name = "request_message", columnDefinition = "TEXT")
+    private String requestMessage;
+
+    @NotNull
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /* TODO. admin PR 머지 되면 admin으로 바꾸기 */
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public AdminActivityHistory(Integer domainId, String requestMethod, String domainName, String requestMessage,
+        LocalDateTime createdAt, User user) {
+        this.domainId = domainId;
+        this.requestMethod = requestMethod;
+        this.domainName = domainName;
+        this.requestMessage = requestMessage;
+        this.createdAt = createdAt;
+        this.user = user;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/history/repository/AdminActivityHistoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/history/repository/AdminActivityHistoryRepository.java
@@ -1,0 +1,35 @@
+package in.koreatech.koin.admin.history.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import in.koreatech.koin.admin.history.dto.AdminHistorysCondition;
+import in.koreatech.koin.admin.history.exception.AdminActivityHistoryNotFoundException;
+import in.koreatech.koin.admin.history.model.AdminActivityHistory;
+
+public interface AdminActivityHistoryRepository extends Repository<AdminActivityHistory, Integer> {
+
+    Optional<AdminActivityHistory> findById(Integer id);
+
+    default AdminActivityHistory getById(Integer id) {
+        return findById(id)
+            .orElseThrow(() -> new AdminActivityHistoryNotFoundException("admin_activity_history id: " + id));
+    }
+
+    @Query("SELECT COUNT(*) FROM AdminActivityHistory")
+    Integer countAdminActivityHistory();
+
+    @Query("""
+        SELECT a FROM AdminActivityHistory a WHERE
+        (:#{#condition.requestMethod} IS NULL OR a.requestMethod = :#{#condition.requestMethod}) AND
+        (:#{#condition.domainName} IS NULL OR a.domainName = :#{#condition.domainName}) AND
+        (:#{#condition.domainId} IS NULL OR a.domainId = :#{#condition.domainId})
+        """)
+    Page<AdminActivityHistory> findByConditions(@Param("condition") AdminHistorysCondition adminsCondition,
+        Pageable pageable);
+}

--- a/src/main/java/in/koreatech/koin/admin/history/repository/AdminActivityHistoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/history/repository/AdminActivityHistoryRepository.java
@@ -13,6 +13,7 @@ import in.koreatech.koin.admin.history.exception.AdminActivityHistoryNotFoundExc
 import in.koreatech.koin.admin.history.model.AdminActivityHistory;
 
 public interface AdminActivityHistoryRepository extends Repository<AdminActivityHistory, Integer> {
+    AdminActivityHistory save(AdminActivityHistory adminActivityHistory);
 
     Optional<AdminActivityHistory> findById(Integer id);
 

--- a/src/main/java/in/koreatech/koin/admin/history/service/HistoryService.java
+++ b/src/main/java/in/koreatech/koin/admin/history/service/HistoryService.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.admin.history.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.admin.history.dto.AdminHistoryResponse;
+import in.koreatech.koin.admin.history.dto.AdminHistorysCondition;
+import in.koreatech.koin.admin.history.dto.AdminHistorysResponse;
+import in.koreatech.koin.admin.history.model.AdminActivityHistory;
+import in.koreatech.koin.admin.history.repository.AdminActivityHistoryRepository;
+import in.koreatech.koin.global.model.Criteria;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final AdminActivityHistoryRepository adminActivityHistoryRepository;
+
+    public AdminHistorysResponse getHistorys(AdminHistorysCondition condition) {
+        Integer total = adminActivityHistoryRepository.countAdminActivityHistory();
+        Criteria criteria = Criteria.of(condition.page(), condition.limit(), total);
+
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit());
+        Page<AdminActivityHistory> adminActivityHistoryRepositoryPage = adminActivityHistoryRepository.findByConditions(
+            condition,
+            pageRequest);
+
+        return AdminHistorysResponse.of(adminActivityHistoryRepositoryPage);
+    }
+
+    public AdminHistoryResponse getHistory(Integer id) {
+        AdminActivityHistory adminActivityHistory = adminActivityHistoryRepository.getById(id);
+        return AdminHistoryResponse.from(adminActivityHistory);
+    }
+}

--- a/src/main/resources/db/migration/V82__add_admin_activity_history_table.sql
+++ b/src/main/resources/db/migration/V82__add_admin_activity_history_table.sql
@@ -1,11 +1,13 @@
-CREATE TABLE `koin`.`admins_activity_history`(
-    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 id',
-    `domain_id` INT UNSIGNED NULL COMMENT '도메인 엔티티 id',
-    `user_id` INT UNSIGNED NOT NULL COMMENT '유저 고유 id',
-    `request_method` VARCHAR(10) NOT NULL COMMENT 'HTTP 요청 메소드',
-    `domain_name` VARCHAR(20) NOT NULL COMMENT '도메인 이름',
+CREATE TABLE `koin`.`admins_activity_history`
+(
+    `id`              INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 id',
+    `domain_id`       INT UNSIGNED NULL COMMENT '도메인 엔티티 id',
+    `user_id`         INT UNSIGNED NOT NULL COMMENT '유저 고유 id',
+    `request_method`  VARCHAR(10) NOT NULL COMMENT 'HTTP 요청 메소드',
+    `domain_name`     VARCHAR(20) NOT NULL COMMENT '도메인 이름',
     `request_message` TEXT NULL COMMENT 'HTTP 요청 메시지 바디',
-    `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `created_at`      timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`      timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '업데이트 일자',
     PRIMARY KEY (id),
     CONSTRAINT `FK_HISTORY_ON_USER` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 )

--- a/src/main/resources/db/migration/V82__add_admin_activity_history_table.sql
+++ b/src/main/resources/db/migration/V82__add_admin_activity_history_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `koin`.`admins_activity_history`(
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 id',
+    `domain_id` INT UNSIGNED NULL COMMENT '도메인 엔티티 id',
+    `user_id` INT UNSIGNED NOT NULL COMMENT '유저 고유 id',
+    `request_method` VARCHAR(10) NOT NULL COMMENT 'HTTP 요청 메소드',
+    `domain_name` VARCHAR(20) NOT NULL COMMENT '도메인 이름',
+    `request_message` TEXT NULL COMMENT 'HTTP 요청 메시지 바디',
+    `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT `FK_HISTORY_ON_USER` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #978 

# 🚀 작업 내용

- 어드민 히스토리 기능을 구현했습니다. 
  - AOP를 이용해서 어드민 CUD 활동을 기록합니다. 
  - 단, 성공한 요청에 대해서만 기록을 합니다.
  - 또한, 개인 정보가 포함된 API 등은 기록하지 않습니다. 
- 히스토리 조회 API를 구현했습니다. 
  - 단건 조회, 리스트 조회 API를 구현했습니다. 

# 💬 리뷰 중점사항
[관련 문서](https://www.notion.so/baefebf7b82d4c90b634925e4be065e6?pvs=4)입니다. 하단에 `히스토리 남겨야 하는 API`을 보시면 히스토리에서 다루는 API를 확인할 수 있습니다. 

API 경로에서 도메인 이름과 id를 추출하기 떄문에 코드가 많이 많이 지저분합니다,,, 관련해서 피드백 주시면 개선하겠습니다. 