### PR TITLE
fix: v2/shops API에서 ShopCategories ID가 잘못 반환되는 에러 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/cache/dto/ShopCategoryCache.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/cache/dto/ShopCategoryCache.java
@@ -10,7 +10,7 @@ public record ShopCategoryCache(
 
     public static ShopCategoryCache from(ShopCategoryMap shopCategoryMap) {
         return new ShopCategoryCache(
-                shopCategoryMap.getId(),
+                shopCategoryMap.getShopCategory().getId(),
                 shopCategoryMap.getShopCategory().getName(),
                 shopCategoryMap.getShopCategory().getImageUrl()
         );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1018 

# 🚀 작업 내용

1. shopCategories ID대신 ShopcategoryMap ID가 반환되는 에러 수정

# 💬 리뷰 중점사항
