### PR TITLE
feat: 어드민, 사장님 상점 생성, 수정시 메인 카테고리, 배너 이미지 추가 

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
@@ -17,7 +17,7 @@ import jakarta.validation.constraints.Size;
 public record AdminCreateShopCategoryRequest(
     @Schema(description = "이미지 URL", example = "https://static.koreatech.in/test.png", requiredMode = RequiredMode.REQUIRED)
     @NotBlank(message = "이미지 URL은 필수입니다.")
-    @Size(max = 100, message = "이미지 URL은 255자 이하로 입력해주세요.")
+    @Size(max = 255, message = "이미지 URL은 255자 이하로 입력해주세요.")
     String imageUrl,
 
     @Schema(description = "이름", example = "햄버거", requiredMode = RequiredMode.REQUIRED)
@@ -27,7 +27,11 @@ public record AdminCreateShopCategoryRequest(
 
     @Schema(description = "상위 카테고리 id", example = "1", requiredMode = REQUIRED)
     @NotNull(message = "상위 카테고리는 필수입니다.")
-    Integer parentCategoryId
+    Integer parentCategoryId,
+
+    @Schema(description = "이벤트 이미지 URL", example = "https://static.koreatech.in/test.png")
+    @Size(max = 255, message = "이벤트 이미지 URL은 255자 이하로 입력해주세요.")
+    String eventImageUrl
 ) {
 
     public ShopCategory toShopCategory(ShopParentCategory shopParentCategory) {
@@ -35,6 +39,7 @@ public record AdminCreateShopCategoryRequest(
             .imageUrl(imageUrl)
             .name(name)
             .parentCategory(shopParentCategory)
+            .eventImageUrl(eventImageUrl)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopCategoryRequest.java
@@ -31,7 +31,7 @@ public record AdminCreateShopCategoryRequest(
 
     @Schema(description = "이벤트 이미지 URL", example = "https://static.koreatech.in/test.png")
     @Size(max = 255, message = "이벤트 이미지 URL은 255자 이하로 입력해주세요.")
-    String eventImageUrl
+    String eventBannerImageUrl
 ) {
 
     public ShopCategory toShopCategory(ShopParentCategory shopParentCategory) {
@@ -39,7 +39,7 @@ public record AdminCreateShopCategoryRequest(
             .imageUrl(imageUrl)
             .name(name)
             .parentCategory(shopParentCategory)
-            .eventImageUrl(eventImageUrl)
+            .eventBannerImageUrl(eventBannerImageUrl)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminCreateShopRequest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
 import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueId;
@@ -31,7 +32,11 @@ public record AdminCreateShopRequest(
     @Size(min = 1, max = 100, message = "주소는 1자 이상, 100자 이하로 입력해주세요.")
     String address,
 
-    @Schema(description = "상점 카테고리 고유 id 리스트", example = "[1, 2]", requiredMode = REQUIRED)
+    @Schema(description = "메인 카테고리 고유 id", example = "2", requiredMode = REQUIRED)
+    @NotNull(message = "메인 카테고리는 필수입니다.")
+    Integer mainCategoryId,
+
+    @Schema(description = "상점 카테고리 고유 id 리스트(메인 카테고리 포함)", example = "[1, 2]", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
     @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     @Size(min = 1, message = "최소 한 개의 카테고리가 필요합니다.")
@@ -84,8 +89,9 @@ public record AdminCreateShopRequest(
     String phone
 ) {
 
-    public Shop toShop() {
+    public Shop toShop(ShopCategory shopCategory) {
         return Shop.builder()
+            .shopMainCategory(shopCategory)
             .address(address)
             .delivery(delivery)
             .deliveryPrice(deliveryPrice)

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
@@ -29,7 +29,7 @@ public record AdminModifyShopCategoryRequest(
 
     @Schema(description = "이벤트 이미지 URL", example = "https://static.koreatech.in/test.png")
     @Size(max = 255, message = "이벤트 이미지 URL은 255자 이하로 입력해주세요.")
-    String eventImageUrl
+    String eventBannerImageUrl
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopCategoryRequest.java
@@ -25,7 +25,11 @@ public record AdminModifyShopCategoryRequest(
 
     @Schema(description = "상위 카테고리 id", example = "1", requiredMode = REQUIRED)
     @NotNull(message = "상위 카테고리는 필수입니다.")
-    Integer parentCategoryId
+    Integer parentCategoryId,
+
+    @Schema(description = "이벤트 이미지 URL", example = "https://static.koreatech.in/test.png")
+    @Size(max = 255, message = "이벤트 이미지 URL은 255자 이하로 입력해주세요.")
+    String eventImageUrl
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminModifyShopRequest.java
@@ -31,7 +31,11 @@ public record AdminModifyShopRequest(
     @Size(min = 1, max = 100, message = "주소는 1자 이상, 100자 이하로 입력해주세요.")
     String address,
 
-    @Schema(description = "상점 카테고리 고유 id 리스트", example = "[1, 2]", requiredMode = REQUIRED)
+    @Schema(description = "메인 카테고리 고유 id", example = "2", requiredMode = REQUIRED)
+    @NotNull(message = "메인 카테고리는 필수입니다.")
+    Integer mainCategoryId,
+
+    @Schema(description = "상점 카테고리 고유 id 리스트(메인 카테고리 포함)", example = "[1, 2]", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
     @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")
     @Size(min = 1, message = "최소 한 개의 카테고리가 필요합니다.")

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
@@ -18,7 +18,10 @@ public record AdminShopCategoryResponse(
     String name,
 
     @Schema(description = "상위 카테고리 ID", example = "1")
-    Integer parentCategoryId
+    Integer parentCategoryId,
+
+    @Schema(description = "카테고리 이벤트 이미지 URL", example = "string")
+    String eventImageUrl
 ) {
 
     public static AdminShopCategoryResponse from(ShopCategory shopCategory) {
@@ -26,7 +29,8 @@ public record AdminShopCategoryResponse(
             shopCategory.getId(),
             shopCategory.getImageUrl(),
             shopCategory.getName(),
-            shopCategory.getParentCategory().getId()
+            shopCategory.getParentCategory().getId(),
+            shopCategory.getEventImageUrl()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopCategoryResponse.java
@@ -21,7 +21,7 @@ public record AdminShopCategoryResponse(
     Integer parentCategoryId,
 
     @Schema(description = "카테고리 이벤트 이미지 URL", example = "string")
-    String eventImageUrl
+    String eventBannerImageUrl
 ) {
 
     public static AdminShopCategoryResponse from(ShopCategory shopCategory) {
@@ -30,7 +30,7 @@ public record AdminShopCategoryResponse(
             shopCategory.getImageUrl(),
             shopCategory.getName(),
             shopCategory.getParentCategory().getId(),
-            shopCategory.getEventImageUrl()
+            shopCategory.getEventBannerImageUrl()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/AdminShopResponse.java
@@ -59,6 +59,9 @@ public record AdminShopResponse(
     @Schema(description = "소속된 상점 카테고리 리스트")
     List<InnerShopCategory> shopCategories,
 
+    @Schema(description = "메인 카테고리 id", example = "1")
+    Integer mainCategoryId,
+
     @JsonFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "업데이트 날짜", example = "2024-03-01", requiredMode = REQUIRED)
     LocalDateTime updatedAt,
@@ -112,6 +115,7 @@ public record AdminShopResponse(
                     shopCategory.getName()
                 );
             }).toList(),
+            shop.getShopMainCategory() != null ? shop.getShopMainCategory().getId() : null,
             shop.getUpdatedAt(),
             shop.isDeleted(),
             isEvent,

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -126,7 +126,8 @@ public class AdminShopService {
 
     @Transactional
     public void createShop(AdminCreateShopRequest adminCreateShopRequest) {
-        Shop shop = adminCreateShopRequest.toShop();
+        ShopCategory shopCategory = adminShopCategoryRepository.getById(adminCreateShopRequest.mainCategoryId());
+        Shop shop = adminCreateShopRequest.toShop(shopCategory);
         Shop savedShop = adminShopRepository.save(shop);
         List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
         for (String categoryName : categoryNames) {
@@ -154,9 +155,9 @@ public class AdminShopService {
             savedShop.getShopOpens().add(shopOpen);
         }
         List<ShopCategory> categories = adminShopCategoryRepository.findAllByIdIn(adminCreateShopRequest.categoryIds());
-        for (ShopCategory shopCategory : categories) {
+        for (ShopCategory category : categories) {
             ShopCategoryMap shopCategoryMap = ShopCategoryMap.builder()
-                .shopCategory(shopCategory)
+                .shopCategory(category)
                 .shop(savedShop)
                 .build();
             savedShop.getShopCategories().add(shopCategoryMap);
@@ -234,6 +235,7 @@ public class AdminShopService {
     @Transactional
     public void modifyShop(Integer shopId, AdminModifyShopRequest adminModifyShopRequest) {
         Shop shop = adminShopRepository.getById(shopId);
+        ShopCategory shopMainCategory = adminShopCategoryRepository.getById(adminModifyShopRequest.mainCategoryId());
         shop.modifyShop(
             adminModifyShopRequest.name(),
             adminModifyShopRequest.phone(),
@@ -244,7 +246,8 @@ public class AdminShopService {
             adminModifyShopRequest.payCard(),
             adminModifyShopRequest.payBank(),
             adminModifyShopRequest.bank(),
-            adminModifyShopRequest.accountNumber()
+            adminModifyShopRequest.accountNumber(),
+            shopMainCategory
         );
         shop.modifyShopCategories(
             adminShopCategoryRepository.findAllByIdIn(adminModifyShopRequest.categoryIds()),

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -267,7 +267,7 @@ public class AdminShopService {
             adminModifyShopCategoryRequest.name(),
             adminModifyShopCategoryRequest.imageUrl(),
             shopParentCategory,
-            adminModifyShopCategoryRequest.eventImageUrl()
+            adminModifyShopCategoryRequest.eventBannerImageUrl()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -266,7 +266,8 @@ public class AdminShopService {
         shopCategory.modifyShopCategory(
             adminModifyShopCategoryRequest.name(),
             adminModifyShopCategoryRequest.imageUrl(),
-            shopParentCategory
+            shopParentCategory,
+            adminModifyShopCategoryRequest.eventImageUrl()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -126,8 +126,8 @@ public class AdminShopService {
 
     @Transactional
     public void createShop(AdminCreateShopRequest adminCreateShopRequest) {
-        ShopCategory shopCategory = adminShopCategoryRepository.getById(adminCreateShopRequest.mainCategoryId());
-        Shop shop = adminCreateShopRequest.toShop(shopCategory);
+        ShopCategory shopMainCategory = adminShopCategoryRepository.getById(adminCreateShopRequest.mainCategoryId());
+        Shop shop = adminCreateShopRequest.toShop(shopMainCategory);
         Shop savedShop = adminShopRepository.save(shop);
         List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
         for (String categoryName : categoryNames) {
@@ -155,9 +155,9 @@ public class AdminShopService {
             savedShop.getShopOpens().add(shopOpen);
         }
         List<ShopCategory> categories = adminShopCategoryRepository.findAllByIdIn(adminCreateShopRequest.categoryIds());
-        for (ShopCategory category : categories) {
+        for (ShopCategory shopCategory : categories) {
             ShopCategoryMap shopCategoryMap = ShopCategoryMap.builder()
-                .shopCategory(category)
+                .shopCategory(shopCategory)
                 .shop(savedShop)
                 .build();
             savedShop.getShopCategories().add(shopCategoryMap);

--- a/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/dto/OwnerShopsRequest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.global.validation.NotBlankElement;
 import in.koreatech.koin.global.validation.UniqueId;
 import in.koreatech.koin.global.validation.UniqueUrl;
@@ -27,6 +28,10 @@ public record OwnerShopsRequest(
     @Schema(description = "주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = REQUIRED)
     @NotBlank(message = "주소를 입력해주세요.")
     String address,
+
+    @Schema(description = "메인 카테고리 고유 id", example = "2", requiredMode = REQUIRED)
+    @NotNull(message = "메인 카테고리는 필수입니다.")
+    Integer mainCategoryId,
 
     @Schema(description = "상점 카테고리 고유 id 리스트", example = "[1]", requiredMode = REQUIRED)
     @NotNull(message = "카테고리를 입력해주세요.")
@@ -79,9 +84,10 @@ public record OwnerShopsRequest(
     String phone
 ) {
 
-    public Shop toEntity(Owner owner) {
+    public Shop toEntity(Owner owner, ShopCategory shopMainCategory) {
         return Shop.builder()
             .owner(owner)
+            .shopMainCategory(shopMainCategory)
             .address(address)
             .deliveryPrice(deliveryPrice)
             .delivery(delivery)

--- a/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/service/OwnerShopService.java
@@ -89,7 +89,8 @@ public class OwnerShopService {
     @Transactional
     public void createOwnerShops(Integer ownerId, OwnerShopsRequest ownerShopsRequest) {
         Owner owner = ownerRepository.getById(ownerId);
-        Shop newShop = ownerShopsRequest.toEntity(owner);
+        ShopCategory shopMainCategory = shopCategoryRepository.getById(ownerShopsRequest.mainCategoryId());
+        Shop newShop = ownerShopsRequest.toEntity(owner, shopMainCategory);
         Shop savedShop = shopRepository.save(newShop);
         List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
         for (String categoryName : categoryNames) {
@@ -253,6 +254,7 @@ public class OwnerShopService {
     @Transactional
     public void modifyShop(Integer ownerId, Integer shopId, ModifyShopRequest modifyShopRequest) {
         Shop shop = getOwnerShopById(shopId, ownerId);
+        ShopCategory shopCategory = shopCategoryRepository.getById(modifyShopRequest.mainCategoryId());
         shop.modifyShop(
             modifyShopRequest.name(),
             modifyShopRequest.phone(),
@@ -263,7 +265,8 @@ public class OwnerShopService {
             modifyShopRequest.payCard(),
             modifyShopRequest.payBank(),
             modifyShopRequest.bank(),
-            modifyShopRequest.accountNumber()
+            modifyShopRequest.accountNumber(),
+            shopCategory
         );
         shop.modifyShopImages(modifyShopRequest.imageUrls(), entityManager);
         shop.modifyShopOpens(modifyShopRequest.open(), entityManager);

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -21,9 +21,10 @@ import in.koreatech.koin.domain.shop.dto.menu.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.review.ModifyReviewRequest;
 import in.koreatech.koin.domain.shop.dto.review.ReviewsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopCategoriesResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopEventsResponse;
 import in.koreatech.koin.domain.shop.dto.menu.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.review.ShopMyReviewsResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithBannerUrlResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithThumbnailUrlResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.review.ShopReviewReportCategoryResponse;
 import in.koreatech.koin.domain.shop.dto.review.ShopReviewReportRequest;
@@ -134,7 +135,7 @@ public interface ShopApi {
     )
     @Operation(summary = "특정 상점의 모든 이벤트 조회")
     @GetMapping("/shops/{shopId}/events")
-    ResponseEntity<ShopEventsResponse> getShopEvents(
+    ResponseEntity<ShopEventsWithThumbnailUrlResponse> getShopEvents(
         @PathVariable Integer shopId
     );
 
@@ -148,7 +149,7 @@ public interface ShopApi {
     )
     @Operation(summary = "모든 상점의 모든 이벤트 조회")
     @GetMapping("/shops/events")
-    ResponseEntity<ShopEventsResponse> getShopAllEvent();
+    ResponseEntity<ShopEventsWithBannerUrlResponse> getShopAllEvent();
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -16,7 +16,8 @@ import in.koreatech.koin.domain.shop.dto.review.ShopReviewResponse;
 import in.koreatech.koin.domain.shop.dto.review.ShopReviewsResponse;
 import in.koreatech.koin.domain.shop.dto.search.RelatedKeyword;
 import in.koreatech.koin.domain.shop.dto.shop.ShopCategoriesResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopEventsResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithBannerUrlResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithThumbnailUrlResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsResponse;
@@ -97,7 +98,7 @@ public class ShopController implements ShopApi {
     }
 
     @GetMapping("/shops/{shopId}/events")
-    public ResponseEntity<ShopEventsResponse> getShopEvents(
+    public ResponseEntity<ShopEventsWithThumbnailUrlResponse> getShopEvents(
         @PathVariable Integer shopId
     ) {
         var response = shopService.getShopEvents(shopId);
@@ -105,7 +106,7 @@ public class ShopController implements ShopApi {
     }
 
     @GetMapping("/shops/events")
-    public ResponseEntity<ShopEventsResponse> getShopAllEvent() {
+    public ResponseEntity<ShopEventsWithBannerUrlResponse> getShopAllEvent() {
         var response = shopService.getAllEvents();
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ModifyShopRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ModifyShopRequest.java
@@ -28,6 +28,10 @@ public record ModifyShopRequest(
     @Schema(example = "충청남도 천안시 동남구 병천면", description = "주소", requiredMode = NOT_REQUIRED)
     String address,
 
+    @Schema(description = "메인 카테고리 고유 id", example = "2", requiredMode = REQUIRED)
+    @NotNull(message = "메인 카테고리는 필수입니다.")
+    Integer mainCategoryId,
+
     @Schema(example = "[1, 2]", description = "상점 카테고리 고유 id 리스트", requiredMode = REQUIRED)
     @NotNull(message = "카테고리는 필수입니다.")
     @UniqueId(message = "카테고리 ID는 중복될 수 없습니다.")

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
@@ -7,6 +7,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.shop.model.article.EventArticle;
 import in.koreatech.koin.domain.shop.model.article.EventArticleImage;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -62,9 +64,11 @@ public record ShopEventsResponse(
                 eventArticle.getId(),
                 eventArticle.getTitle(),
                 eventArticle.getContent(),
-                eventArticle.getThumbnailImages()
-                    .stream().map(EventArticleImage::getThumbnailImage)
-                    .toList(),
+                Optional.ofNullable(eventArticle.getShop())
+                    .map(Shop::getShopMainCategory)
+                    .map(ShopCategory::getEventImageUrl)
+                    .map(List::of)
+                    .orElse(null),
                 eventArticle.getStartDate(),
                 eventArticle.getEndDate()
             );

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
@@ -57,14 +57,14 @@ public record ShopEventsResponse(
         LocalDate endDate
     ) {
 
-        public static InnerShopEventResponse fromWithEventUrl(EventArticle eventArticle) {
+        public static InnerShopEventResponse fromWithEventUrl(EventArticle eventArticle, Shop shop) {
             return new InnerShopEventResponse(
-                eventArticle.getShop().getId(),
-                eventArticle.getShop().getName(),
+                shop.getId(),
+                shop.getName(),
                 eventArticle.getId(),
                 eventArticle.getTitle(),
                 eventArticle.getContent(),
-                Optional.ofNullable(eventArticle.getShop())
+                Optional.ofNullable(shop)
                     .map(Shop::getShopMainCategory)
                     .map(ShopCategory::getEventImageUrl)
                     .map(List::of)
@@ -96,7 +96,7 @@ public record ShopEventsResponse(
             for (EventArticle eventArticle : shop.getEventArticles()) {
                 if (!eventArticle.getStartDate().isAfter(LocalDate.now(clock)) &&
                     !eventArticle.getEndDate().isBefore(LocalDate.now(clock))) {
-                    innerShopEventResponses.add(InnerShopEventResponse.fromWithEventUrl(eventArticle));
+                    innerShopEventResponses.add(InnerShopEventResponse.fromWithEventUrl(eventArticle, shop));
                 }
             }
         }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsResponse.java
@@ -57,7 +57,7 @@ public record ShopEventsResponse(
         LocalDate endDate
     ) {
 
-        public static InnerShopEventResponse from(EventArticle eventArticle) {
+        public static InnerShopEventResponse fromWithEventUrl(EventArticle eventArticle) {
             return new InnerShopEventResponse(
                 eventArticle.getShop().getId(),
                 eventArticle.getShop().getName(),
@@ -73,6 +73,21 @@ public record ShopEventsResponse(
                 eventArticle.getEndDate()
             );
         }
+
+        public static InnerShopEventResponse fromWithThumbnailUrl(EventArticle eventArticle) {
+            return new InnerShopEventResponse(
+                eventArticle.getShop().getId(),
+                eventArticle.getShop().getName(),
+                eventArticle.getId(),
+                eventArticle.getTitle(),
+                eventArticle.getContent(),
+                eventArticle.getThumbnailImages()
+                    .stream().map(EventArticleImage::getThumbnailImage)
+                    .toList(),
+                eventArticle.getStartDate(),
+                eventArticle.getEndDate()
+            );
+        }
     }
 
     public static ShopEventsResponse of(List<Shop> shops, Clock clock) {
@@ -81,7 +96,7 @@ public record ShopEventsResponse(
             for (EventArticle eventArticle : shop.getEventArticles()) {
                 if (!eventArticle.getStartDate().isAfter(LocalDate.now(clock)) &&
                     !eventArticle.getEndDate().isBefore(LocalDate.now(clock))) {
-                    innerShopEventResponses.add(InnerShopEventResponse.from(eventArticle));
+                    innerShopEventResponses.add(InnerShopEventResponse.fromWithEventUrl(eventArticle));
                 }
             }
         }
@@ -93,7 +108,7 @@ public record ShopEventsResponse(
         for (EventArticle eventArticle : shop.getEventArticles()) {
             if (!eventArticle.getStartDate().isAfter(LocalDate.now(clock)) &&
                 !eventArticle.getEndDate().isBefore(LocalDate.now(clock))) {
-                innerShopEventResponses.add(InnerShopEventResponse.from(eventArticle));
+                innerShopEventResponses.add(InnerShopEventResponse.fromWithThumbnailUrl(eventArticle));
             }
         }
         return new ShopEventsResponse(innerShopEventResponses);

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsWithBannerUrlResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsWithBannerUrlResponse.java
@@ -65,7 +65,7 @@ public record ShopEventsWithBannerUrlResponse(
                 eventArticle.getContent(),
                 Optional.ofNullable(shop)
                     .map(Shop::getShopMainCategory)
-                    .map(ShopCategory::getEventImageUrl)
+                    .map(ShopCategory::getEventBannerImageUrl)
                     .map(List::of)
                     .orElse(null),
                 eventArticle.getStartDate(),

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsWithBannerUrlResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopEventsWithBannerUrlResponse.java
@@ -1,0 +1,89 @@
+package in.koreatech.koin.domain.shop.dto.shop;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.shop.model.article.EventArticle;
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ShopEventsWithBannerUrlResponse(
+
+    @Schema(description = "이벤트 목록")
+    List<InnerShopEventResponse> events
+) {
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerShopEventResponse(
+        @Schema(description = "상점 ID", example = "1", requiredMode = REQUIRED)
+        Integer shopId,
+
+        @Schema(description = "상점 이름", example = "술꾼", requiredMode = REQUIRED)
+        String shopName,
+
+        @Schema(description = "이벤트 ID", example = "1", requiredMode = REQUIRED)
+        Integer eventId,
+
+        @Schema(description = "이벤트 제목", example = "콩순이 사장님이 미쳤어요!!", requiredMode = REQUIRED)
+        String title,
+
+        @Schema(description = "이벤트 내용", example = "콩순이 가게 전메뉴 90% 할인! 가게 폐업 임박...", requiredMode = REQUIRED)
+        String content,
+
+        @Schema(description = "이벤트 이미지", example = """
+            [ "https://static.koreatech.in/example.png" ]
+            """, requiredMode = NOT_REQUIRED)
+        List<String> thumbnailImages,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @Schema(description = "시작일", example = "2024-10-22", requiredMode = REQUIRED)
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @Schema(description = "종료일", example = "2024-10-25", requiredMode = REQUIRED)
+        LocalDate endDate
+    ) {
+
+        public static InnerShopEventResponse from(EventArticle eventArticle, Shop shop) {
+            return new InnerShopEventResponse(
+                shop.getId(),
+                shop.getName(),
+                eventArticle.getId(),
+                eventArticle.getTitle(),
+                eventArticle.getContent(),
+                Optional.ofNullable(shop)
+                    .map(Shop::getShopMainCategory)
+                    .map(ShopCategory::getEventImageUrl)
+                    .map(List::of)
+                    .orElse(null),
+                eventArticle.getStartDate(),
+                eventArticle.getEndDate()
+            );
+        }
+    }
+
+    public static ShopEventsWithBannerUrlResponse of(List<Shop> shops, Clock clock) {
+        List<InnerShopEventResponse> innerShopEventResponses = new ArrayList<>();
+        for (Shop shop : shops) {
+            for (EventArticle eventArticle : shop.getEventArticles()) {
+                if (!eventArticle.getStartDate().isAfter(LocalDate.now(clock)) &&
+                    !eventArticle.getEndDate().isBefore(LocalDate.now(clock))) {
+                    innerShopEventResponses.add(InnerShopEventResponse.from(eventArticle, shop));
+                }
+            }
+        }
+        return new ShopEventsWithBannerUrlResponse(innerShopEventResponses);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/ShopResponse.java
@@ -56,6 +56,9 @@ public record ShopResponse(
     @Schema(example = "041-000-0000", description = "전화번호", requiredMode = NOT_REQUIRED)
     String phone,
 
+    @Schema(description = "메인 카테고리 고유 id", example = "2")
+    Integer mainCategoryId,
+
     @Schema(description = "소속된 상점 카테고리 리스트")
     List<InnerShopCategory> shopCategories,
 
@@ -102,6 +105,7 @@ public record ShopResponse(
             shop.isPayBank(),
             shop.isPayCard(),
             shop.getPhone(),
+            shop.getShopMainCategory() != null ? shop.getShopMainCategory().getId() : null,
             shop.getShopCategories().stream().map(shopCategoryMap -> {
                 ShopCategory shopCategory = shopCategoryMap.getShopCategory();
                 return new InnerShopCategory(

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -114,6 +114,10 @@ public class Shop extends BaseEntity {
     @Column(name = "hit", nullable = false)
     private Integer hit;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_category_id", referencedColumnName = "id")
+    private ShopCategory shopMainCategory;
+
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
     private Set<ShopCategoryMap> shopCategories = new HashSet<>();
 
@@ -161,7 +165,8 @@ public class Shop extends BaseEntity {
         String remarks,
         Integer hit,
         String bank,
-        String accountNumber
+        String accountNumber,
+        ShopCategory shopMainCategory
     ) {
         this.owner = owner;
         this.name = name;
@@ -180,6 +185,7 @@ public class Shop extends BaseEntity {
         this.hit = hit;
         this.bank = bank;
         this.accountNumber = accountNumber;
+        this.shopMainCategory = shopMainCategory;
     }
 
     public void modifyShop(
@@ -192,7 +198,8 @@ public class Shop extends BaseEntity {
         Boolean payCard,
         boolean payBank,
         String bank,
-        String accountNumber
+        String accountNumber,
+        ShopCategory shopMainCategory
     ) {
         this.address = address;
         this.delivery = delivery;
@@ -204,6 +211,7 @@ public class Shop extends BaseEntity {
         this.phone = phone;
         this.bank = bank;
         this.accountNumber = accountNumber;
+        this.shopMainCategory = shopMainCategory;
     }
 
     public boolean isOpen(LocalDateTime now) {

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
@@ -41,6 +41,10 @@ public class ShopCategory extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
+    @Size(max = 255)
+    @Column(name = "event_image_url")
+    private String eventImageUrl;
+
     @OneToMany(mappedBy = "shopCategory", orphanRemoval = true, cascade = {PERSIST, REMOVE})
     private List<ShopCategoryMap> shopCategoryMaps = new ArrayList<>();
 
@@ -49,15 +53,17 @@ public class ShopCategory extends BaseEntity {
     private ShopParentCategory parentCategory;
 
     @Builder
-    private ShopCategory(String name, String imageUrl, ShopParentCategory parentCategory) {
+    private ShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventImageUrl) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.parentCategory = parentCategory;
+        this.eventImageUrl = eventImageUrl;
     }
 
-    public void modifyShopCategory(String name, String imageUrl, ShopParentCategory parentCategory) {
+    public void modifyShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventImageUrl) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.parentCategory = parentCategory;
+        this.eventImageUrl = eventImageUrl;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/ShopCategory.java
@@ -42,8 +42,8 @@ public class ShopCategory extends BaseEntity {
     private String imageUrl;
 
     @Size(max = 255)
-    @Column(name = "event_image_url")
-    private String eventImageUrl;
+    @Column(name = "event_banner_image_url")
+    private String eventBannerImageUrl;
 
     @OneToMany(mappedBy = "shopCategory", orphanRemoval = true, cascade = {PERSIST, REMOVE})
     private List<ShopCategoryMap> shopCategoryMaps = new ArrayList<>();
@@ -53,17 +53,17 @@ public class ShopCategory extends BaseEntity {
     private ShopParentCategory parentCategory;
 
     @Builder
-    private ShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventImageUrl) {
+    private ShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventBannerImageUrl) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.parentCategory = parentCategory;
-        this.eventImageUrl = eventImageUrl;
+        this.eventBannerImageUrl = eventBannerImageUrl;
     }
 
-    public void modifyShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventImageUrl) {
+    public void modifyShopCategory(String name, String imageUrl, ShopParentCategory parentCategory, String eventBannerImageUrl) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.parentCategory = parentCategory;
-        this.eventImageUrl = eventImageUrl;
+        this.eventBannerImageUrl = eventBannerImageUrl;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -8,7 +8,8 @@ import in.koreatech.koin.domain.shop.dto.menu.MenuCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.menu.MenuDetailResponse;
 import in.koreatech.koin.domain.shop.dto.menu.ShopMenuResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopCategoriesResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopEventsResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithBannerUrlResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopEventsWithThumbnailUrlResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopResponse;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsResponse;
@@ -103,14 +104,14 @@ public class ShopService {
         return ShopCategoriesResponse.from(shopCategories);
     }
 
-    public ShopEventsResponse getShopEvents(Integer shopId) {
+    public ShopEventsWithThumbnailUrlResponse getShopEvents(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
-        return ShopEventsResponse.of(shop, clock);
+        return ShopEventsWithThumbnailUrlResponse.of(shop, clock);
     }
 
-    public ShopEventsResponse getAllEvents() {
+    public ShopEventsWithBannerUrlResponse getAllEvents() {
         List<Shop> shops = shopRepository.findAll();
-        return ShopEventsResponse.of(shops, clock);
+        return ShopEventsWithBannerUrlResponse.of(shops, clock);
     }
 
     public ShopsResponseV2 getShopsV2(

--- a/src/main/resources/db/migration/V96__alter_shops_add_main_category_id_column.sql
+++ b/src/main/resources/db/migration/V96__alter_shops_add_main_category_id_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `shops`
+    ADD COLUMN `main_category_id` INT UNSIGNED COMMENT '메인 카테고리 id',
+    ADD CONSTRAINT `FK_SHOPS_ON_SHOP_CATEGORIES`
+    FOREIGN KEY (`main_category_id`)
+    REFERENCES `shop_categories` (`id`);

--- a/src/main/resources/db/migration/V97__alter_shop_categories_add_event_banner_image_url_column.sql
+++ b/src/main/resources/db/migration/V97__alter_shop_categories_add_event_banner_image_url_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shop_categories
+    ADD COLUMN event_banner_image_url VARCHAR(255) NULL COMMENT '이벤트 배너 이미지'

--- a/src/main/resources/db/migration/V97__alter_shop_categories_add_event_image_url_column.sql
+++ b/src/main/resources/db/migration/V97__alter_shop_categories_add_event_image_url_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shop_categories
+    ADD COLUMN event_image_url VARCHAR(255) NULL COMMENT '이벤트 배너 이미지'

--- a/src/main/resources/db/migration/V97__alter_shop_categories_add_event_image_url_column.sql
+++ b/src/main/resources/db/migration/V97__alter_shop_categories_add_event_image_url_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE shop_categories
-    ADD COLUMN event_image_url VARCHAR(255) NULL COMMENT '이벤트 배너 이미지'

--- a/src/test/java/in/koreatech/koin/acceptance/BenefitApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/BenefitApiTest.java
@@ -14,10 +14,16 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.benefit.model.BenefitCategory;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.BenefitCategoryFixture;
 import in.koreatech.koin.fixture.BenefitCategoryMapFixture;
+import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.ShopReviewFixture;
 import in.koreatech.koin.fixture.UserFixture;
 
@@ -40,6 +46,15 @@ public class BenefitApiTest extends AcceptanceTest {
     @Autowired
     UserFixture userFixture;
 
+    @Autowired
+    ShopCategoryFixture shopCategoryFixture;
+
+    @Autowired
+    ShopParentCategoryFixture shopParentCategoryFixture;
+
+    @Autowired
+    ShopNotificationMessageFixture shopNotificationMessageFixture;
+
     BenefitCategory 배달비_무료;
     BenefitCategory 최소주문금액_무료;
     BenefitCategory 서비스_증정;
@@ -54,6 +69,11 @@ public class BenefitApiTest extends AcceptanceTest {
     Shop 영업중인_티바;
     Shop 영업중이_아닌_신전_떡볶이;
 
+    private ShopCategory shopCategory_치킨;
+    private ShopCategory shopCategory_일반;
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
+
     @BeforeAll
     void setup() {
         clear();
@@ -63,10 +83,15 @@ public class BenefitApiTest extends AcceptanceTest {
         서비스_증정 = benefitCategoryFixture.서비스_증정();
         가게까지_픽업 = benefitCategoryFixture.가게까지_픽업();
 
-        마슬랜 = shopFixture.마슬랜(현수_사장님);
-        김밥천국 = shopFixture.김밥천국(현수_사장님);
+        마슬랜 = shopFixture.마슬랜(현수_사장님, shopCategory_치킨);
+        김밥천국 = shopFixture.김밥천국(현수_사장님, shopCategory_일반);
         영업중인_티바 = shopFixture.영업중인_티바(현수_사장님);
         영업중이_아닌_신전_떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(현수_사장님);
+
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
+        shopCategory_일반 = shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
 
         성빈_학생 = userFixture.성빈_학생();
 

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -103,7 +103,7 @@ class OwnerApiTest extends AcceptanceTest {
     void 로그인된_사장님_정보를_조회한다() throws Exception {
         // given
         Owner owner = userFixture.현수_사장님();
-        Shop shop = shopFixture.마슬랜(owner);
+        Shop shop = shopFixture.마슬랜(owner, null);
         String token = userFixture.getToken(owner.getUser());
 
         mockMvc.perform(
@@ -370,7 +370,7 @@ class OwnerApiTest extends AcceptanceTest {
         @Test
         void 사장님이_회원가입_요청을_한다_기존에_존재하는_상점과_함께_회원가입() throws Exception {
             // given
-            Shop shop = shopFixture.마슬랜(null);
+            Shop shop = shopFixture.마슬랜(null, null);
             mockMvc.perform(
                     post("/owners/register")
                         .content(String.format("""

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerShopApiTest.java
@@ -100,12 +100,12 @@ class OwnerShopApiTest extends AcceptanceTest {
     private Owner owner_준영;
     private String token_준영;
     private Shop shop_마슬랜;
+    private ShopNotificationMessage notificationMessage_가게;
+    private ShopParentCategory shopParentCategory_가게;
     private ShopCategory shopCategory_치킨;
     private ShopCategory shopCategory_일반;
     private MenuCategory menuCategory_메인;
     private MenuCategory menuCategory_사이드;
-    private ShopParentCategory shopParentCategory_가게;
-    private ShopNotificationMessage notificationMessage_가게;
 
     @BeforeAll
     void setUp() {
@@ -114,13 +114,13 @@ class OwnerShopApiTest extends AcceptanceTest {
         token_현수 = userFixture.getToken(owner_현수.getUser());
         owner_준영 = userFixture.준영_사장님();
         token_준영 = userFixture.getToken(owner_준영.getUser());
-        shop_마슬랜 = shopFixture.마슬랜(owner_현수);
-        menuCategory_메인 = menuCategoryFixture.메인메뉴(shop_마슬랜);
-        menuCategory_사이드 = menuCategoryFixture.사이드메뉴(shop_마슬랜);
         notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
         shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
         shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
         shopCategory_일반 = shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
+        shop_마슬랜 = shopFixture.마슬랜(owner_현수, shopCategory_치킨);
+        menuCategory_메인 = menuCategoryFixture.메인메뉴(shop_마슬랜);
+        menuCategory_사이드 = menuCategoryFixture.사이드메뉴(shop_마슬랜);
     }
 
     @Test
@@ -162,6 +162,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                     .content(String.format("""
                         {
                             "address": "대전광역시 유성구 대학로 291",
+                            "main_category_id": 1,
                             "category_ids": [
                                 %d
                             ],
@@ -287,6 +288,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                      "pay_bank": true,
                      "pay_card": true,
                      "phone": "010-7574-1212",
+                     "main_category_id": 1,
                      "shop_categories": [
                      ],
                      "updated_at": "2024-01-15",
@@ -640,6 +642,7 @@ class OwnerShopApiTest extends AcceptanceTest {
                     .content(String.format("""
                             {
                               "address": "충청남도 천안시 동남구 병천면 충절로 1600",
+                              "main_category_id": 1,
                               "category_ids": [
                                %d, %d
                               ],
@@ -682,6 +685,7 @@ class OwnerShopApiTest extends AcceptanceTest {
             assertSoftly(
                 softly -> {
                     softly.assertThat(result.getAddress()).isEqualTo("충청남도 천안시 동남구 병천면 충절로 1600");
+                    softly.assertThat(result.getShopMainCategory().getId()).isEqualTo(1);
                     softly.assertThat(result.isDeleted()).isFalse();
                     softly.assertThat(result.getDeliveryPrice()).isEqualTo(1000);
                     softly.assertThat(result.getDescription()).isEqualTo("이번주 전 메뉴 10% 할인 이벤트합니다.");

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -20,6 +20,7 @@ import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.student.model.Student;
@@ -78,16 +79,18 @@ class ShopApiTest extends AcceptanceTest {
     private ShopParentCategory shopParentCategory_가게;
     private ShopNotificationMessage notificationMessage_가게;
 
+    private ShopCategory shopCategory_치킨;
+
     @BeforeAll
     void setUp() {
         clear();
         owner = userFixture.준영_사장님();
-        마슬랜 = shopFixture.마슬랜(owner);
         익명_학생 = userFixture.익명_학생();
         token_익명 = userFixture.getToken(익명_학생.getUser());
-
         notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
         shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
+        마슬랜 = shopFixture.마슬랜(owner, shopCategory_치킨);
     }
 
     @Test
@@ -198,7 +201,6 @@ class ShopApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk())
             .andExpect(content().json("""
-                            
                     {
                          "address": "천안시 동남구 병천면 1600",
                          "delivery": true,
@@ -420,7 +422,6 @@ class ShopApiTest extends AcceptanceTest {
     @Test
     void 상점들의_모든_카테고리를_조회한다() throws Exception {
         shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
-        shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
 
         mockMvc.perform(
                 get("/shops/categories")
@@ -432,14 +433,15 @@ class ShopApiTest extends AcceptanceTest {
                          "shop_categories": [
                              {
                                  "id": 1,
-                                 "image_url": "https://test-image.com/normal.jpg",
-                                 "name": "일반음식점"
+                                 "image_url": "https://test-image.com/ckicken.jpg",
+                                 "name": "치킨"
                              },
                              {
                                  "id": 2,
-                                 "image_url": "https://test-image.com/ckicken.jpg",
-                                 "name": "치킨"
-                             }
+                                 "image_url": "https://test-image.com/normal.jpg",
+                                 "name": "일반음식점"
+                             },
+                         
                          ]
                      }
                 """));

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -526,7 +526,7 @@ class ShopApiTest extends AcceptanceTest {
     void 이벤트_베너_조회() throws Exception {
         eventArticleFixture.참여_이벤트(마슬랜, LocalDate.now(clock), LocalDate.now(clock).plusDays(10));
         eventArticleFixture.할인_이벤트(마슬랜, LocalDate.now(clock).minusDays(10), LocalDate.now(clock).minusDays(1));
-
+        
         mockMvc.perform(
                 get("/shops/events")
             )
@@ -541,8 +541,7 @@ class ShopApiTest extends AcceptanceTest {
                             "title": "참여 이벤트",
                             "content": "사장님과 참여해요!!!",
                             "thumbnail_images": [
-                                "https://eventimage.com/참여_이벤트.jpg",
-                                "https://eventimage.com/참여_이벤트.jpg"
+                                "https://test-image.com/chicken-event.jpg"
                             ],
                             "start_date": "2024-01-15",
                             "end_date": "2024-01-25"

--- a/src/test/java/in/koreatech/koin/acceptance/ShopSearchApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopSearchApiTest.java
@@ -14,6 +14,9 @@ import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
 import in.koreatech.koin.domain.shop.model.menu.MenuSearchKeyWord;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.shop.repository.menu.MenuSearchKeywordRepository;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.EventArticleFixture;
@@ -21,6 +24,8 @@ import in.koreatech.koin.fixture.MenuCategoryFixture;
 import in.koreatech.koin.fixture.MenuFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.ShopReviewFixture;
 import in.koreatech.koin.fixture.ShopReviewReportFixture;
 import in.koreatech.koin.fixture.UserFixture;
@@ -30,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 
 @Transactional
 @SuppressWarnings("NonAsciiCharacters")
@@ -51,14 +57,31 @@ class ShopSearchApiTest extends AcceptanceTest {
     @Autowired
     private MenuSearchKeywordRepository menuSearchKeywordRepository;
 
+    @Autowired
+    private ShopCategoryFixture shopCategoryFixture;
+
+    @Autowired
+    private ShopNotificationMessageFixture shopNotificationMessageFixture;
+
+    @Autowired
+    private ShopParentCategoryFixture shopParentCategoryFixture;
+
     private Shop 마슬랜;
     private Owner owner;
+
+    private ShopCategory shopCategory_치킨;
+    private ShopCategory shopCategory_일반;
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
 
     @BeforeAll
     void setUp() {
         clear();
         owner = userFixture.준영_사장님();
-        마슬랜 = shopFixture.마슬랜(owner);
+        마슬랜 = shopFixture.마슬랜(owner, shopCategory_치킨);
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
         menuSearchKeywordRepository.save(MenuSearchKeyWord.builder()
                 .keyword("짜장면")
                 .build());

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminBenefitApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminBenefitApiTest.java
@@ -22,9 +22,15 @@ import in.koreatech.koin.domain.benefit.model.BenefitCategory;
 import in.koreatech.koin.domain.benefit.model.BenefitCategoryMap;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.fixture.BenefitCategoryFixture;
 import in.koreatech.koin.fixture.BenefitCategoryMapFixture;
+import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.UserFixture;
 
 @Transactional
@@ -49,6 +55,15 @@ public class AdminBenefitApiTest extends AcceptanceTest {
     @Autowired
     UserFixture userFixture;
 
+    @Autowired
+    ShopParentCategoryFixture shopParentCategoryFixture;
+
+    @Autowired
+    ShopCategoryFixture shopCategoryFixture;
+
+    @Autowired
+    ShopNotificationMessageFixture shopNotificationMessageFixture;
+
     Admin admin;
     String token_admin;
     Owner 현수_사장님;
@@ -63,6 +78,11 @@ public class AdminBenefitApiTest extends AcceptanceTest {
     Shop 영업중인_티바;
     Shop 영업중이_아닌_신전_떡볶이;
 
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
+    private ShopCategory shopCategory_치킨;
+    private ShopCategory shopCategory_일반;
+
     @BeforeAll
     void setup() {
         clear();
@@ -74,8 +94,8 @@ public class AdminBenefitApiTest extends AcceptanceTest {
         서비스_증정 = benefitCategoryFixture.서비스_증정();
         가게까지_픽업 = benefitCategoryFixture.가게까지_픽업();
 
-        마슬랜 = shopFixture.마슬랜(현수_사장님);
-        김밥천국 = shopFixture.김밥천국(현수_사장님);
+        마슬랜 = shopFixture.마슬랜(현수_사장님, shopCategory_치킨);
+        김밥천국 = shopFixture.김밥천국(현수_사장님, shopCategory_일반);
         영업중인_티바 = shopFixture.영업중인_티바(현수_사장님);
         영업중이_아닌_신전_떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(현수_사장님);
 
@@ -83,6 +103,10 @@ public class AdminBenefitApiTest extends AcceptanceTest {
         benefitCategoryMapFixture.혜택_추가(마슬랜, 배달비_무료);
         benefitCategoryMapFixture.혜택_추가(영업중인_티바, 배달비_무료);
         benefitCategoryMapFixture.혜택_추가(영업중이_아닌_신전_떡볶이, 배달비_무료);
+
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopApiTest.java
@@ -114,15 +114,15 @@ class AdminShopApiTest extends AcceptanceTest {
         token_admin = userFixture.getToken(admin.getUser());
         owner_현수 = userFixture.현수_사장님();
         owner_준영 = userFixture.준영_사장님();
-        shop_마슬랜 = shopFixture.마슬랜(owner_현수);
-        menuCategory_메인 = menuCategoryFixture.메인메뉴(shop_마슬랜);
-        menuCategory_사이드 = menuCategoryFixture.사이드메뉴(shop_마슬랜);
         notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
         notificationMessage_콜벤 = shopNotificationMessageFixture.알림메시지_콜벤();
         shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
         shopParentCategory_콜벤 = shopParentCategoryFixture.상위_카테고리_콜벤(notificationMessage_콜벤);
         shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
         shopCategory_일반 = shopCategoryFixture.카테고리_일반음식(shopParentCategory_콜벤);
+        shop_마슬랜 = shopFixture.마슬랜(owner_현수, shopCategory_치킨);
+        menuCategory_메인 = menuCategoryFixture.메인메뉴(shop_마슬랜);
+        menuCategory_사이드 = menuCategoryFixture.사이드메뉴(shop_마슬랜);
     }
 
     @Test
@@ -210,6 +210,7 @@ class AdminShopApiTest extends AcceptanceTest {
                      "shop_categories": [
                        
                      ],
+                     "main_category_id": 1,
                      "updated_at": "2024-01-15",
                      "is_deleted": false,
                      "is_event": false,
@@ -403,6 +404,7 @@ class AdminShopApiTest extends AcceptanceTest {
                     .content(String.format("""
                         {
                             "address": "대전광역시 유성구 대학로 291",
+                            "main_category_id": 1,
                             "category_ids": [
                                 %d
                             ],
@@ -647,6 +649,7 @@ class AdminShopApiTest extends AcceptanceTest {
                     .content(String.format("""
                         {
                           "address": "충청남도 천안시 동남구 병천면 충절로 1600",
+                          "main_category_id": 2,
                           "category_ids": [
                            %d, %d
                           ],
@@ -717,6 +720,7 @@ class AdminShopApiTest extends AcceptanceTest {
 
             assertSoftly(softly -> {
                 softly.assertThat(result.getAddress()).isEqualTo("충청남도 천안시 동남구 병천면 충절로 1600");
+                softly.assertThat(result.getShopMainCategory().getId()).isEqualTo(2);
                 softly.assertThat(result.isDeleted()).isFalse();
                 softly.assertThat(result.getDeliveryPrice()).isEqualTo(1000);
                 softly.assertThat(result.getDescription()).isEqualTo("이번주 전 메뉴 10% 할인 이벤트합니다.");

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopReviewApiTest.java
@@ -24,8 +24,14 @@ import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin.domain.shop.model.review.ShopReviewReport;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
+import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
+import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
+import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
+import in.koreatech.koin.fixture.ShopParentCategoryFixture;
 import in.koreatech.koin.fixture.ShopReviewFixture;
 import in.koreatech.koin.fixture.ShopReviewReportFixture;
 import in.koreatech.koin.fixture.UserFixture;
@@ -51,6 +57,15 @@ class AdminShopReviewApiTest extends AcceptanceTest {
     private ShopFixture shopFixture;
 
     @Autowired
+    private ShopNotificationMessageFixture shopNotificationMessageFixture;
+
+    @Autowired
+    private ShopParentCategoryFixture shopParentCategoryFixture;
+
+    @Autowired
+    private ShopCategoryFixture shopCategoryFixture;
+
+    @Autowired
     private AdminShopReviewRepository adminShopReviewRepository;
 
     private Admin admin;
@@ -59,6 +74,9 @@ class AdminShopReviewApiTest extends AcceptanceTest {
     private ShopReview 준호_리뷰;
     private Shop shop_마슬랜;
     private String token_admin;
+    private ShopCategory shopCategory_치킨;
+    private ShopParentCategory shopParentCategory_가게;
+    private ShopNotificationMessage notificationMessage_가게;
 
     @BeforeAll
     void setUp() {
@@ -67,8 +85,11 @@ class AdminShopReviewApiTest extends AcceptanceTest {
         student_익명 = userFixture.익명_학생();
         token_admin = userFixture.getToken(admin.getUser());
         owner_현수 = userFixture.현수_사장님();
-        shop_마슬랜 = shopFixture.마슬랜(owner_현수);
+        shop_마슬랜 = shopFixture.마슬랜(owner_현수, shopCategory_치킨);
         준호_리뷰 = shopReviewFixture.리뷰_4점(student_익명, shop_마슬랜);
+        notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
+        shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);
+        shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -316,7 +316,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     @Test
     void 관리자가_사장님_권한_요청을_허용한다() throws Exception {
         Owner owner = userFixture.철수_사장님();
-        Shop shop = shopFixture.마슬랜(null);
+        Shop shop = shopFixture.마슬랜(null, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -447,7 +447,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     @Test
     void 관리자가_특정_사장을_조회한다() throws Exception {
         Owner owner = userFixture.현수_사장님();
-        Shop shop = shopFixture.마슬랜(owner);
+        Shop shop = shopFixture.마슬랜(owner, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -485,7 +485,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     @Test
     void 관리자가_특정_사장을_수정한다() throws Exception {
         Owner owner = userFixture.현수_사장님();
-        Shop shop = shopFixture.마슬랜(owner);
+        Shop shop = shopFixture.마슬랜(owner, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -520,7 +520,7 @@ public class AdminUserApiTest extends AcceptanceTest {
     @Test
     void 관리자가_가입_신청한_사장님_리스트_조회한다() throws Exception {
         Owner owner = userFixture.철수_사장님();
-        Shop shop = shopFixture.마슬랜(null);
+        Shop shop = shopFixture.마슬랜(null, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());

--- a/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
@@ -22,7 +22,7 @@ public class ShopCategoryFixture {
                 .name("치킨")
                 .imageUrl("https://test-image.com/ckicken.jpg")
                 .parentCategory(parentCategory)
-                .eventImageUrl("https://test-image.com/chicken-event.jpg")
+                .eventBannerImageUrl("https://test-image.com/chicken-event.jpg")
                 .build()
         );
     }
@@ -33,7 +33,7 @@ public class ShopCategoryFixture {
                 .name("일반음식점")
                 .imageUrl("https://test-image.com/normal.jpg")
                 .parentCategory(parentCategory)
-                .eventImageUrl("https://test-image.com/normal-event.jpg")
+                .eventBannerImageUrl("https://test-image.com/normal-event.jpg")
                 .build()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopCategoryFixture.java
@@ -22,6 +22,7 @@ public class ShopCategoryFixture {
                 .name("치킨")
                 .imageUrl("https://test-image.com/ckicken.jpg")
                 .parentCategory(parentCategory)
+                .eventImageUrl("https://test-image.com/chicken-event.jpg")
                 .build()
         );
     }
@@ -32,6 +33,7 @@ public class ShopCategoryFixture {
                 .name("일반음식점")
                 .imageUrl("https://test-image.com/normal.jpg")
                 .parentCategory(parentCategory)
+                .eventImageUrl("https://test-image.com/normal-event.jpg")
                 .build()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/ShopFixture.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategoryMap;
 import in.koreatech.koin.domain.shop.model.shop.ShopImage;
 import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
@@ -24,10 +25,11 @@ public final class ShopFixture {
         this.shopRepository = shopRepository;
     }
 
-    public Shop 김밥천국(Owner owner) {
+    public Shop 김밥천국(Owner owner, ShopCategory shopMainCategory) {
         var shop = shopRepository.save(
             Shop.builder()
                 .owner(owner)
+                .shopMainCategory(shopMainCategory)
                 .name("김밥천국")
                 .internalName("김천")
                 .chosung("김")
@@ -79,10 +81,11 @@ public final class ShopFixture {
         return shopRepository.save(shop);
     }
 
-    public Shop 마슬랜(Owner owner) {
+    public Shop 마슬랜(Owner owner, ShopCategory shopMainCategory) {
         var shop = shopRepository.save(
             Shop.builder()
                 .owner(owner)
+                .shopMainCategory(shopMainCategory)
                 .name("마슬랜 치킨")
                 .internalName("마슬랜")
                 .chosung("마")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1005

# 🚀 작업 내용
- 어드민과 사장님 상점에서 생성, 수정시 메인 카테고리를 선택할 수 있는 기능 추가
1. shops테이블에 메인 카테고리를 관리하기 위한 main_category_id 필드 추가
2. 어드민, 사장님 상점 생성, 수정 DTO에  mainCategoryId 필드 추가
3. 카테고리 테이블에 배너 이미지를 관리하기 위한 필드 추가
4. 관련 테스트코드 수정

# 💬 리뷰 중점사항
- 외래키 관계로 인해 테스트 코드 작성 시 많은 변화가 필요해서 리팩토링 기간에 외래키 작성에 대해 고민해보아야 할 것 같습니다
