### PR TITLE
feat: 어드민 상점 카테고리 생성, 수정시 상위 카테고리 선택 기능 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/controller/AdminShopApi.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/controller/AdminShopApi.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.admin.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
+import java.util.List;
+
 import in.koreatech.koin.admin.shop.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -86,6 +88,19 @@ public interface AdminShopApi {
     @GetMapping("/admin/shops/categories/{id}")
     ResponseEntity<AdminShopCategoryResponse> getShopCategory(
         @Parameter(in = PATH) @PathVariable Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "상점의 모든 상위 카테고리 조회")
+    @GetMapping("/admin/shops/parent-categories")
+    ResponseEntity<List<AdminShopParentCategoryResponse>> getShopParentCategories(
         @Auth(permit = {ADMIN}) Integer adminId
     );
 

--- a/src/main/java/in/koreatech/koin/admin/shop/controller/AdminShopController.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/controller/AdminShopController.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.admin.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
+import java.util.List;
+
 import in.koreatech.koin.admin.shop.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
@@ -65,6 +67,14 @@ public class AdminShopController implements AdminShopApi {
     ) {
         AdminShopCategoryResponse response = adminShopService.getShopCategory(id);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/admin/shops/parent-categories")
+    public ResponseEntity<List<AdminShopParentCategoryResponse>> getShopParentCategories(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        List<AdminShopParentCategoryResponse> responses = adminShopService.getShopParentCategories();
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/admin/shops/{id}/menus")

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
@@ -1,12 +1,16 @@
 package in.koreatech.koin.admin.shop.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
@@ -19,13 +23,18 @@ public record AdminCreateShopCategoryRequest(
     @Schema(description = "이름", example = "햄버거", requiredMode = RequiredMode.REQUIRED)
     @NotBlank(message = "카테고리명은 필수입니다.")
     @Size(min = 1, max = 25, message = "이름은 1자 이상, 25자 이하로 입력해주세요.")
-    String name
+    String name,
+
+    @Schema(description = "상위 카테고리 id", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "상위 카테고리는 필수입니다.")
+    Integer parentCategoryId
 ) {
 
-    public ShopCategory toShopCategory() {
+    public ShopCategory toShopCategory(ShopParentCategory shopParentCategory) {
         return ShopCategory.builder()
             .imageUrl(imageUrl)
             .name(name)
+            .parentCategory(shopParentCategory)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
@@ -1,11 +1,14 @@
 package in.koreatech.koin.admin.shop.dto;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
@@ -18,7 +21,11 @@ public record AdminModifyShopCategoryRequest(
     @Schema(description = "이름", example = "햄버거", requiredMode = RequiredMode.REQUIRED)
     @NotBlank(message = "카테고리명은 필수입니다.")
     @Size(min = 1, max = 25, message = "이름은 1자 이상, 25자 이하로 입력해주세요.")
-    String name
+    String name,
+
+    @Schema(description = "상위 카테고리 id", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "상위 카테고리는 필수입니다.")
+    Integer parentCategoryId
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopReviewReportStatusRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopReviewReportStatusRequest.java
@@ -2,14 +2,14 @@ package in.koreatech.koin.admin.shop.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.review.ReportStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public record AdminModifyShopReviewReportStatusRequest(
     @Schema(description = "신고 상태", example = "DISMISSED", requiredMode = REQUIRED)
     @NotNull(message = "변경하려는 상태는 필수입니다.")

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
@@ -15,14 +15,18 @@ public record AdminShopCategoryResponse(
     String imageUrl,
 
     @Schema(description = "카테고리 이름", example = "string")
-    String name
+    String name,
+
+    @Schema(description = "상위 카테고리 ID", example = "1")
+    Integer parentCategoryId
 ) {
 
     public static AdminShopCategoryResponse from(ShopCategory shopCategory) {
         return new AdminShopCategoryResponse(
             shopCategory.getId(),
             shopCategory.getImageUrl(),
-            shopCategory.getName()
+            shopCategory.getName(),
+            shopCategory.getParentCategory().getId()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopParentCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopParentCategoryResponse.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.admin.shop.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AdminShopParentCategoryResponse(
+    @Schema(description = "상위 카테고리 고유 ID", example = "1")
+    int id,
+
+    @Schema(description = "상위 카테고리 이름", example = "가게")
+    String name
+) {
+
+    public static AdminShopParentCategoryResponse from(ShopParentCategory shopParentCategory) {
+        return new AdminShopParentCategoryResponse(
+            shopParentCategory.getId(),
+            shopParentCategory.getName()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopParentCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopParentCategoryResponse.java
@@ -1,12 +1,13 @@
 package in.koreatech.koin.admin.shop.dto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminShopParentCategoryResponse(
     @Schema(description = "상위 카테고리 고유 ID", example = "1")
     int id,

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopsReviewsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopsReviewsResponse.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.admin.shop.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
@@ -17,10 +16,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static in.koreatech.koin.domain.shop.model.review.ReportStatus.UNHANDLED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminShopsReviewsResponse(
 
     @Schema(description = "총 상점의 수", example = "57", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/shop/exception/ShopParentCategoryNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/exception/ShopParentCategoryNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.admin.shop.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class ShopParentCategoryNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 상위 카테고리입니다.";
+
+    public ShopParentCategoryNotFoundException(String message) {
+        super(message);
+    }
+
+    public ShopParentCategoryNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ShopParentCategoryNotFoundException withDetail(String detail) {
+        return new ShopParentCategoryNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopCategoryRepository.java
@@ -14,6 +14,8 @@ import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 
 public interface AdminShopCategoryRepository extends Repository<ShopCategory, Integer> {
 
+    boolean existsByNameAndIdNot(String name, Integer shopCategoryId);
+
     Page<ShopCategory> findAll(Pageable pageable);
 
     @Query(value = "SELECT * FROM shop_categories WHERE id = :shopCategoryId", nativeQuery = true)

--- a/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopNotificationMessageRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopNotificationMessageRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.admin.shop.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+
+public interface AdminShopNotificationMessageRepository extends Repository<ShopNotificationMessage, Integer> {
+
+    ShopNotificationMessage save(ShopNotificationMessage shopNotificationMessage);
+}

--- a/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
@@ -1,12 +1,21 @@
 package in.koreatech.koin.admin.shop.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.admin.shop.exception.ShopParentCategoryNotFoundException;
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 
 public interface AdminShopParentCategoryRepository extends Repository<ShopParentCategory, Integer> {
+
+    Optional<ShopParentCategory> findById(Integer shopParentCategoryId);
+
+    default ShopParentCategory getById(Integer shopParentCategoryId) {
+        return findById(shopParentCategoryId)
+            .orElseThrow(() -> ShopParentCategoryNotFoundException.withDetail("shopParentCategoryId: " + shopParentCategoryId));
+    }
 
     List<ShopParentCategory> findAll();
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
@@ -10,6 +10,8 @@ import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 
 public interface AdminShopParentCategoryRepository extends Repository<ShopParentCategory, Integer> {
 
+    ShopParentCategory save(ShopParentCategory shopParentCategory);
+
     Optional<ShopParentCategory> findById(Integer shopParentCategoryId);
 
     default ShopParentCategory getById(Integer shopParentCategoryId) {

--- a/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/repository/AdminShopParentCategoryRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.admin.shop.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+
+public interface AdminShopParentCategoryRepository extends Repository<ShopParentCategory, Integer> {
+
+    List<ShopParentCategory> findAll();
+}

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -256,7 +256,7 @@ public class AdminShopService {
 
     @Transactional
     public void modifyShopCategory(Integer categoryId, AdminModifyShopCategoryRequest adminModifyShopCategoryRequest) {
-        isExistCategoryName(adminModifyShopCategoryRequest.name(), categoryId);
+        validateExistCategoryName(adminModifyShopCategoryRequest.name(), categoryId);
         ShopCategory shopCategory = adminShopCategoryRepository.getById(categoryId);
         ShopParentCategory shopParentCategory =
             adminShopParentCategoryRepository.getById(adminModifyShopCategoryRequest.parentCategoryId());
@@ -267,7 +267,7 @@ public class AdminShopService {
         );
     }
 
-    private void isExistCategoryName(String name, Integer categoryId) {
+    private void validateExistCategoryName(String name, Integer categoryId) {
         if (adminShopCategoryRepository.existsByNameAndIdNot(name, categoryId)) {
             throw ShopCategoryDuplicationException.withDetail("name: " + name);
         }

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -36,6 +36,7 @@ import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategoryMap;
 import in.koreatech.koin.domain.shop.model.shop.ShopImage;
 import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import in.koreatech.koin.global.model.Criteria;
 import jakarta.persistence.EntityManager;
@@ -52,6 +53,7 @@ public class AdminShopService {
     private final AdminMenuCategoryRepository adminMenuCategoryRepository;
     private final AdminShopCategoryMapRepository adminShopCategoryMapRepository;
     private final AdminShopCategoryRepository adminShopCategoryRepository;
+    private final AdminShopParentCategoryRepository adminShopParentCategoryRepository;
     private final AdminShopImageRepository adminShopImageRepository;
     private final AdminShopOpenRepository adminShopOpenRepository;
     private final AdminShopRepository adminShopRepository;
@@ -89,6 +91,13 @@ public class AdminShopService {
     public AdminShopCategoryResponse getShopCategory(Integer categoryId) {
         ShopCategory shopCategory = adminShopCategoryRepository.getById(categoryId);
         return AdminShopCategoryResponse.from(shopCategory);
+    }
+
+    public List<AdminShopParentCategoryResponse> getShopParentCategories() {
+        List<ShopParentCategory> shopParentCategories = adminShopParentCategoryRepository.findAll();
+        return shopParentCategories.stream()
+            .map(AdminShopParentCategoryResponse::from)
+            .toList();
     }
 
     public AdminShopMenuResponse getAllMenus(Integer shopId) {

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -168,7 +168,9 @@ public class AdminShopService {
         if (adminShopCategoryRepository.findByName(adminCreateShopCategoryRequest.name()).isPresent()) {
             throw ShopCategoryDuplicationException.withDetail("name: " + adminCreateShopCategoryRequest.name());
         }
-        ShopCategory shopCategory = adminCreateShopCategoryRequest.toShopCategory();
+        ShopParentCategory shopParentCategory =
+            adminShopParentCategoryRepository.getById(adminCreateShopCategoryRequest.parentCategoryId());
+        ShopCategory shopCategory = adminCreateShopCategoryRequest.toShopCategory(shopParentCategory);
         adminShopCategoryRepository.save(shopCategory);
     }
 
@@ -254,14 +256,21 @@ public class AdminShopService {
 
     @Transactional
     public void modifyShopCategory(Integer categoryId, AdminModifyShopCategoryRequest adminModifyShopCategoryRequest) {
-        if (adminShopCategoryRepository.findByName(adminModifyShopCategoryRequest.name()).isPresent()) {
-            throw ShopCategoryDuplicationException.withDetail("name: " + adminModifyShopCategoryRequest.name());
-        }
+        isExistCategoryName(adminModifyShopCategoryRequest.name(), categoryId);
         ShopCategory shopCategory = adminShopCategoryRepository.getById(categoryId);
+        ShopParentCategory shopParentCategory =
+            adminShopParentCategoryRepository.getById(adminModifyShopCategoryRequest.parentCategoryId());
         shopCategory.modifyShopCategory(
             adminModifyShopCategoryRequest.name(),
-            adminModifyShopCategoryRequest.imageUrl()
+            adminModifyShopCategoryRequest.imageUrl(),
+            shopParentCategory
         );
+    }
+
+    private void isExistCategoryName(String name, Integer categoryId) {
+        if (adminShopCategoryRepository.existsByNameAndIdNot(name, categoryId)) {
+            throw ShopCategoryDuplicationException.withDetail("name: " + name);
+        }
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
@@ -49,13 +49,15 @@ public class ShopCategory extends BaseEntity {
     private ShopParentCategory parentCategory;
 
     @Builder
-    private ShopCategory(String name, String imageUrl) {
+    private ShopCategory(String name, String imageUrl, ShopParentCategory parentCategory) {
         this.name = name;
         this.imageUrl = imageUrl;
+        this.parentCategory = parentCategory;
     }
 
-    public void modifyShopCategory(String name, String imageUrl) {
+    public void modifyShopCategory(String name, String imageUrl, ShopParentCategory parentCategory) {
         this.name = name;
         this.imageUrl = imageUrl;
+        this.parentCategory = parentCategory;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
@@ -45,8 +45,8 @@ public class ShopCategory extends BaseEntity {
     private List<ShopCategoryMap> shopCategoryMaps = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "main_category_id", referencedColumnName = "id")
-    private ShopMainCategory mainCategory;
+    @JoinColumn(name = "parent_category_id", referencedColumnName = "id")
+    private ShopParentCategory parentCategory;
 
     @Builder
     private ShopCategory(String name, String imageUrl) {

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopNotificationMessage.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopNotificationMessage.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,11 @@ public class ShopNotificationMessage extends BaseEntity {
     @Size(max = 255)
     @Column(name = "content", nullable = false)
     private String content;
+
+    @Builder
+    private ShopNotificationMessage(Integer id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
@@ -20,8 +20,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-@Table(name = "shop_main_categories")
-public class ShopMainCategory extends BaseEntity {
+@Table(name = "shop_parent_categories")
+public class ShopParentCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopParentCategory.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,11 @@ public class ShopParentCategory extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notification_message_id", referencedColumnName = "id", nullable = false)
     private ShopNotificationMessage notificationMessage;
+
+    @Builder
+    private ShopParentCategory(Integer id, String name, ShopNotificationMessage notificationMessage) {
+        this.id = id;
+        this.name = name;
+        this.notificationMessage = notificationMessage;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopNotificationBufferRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopNotificationBufferRepository.java
@@ -19,7 +19,7 @@ public interface ShopNotificationBufferRepository extends Repository<ShopNotific
             JOIN FETCH b.user u
             JOIN FETCH s.shopCategories scm
             JOIN FETCH scm.shopCategory sc
-            JOIN FETCH sc.mainCategory smc
+            JOIN FETCH sc.parentCategory smc
             JOIN FETCH smc.notificationMessage m
             WHERE b.notificationTime < :now
                   AND sc.id = (

--- a/src/main/java/in/koreatech/koin/domain/shop/service/NotificationScheduleService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/NotificationScheduleService.java
@@ -55,7 +55,7 @@ public class NotificationScheduleService {
         ShopNotificationMessage shopNotificationMessage = shop.getShopCategories().stream()
             .findFirst()
             .map(ShopCategoryMap::getShopCategory)
-            .map(shopCategory -> shopCategory.getMainCategory().getNotificationMessage())
+            .map(shopCategory -> shopCategory.getParentCategory().getNotificationMessage())
             .orElseThrow(() -> NotificationMessageNotFoundException.withDetail("shopId: " + shop.getId()));
 
         return notificationFactory.generateReviewPromptNotification(

--- a/src/main/resources/db/migration/V93__alter_shop_main_categories_table_name.sql
+++ b/src/main/resources/db/migration/V93__alter_shop_main_categories_table_name.sql
@@ -1,0 +1,15 @@
+RENAME TABLE `shop_main_categories` TO `shop_parent_categories`;
+
+ALTER TABLE `shop_categories`
+    CHANGE `main_category_id` `parent_category_id` INT UNSIGNED COMMENT '상위 카테고리 id';
+
+ALTER TABLE `shop_categories`
+DROP FOREIGN KEY `FK_SHOP_CATEGORIES_ON_SHOP_MAIN_CATEGORIES`;
+
+ALTER TABLE `shop_categories`
+    ADD CONSTRAINT `FK_SHOP_CATEGORIES_ON_SHOP_PARENT_CATEGORIES`
+        FOREIGN KEY (`parent_category_id`)
+            REFERENCES `shop_parent_categories` (`id`);
+
+ALTER TABLE `shop_parent_categories`
+    MODIFY `id` INT UNSIGNED AUTO_INCREMENT COMMENT 'shop_parent_categories 고유 id';

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -34,7 +34,9 @@ import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategoryMap;
 import in.koreatech.koin.domain.shop.model.shop.ShopImage;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
 import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.shop.repository.event.EventArticleRepository;
 import in.koreatech.koin.domain.shop.repository.menu.MenuCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.menu.MenuRepository;
@@ -44,6 +46,8 @@ import in.koreatech.koin.fixture.MenuCategoryFixture;
 import in.koreatech.koin.fixture.MenuFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import jakarta.transaction.Transactional;
 
@@ -80,6 +84,12 @@ class OwnerShopApiTest extends AcceptanceTest {
     private ShopCategoryFixture shopCategoryFixture;
 
     @Autowired
+    private ShopParentCategoryFixture shopParentCategoryFixture;
+
+    @Autowired
+    private ShopNotificationMessageFixture shopNotificationMessageFixture;;
+
+    @Autowired
     private MenuCategoryFixture menuCategoryFixture;
 
     @Autowired
@@ -94,6 +104,8 @@ class OwnerShopApiTest extends AcceptanceTest {
     private ShopCategory shopCategory_일반;
     private MenuCategory menuCategory_메인;
     private MenuCategory menuCategory_사이드;
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
 
     @BeforeAll
     void setUp() {
@@ -103,10 +115,12 @@ class OwnerShopApiTest extends AcceptanceTest {
         owner_준영 = userFixture.준영_사장님();
         token_준영 = userFixture.getToken(owner_준영.getUser());
         shop_마슬랜 = shopFixture.마슬랜(owner_현수);
-        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨();
-        shopCategory_일반 = shopCategoryFixture.카테고리_일반음식();
         menuCategory_메인 = menuCategoryFixture.메인메뉴(shop_마슬랜);
         menuCategory_사이드 = menuCategoryFixture.사이드메뉴(shop_마슬랜);
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
+        shopCategory_일반 = shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -20,12 +20,16 @@ import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.EventArticleFixture;
 import in.koreatech.koin.fixture.MenuCategoryFixture;
 import in.koreatech.koin.fixture.MenuFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.ShopReviewFixture;
 import in.koreatech.koin.fixture.ShopReviewReportFixture;
 import in.koreatech.koin.fixture.UserFixture;
@@ -59,11 +63,20 @@ class ShopApiTest extends AcceptanceTest {
     @Autowired
     private ShopCategoryFixture shopCategoryFixture;
 
+    @Autowired
+    private ShopParentCategoryFixture shopParentCategoryFixture;
+
+    @Autowired
+    private ShopNotificationMessageFixture shopNotificationMessageFixture;
+
     private Shop 마슬랜;
     private Owner owner;
 
     private Student 익명_학생;
     private String token_익명;
+
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
 
     @BeforeAll
     void setUp() {
@@ -72,6 +85,9 @@ class ShopApiTest extends AcceptanceTest {
         마슬랜 = shopFixture.마슬랜(owner);
         익명_학생 = userFixture.익명_학생();
         token_익명 = userFixture.getToken(익명_학생.getUser());
+
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
     }
 
     @Test
@@ -403,8 +419,8 @@ class ShopApiTest extends AcceptanceTest {
 
     @Test
     void 상점들의_모든_카테고리를_조회한다() throws Exception {
-        shopCategoryFixture.카테고리_일반음식();
-        shopCategoryFixture.카테고리_치킨();
+        shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
+        shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
 
         mockMvc.perform(
                 get("/shops/categories")

--- a/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.fixture;
 import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.shop.repository.shop.ShopCategoryRepository;
 
 @Component
@@ -15,20 +16,22 @@ public class ShopCategoryFixture {
         this.categoryRepository = categoryRepository;
     }
 
-    public ShopCategory 카테고리_치킨() {
+    public ShopCategory 카테고리_치킨(ShopParentCategory parentCategory) {
         return categoryRepository.save(
             ShopCategory.builder()
                 .name("치킨")
                 .imageUrl("https://test-image.com/ckicken.jpg")
+                .parentCategory(parentCategory)
                 .build()
         );
     }
 
-    public ShopCategory 카테고리_일반음식() {
+    public ShopCategory 카테고리_일반음식(ShopParentCategory parentCategory) {
         return categoryRepository.save(
             ShopCategory.builder()
                 .name("일반음식점")
                 .imageUrl("https://test-image.com/normal.jpg")
+                .parentCategory(parentCategory)
                 .build()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/ShopNotificationMessageFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopNotificationMessageFixture.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.fixture;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.admin.shop.repository.AdminShopNotificationMessageRepository;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+
+@Component
+@SuppressWarnings("NonAsciiCharacters")
+public class ShopNotificationMessageFixture {
+
+    private final AdminShopNotificationMessageRepository adminShopNotificationMessageRepository;
+
+    public ShopNotificationMessageFixture(
+        AdminShopNotificationMessageRepository adminShopNotificationMessageRepository
+    ) {
+        this.adminShopNotificationMessageRepository = adminShopNotificationMessageRepository;
+    }
+
+    public ShopNotificationMessage 알림메시지_가게() {
+        return adminShopNotificationMessageRepository.save(
+            ShopNotificationMessage.builder()
+                .title(",맛있게 드셨나요?")
+                .content("가게에 리뷰를 남겨보세요!")
+                .build()
+        );
+    }
+
+    public ShopNotificationMessage 알림메시지_콜벤() {
+        return adminShopNotificationMessageRepository.save(
+            ShopNotificationMessage.builder()
+                .title(",편안히 이용하셨나요?")
+                .content("리뷰를 남겨보세요!")
+                .build()
+        );
+    }
+}

--- a/src/test/java/in/koreatech/koin/fixture/ShopParentCategoryFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopParentCategoryFixture.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.fixture;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.admin.shop.repository.AdminShopParentCategoryRepository;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+
+@Component
+@SuppressWarnings("NonAsciiCharacters")
+public class ShopParentCategoryFixture {
+
+    private final AdminShopParentCategoryRepository shopParentCategoryRepository;
+
+    public ShopParentCategoryFixture(AdminShopParentCategoryRepository shopParentCategoryRepository) {
+        this.shopParentCategoryRepository = shopParentCategoryRepository;
+    }
+
+    public ShopParentCategory 상위_카테고리_가게(ShopNotificationMessage notificationMessage) {
+        return shopParentCategoryRepository.save(
+            ShopParentCategory.builder()
+                .name("가게")
+                .notificationMessage(notificationMessage)
+                .build()
+        );
+    }
+
+    public ShopParentCategory 상위_카테고리_콜벤(ShopNotificationMessage notificationMessage) {
+        return shopParentCategoryRepository.save(
+            ShopParentCategory.builder()
+                .name("콜벤")
+                .notificationMessage(notificationMessage)
+                .build()
+        );
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1004

# 🚀 작업 내용
- 어드민 상점 카테고리를 생성하거나 수정할 때 상위 카테고리를 선택하는 기능 추가
1. 메인 카테고리의 추가로 인한 이름 충돌 방지를 위해 main_category를 parent_category로 변경
2. 드롭다운을 위해 상점의 모든 상위 카테고리를 조회하는 api 추가
3. 기존 상점 카테고리 생성, 수정 dto에 상위 카테고리 id 필드 추가
4. 기존 상점 카테고리 단일 조회 dto에 상위 카테고리 id 필드 추가
5. 기존 상점 카테고리 수정 시 카테고리명을 그대로 사용할 경우 중복예외처리하는 오류 수정
6. 테스트 코드 작성 및 기존 테스트 코드 수정

# 💬 리뷰 중점사항
