### PR TITLE
fix : 강제업데이트 히스토리 조회 내림차순으로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/version/repository/AdminVersionRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/version/repository/AdminVersionRepository.java
@@ -21,7 +21,7 @@ public interface AdminVersionRepository extends Repository<Version, Integer> {
 
     Page<Version> findAllByIsPrevious(boolean isPrevious, Pageable pageable);
 
-    Page<Version> findAllByType(String type, PageRequest pageRequest);
+    Page<Version> findAllByTypeOrderByVersionDesc(String type, PageRequest pageRequest);
 
     Optional<Version> findById(Integer id);
 

--- a/src/main/java/in/koreatech/koin/admin/version/service/AdminVersionService.java
+++ b/src/main/java/in/koreatech/koin/admin/version/service/AdminVersionService.java
@@ -63,7 +63,7 @@ public class AdminVersionService {
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(),
             Sort.by(Sort.Direction.ASC, "id"));
 
-        Page<Version> result = adminVersionRepository.findAllByType(versionType.getValue(), pageRequest);
+        Page<Version> result = adminVersionRepository.findAllByTypeOrderByVersionDesc(versionType.getValue(), pageRequest);
 
         return AdminVersionHistoryResponse.of(result, criteria);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 강제업데이트 히스토리 조회 시 오름차순에서 내림차순으로 나오도록 수정했습니다.

# 💬 리뷰 중점사항
