### PR TITLE
feat: 모바일 정규 강의 삭제 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -175,4 +175,20 @@ public interface TimetableApiV2 {
         @PathVariable(value = "id") Integer timetableLectureId,
         @Auth(permit = {STUDENT}) Integer userId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "시간표 프레임 Id를 이용해서 정규 강의 정보 삭제")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @DeleteMapping("/v2/timetables/frame/{frameId}/lecture/{lectureId}")
+    ResponseEntity<Void> deleteTimetableLectureByFrameId(
+        @PathVariable(value = "frameId") Integer frameId,
+        @PathVariable(value = "lectureId") Integer lectureId,
+        @Auth(permit = {STUDENT}) Integer userId
+    );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
@@ -115,4 +115,14 @@ public class TimetableControllerV2 implements TimetableApiV2 {
         timetableServiceV2.deleteTimetableLecture(userId, timetableLectureId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/v2/timetables/frame/{frameId}/lecture/{lectureId}")
+    public ResponseEntity<Void> deleteTimetableLectureByFrameId(
+        @PathVariable(value = "frameId") Integer frameId,
+        @PathVariable(value = "lectureId") Integer lectureId,
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        timetableServiceV2.deleteTimetableLectureByFrameId(frameId, lectureId, userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
@@ -3,7 +3,10 @@ package in.koreatech.koin.domain.timetableV2.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.timetableV2.exception.TimetableLectureNotFoundException;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
@@ -20,5 +23,14 @@ public interface TimetableLectureRepositoryV2 extends Repository<TimetableLectur
         return findById(id)
             .orElseThrow(() -> TimetableLectureNotFoundException.withDetail("id: " + id));
     }
+
     TimetableLecture save(TimetableLecture timetableLecture);
+
+    @Modifying
+    @Query(value = """
+        DELETE FROM timetable_lecture
+        WHERE frame_id = :frameId
+        AND lectures_id = :lectureId
+        """, nativeQuery = true)
+    void deleteByFrameIdAndLectureId(@Param("frameId") Integer frameId, @Param("lectureId") Integer lectureId);
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -10,6 +10,7 @@ import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
@@ -197,5 +198,18 @@ public class TimetableServiceV2 {
         Semester userSemester = semesterRepositoryV2.findBySemester(semester)
             .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
         timetableFrameRepositoryV2.deleteAllByUserAndSemester(user, userSemester);
+    }
+
+    @Transactional
+    public void deleteTimetableLectureByFrameId(
+        @PathVariable(value = "frameId") Integer frameId,
+        @PathVariable(value = "lectureId") Integer lectureId,
+        Integer userId
+    ) {
+        TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(frameId);
+        if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
+            throw AuthorizationException.withDetail("userId: " + userId);
+        }
+        timetableLectureRepositoryV2.deleteByFrameIdAndLectureId(frameId, lectureId);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
@@ -495,6 +495,27 @@ public class TimetableV2ApiTest extends AcceptanceTest {
             .andExpect(status().isNoContent());
     }
 
+    @Test
+    void 시간표에서_특정_강의를_삭제한다_V2() throws Exception {
+        User user1 = userFixture.준호_학생().getUser();
+        String token = userFixture.getToken(user1);
+        Semester semester = semesterFixture.semester("20192");
+        Lecture lecture1 = lectureFixture.HRD_개론("20192");
+        Lecture lecture2 = lectureFixture.영어청해("20192");
+        TimetableFrame frame = timetableV2Fixture.시간표4(user1, semester, lecture1, lecture2);
+
+        Integer frameId = frame.getId();
+        Integer lectureId = lecture1.getId();
+
+        mockMvc.perform(
+                delete("/v2/timetables/frame/{frameId}/lecture/{lectureId}", frameId, lectureId)
+                    .header("Authorization", "Bearer " + token)
+                    .param("timetable_frame_id", String.valueOf(frame.getId()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNoContent());
+    }
+
     /*@Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void isMain이_false인_frame과_true인_frame을_동시에_삭제한다() {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #994 

# 🚀 작업 내용

- frame_id와 lecture_id를 이용해서 timetableLecture를 삭제하는 API를 추가했습니다. 
- 관련 테스트 코드 추가했습니다.

# 💬 리뷰 중점사항
모바일 시간표에서 정규 강의 삭제 API [요청](https://bcsdlab.slack.com/archives/C06NEM6EY3W/p1730645754281849)이 있어서 작업을 진행했습니다.

강의에서 `is_deleted` 필드를 사용하지 않고, 하드 딜리트 하는 로직으로 보여서 `네이티브 쿼리`를 사용했습니다.
- JPQL 쿼리
```sql
Hibernate: 
    delete 
    from
        timetable_lecture 
    where
        frame_id=? 
        and lectures_id=? 
        and (
            timetable_lecture.is_deleted=0
        )
```
- 네이티브 쿼리
```sql
Hibernate: 
    DELETE 
    FROM
        timetable_lecture 
    WHERE
        frame_id = ? 
        AND lectures_id = ? 
```

**메소드 네이밍이 조금 쉽지않은데,, 추천 받습니다..!**