### PR TITLE
fix: timetableLecture DTO swagger 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -122,7 +122,11 @@ public interface TimetableApiV2 {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
         }
     )
-    @Operation(summary = "시간표에 강의 정보 추가")
+    @Operation(summary = "시간표에 강의 정보 추가",
+        description = """
+            lecture_id가 있는 경우 class_title, class_time, professor은 null, grades는 '0'으로 입력해야합니다.\n
+            lecture_id가 없는 경우 class_title, class_time, professor, grades을 선택적으로 입력합니다.
+            """)
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/timetables/lecture")
     ResponseEntity<TimetableLectureResponse> createTimetableLecture(

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureCreateRequest.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableLectureCreateRequest(
-    @Schema(description = "시간표 프레임 id", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "시간표 프레임 id", example = "1213", requiredMode = REQUIRED)
     Integer timetableFrameId,
 
     @Valid
@@ -28,30 +28,30 @@ public record TimetableLectureCreateRequest(
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerTimeTableLectureRequest(
-        @Schema(description = "강의 이름", example = "기상분석", requiredMode = REQUIRED)
+        @Schema(description = "강의 이름", example = "null", requiredMode = NOT_REQUIRED)
         @Size(max = 100, message = "강의 이름의 최대 글자는 100글자입니다.")
         String classTitle,
 
-        @Schema(description = "강의 시간", example = "[210, 211]", requiredMode = REQUIRED)
+        @Schema(description = "강의 시간", example = "null", requiredMode = NOT_REQUIRED)
         List<Integer> classTime,
 
         @Schema(description = "강의 장소", example = "도서관", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
-        @Schema(description = "교수명", example = "이강환", requiredMode = NOT_REQUIRED)
+        @Schema(description = "교수명", example = "null", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 
-        @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
-        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다.")
+        @Schema(description = "학점", example = "0", requiredMode = REQUIRED)
+        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다. (0~9)")
         String grades,
 
         @Schema(description = "메모", example = "메모메모", requiredMode = NOT_REQUIRED)
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo,
 
-        @Schema(description = "강의 고유 번호", example = "1", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 고유 번호", example = "14", requiredMode = NOT_REQUIRED)
         Integer lectureId
     ) {
         public InnerTimeTableLectureRequest {

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
@@ -32,7 +32,7 @@ public record TimetableLectureUpdateRequest(
         @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
         Integer lectureId,
 
-        @Schema(description = "강의 이름", example = "운영체제", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 이름", example = "null", requiredMode = NOT_REQUIRED)
         @Size(max = 100, message = "강의 이름의 최대 글자는 100글자입니다.")
         String classTitle,
 
@@ -44,12 +44,12 @@ public record TimetableLectureUpdateRequest(
         @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
-        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "null", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 
-        @Schema(description = "학점", example = "3", requiredMode = NOT_REQUIRED)
-        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다.")
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
+        @Size(max = 2, message = "학점은 두 글자 이상일 수 없습니다. (0-9)")
         String grades,
 
         @Schema(description = "memo", example = "메모메모", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/TimetableLectureUpdateRequest.java
@@ -32,7 +32,7 @@ public record TimetableLectureUpdateRequest(
         @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
         Integer lectureId,
 
-        @Schema(description = "강의 이름", example = "null", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 이름", example = "운영체제", requiredMode = NOT_REQUIRED)
         @Size(max = 100, message = "강의 이름의 최대 글자는 100글자입니다.")
         String classTitle,
 
@@ -44,7 +44,7 @@ public record TimetableLectureUpdateRequest(
         @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
         String classPlace,
 
-        @Schema(description = "강의 교수", example = "null", requiredMode = NOT_REQUIRED)
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
         @Size(max = 30, message = "교수 명의 최대 글자는 30글자입니다.")
         String professor,
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1024

# 🚀 작업 내용

1. 클라이언트들이 정규강의에 대해서 기본적으로 보내야 할 값의 예시를 수정하였습니다.

# 💬 리뷰 중점사항
