### PR TITLE
feat: 로그인 어드민 계정 정보 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserApi.java
@@ -152,6 +152,20 @@ public interface AdminUserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
+    @Operation(summary = "로그인 어드민 계정 정보 조회")
+    @GetMapping("/admin")
+    ResponseEntity<AdminResponse> getLoginAdminInfo(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
     @Operation(summary = "어드민 계정 정보 조회")
     @GetMapping("/admin/{id}")
     ResponseEntity<AdminResponse> getAdmin(

--- a/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
+++ b/src/main/java/in/koreatech/koin/admin/user/controller/AdminUserController.java
@@ -118,6 +118,14 @@ public class AdminUserController implements AdminUserApi{
             .body(tokenGroupResponse);
     }
 
+    @GetMapping("/admin")
+    public ResponseEntity<AdminResponse> getLoginAdminInfo(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        AdminResponse adminResponse = adminUserService.getAdmin(adminId);
+        return ResponseEntity.ok(adminResponse);
+    }
+
     @GetMapping("/admin/{id}")
     public ResponseEntity<AdminResponse> getAdmin(
         @PathVariable("id") Integer id,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1016 

# 🚀 작업 내용

1. 클라이언트 요청이 들어와서 어드민 본인의 정보를 조회하는 API를 추가했습니다.

# 💬 리뷰 중점사항
