### PR TITLE
fix: 키워드 알림 메시지에서 중괄호 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
@@ -90,6 +90,6 @@ public class ArticleKeywordEventListener {
     }
 
     private String generateDescription(String keyword) {
-        return "방금 등록된 {%s} 공지를 확인해보세요!".formatted(keyword);
+        return "방금 등록된 %s 공지를 확인해보세요!".formatted(keyword);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 키워드 알림 메시지에서 중괄호를 제거했습니다.

# 💬 리뷰 중점사항
