### PR TITLE
chore: event_articles 테이블 및 엔티티의 미사용 컬럼 삭제

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/model/article/EventArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/article/EventArticle.java
@@ -54,15 +54,6 @@ public class EventArticle extends BaseEntity {
     @OneToMany(mappedBy = "eventArticle", orphanRemoval = true, cascade = ALL)
     private List<EventArticleImage> thumbnailImages = new ArrayList<>();
 
-    /**
-     * 미사용 컬럼
-     * TODO: 마이그레이션 종료 후 flyway로 제거
-     */
-    @Size(max = 50)
-    @NotNull
-    @Column(name = "event_title", nullable = false)
-    private String eventTitle = "";
-
     @NotNull
     @Column(name = "content", nullable = false)
     private String content;
@@ -70,23 +61,6 @@ public class EventArticle extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
-    /**
-     * 미사용 컬럼
-     * TODO: 마이그레이션 종료 후 flyway로 제거
-     */
-    @Size(max = 50)
-    @NotNull
-    @Column(name = "nickname", nullable = false)
-    private String nickname = "";
-
-    /**
-     * 미사용 컬럼
-     * TODO: 마이그레이션 종료 후 flyway로 제거
-     */
-    @Size(max = 255)
-    @Column(name = "thumbnail")
-    private String thumbnail;
 
     @NotNull
     @Column(name = "hit", nullable = false)
@@ -104,14 +78,6 @@ public class EventArticle extends BaseEntity {
     @NotNull
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
-
-    /**
-     * 미사용 컬럼
-     * TODO: 마이그레이션 종료 후 flyway로 제거
-     */
-    @NotNull
-    @Column(name = "comment_count", nullable = false)
-    private boolean commentCount = false;
 
     @NotNull
     @Column(name = "is_deleted", nullable = false)

--- a/src/main/resources/db/migration/V99__alter_event_articles_drop_unused_column.sql
+++ b/src/main/resources/db/migration/V99__alter_event_articles_drop_unused_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE event_articles
+DROP COLUMN event_title,
+DROP COLUMN nickname,
+DROP COLUMN thumbnail,
+DROP COLUMN comment_count;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1043

# 🚀 작업 내용

1. event_articles 테이블 및 엔티티에 남아있던 미사용 컬럼을 제거하였습니다.

# 💬 리뷰 중점사항
- 