### PR TITLE
feat: Objectoptimisticlockingfailureexception 핸들러 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -196,7 +196,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         log.warn(e.getMessage());
         requestLogging(((ServletWebRequest)request).getRequest());
-        return buildErrorResponse(HttpStatus.CONFLICT, e.getMessage());
+        return buildErrorResponse(HttpStatus.CONFLICT, "이미 처리된 요청입니다.");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -196,7 +196,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ) {
         log.warn(e.getMessage());
         requestLogging(((ServletWebRequest)request).getRequest());
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        return buildErrorResponse(HttpStatus.CONFLICT, e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -186,6 +187,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("유효하지 않은 API 경로입니다. " + e.getRequestURL());
         requestLogging(((ServletWebRequest)request).getRequest());
         return buildErrorResponse(HttpStatus.NOT_FOUND, "유효하지 않은 API 경로입니다.");
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<Object> handleOptimisticLockException(
+        HttpServletRequest request,
+        ObjectOptimisticLockingFailureException e
+    ) {
+        log.warn(e.getMessage());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1039 

# 🚀 작업 내용

- Objectoptimisticlockingfailureexception 예외 핸들러를 추가했습니다.

# 💬 리뷰 중점사항
![스크린샷 2024-11-23 140420](https://github.com/user-attachments/assets/e85d0af9-5e27-4819-9450-886c1ba82642)
![스크린샷 2024-11-23 133225](https://github.com/user-attachments/assets/b70ab762-9ffa-44f3-96f1-003acad41034)

한 주간 발생한 `Objectoptimisticlockingfailureexception` 예외는 `StaleObjectStateException`라는 예외를 매핑한 예외임을 확인했습니다. `Objectoptimisticlockingfailureexception` 예외는 낙관적 락 충돌 시 JPA 발생하는 예외, `StaleObjectStateException`는 하이버네이트에서 발생하는 예외라고 합니다.

코인에서는 `@Version` 혹은 `@Lock` 어노테이션을 통해 낙관적 락을 설정하는 부분이 잘 보이지 않았습니다. 관련해서 찾아보니 `StaleObjectStateException` 예외는 `존재하지 않는 행을 삭제하거나 업데이트하려고 시도하는 경우에도 발생합니다.`라고 합니다. [문서](https://docs.jboss.org/hibernate/orm/6.5/javadocs/org/hibernate/StaleStateException.html)

해당 예외를 처리하는 방법에는 재시도 로직, 에러로 처리하는 방법 그리고 네이티브 쿼리로 처리하는 방법이 있다고 합니다. 
[참고 자료](https://www.inflearn.com/community/questions/266817/objectoptimisticlockingfailureexception?srsltid=AfmBOopbxlCajpHH0I3S9bIzBeyiX2ToeIgA0w7Cfl79pgKvKKyTlfZI)

`현재 코인에서 재시도 로직을 넣을 만큼 크리티컬한가?`라는 의문에는 `아니다`라고 생각을 했습니다. 재시도 로직이 필요하면, 해당 로직에 비관적 락 혹은 분산 락을 도입하는 방법이 더 낫다고 생각했기 때문입니다. 또한, 코인에서는 현재 사용자가 사용자의 데이터에 대한 수정 및 삭제가 주로 이뤄지기 때문에 큰 문제가 없다고 생각했습니다. 

관련해서 의견 주시면 감사하겠습니다.