### PR TITLE
feat: timetableLecture id를 리스트로 받아 삭제하는 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.timetableV2.dto.TimeTableLecturesDeleteRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameResponse;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameUpdateRequest;
@@ -173,6 +174,21 @@ public interface TimetableApiV2 {
     @DeleteMapping("/v2/timetables/lecture/{id}")
     ResponseEntity<Void> deleteTimetableLecture(
         @PathVariable(value = "id") Integer timetableLectureId,
+        @Auth(permit = {STUDENT}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "시간표에서 여러 개의 강의 정보 삭제")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @DeleteMapping("/v2/timetables/lectures")
+    ResponseEntity<Void> deleteTimetableLectures(
+        @RequestParam(name = "timetable_lecture_ids") List<Integer> request,
         @Auth(permit = {STUDENT}) Integer userId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.timetableV2.dto.TimeTableLecturesDeleteRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameResponse;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameUpdateRequest;
@@ -93,7 +94,8 @@ public class TimetableControllerV2 implements TimetableApiV2 {
         @Valid @RequestBody TimetableLectureUpdateRequest request,
         @Auth(permit = {STUDENT}) Integer userId
     ) {
-        TimetableLectureResponse timetableLectureResponse = timetableServiceV2.updateTimetablesLectures(userId, request);
+        TimetableLectureResponse timetableLectureResponse = timetableServiceV2.updateTimetablesLectures(userId,
+            request);
         return ResponseEntity.ok(timetableLectureResponse);
     }
 
@@ -113,6 +115,15 @@ public class TimetableControllerV2 implements TimetableApiV2 {
         @Auth(permit = {STUDENT}) Integer userId
     ) {
         timetableServiceV2.deleteTimetableLecture(userId, timetableLectureId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/v2/timetables/lectures")
+    public ResponseEntity<Void> deleteTimetableLectures(
+        @RequestParam(name = "timetable_lecture_ids") List<Integer> request,
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        timetableServiceV2.deleteTimetableLectures(request, userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimeTableLecturesDeleteRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimeTableLecturesDeleteRequest.java
@@ -1,0 +1,13 @@
+package in.koreatech.koin.domain.timetableV2.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TimeTableLecturesDeleteRequest(
+    @Schema(description = "timetableLecture id 리스트", example = "[1, 2, 3]", requiredMode = REQUIRED)
+    List<Integer> timetablesLectureIds
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
@@ -33,4 +33,6 @@ public interface TimetableLectureRepositoryV2 extends Repository<TimetableLectur
         AND lectures_id = :lectureId
         """, nativeQuery = true)
     void deleteByFrameIdAndLectureId(@Param("frameId") Integer frameId, @Param("lectureId") Integer lectureId);
+
+
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
@@ -33,6 +33,4 @@ public interface TimetableLectureRepositoryV2 extends Repository<TimetableLectur
         AND lectures_id = :lectureId
         """, nativeQuery = true)
     void deleteByFrameIdAndLectureId(@Param("frameId") Integer frameId, @Param("lectureId") Integer lectureId);
-
-
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -8,12 +8,10 @@ import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
-import in.koreatech.koin.domain.timetableV2.dto.TimeTableLecturesDeleteRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameResponse;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameUpdateRequest;
@@ -214,11 +212,7 @@ public class TimetableServiceV2 {
     }
 
     @Transactional
-    public void deleteTimetableLectureByFrameId(
-        @PathVariable(value = "frameId") Integer frameId,
-        @PathVariable(value = "lectureId") Integer lectureId,
-        Integer userId
-    ) {
+    public void deleteTimetableLectureByFrameId(Integer frameId, Integer lectureId, Integer userId) {
         TimetableFrame timetableFrame = timetableFrameRepositoryV2.getById(frameId);
         if (!Objects.equals(timetableFrame.getUser().getId(), userId)) {
             throw AuthorizationException.withDetail("userId: " + userId);

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableServiceV2.java
@@ -1,19 +1,19 @@
 package in.koreatech.koin.domain.timetableV2.service;
 
-import static in.koreatech.koin.domain.timetableV2.dto.TimetableLectureCreateRequest.*;
-import static in.koreatech.koin.domain.timetableV2.dto.TimetableLectureUpdateRequest.*;
+import static in.koreatech.koin.domain.timetableV2.dto.TimetableLectureCreateRequest.InnerTimeTableLectureRequest;
+import static in.koreatech.koin.domain.timetableV2.dto.TimetableLectureUpdateRequest.InnerTimetableLectureRequest;
 
 import java.util.List;
 import java.util.Objects;
 
-import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
-import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
+import in.koreatech.koin.domain.timetableV2.dto.TimeTableLecturesDeleteRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameResponse;
 import in.koreatech.koin.domain.timetableV2.dto.TimetableFrameUpdateRequest;
@@ -31,6 +31,7 @@ import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.global.concurrent.ConcurrencyGuard;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -90,7 +91,8 @@ public class TimetableServiceV2 {
         if (frame.isMain()) {
             TimetableFrame nextMainFrame =
                 timetableFrameRepositoryV2.
-                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId, frame.getSemester().getId());
+                    findFirstByUserIdAndSemesterIdAndIsMainFalseOrderByCreatedAtAsc(userId,
+                        frame.getSemester().getId());
             if (nextMainFrame != null) {
                 nextMainFrame.updateStatusMain(true);
             }
@@ -198,6 +200,17 @@ public class TimetableServiceV2 {
         Semester userSemester = semesterRepositoryV2.findBySemester(semester)
             .orElseThrow(() -> new SemesterNotFoundException("해당하는 시간표 프레임이 없습니다"));
         timetableFrameRepositoryV2.deleteAllByUserAndSemester(user, userSemester);
+    }
+
+    @Transactional
+    public void deleteTimetableLectures(List<Integer> request, Integer userId) {
+        for (int timetablesLectureId : request) {
+            TimetableLecture timetableLecture = timetableLectureRepositoryV2.getById(timetablesLectureId);
+            if (!Objects.equals(timetableLecture.getTimetableFrame().getUser().getId(), userId)) {
+                throw AuthorizationException.withDetail("userId: " + userId);
+            }
+            timetableLectureRepositoryV2.deleteById(timetablesLectureId);
+        }
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
@@ -2,7 +2,11 @@ package in.koreatech.koin.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,7 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
+import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
 import in.koreatech.koin.domain.user.model.User;
@@ -290,46 +295,46 @@ public class TimetableV2ApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk())
             .andExpect(content().json("""
-            {
-                "timetable_frame_id": 1,
-                "timetable": [
-                    {
-                        "id": 1,
-                        "lecture_id" : null,
-                        "regular_number": null,
-                        "code": null,
-                        "design_score": null,
-                        "class_time": [200, 201],
-                        "class_place": "한기대",
-                        "memo": "메모",
-                        "grades": "2",
-                        "class_title": "커스텀생성1",
-                        "lecture_class": null,
-                        "target": null,
-                        "professor": "서정빈",
-                        "department": null
-                    },
-                    {
-                        "id": 2,
-                        "lecture_id" : null,
-                        "regular_number": null,
-                        "code": null,
-                        "design_score": null,
-                        "class_time": [202, 203],
-                        "class_place": "참빛관 편의점",
-                        "memo": "메모",
-                        "grades": "1",
-                        "class_title": "커스텀생성2",
-                        "lecture_class": null,
-                        "target": null,
-                        "professor": "감사 서정빈",
-                        "department": null
-                    }
-                ],
-                "grades": 3,
-                "total_grades": 3
-            }
-            """));
+                {
+                    "timetable_frame_id": 1,
+                    "timetable": [
+                        {
+                            "id": 1,
+                            "lecture_id" : null,
+                            "regular_number": null,
+                            "code": null,
+                            "design_score": null,
+                            "class_time": [200, 201],
+                            "class_place": "한기대",
+                            "memo": "메모",
+                            "grades": "2",
+                            "class_title": "커스텀생성1",
+                            "lecture_class": null,
+                            "target": null,
+                            "professor": "서정빈",
+                            "department": null
+                        },
+                        {
+                            "id": 2,
+                            "lecture_id" : null,
+                            "regular_number": null,
+                            "code": null,
+                            "design_score": null,
+                            "class_time": [202, 203],
+                            "class_place": "참빛관 편의점",
+                            "memo": "메모",
+                            "grades": "1",
+                            "class_title": "커스텀생성2",
+                            "lecture_class": null,
+                            "target": null,
+                            "professor": "감사 서정빈",
+                            "department": null
+                        }
+                    ],
+                    "grades": 3,
+                    "total_grades": 3
+                }
+                """));
     }
 
     @Test
@@ -372,46 +377,46 @@ public class TimetableV2ApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk())
             .andExpect(content().json("""
-            {
-                "timetable_frame_id": 1,
-                "timetable": [
-                    {
-                        "id": 1,
-                        "lecture_id" : null,
-                        "regular_number": null,
-                        "code": null,
-                        "design_score": null,
-                        "class_time": [200, 201],
-                        "class_place": "한기대",
-                        "memo": "메모한당 히히",
-                        "grades": "0",
-                        "class_title": "커스텀바꿔요1",
-                        "lecture_class": null,
-                        "target": null,
-                        "professor": "서정빈",
-                        "department": null
-                    },
-                    {
-                        "id": 2,
-                        "lecture_id" : null,
-                        "regular_number": null,
-                        "code": null,
-                        "design_score": null,
-                        "class_time": [202, 203],
-                        "class_place": "참빛관 편의점",
-                        "memo": "메모한당 히히",
-                        "grades": "0",
-                        "class_title": "커스텀바꿔요2",
-                        "lecture_class": null,
-                        "target": null,
-                        "professor": "알바 서정빈",
-                        "department": null
-                    }
-                ],
-                "grades": 0,
-                "total_grades": 0
-            }
-            """));
+                {
+                    "timetable_frame_id": 1,
+                    "timetable": [
+                        {
+                            "id": 1,
+                            "lecture_id" : null,
+                            "regular_number": null,
+                            "code": null,
+                            "design_score": null,
+                            "class_time": [200, 201],
+                            "class_place": "한기대",
+                            "memo": "메모한당 히히",
+                            "grades": "0",
+                            "class_title": "커스텀바꿔요1",
+                            "lecture_class": null,
+                            "target": null,
+                            "professor": "서정빈",
+                            "department": null
+                        },
+                        {
+                            "id": 2,
+                            "lecture_id" : null,
+                            "regular_number": null,
+                            "code": null,
+                            "design_score": null,
+                            "class_time": [202, 203],
+                            "class_place": "참빛관 편의점",
+                            "memo": "메모한당 히히",
+                            "grades": "0",
+                            "class_title": "커스텀바꿔요2",
+                            "lecture_class": null,
+                            "target": null,
+                            "professor": "알바 서정빈",
+                            "department": null
+                        }
+                    ],
+                    "grades": 0,
+                    "total_grades": 0
+                }
+                """));
     }
 
     @Test
@@ -433,46 +438,46 @@ public class TimetableV2ApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk())
             .andExpect(content().json("""
-            {
-                "timetable_frame_id": 1,
-                "timetable": [
-                    {
-                        "id" : 1,
-                        "lecture_id" : 1,
-                        "regular_number": "25",
-                        "code": "ARB244",
-                        "design_score": "0",
-                        "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
-                        "class_place": null,
-                        "memo": null,
-                        "grades": "3",
-                        "class_title": "건축구조의 이해 및 실습",
-                        "lecture_class": "01",
-                        "target": "디자 1 건축",
-                        "professor": "황현식",
-                        "department": "디자인ㆍ건축공학부"
-                    },
-                    {
-                        "id": 2,
-                        "lecture_id": 2,
-                        "regular_number": "22",
-                        "code": "BSM590",
-                        "design_score": "0",
-                        "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
-                        "class_place": null,
-                        "memo": null,
-                        "grades": "3",
-                        "class_title": "컴퓨팅사고",
-                        "lecture_class": "06",
-                        "target": "기공1",
-                        "professor": "박한수,최준호",
-                        "department": "기계공학부"
-                    }
-                ],
-                "grades": 6,
-                "total_grades": 6
-            }
-            """));
+                {
+                    "timetable_frame_id": 1,
+                    "timetable": [
+                        {
+                            "id" : 1,
+                            "lecture_id" : 1,
+                            "regular_number": "25",
+                            "code": "ARB244",
+                            "design_score": "0",
+                            "class_time": [200, 201, 202, 203, 204, 205, 206, 207],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "건축구조의 이해 및 실습",
+                            "lecture_class": "01",
+                            "target": "디자 1 건축",
+                            "professor": "황현식",
+                            "department": "디자인ㆍ건축공학부"
+                        },
+                        {
+                            "id": 2,
+                            "lecture_id": 2,
+                            "regular_number": "22",
+                            "code": "BSM590",
+                            "design_score": "0",
+                            "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                            "class_place": null,
+                            "memo": null,
+                            "grades": "3",
+                            "class_title": "컴퓨팅사고",
+                            "lecture_class": "06",
+                            "target": "기공1",
+                            "professor": "박한수,최준호",
+                            "department": "기계공학부"
+                        }
+                    ],
+                    "grades": 6,
+                    "total_grades": 6
+                }
+                """));
     }
 
     @Test
@@ -511,6 +516,30 @@ public class TimetableV2ApiTest extends AcceptanceTest {
                 delete("/v2/timetables/frame/{frameId}/lecture/{lectureId}", frameId, lectureId)
                     .header("Authorization", "Bearer " + token)
                     .param("timetable_frame_id", String.valueOf(frame.getId()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 시간표에서_여러개의_강의를_한번에_삭제한다_V2() throws Exception {
+        User user1 = userFixture.준호_학생().getUser();
+        String token = userFixture.getToken(user1);
+        Semester semester = semesterFixture.semester("20192");
+        Lecture lecture1 = lectureFixture.HRD_개론("20192");
+        Lecture lecture2 = lectureFixture.영어청해("20192");
+        TimetableFrame frame = timetableV2Fixture.시간표4(user1, semester, lecture1, lecture2);
+
+        List<Integer> timetableLectureIds = frame.getTimetableLectures().stream()
+            .map(TimetableLecture::getId)
+            .toList();
+
+        mockMvc.perform(
+                delete("/v2/timetables/lectures")
+                    .header("Authorization", "Bearer " + token)
+                    .param("timetable_lecture_ids", timetableLectureIds.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(",")))
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isNoContent());

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableV2ApiTest.java
@@ -515,7 +515,6 @@ public class TimetableV2ApiTest extends AcceptanceTest {
         mockMvc.perform(
                 delete("/v2/timetables/frame/{frameId}/lecture/{lectureId}", frameId, lectureId)
                     .header("Authorization", "Bearer " + token)
-                    .param("timetable_frame_id", String.valueOf(frame.getId()))
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isNoContent());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #998 

# 🚀 작업 내용

- timetableLecture id 리스트를 쿼리 파라미터로 받아 강의를 삭제하는 API를 추가했습니다.
- 관련 테스트 코드 추가했습니다.
- 이전 작업에서 잘못 추가된 코드를 삭제했습니다.
![스크린샷 2024-11-06 165024](https://github.com/user-attachments/assets/f414779f-03ec-45a1-ba48-ea5a529532f5)

# 💬 리뷰 중점사항