### PR TITLE
feat: 어드민 비밀번호 검증 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
+++ b/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
@@ -49,6 +49,7 @@ public class AdminActivityHistoryAspect {
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.refresh(..)) && "
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.createAdmin(..)) && "
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.adminPasswordChange(..)) && "
+        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.checkAdminPassword(..)) &&"
         + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.assignOrGetAbtestVariable(..))")
     private void excludeSpecificMethods() {
     }

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.admin.user.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +21,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
+import in.koreatech.koin.admin.user.dto.AdminPasswordCheckRequest;
 import in.koreatech.koin.admin.user.dto.AdminPermissionUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
@@ -97,6 +98,22 @@ public interface AdminUserApi {
     @PostMapping("/admin/user/login")
     ResponseEntity<AdminLoginResponse> adminLogin(
         @RequestBody @Valid AdminLoginRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "어드민 비밀번호 검증")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/admin/password/check")
+    ResponseEntity<Void> checkAdminPassword(
+        @Valid @RequestBody AdminPasswordCheckRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -24,6 +24,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
+import in.koreatech.koin.admin.user.dto.AdminPasswordCheckRequest;
 import in.koreatech.koin.admin.user.dto.AdminPermissionUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
@@ -81,6 +82,15 @@ public class AdminUserController implements AdminUserApi{
     ) {
         AdminResponse response = adminUserService.createAdmin(request, adminId);
         return ResponseEntity.created(URI.create("/" + response.id())).build();
+    }
+
+    @PostMapping("/admin/password/check")
+    public ResponseEntity<Void> checkAdminPassword(
+        @Valid @RequestBody AdminPasswordCheckRequest request,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminUserService.checkAdminPassword(request, adminId);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/admin/password")

--- a/src/main/java/in/koreatech/koin/admin/user/dto/AdminPasswordCheckRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/user/dto/AdminPasswordCheckRequest.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.admin.user.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminPasswordCheckRequest(
+    @Schema(description = "256 SHA 알고리즘으로 암호화된 비밀번호", example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
+++ b/src/main/java/in/koreatech/koin/admin/user/service/AdminUserService.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.user.dto.AdminOwnersResponse;
 import in.koreatech.koin.admin.user.dto.AdminPasswordChangeRequest;
+import in.koreatech.koin.admin.user.dto.AdminPasswordCheckRequest;
 import in.koreatech.koin.admin.user.dto.AdminPermissionUpdateRequest;
 import in.koreatech.koin.admin.user.dto.AdminResponse;
 import in.koreatech.koin.admin.user.dto.AdminStudentResponse;
@@ -118,6 +119,13 @@ public class AdminUserService {
             .ifPresent(user -> {
                 throw DuplicationEmailException.withDetail("email: " + request.email());
             });
+    }
+
+    public void checkAdminPassword(AdminPasswordCheckRequest request, Integer adminId) {
+        Admin admin = adminRepository.getById(adminId);
+        if (!admin.getUser().isSamePassword(passwordEncoder, request.password())) {
+            throw new KoinIllegalArgumentException("올바르지 않은 비밀번호입니다.");
+        }
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -776,6 +776,24 @@ public class AdminUserApiTest extends AcceptanceTest {
     }
 
     @Test
+    void 관리자_비밀번호를_통해_검증한다() throws Exception {
+        Admin admin = userFixture.코인_운영자();
+        String token = userFixture.getToken(admin.getUser());
+
+        mockMvc.perform(
+                post("/admin/password/check")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "password": "1234"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
+    }
+
+    @Test
     void 관리자가_특정_관리자의_계정을_조회한다() throws Exception {
         Admin admin = userFixture.코인_운영자();
         String token = userFixture.getToken(admin.getUser());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1008 

# 🚀 작업 내용

1. 클라이언트 요청이 들어와서 어드민 비밀번호 검증 API를 추가했습니다.
2. 히스토리를 남기면 안 되기 때문에 제외시켰습니다.
3. 테스트 코드 작성했습니다.

# 💬 리뷰 중점사항
