### PR TITLE
chore : Swagger 일관성을 위해 name -> description으로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/LectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/LectureResponse.java
@@ -15,43 +15,43 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record LectureResponse(
 
-    @Schema(name = "과목 id", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "과목 id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
-    @Schema(name = "과목 코드", example = "ARB244", requiredMode = REQUIRED)
+    @Schema(description = "과목 코드", example = "ARB244", requiredMode = REQUIRED)
     String code,
 
-    @Schema(name = "과목 이름", example = "건축구조의 이해 및 실습", requiredMode = REQUIRED)
+    @Schema(description = "과목 이름", example = "건축구조의 이해 및 실습", requiredMode = REQUIRED)
     String name,
 
-    @Schema(name = "대상 학년", example = "3", requiredMode = REQUIRED)
+    @Schema(description = "대상 학년", example = "3", requiredMode = REQUIRED)
     String grades,
 
-    @Schema(name = "분반", example = "01", requiredMode = REQUIRED)
+    @Schema(description = "분반", example = "01", requiredMode = REQUIRED)
     String lectureClass,
 
-    @Schema(name = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
+    @Schema(description = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
     String regularNumber,
 
-    @Schema(name = "학부", example = "디자인ㆍ건축공학부", requiredMode = REQUIRED)
+    @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = REQUIRED)
     String department,
 
-    @Schema(name = "대상", example = "디자 1 건축", requiredMode = REQUIRED)
+    @Schema(description = "대상", example = "디자 1 건축", requiredMode = REQUIRED)
     String target,
 
-    @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+    @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
     String professor,
 
-    @Schema(name = "영어 수업인지", example = "N", requiredMode = REQUIRED)
+    @Schema(description = "영어 수업인지", example = "N", requiredMode = REQUIRED)
     String isEnglish,
 
-    @Schema(name = "설계 학점", example = "0", requiredMode = REQUIRED)
+    @Schema(description = "설계 학점", example = "0", requiredMode = REQUIRED)
     String designScore,
 
-    @Schema(name = "이러닝인지", example = "Y", requiredMode = REQUIRED)
+    @Schema(description = "이러닝인지", example = "Y", requiredMode = REQUIRED)
     String isElearning,
 
-    @Schema(name = "강의 시간", example = "[200,201,202,203,204,205,206,207]", requiredMode = REQUIRED)
+    @Schema(description = "강의 시간", example = "[200,201,202,203,204,205,206,207]", requiredMode = REQUIRED)
     List<Long> classTime
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableCreateRequest.java
@@ -43,33 +43,33 @@ public record TimetableCreateRequest(
         @Schema(description = "강의 장소", example = "2공학관", requiredMode = NOT_REQUIRED)
         String classPlace,
 
-        @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
         @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
-        @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
         @Size(max = 3, message = "분반은 3자 이하로 입력해주세요.")
         String lectureClass,
 
-        @Schema(name = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "대상은 200자 이하로 입력해주세요.")
         String target,
 
-        @Schema(name = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
+        @Schema(description = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
         @Size(max = 4, message = "수강 인원은 4자 이하로 입력해주세요.")
         String regularNumber,
 
-        @Schema(name = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
+        @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
         @Size(max = 4, message = "설계 학점은 4자 이하로 입력해주세요.")
         String designScore,
 
-        @Schema(name = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "학부는 30자 이하로 입력해주세요.")
         String department,
 
-        @Schema(name = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
+        @Schema(description = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
@@ -16,28 +16,28 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableResponse(
-    @Schema(name = "학기", example = "20241", requiredMode = REQUIRED)
+    @Schema(description = "학기", example = "20241", requiredMode = REQUIRED)
     String semester,
 
-    @Schema(name = "시간표 상세정보")
+    @Schema(description = "시간표 상세정보")
     List<InnerTimetableResponse> timetable,
 
-    @Schema(name = "해당 학기 학점", example = "21")
+    @Schema(description = "해당 학기 학점", example = "21")
     Integer grades,
 
-    @Schema(name = "전체 학기 학점", example = "121")
+    @Schema(description = "전체 학기 학점", example = "121")
     Integer totalGrades
 ) {
 
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimetableResponse(
-        @Schema(name = "시간표 id", example = "1", requiredMode = REQUIRED)
+        @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
         Integer id,
 
-        @Schema(name = "수강 정원", example = "40", requiredMode = NOT_REQUIRED)
+        @Schema(description = "수강 정원", example = "40", requiredMode = NOT_REQUIRED)
         String regularNumber,
 
-        @Schema(name = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
+        @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
         String code,
 
         @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
@@ -52,22 +52,22 @@ public record TimetableResponse(
         @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
         String memo,
 
-        @Schema(name = "학점", example = "3", requiredMode = REQUIRED)
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
         String grades,
 
-        @Schema(name = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
+        @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
         String classTitle,
 
-        @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
         String lectureClass,
 
-        @Schema(name = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
         String target,
 
-        @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
-        @Schema(name = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
         String department
     ) {
 

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableUpdateRequest.java
@@ -48,33 +48,33 @@ public record TimetableUpdateRequest(
         @Schema(description = "강의 장소", example = "null", requiredMode = NOT_REQUIRED)
         String classPlace,
 
-        @Schema(name = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         String professor,
 
         @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
         String grades,
 
-        @Schema(name = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
         @Size(max = 3, message = "분반은 3자 이하로 입력해주세요.")
         String lectureClass,
 
-        @Schema(name = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "대상은 200자 이하로 입력해주세요.")
         String target,
 
-        @Schema(name = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
+        @Schema(description = "수강 인원", example = "25", requiredMode = NOT_REQUIRED)
         @Size(max = 4, message = "수강 인원은 4자 이하로 입력해주세요.")
         String regularNumber,
 
-        @Schema(name = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
+        @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
         @Size(max = 4, message = "설계 학점은 4자 이하로 입력해주세요.")
         String designScore,
 
-        @Schema(name = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "학부는 30자 이하로 입력해주세요.")
         String department,
 
-        @Schema(name = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
+        @Schema(description = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #993 

# 🚀 작업 내용

1. 옛날 사용하던 Timetable 관련 Swagger 문서를 수정했습니다.
-> 일관성이 없어 관련 값을 알아보기 힘들다는 클라이언트의 요청이 있어, description으로 통일했습니다.

수정 전
<img width="963" alt="image" src="https://github.com/user-attachments/assets/a2001d96-0ac3-4df9-8dd0-a40ddb36637d">

수정 후
<img width="981" alt="image" src="https://github.com/user-attachments/assets/73e519bd-fe71-4ead-b999-e2fed57a4ddf">


# 💬 리뷰 중점사항
현재 웹에선 사용하진 않는 코드긴 한데, 모바일 커스텀 시간표 개발 중 클라이언트님들의 편의성을 위해 수정했씁니다.
그냥 진짜 간단한 수정이라서 잔디 채우셔도 됩니다.