### PR TITLE
refactor: User, Student 패키지 리팩토링

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/student/service/AdminStudentService.java
+++ b/src/main/java/in/koreatech/koin/admin/student/service/AdminStudentService.java
@@ -54,8 +54,8 @@ public class AdminStudentService {
         validateDepartmentValid(adminRequest.major());
         user.update(adminRequest.nickname(), adminRequest.name(),
             adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
-        user.updateStudentPassword(passwordEncoder, adminRequest.password());
-        student.update(adminRequest.studentNumber(), adminRequest.major());
+        user.updatePassword(passwordEncoder, adminRequest.password());
+        student.updateInfo(adminRequest.studentNumber(), adminRequest.major());
         adminStudentRepository.save(student);
 
         return AdminStudentUpdateResponse.from(student);

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -38,7 +38,7 @@ public interface StudentApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "회원 정보 조회")
+    @Operation(summary = "학생 정보 조회")
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/user/student/me")
     ResponseEntity<StudentResponse> getStudent(
@@ -54,7 +54,7 @@ public interface StudentApi {
             @ApiResponse(responseCode = "409", content = @Content(schema = @Schema(hidden = true)))
         }
     )
-    @Operation(summary = "회원 정보 수정")
+    @Operation(summary = "학생 정보 수정")
     @SecurityRequirement(name = "Jwt Authentication")
     @PutMapping("/user/student/me")
     ResponseEntity<StudentUpdateResponse> updateStudent(

--- a/src/main/java/in/koreatech/koin/domain/student/dto/StudentLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/StudentLoginRequest.java
@@ -1,10 +1,14 @@
 package in.koreatech.koin.domain.student.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record StudentLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")

--- a/src/main/java/in/koreatech/koin/domain/student/dto/StudentLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/StudentLoginResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+// SnakeCase X
 public record StudentLoginResponse(
     @Schema(
         description = "Jwt accessToken",

--- a/src/main/java/in/koreatech/koin/domain/student/model/Student.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/Student.java
@@ -66,12 +66,8 @@ public class Student {
         this.user = user;
     }
 
-    public void update(String studentNumber, String department) {
+    public void updateInfo(String studentNumber, String department) {
         this.studentNumber = studentNumber;
         this.department = department;
-    }
-
-    public static Integer parseStudentNumberYear(String studentNumber) {
-        return Integer.parseInt(studentNumber.substring(0, 4));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -1,150 +1,63 @@
 package in.koreatech.koin.domain.student.service;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.UUID;
 
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.student.model.StudentEmailRequestEvent;
+import in.koreatech.koin.domain.student.model.StudentRegisterEvent;
+import in.koreatech.koin.domain.user.dto.UserPasswordChangeRequest;
+import in.koreatech.koin.domain.user.model.*;
+import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
+import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.ModelAndView;
+import in.koreatech.koin.domain.user.dto.AuthTokenRequest;
+import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
 import in.koreatech.koin.domain.student.dto.StudentLoginRequest;
 import in.koreatech.koin.domain.student.dto.StudentLoginResponse;
 import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.student.dto.StudentResponse;
 import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
 import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
-import in.koreatech.koin.domain.student.exception.StudentDepartmentNotValidException;
-import in.koreatech.koin.domain.student.exception.StudentNumberNotValidException;
-import in.koreatech.koin.domain.student.model.Student;
-import in.koreatech.koin.domain.student.model.StudentDepartment;
-import in.koreatech.koin.domain.student.model.StudentEmailRequestEvent;
-import in.koreatech.koin.domain.student.model.StudentRegisterEvent;
-import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
-import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
-import in.koreatech.koin.domain.student.repository.StudentRepository;
-import in.koreatech.koin.domain.user.dto.AuthTokenRequest;
-import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
-import in.koreatech.koin.domain.user.dto.UserPasswordChangeRequest;
 import in.koreatech.koin.domain.user.dto.UserPasswordChangeSubmitRequest;
-import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
-import in.koreatech.koin.domain.user.model.User;
-import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
-import in.koreatech.koin.global.auth.JwtProvider;
-import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import in.koreatech.koin.domain.user.service.UserService;
+import in.koreatech.koin.domain.user.service.UserTokenService;
+import in.koreatech.koin.domain.user.service.UserValidationService;
 import in.koreatech.koin.global.concurrent.ConcurrencyGuard;
-import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
 import in.koreatech.koin.global.domain.email.form.StudentPasswordChangeData;
 import in.koreatech.koin.global.domain.email.form.StudentRegistrationData;
-import in.koreatech.koin.global.domain.email.model.EmailAddress;
 import in.koreatech.koin.global.domain.email.service.MailService;
-import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
-import java.time.Clock;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.joda.time.LocalDateTime;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.ModelAndView;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StudentService {
 
+    private final MailService mailService;
+    private final UserService userService;
+    private final UserValidationService userValidationService;
+    private final StudentValidationService studentValidationService;
+    private final UserRepository userRepository;
+    private final UserTokenService userTokenService;
+    private final UserTokenRepository userTokenRepository;
     private final StudentRepository studentRepository;
     private final StudentRedisRepository studentRedisRepository;
-    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final MailService mailService;
     private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
-    private final UserTokenRepository userTokenRepository;
-    private final JwtProvider jwtProvider;
-
-    public StudentResponse getStudent(Integer userId) {
-        Student student = studentRepository.getById(userId);
-        return StudentResponse.from(student);
-    }
-
-    @Transactional
-    public StudentLoginResponse studentLogin(StudentLoginRequest request) {
-        User user = userRepository.getByEmail(request.email());
-        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findById(request.email());
-
-        if (!user.isSamePassword(passwordEncoder, request.password())) {
-            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
-        }
-
-        if (studentTemporaryStatus.isPresent()) {
-            throw new AuthorizationException("미인증 상태입니다. 아우누리에서 인증메일을 확인해주세요");
-        }
-
-        String accessToken = jwtProvider.createToken(user);
-        String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
-        UserToken savedToken = userTokenRepository.save(UserToken.create(user.getId(), refreshToken));
-        user.updateLastLoggedTime(java.time.LocalDateTime.now());
-
-        return StudentLoginResponse.of(accessToken, savedToken.getRefreshToken());
-    }
-
-    @Transactional
-    public StudentUpdateResponse updateStudent(Integer userId, StudentUpdateRequest request) {
-        Student student = studentRepository.getById(userId);
-        User user = student.getUser();
-        checkNicknameDuplication(request.nickname(), userId);
-        checkDepartmentValid(request.major());
-        updateUserDetails(user, request);
-        user.updateStudentPassword(passwordEncoder, request.password());
-        student.update(request.studentNumber(), request.major());
-        studentRepository.save(student);
-        return StudentUpdateResponse.from(student);
-    }
-
-    private void updateUserDetails(User user, StudentUpdateRequest request) {
-        user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());
-    }
-
-    public void checkNicknameDuplication(String nickname, Integer userId) {
-        User checkUser = userRepository.getById(userId);
-        if (nickname != null && !nickname.equals(checkUser.getNickname())
-            && userRepository.existsByNickname(nickname)) {
-            throw DuplicationNicknameException.withDetail("nickname : " + nickname);
-        }
-    }
-
-    public void checkDepartmentValid(String department) {
-        if (department != null && !StudentDepartment.isValid(department)) {
-            throw StudentDepartmentNotValidException.withDetail("학부(학과) : " + department);
-        }
-    }
-
-    @Transactional
-    public ModelAndView authenticate(AuthTokenRequest request) {
-        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findByAuthToken(request.authToken());
-
-        if (studentTemporaryStatus.isEmpty()) {
-            ModelAndView modelAndView = new ModelAndView("error_config");
-            modelAndView.addObject("errorMessage", "토큰이 유효하지 않습니다.");
-            return modelAndView;
-        }
-
-        Student student = studentTemporaryStatus.get().toStudent(passwordEncoder);
-        saveStudentDataAndPublishEvent(student);
-
-        studentRedisRepository.deleteById(student.getUser().getEmail());
-
-        return new ModelAndView("success_register_config");
-    }
-
-    @ConcurrencyGuard(lockName = "studentAuthenticate")
-    private void saveStudentDataAndPublishEvent(Student student) {
-        studentRepository.save(student);
-        userRepository.save(student.getUser());
-        eventPublisher.publishEvent(new StudentRegisterEvent(student.getUser().getEmail()));
-    }
 
     @Transactional
     public void studentRegister(StudentRegisterRequest request, String serverURL) {
-
-        validateStudentRegister(request);
+        studentValidationService.validateStudentRegister(request);
         String authToken = UUID.randomUUID().toString();
 
         StudentTemporaryStatus studentTemporaryStatus = StudentTemporaryStatus.of(request, authToken);
@@ -154,46 +67,49 @@ public class StudentService {
         eventPublisher.publishEvent(new StudentEmailRequestEvent(request.email()));
     }
 
-    private void validateStudentRegister(StudentRegisterRequest request) {
-        EmailAddress emailAddress = EmailAddress.from(request.email());
-        emailAddress.validateKoreatechEmail();
+    @Transactional
+    public StudentLoginResponse studentLogin(StudentLoginRequest request) {
+        User user = userValidationService.checkLoginCredentials(request.email(), request.password());
+        userValidationService.checkUserAuthentication(request.email());
 
-        validateDataExist(request);
-        validateStudentNumber(request.studentNumber());
-        checkDepartmentValid(request.major());
+        String accessToken = userTokenService.createAccessToken(user);
+        String refreshToken = userTokenService.generateRefreshToken(user);
+        UserToken savedToken = userTokenRepository.save(UserToken.create(user.getId(), refreshToken));
+        userService.updateLastLoginTime(user);
+
+        return StudentLoginResponse.of(accessToken, savedToken.getRefreshToken());
     }
 
-    private void validateDataExist(StudentRegisterRequest request) {
-        userRepository.findByEmail(request.email())
-            .ifPresent(user -> {
-                throw DuplicationEmailException.withDetail("account: " + request.email());
-            });
-        studentRedisRepository.findById(request.email())
-            .ifPresent(studentTemporaryStatus -> {
-                throw DuplicationEmailException.withDetail("account: " + request.email());
-            });
+    @Transactional
+    public StudentUpdateResponse updateStudent(Integer userId, StudentUpdateRequest request) {
+        studentValidationService.validateUpdateNickname(request.nickname(), userId);
+        studentValidationService.validateDepartment(request.major());
 
-        if (request.nickname() != null) {
-            userRepository.findByNickname(request.nickname())
-                .ifPresent(user -> {
-                    throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
-                });
-            studentRedisRepository.findByNickname(request.nickname())
-                .ifPresent(studentTemporaryStatus -> {
-                    throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
-                });
-        }
+        Student student = studentRepository.getById(userId);
+        User user = student.getUser();
+
+        user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());
+        user.updatePassword(passwordEncoder, request.password());
+        student.updateInfo(request.studentNumber(), request.major());
+
+        return StudentUpdateResponse.from(student);
     }
 
-    private void validateStudentNumber(String studentNumber) {
-        if (studentNumber == null) {
-            return;
+    @ConcurrencyGuard(lockName = "studentAuthenticate")
+    public ModelAndView authenticate(AuthTokenRequest request) {
+        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findByAuthToken(
+            request.authToken());
+        if (studentTemporaryStatus.isEmpty()) {
+            ModelAndView modelAndView = new ModelAndView("error_config");
+            modelAndView.addObject("errorMessage", "토큰이 유효하지 않습니다.");
+            return modelAndView;
         }
-        int studentNumberYear = Student.parseStudentNumberYear(studentNumber);
-        if (studentNumberYear < 1992
-            || LocalDateTime.now().getYear() < studentNumberYear) {
-            throw StudentNumberNotValidException.withDetail("studentNumber: " + studentNumber);
-        }
+        Student student = studentTemporaryStatus.get().toStudent(passwordEncoder);
+        studentRepository.save(student);
+        userRepository.save(student.getUser());
+        studentRedisRepository.deleteById(student.getUser().getEmail());
+        eventPublisher.publishEvent(new StudentRegisterEvent(student.getUser().getEmail()));
+        return new ModelAndView("success_register_config");
     }
 
     @Transactional
@@ -204,18 +120,16 @@ public class StudentService {
         mailService.sendMail(request.email(), new StudentPasswordChangeData(serverURL, authedUser.getResetToken()));
     }
 
-    public ModelAndView checkResetToken(String resetToken, String serverUrl) {
-        ModelAndView modelAndView = new ModelAndView("change_password_config");
-        modelAndView.addObject("contextPath", serverUrl);
-        modelAndView.addObject("resetToken", resetToken);
-        return modelAndView;
+    public StudentResponse getStudent(Integer userId) {
+        Student student = studentRepository.getById(userId);
+        return StudentResponse.from(student);
     }
 
     @Transactional
     public void changePassword(Integer userId, UserPasswordChangeRequest request) {
         Student student = studentRepository.getById(userId);
         User user = student.getUser();
-        user.updateStudentPassword(passwordEncoder, request.password());
+        user.updatePassword(passwordEncoder, request.password());
     }
 
     @Transactional
@@ -223,6 +137,12 @@ public class StudentService {
         User authedUser = userRepository.getByResetToken(resetToken);
         authedUser.validateResetToken();
         authedUser.updatePassword(passwordEncoder, request.password());
-        userRepository.save(authedUser);
+    }
+
+    public ModelAndView checkResetToken(String resetToken, String serverUrl) {
+        ModelAndView modelAndView = new ModelAndView("change_password_config");
+        modelAndView.addObject("contextPath", serverUrl);
+        modelAndView.addObject("resetToken", resetToken);
+        return modelAndView;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentValidationService.java
@@ -1,0 +1,91 @@
+package in.koreatech.koin.domain.student.service;
+
+import org.joda.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
+import in.koreatech.koin.domain.student.exception.StudentDepartmentNotValidException;
+import in.koreatech.koin.domain.student.exception.StudentNumberNotValidException;
+import in.koreatech.koin.domain.student.model.StudentDepartment;
+import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
+import in.koreatech.koin.domain.student.util.StudentUtil;
+import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
+import in.koreatech.koin.global.domain.email.model.EmailAddress;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StudentValidationService {
+
+    private final UserRepository userRepository;
+    private final StudentRedisRepository studentRedisRepository;
+
+    private static final int MIN_YEAR = 1992;
+
+    public void validateStudentRegister(StudentRegisterRequest request) {
+        EmailAddress emailAddress = EmailAddress.from(request.email());
+        emailAddress.validateKoreatechEmail();
+
+        validateDataExist(request);
+        validateStudentNumber(request.studentNumber());
+        validateDepartment(request.major());
+    }
+
+    public void validateUpdateNickname(String nickname, Integer userId) {
+        User checkUser = userRepository.getById(userId);
+        if (nickname != null && !nickname.equals(checkUser.getNickname())
+            && userRepository.existsByNickname(nickname)) {
+            throw DuplicationNicknameException.withDetail("nickname : " + nickname);
+        }
+    }
+
+    public void validateDepartment(String department) {
+        if (department != null && !StudentDepartment.isValid(department)) {
+            throw StudentDepartmentNotValidException.withDetail("학부(학과) : " + department);
+        }
+    }
+
+    public void validateDataExist(StudentRegisterRequest request) {
+        validateEmailExist(request.email());
+        validateNicknameExist(request.nickname());
+    }
+
+    public void validateEmailExist(String email) {
+        userRepository.findByEmail(email)
+            .ifPresent(user -> {
+                throw DuplicationEmailException.withDetail("email: " + email);
+            });
+        studentRedisRepository.findById(email)
+            .ifPresent(status -> {
+                throw DuplicationEmailException.withDetail("email: " + email);
+            });
+    }
+
+    public void validateNicknameExist(String nickname) {
+        if (nickname == null) {
+            return;
+        }
+        userRepository.findByNickname(nickname)
+            .ifPresent(user -> {
+                throw DuplicationNicknameException.withDetail("nickname: " + nickname);
+            });
+        studentRedisRepository.findByNickname(nickname)
+            .ifPresent(status -> {
+                throw DuplicationNicknameException.withDetail("nickname: " + nickname);
+            });
+    }
+
+    public void validateStudentNumber(String studentNumber) {
+        if (studentNumber == null) {
+            return;
+        }
+        int studentNumberYear = StudentUtil.parseStudentNumberYear(studentNumber);
+        if (studentNumberYear < MIN_YEAR
+            || LocalDateTime.now().getYear() < studentNumberYear) {
+            throw StudentNumberNotValidException.withDetail("studentNumber: " + studentNumber);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/student/util/StudentUtil.java
+++ b/src/main/java/in/koreatech/koin/domain/student/util/StudentUtil.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.domain.student.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class StudentUtil {
+
+    public static Integer parseStudentNumberYear(String studentNumber) {
+        return Integer.parseInt(studentNumber.substring(0, 4));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -4,12 +4,6 @@ import static in.koreatech.koin.domain.user.model.UserType.COOP;
 import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
-import in.koreatech.koin.domain.student.dto.StudentLoginRequest;
-import in.koreatech.koin.domain.student.dto.StudentLoginResponse;
-import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
-import in.koreatech.koin.domain.student.dto.StudentResponse;
-import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
-import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
 import in.koreatech.koin.domain.user.dto.*;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -17,11 +11,9 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin.global.auth.Auth;
-import in.koreatech.koin.global.host.ServerURL;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,21 +25,6 @@ import jakarta.validation.Valid;
 
 @Tag(name = "(Normal) User: 회원", description = "회원 관련 API")
 public interface UserApi {
-
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
-        }
-    )
-    @Operation(summary = "영양사 정보 조회")
-    @SecurityRequirement(name = "Jwt Authentication")
-    @GetMapping("/user/coop/me")
-    ResponseEntity<CoopResponse> getCoop(
-        @Auth(permit = COOP) Integer userId
-    );
 
     @ApiResponses(
         value = {
@@ -90,6 +67,21 @@ public interface UserApi {
     @PostMapping("/user/refresh")
     ResponseEntity<UserTokenRefreshResponse> refresh(
         @RequestBody @Valid UserTokenRefreshRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "사용자 권한 조회")
+    @GetMapping("/user/auth")
+    ResponseEntity<AuthResponse> getAuth(
+        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
     );
 
     @ApiResponses(
@@ -144,21 +136,6 @@ public interface UserApi {
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
-        }
-    )
-    @Operation(summary = "사용자 권한 조회")
-    @GetMapping("/user/auth")
-    ResponseEntity<AuthResponse> getAuth(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
-    );
-
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
         }
     )
     @Operation(summary = "비밀번호 검증")
@@ -181,5 +158,21 @@ public interface UserApi {
     ResponseEntity<Void> checkLogin(
             @ParameterObject @ModelAttribute(value = "access_token")
             @Valid UserAccessTokenRequest request
+    );
+
+    // 추후 이동
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "영양사 정보 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/user/coop/me")
+    ResponseEntity<CoopResponse> getCoop(
+        @Auth(permit = COOP) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -6,29 +6,20 @@ import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.net.URI;
 
-import in.koreatech.koin.domain.student.dto.StudentLoginRequest;
-import in.koreatech.koin.domain.student.dto.StudentLoginResponse;
-import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
-import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
-import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
 import in.koreatech.koin.domain.user.dto.*;
+
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.ModelAndView;
 
 import in.koreatech.koin.domain.user.service.UserService;
+import in.koreatech.koin.domain.user.service.UserValidationService;
 import in.koreatech.koin.global.auth.Auth;
-import in.koreatech.koin.global.host.ServerURL;
-import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -37,14 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController implements UserApi {
 
     private final UserService userService;
-
-    @GetMapping("/user/coop/me")
-    public ResponseEntity<CoopResponse> getCoop(
-        @Auth(permit = COOP) Integer userId
-    ) {
-        CoopResponse coopResponse = userService.getCoop(userId);
-        return ResponseEntity.ok().body(coopResponse);
-    }
+    private final UserValidationService userValidationService;
 
     @PostMapping("/user/login")
     public ResponseEntity<UserLoginResponse> login(
@@ -72,32 +56,6 @@ public class UserController implements UserApi {
             .body(tokenGroupResponse);
     }
 
-    @DeleteMapping("/user")
-    public ResponseEntity<Void> withdraw(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
-    ) {
-        userService.withdraw(userId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/user/check/email")
-    public ResponseEntity<Void> checkUserEmailExist(
-        @ModelAttribute(value = "address")
-        @Valid EmailCheckExistsRequest request
-    ) {
-        userService.checkExistsEmail(request);
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/user/check/nickname")
-    public ResponseEntity<Void> checkDuplicationOfNickname(
-        @ModelAttribute("nickname")
-        @Valid NicknameCheckExistsRequest request
-    ) {
-        userService.checkUserNickname(request);
-        return ResponseEntity.ok().build();
-    }
-
     @GetMapping("/user/auth")
     public ResponseEntity<AuthResponse> getAuth(
         @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
@@ -106,12 +64,38 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().body(authResponse);
     }
 
+    @DeleteMapping("/user")
+    public ResponseEntity<Void> withdraw(
+        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+    ) {
+        userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/user/check/login")
     public ResponseEntity<Void> checkLogin(
-            @ParameterObject @ModelAttribute(value = "access_token")
-            @Valid UserAccessTokenRequest request
+        @ParameterObject @ModelAttribute(value = "access_token")
+        @Valid UserAccessTokenRequest request
     ) {
         userService.checkLogin(request.accessToken());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/check/email")
+    public ResponseEntity<Void> checkUserEmailExist(
+        @ModelAttribute(value = "address")
+        @Valid EmailCheckExistsRequest request
+    ) {
+        userValidationService.checkExistsEmail(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/check/nickname")
+    public ResponseEntity<Void> checkDuplicationOfNickname(
+        @ModelAttribute("nickname")
+        @Valid NicknameCheckExistsRequest request
+    ) {
+        userValidationService.checkUserNickname(request);
         return ResponseEntity.ok().build();
     }
 
@@ -120,7 +104,16 @@ public class UserController implements UserApi {
         @Valid @RequestBody UserPasswordCheckRequest request,
         @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
     ) {
-        userService.checkPassword(request, userId);
+        userValidationService.checkPassword(request, userId);
         return ResponseEntity.ok().build();
+    }
+
+    // 영양사로 옮길 예정
+    @GetMapping("/user/coop/me")
+    public ResponseEntity<CoopResponse> getCoop(
+        @Auth(permit = COOP) Integer userId
+    ) {
+        CoopResponse coopResponse = userService.getCoop(userId);
+        return ResponseEntity.ok().body(coopResponse);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/AuthResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/AuthResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record AuthResponse(
     @Schema(description = "사용자 권한 타입", example = "STUDENT", requiredMode = REQUIRED)
     String userType

--- a/src/main/java/in/koreatech/koin/domain/user/dto/CoopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/CoopResponse.java
@@ -1,15 +1,15 @@
 package in.koreatech.koin.domain.user.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record CoopResponse(
     @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     String email,

--- a/src/main/java/in/koreatech/koin/domain/user/dto/EmailCheckExistsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/EmailCheckExistsRequest.java
@@ -1,11 +1,15 @@
 package in.koreatech.koin.domain.user.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record EmailCheckExistsRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @Email(message = "이메일 형식이 올바르지 않습니다. ${validatedValue}")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/FindPasswordRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/FindPasswordRequest.java
@@ -1,11 +1,15 @@
 package in.koreatech.koin.domain.user.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record FindPasswordRequest(
     @Schema(description = "이메일 주소", example = "asdf@koreatech.ac.kr", requiredMode = REQUIRED)
     @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@koreatech.ac.kr$", message = "아우누리 계정 형식이 아닙니다. ${validatedValue}")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/NicknameCheckExistsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/NicknameCheckExistsRequest.java
@@ -2,10 +2,14 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record NicknameCheckExistsRequest(
     @Schema(description = "닉네임", example = "홍길동", requiredMode = REQUIRED)
     @Size(max = 10, message = "닉네임은 최대 10자입니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserAccessTokenRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserAccessTokenRequest.java
@@ -1,16 +1,17 @@
 package in.koreatech.koin.domain.user.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UserAccessTokenRequest(
         @Schema(description = "access_token", example = "eyJ0eXAiOiJKV1QiLCJhbGcIUzUxMic9.eyJpZCI6NTM5NhwIjoxkzI3MTA5ODE5fQ.rLEYGQfKI5_24ZlwLVwlgwnriqySPKwXNOeTRrbmxoCtlOzCVvM8FFcO9BA2vkqsmhf-w", requiredMode = REQUIRED)
         @NotBlank(message = "access_token을 입력해주세요.")
-        @JsonProperty("access_token")
         String accessToken
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequest.java
@@ -1,12 +1,15 @@
 package in.koreatech.koin.domain.user.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.global.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UserLoginRequest(
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @NotBlank(message = "이메일을 입력해주세요.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+// SnakeCase X
 public record UserLoginResponse(
     @Schema(
         description = "Jwt accessToken",

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordChangeRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordChangeRequest.java
@@ -1,14 +1,14 @@
 package in.koreatech.koin.domain.user.dto;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UserPasswordChangeRequest(
     @Schema(description = "변경할 비밀번호 (SHA 256 해싱된 값)", example = "password", requiredMode = REQUIRED)
     @NotBlank(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordChangeSubmitRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordChangeSubmitRequest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonNaming(SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UserPasswordChangeSubmitRequest(
     @Schema(description = "변경할 비밀번호 (SHA 256 해싱된 값)", example = "password", requiredMode = REQUIRED)
     @NotBlank(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordCheckRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserPasswordCheckRequest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-@JsonNaming(SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UserPasswordCheckRequest(
     @Schema(
         description = "확인할 비밀번호 (SHA 256 해싱된 값)",

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserTokenRefreshRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserTokenRefreshRequest.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.user.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -13,7 +12,6 @@ import jakarta.validation.constraints.NotNull;
 public record UserTokenRefreshRequest(
     @Schema(description = "refresh_token", example = "eyJhbGciOiJIUzI1NiJ9", requiredMode = REQUIRED)
     @NotNull(message = "refresh_token을 입력해주세요.")
-    @JsonProperty("refresh_token")
     String refreshToken
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserTokenRefreshResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserTokenRefreshResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+// SnakeCase X
 public record UserTokenRefreshResponse(
     @Schema(
         description = "Jwt accessToken",

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -125,28 +125,10 @@ public class User extends BaseEntity {
         this.deviceToken = deviceToken;
     }
 
-    public boolean isSamePassword(PasswordEncoder passwordEncoder, String password) {
-        return passwordEncoder.matches(password, this.password);
-    }
-
-    public void permitNotification(String deviceToken) {
-        this.deviceToken = deviceToken;
-    }
-
-    public void rejectNotification() {
-        this.deviceToken = null;
-    }
-
-    public void updateLastLoggedTime(LocalDateTime lastLoggedTime) {
-        lastLoggedAt = lastLoggedTime;
-    }
-
-    public void updatePassword(PasswordEncoder passwordEncoder, String password) {
-        this.password = passwordEncoder.encode(password);
-    }
+    private static final int ONE_HOUR = 1;
 
     public void generateResetTokenForFindPassword(Clock clock) {
-        this.resetExpiredAt = LocalDateTime.now(clock).plusHours(1);
+        this.resetExpiredAt = LocalDateTime.now(clock).plusHours(ONE_HOUR);
         this.resetToken = this.email + this.resetExpiredAt;
     }
 
@@ -157,17 +139,19 @@ public class User extends BaseEntity {
         this.gender = gender;
     }
 
-    public void updateStudentPassword(PasswordEncoder passwordEncoder, String password) {
-        if (password != null && !password.isEmpty())
-            this.password = passwordEncoder.encode(password);
-    }
-
-    public void auth() {
-        this.isAuthed = true;
-    }
-
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateLastLoggedTime(LocalDateTime lastLoggedTime) {
+        lastLoggedAt = lastLoggedTime;
+    }
+    public void updatePassword(PasswordEncoder passwordEncoder, String password) {
+        this.password = passwordEncoder.encode(password);
+    }
+
+    public boolean isSamePassword(PasswordEncoder passwordEncoder, String password) {
+        return passwordEncoder.matches(password, this.password);
     }
 
     public void validateResetToken() {
@@ -176,6 +160,19 @@ public class User extends BaseEntity {
         }
     }
 
+    public void auth() {
+        this.isAuthed = true;
+    }
+
+    public void permitNotification(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+
+    public void rejectNotification() {
+        this.deviceToken = null;
+    }
+
+    // 어드민 측에서 코드 삭제시 이 쪽도 삭제
     public void undelete() {
         this.isDeleted = false;
     }

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -47,11 +47,6 @@ public interface UserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("id: " + id));
     }
 
-    default User getByNickname(String nickname) {
-        return findByNickname(nickname)
-            .orElseThrow(() -> UserNotFoundException.withDetail("nickname: " + nickname));
-    }
-
     default User getByResetToken(String resetToken) {
         return findAllByResetToken(resetToken)
             .orElseThrow(() -> UserNotFoundException.withDetail("resetToken: " + resetToken));
@@ -60,10 +55,6 @@ public interface UserRepository extends Repository<User, Integer> {
     boolean existsByNickname(String nickname);
 
     void delete(User user);
-
-    List<User> findAllByDeviceTokenIsNotNull();
-
-    Optional<User> findByPhoneNumber(String phoneNumber);
 
     List<User> findAllByName(String name);
 

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserTokenRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserTokenRepository.java
@@ -13,10 +13,10 @@ public interface UserTokenRepository extends Repository<UserToken, Integer> {
 
     Optional<UserToken> findById(Integer userId);
 
-    void deleteById(Integer id);
-
     default UserToken getById(Integer userId) {
         return findById(userId)
             .orElseThrow(() -> new KoinIllegalArgumentException("refresh token이 존재하지 않습니다.", "userId: " + userId));
     }
+
+    void deleteById(Integer id);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -1,14 +1,8 @@
 package in.koreatech.koin.domain.user.service;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 
-import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
-import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,14 +10,10 @@ import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.CoopResponse;
-import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
-import in.koreatech.koin.domain.user.dto.NicknameCheckExistsRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
-import in.koreatech.koin.domain.user.dto.UserPasswordCheckRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
-import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserDeleteEvent;
 import in.koreatech.koin.domain.user.model.UserToken;
@@ -31,10 +21,6 @@ import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRepository;
-import in.koreatech.koin.global.auth.JwtProvider;
-import in.koreatech.koin.global.auth.exception.AuthorizationException;
-import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
-import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -42,36 +28,26 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
-    private final StudentRedisRepository studentRedisRepository;
     private final OwnerRepository ownerRepository;
-    private final PasswordEncoder passwordEncoder;
     private final UserTokenRepository userTokenRepository;
-    private final ApplicationEventPublisher eventPublisher;
     private final TimetableFrameRepositoryV2 timetableFrameRepositoryV2;
+    private final ApplicationEventPublisher eventPublisher;
+    private final UserValidationService userValidationService;
+    private final UserTokenService userTokenService;
 
     @Transactional
     public UserLoginResponse login(UserLoginRequest request) {
-        User user = userRepository.getByEmail(request.email());
-        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findById(request.email());
+        User user = userValidationService.checkLoginCredentials(request.email(), request.password());
+        userValidationService.checkUserAuthentication(request.email());
 
-        if (!user.isSamePassword(passwordEncoder, request.password())) {
-            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
-        }
-
-        if (studentTemporaryStatus.isPresent()) {
-            throw new AuthorizationException("미인증 상태입니다. 아우누리에서 인증메일을 확인해주세요");
-        }
-
-        String accessToken = jwtProvider.createToken(user);
-        String refreshToken = String.format("%s-%d", UUID.randomUUID(), user.getId());
+        String accessToken = userTokenService.createAccessToken(user);
+        String refreshToken = userTokenService.generateRefreshToken(user);
         UserToken savedToken = userTokenRepository.save(UserToken.create(user.getId(), refreshToken));
-        user.updateLastLoggedTime(LocalDateTime.now());
-        User saved = userRepository.save(user);
+        updateLastLoginTime(user);
 
-        return UserLoginResponse.of(accessToken, savedToken.getRefreshToken(), saved.getUserType().getValue());
+        return UserLoginResponse.of(accessToken, savedToken.getRefreshToken(), user.getUserType().getValue());
     }
 
     @Transactional
@@ -79,24 +55,23 @@ public class UserService {
         userTokenRepository.deleteById(userId);
     }
 
-    public UserTokenRefreshResponse refresh(UserTokenRefreshRequest request) {
-        String userId = getUserId(request.refreshToken());
-        UserToken userToken = userTokenRepository.getById(Integer.parseInt(userId));
-        if (!Objects.equals(userToken.getRefreshToken(), request.refreshToken())) {
-            throw new KoinIllegalArgumentException("refresh token이 일치하지 않습니다.", "request: " + request);
-        }
-        User user = userRepository.getById(userToken.getId());
-
-        String accessToken = jwtProvider.createToken(user);
-        return UserTokenRefreshResponse.of(accessToken, userToken.getRefreshToken());
+    public void checkLogin(String accessToken) {
+        userTokenService.checkLoginStatus(accessToken);
     }
 
-    private String getUserId(String refreshToken) {
-        String[] split = refreshToken.split("-");
-        if (split.length == 0) {
-            throw new AuthorizationException("올바르지 않은 인증 토큰입니다. refreshToken: " + refreshToken);
-        }
-        return split[split.length - 1];
+    public AuthResponse getAuth(Integer userId) {
+        User user = userRepository.getById(userId);
+        return AuthResponse.from(user);
+    }
+
+    public UserTokenRefreshResponse refresh(UserTokenRefreshRequest request) {
+        String userId = userTokenService.extractUserId(request.refreshToken());
+        UserToken userToken = userTokenService.validateRefreshToken(request.refreshToken(), Integer.parseInt(userId));
+
+        User user = userRepository.getById(userToken.getId());
+        String accessToken = userTokenService.createAccessToken(user);
+
+        return UserTokenRefreshResponse.of(accessToken, userToken.getRefreshToken());
     }
 
     @Transactional
@@ -112,36 +87,13 @@ public class UserService {
         eventPublisher.publishEvent(new UserDeleteEvent(user.getEmail(), user.getUserType()));
     }
 
-    public void checkLogin(String accessToken) {
-        jwtProvider.getUserId(accessToken);
-    }
-
-    public void checkPassword(UserPasswordCheckRequest request, Integer userId) {
-        User user = userRepository.getById(userId);
-        if (!user.isSamePassword(passwordEncoder, request.password())) {
-            throw new KoinIllegalArgumentException("올바르지 않은 비밀번호입니다.");
-        }
-    }
-
-    public void checkExistsEmail(EmailCheckExistsRequest request) {
-        userRepository.findByEmail(request.email()).ifPresent(user -> {
-            throw DuplicationEmailException.withDetail("account: " + user.getEmail());
-        });
-    }
-
-    public void checkUserNickname(NicknameCheckExistsRequest request) {
-        userRepository.findByNickname(request.nickname()).ifPresent(user -> {
-            throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
-        });
-    }
-
-    public AuthResponse getAuth(Integer userId) {
-        User user = userRepository.getById(userId);
-        return AuthResponse.from(user);
-    }
-
+    // 이거 옮길 예정
     public CoopResponse getCoop(Integer userId) {
         User user = userRepository.getById(userId);
         return CoopResponse.from(user);
+    }
+
+    public void updateLastLoginTime(User user) {
+        user.updateLastLoggedTime(LocalDateTime.now());
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserTokenService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserTokenService.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.domain.user.service;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserToken;
+import in.koreatech.koin.domain.user.repository.UserTokenRepository;
+import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserTokenService {
+
+    private final JwtProvider jwtProvider;
+    private final UserTokenRepository userTokenRepository;
+
+    public String createAccessToken(User user) {
+        return jwtProvider.createToken(user);
+    }
+
+    public String generateRefreshToken(User user) {
+        return String.format("%s-%d", UUID.randomUUID(), user.getId());
+    }
+
+    public void checkLoginStatus(String accessToken) {
+        jwtProvider.getUserId(accessToken);
+    }
+
+    public UserToken validateRefreshToken(String refreshToken, Integer userId) {
+        UserToken userToken = userTokenRepository.getById(userId);
+        if (!Objects.equals(userToken.getRefreshToken(), refreshToken)) {
+            throw new KoinIllegalArgumentException("refresh token이 일치하지 않습니다.", "refreshToken: " + refreshToken);
+        }
+        return userToken;
+    }
+
+    public String extractUserId(String refreshToken) {
+        String[] split = refreshToken.split("-");
+        if (split.length == 0) {
+            throw new AuthorizationException("올바르지 않은 인증 토큰입니다. refreshToken: " + refreshToken);
+        }
+        return split[split.length - 1];
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -1,0 +1,62 @@
+package in.koreatech.koin.domain.user.service;
+
+import java.util.Optional;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
+import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
+import in.koreatech.koin.domain.user.dto.EmailCheckExistsRequest;
+import in.koreatech.koin.domain.user.dto.NicknameCheckExistsRequest;
+import in.koreatech.koin.domain.user.dto.UserPasswordCheckRequest;
+import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
+import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserValidationService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final StudentRedisRepository studentRedisRepository;
+
+    public void checkPassword(UserPasswordCheckRequest request, Integer userId) {
+        User user = userRepository.getById(userId);
+        if (!user.isSamePassword(passwordEncoder, request.password())) {
+            throw new KoinIllegalArgumentException("올바르지 않은 비밀번호입니다.");
+        }
+    }
+
+    public void checkExistsEmail(EmailCheckExistsRequest request) {
+        userRepository.findByEmail(request.email()).ifPresent(user -> {
+            throw DuplicationEmailException.withDetail("email: " + user.getEmail());
+        });
+    }
+
+    public void checkUserNickname(NicknameCheckExistsRequest request) {
+        userRepository.findByNickname(request.nickname()).ifPresent(user -> {
+            throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
+        });
+    }
+
+    public User checkLoginCredentials(String email, String password) {
+        User user = userRepository.getByEmail(email);
+        if (!user.isSamePassword(passwordEncoder, password)) {
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+        }
+        return user;
+    }
+
+    public void checkUserAuthentication(String email) {
+        Optional<StudentTemporaryStatus> studentTemporaryStatus = studentRedisRepository.findById(email);
+        if (studentTemporaryStatus.isPresent()) {
+            throw new AuthorizationException("미인증 상태입니다. 아우누리에서 인증메일을 확인해주세요");
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
@@ -1,0 +1,464 @@
+package in.koreatech.koin.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.dept.model.Dept;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
+import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.fixture.UserFixture;
+import in.koreatech.koin.global.auth.JwtProvider;
+
+@SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class StudentApiTest extends AcceptanceTest {
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @Autowired
+    private StudentRedisRepository studentRedisRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @BeforeAll
+    void setup() {
+        clear();
+    }
+
+    @Test
+    void 학생이_로그인을_진행한다_신규_API_student_login() throws Exception {
+        Student student = userFixture.성빈_학생();
+        String email = student.getUser().getEmail();
+        String password = "1234";
+
+        mockMvc.perform(
+                post("/student/login")
+                    .content("""
+                        {
+                          "email" : "%s",
+                          "password" : "%s"
+                        }
+                        """.formatted(email, password))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 올바른_학생계정인지_확인한다() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                    "anonymous_nickname": "익명",
+                    "email": "juno@koreatech.ac.kr",
+                    "gender": 0,
+                    "major": "컴퓨터공학부",
+                    "name": "테스트용_준호",
+                    "nickname": "준호",
+                    "phone_number": "01012345678",
+                    "student_number": "2019136135"
+                }
+                """));
+    }
+
+    @Test
+    void 올바른_학생계정인지_확인한다_토큰_정보가_올바르지_않으면_401() throws Exception {
+        userFixture.준호_학생();
+        String token = "invalidToken";
+
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 올바른_학생계정인지_확인한다_회원을_찾을_수_없으면_404() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = jwtProvider.createToken(student.getUser());
+        transactionTemplate.executeWithoutResult(status ->
+            studentRepository.deleteByUserId(student.getId())
+        );
+
+        mockMvc.perform(
+                get("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 학생이_정보를_수정한다() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                        {
+                          "gender" : 1,
+                          "major" : "기계공학부",
+                          "name" : "서정빈",
+                          "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
+                          "nickname" : "duehee",
+                          "phone_number" : "01023456789",
+                          "student_number" : "2019136136"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                    {
+                        "anonymous_nickname": "익명",
+                        "email": "juno@koreatech.ac.kr",
+                        "gender": 1,
+                        "major": "기계공학부",
+                        "name": "서정빈",
+                        "nickname": "duehee",
+                        "phone_number": "01023456789",
+                        "student_number": "2019136136"
+                    }
+                """));
+
+        transactionTemplate.executeWithoutResult(status -> {
+            Student result = studentRepository.getById(student.getId());
+            SoftAssertions.assertSoftly(
+                softly -> {
+                    softly.assertThat(result.getUser().getName()).isEqualTo("서정빈");
+                    softly.assertThat(result.getUser().getNickname()).isEqualTo("duehee");
+                    softly.assertThat(result.getUser().getName()).isEqualTo("서정빈");
+                    softly.assertThat(result.getUser().getGender()).isEqualTo(UserGender.from(1));
+                    softly.assertThat(result.getStudentNumber()).isEqualTo("2019136136");
+                }
+            );
+        });
+    }
+
+    @Test
+    void 학생이_정보를_수정한다_학번의_형식이_맞지_않으면_400() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "gender" : 0,
+                            "major" : "메카트로닉스공학부",
+                            "name" : "최주노",
+                            "nickname" : "juno",
+                            "phone_number" : "01023456789",
+                            "student_number" : "201913613"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 학생이_정보를_수정한다_학부의_형식이_맞지_않으면_400() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "gender" : 0,
+                            "major" : "경영학과",
+                            "name" : "최주노",
+                            "nickname" : "juno",
+                            "phone_number" : "01023456789",
+                            "student_number" : "2019136136"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 학생이_정보를_수정한다_토큰이_올바르지_않다면_401() throws Exception {
+        userFixture.준호_학생();
+        String token = "invalidToken";
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "gender" : 0,
+                            "major" : "메카트로닉스공학부",
+                            "name" : "최주노",
+                            "nickname" : "juno",
+                            "phone_number" : "01023456789",
+                            "student_number" : "2019136136"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 학생이_정보를_수정한다_회원을_찾을_수_없다면_404() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+        transactionTemplate.executeWithoutResult(status ->
+            studentRepository.deleteByUserId(student.getId())
+        );
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "gender" : 0,
+                            "major" : "메카트로닉스공학부",
+                            "name" : "최주노",
+                            "nickname" : "juno",
+                            "phone_number" : "01023456789",
+                            "student_number" : "2019136136"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 학생이_정보를_수정한다_이미_있는_닉네임이라면_409() throws Exception {
+        Student 준호 = userFixture.준호_학생();
+        Student 성빈 = userFixture.성빈_학생();
+        String token = userFixture.getToken(준호.getUser());
+
+        mockMvc.perform(
+                put("/user/student/me")
+                    .header("Authorization", "Bearer " + token)
+                    .content(String.format("""
+                         {
+                            "gender" : 0,
+                            "major" : "테스트학과",
+                            "name" : "최주노",
+                            "nickname" : "%s",
+                            "phone_number" : "01023456789",
+                            "student_number" : "2019136136"
+                         }
+                        """, 성빈.getUser().getNickname()))
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void 학생_회원가입_후_학교_이메일요청_이벤트가_발생하고_Redis에_저장된다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@koreatech.ac.kr",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
+
+        Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
+
+        assertSoftly(
+            softly -> {
+                softly.assertThat(student).isNotNull();
+                softly.assertThat(student.get().getNickname()).isEqualTo("koko");
+                softly.assertThat(student.get().getName()).isEqualTo("김철수");
+                softly.assertThat(student.get().getPhoneNumber()).isEqualTo("01000000000");
+                softly.assertThat(student.get().getEmail()).isEqualTo("koko123@koreatech.ac.kr");
+                softly.assertThat(student.get().getStudentNumber()).isEqualTo("2021136012");
+                softly.assertThat(student.get().getDepartment()).isEqualTo(Dept.COMPUTER_SCIENCE.getName());
+                forceVerify(() -> verify(studentEventListener).onStudentEmailRequest(any()));
+                clear();
+                setup();
+            }
+        );
+    }
+
+    @Test
+    void 이메일_요청을_확인_후_회원가입_이벤트가_발생하고_Redis에_저장된_정보가_삭제된다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@koreatech.ac.kr",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk());
+
+        Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
+        mockMvc.perform(
+                get("/user/authenticate")
+                    .queryParam("auth_token", student.get().getAuthToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andReturn();
+
+        User user = userRepository.getByEmail("koko123@koreatech.ac.kr");
+        assertThat(studentRedisRepository.findById("koko123@koreatech.ac.kr")).isEmpty();
+
+        assertThat(user.isAuthed()).isTrue();
+        forceVerify(() -> verify(studentEventListener).onStudentRegister(any()));
+        clear();
+        setup();
+    }
+
+    @Test
+    void 회원_가입_필수_파라미터를_안넣을시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": null,
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 한기대_이메일이_아닐시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "2021136012",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 유효한_학번의_형식이_아닐시_400에러코드를_반환한다() throws Exception {
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "20211360123324231",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+
+        mockMvc.perform(
+                post("/user/student/register")
+                    .content("""
+                        {
+                          "major": "컴퓨터공학부",
+                          "email": "koko123@gmail.com",
+                          "name": "김철수",
+                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+                          "nickname": "koko",
+                          "gender": "0",
+                          "is_graduated": false,
+                          "student_number": "19911360123",
+                          "phone_number": "01000000000"
+                        }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -3,31 +3,21 @@ package in.koreatech.koin.acceptance;
 import static in.koreatech.koin.domain.user.model.UserIdentity.UNDERGRADUATE;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.Optional;
-
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.coop.model.Coop;
-import in.koreatech.koin.domain.dept.model.Dept;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
-import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
-import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.fixture.UserFixture;
@@ -42,16 +32,10 @@ class UserApiTest extends AcceptanceTest {
     private StudentRepository studentRepository;
 
     @Autowired
-    private StudentRedisRepository studentRedisRepository;
-
-    @Autowired
     private UserRepository userRepository;
 
     @Autowired
     private JwtProvider jwtProvider;
-
-    @Autowired
-    private TransactionTemplate transactionTemplate;
 
     @Autowired
     private UserFixture userFixture;
@@ -80,25 +64,7 @@ class UserApiTest extends AcceptanceTest {
             .andExpect(status().isCreated());
     }
 
-    @Test
-    void 학생이_로그인을_진행한다_신규_API_student_login() throws Exception {
-        Student student = userFixture.성빈_학생();
-        String email = student.getUser().getEmail();
-        String password = "1234";
-
-        mockMvc.perform(
-                post("/student/login")
-                    .content("""
-                        {
-                          "email" : "%s",
-                          "password" : "%s"
-                        }
-                        """.formatted(email, password))
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isCreated());
-    }
-
+    // 영양사로 넘길 예정
     @Test
     void 영양사가_로그인을_진행한다() throws Exception {
         Coop coop = userFixture.준기_영양사();
@@ -129,228 +95,6 @@ class UserApiTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk());
-    }
-
-    @Test
-    void 올바른_학생계정인지_확인한다() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                get("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk())
-            .andExpect(content().json("""
-                {
-                    "anonymous_nickname": "익명",
-                    "email": "juno@koreatech.ac.kr",
-                    "gender": 0,
-                    "major": "컴퓨터공학부",
-                    "name": "테스트용_준호",
-                    "nickname": "준호",
-                    "phone_number": "01012345678",
-                    "student_number": "2019136135"
-                }
-                """));
-    }
-
-    @Test
-    void 올바른_학생계정인지_확인한다_토큰_정보가_올바르지_않으면_401() throws Exception {
-        userFixture.준호_학생();
-        String token = "invalidToken";
-
-        mockMvc.perform(
-                get("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 올바른_학생계정인지_확인한다_회원을_찾을_수_없으면_404() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = jwtProvider.createToken(student.getUser());
-        transactionTemplate.executeWithoutResult(status ->
-            studentRepository.deleteByUserId(student.getId())
-        );
-
-        mockMvc.perform(
-                get("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void 학생이_정보를_수정한다() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                        {
-                          "gender" : 1,
-                          "major" : "기계공학부",
-                          "name" : "서정빈",
-                          "password" : "0c4be6acaba1839d3433c1ccf04e1eec4d1fa841ee37cb019addc269e8bc1b77",
-                          "nickname" : "duehee",
-                          "phone_number" : "01023456789",
-                          "student_number" : "2019136136"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk())
-            .andExpect(content().json("""
-                    {
-                        "anonymous_nickname": "익명",
-                        "email": "juno@koreatech.ac.kr",
-                        "gender": 1,
-                        "major": "기계공학부",
-                        "name": "서정빈",
-                        "nickname": "duehee",
-                        "phone_number": "01023456789",
-                        "student_number": "2019136136"
-                    }
-                """));
-
-        transactionTemplate.executeWithoutResult(status -> {
-            Student result = studentRepository.getById(student.getId());
-            SoftAssertions.assertSoftly(
-                softly -> {
-                    softly.assertThat(result.getUser().getName()).isEqualTo("서정빈");
-                    softly.assertThat(result.getUser().getNickname()).isEqualTo("duehee");
-                    softly.assertThat(result.getUser().getName()).isEqualTo("서정빈");
-                    softly.assertThat(result.getUser().getGender()).isEqualTo(UserGender.from(1));
-                    softly.assertThat(result.getStudentNumber()).isEqualTo("2019136136");
-                }
-            );
-        });
-    }
-
-    @Test
-    void 학생이_정보를_수정한다_학번의_형식이_맞지_않으면_400() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "gender" : 0,
-                            "major" : "메카트로닉스공학부",
-                            "name" : "최주노",
-                            "nickname" : "juno",
-                            "phone_number" : "01023456789",
-                            "student_number" : "201913613"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void 학생이_정보를_수정한다_학부의_형식이_맞지_않으면_400() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "gender" : 0,
-                            "major" : "경영학과",
-                            "name" : "최주노",
-                            "nickname" : "juno",
-                            "phone_number" : "01023456789",
-                            "student_number" : "2019136136"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void 학생이_정보를_수정한다_토큰이_올바르지_않다면_401() throws Exception {
-        userFixture.준호_학생();
-        String token = "invalidToken";
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "gender" : 0,
-                            "major" : "메카트로닉스공학부",
-                            "name" : "최주노",
-                            "nickname" : "juno",
-                            "phone_number" : "01023456789",
-                            "student_number" : "2019136136"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 학생이_정보를_수정한다_회원을_찾을_수_없다면_404() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-        transactionTemplate.executeWithoutResult(status ->
-            studentRepository.deleteByUserId(student.getId())
-        );
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "gender" : 0,
-                            "major" : "메카트로닉스공학부",
-                            "name" : "최주노",
-                            "nickname" : "juno",
-                            "phone_number" : "01023456789",
-                            "student_number" : "2019136136"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void 학생이_정보를_수정한다_이미_있는_닉네임이라면_409() throws Exception {
-        Student 준호 = userFixture.준호_학생();
-        Student 성빈 = userFixture.성빈_학생();
-        String token = userFixture.getToken(준호.getUser());
-
-        mockMvc.perform(
-                put("/user/student/me")
-                    .header("Authorization", "Bearer " + token)
-                    .content(String.format("""
-                         {
-                            "gender" : 0,
-                            "major" : "테스트학과",
-                            "name" : "최주노",
-                            "nickname" : "%s",
-                            "phone_number" : "01023456789",
-                            "student_number" : "2019136136"
-                         }
-                        """, 성빈.getUser().getNickname()))
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isConflict());
     }
 
     @Test
@@ -442,6 +186,24 @@ class UserApiTest extends AcceptanceTest {
     }
 
     @Test
+    void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다_비밀번호가_다르면_400_반환() throws Exception {
+        Student student = userFixture.준호_학생();
+        String token = userFixture.getToken(student.getUser());
+
+        mockMvc.perform(
+                post("/user/check/password")
+                    .header("Authorization", "Bearer " + token)
+                    .content("""
+                          {
+                            "password": "123"
+                          }
+                        """)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void 닉네임_제약조건_위반시_상태코드_400를_반환한다() throws Exception {
         User user = User.builder()
             .password("1234")
@@ -506,204 +268,6 @@ class UserApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.user_type").value(user.getUserType().getValue()));
-    }
-
-    @Test
-    void 학생_회원가입_후_학교_이메일요청_이벤트가_발생하고_Redis에_저장된다() throws Exception {
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "email": "koko123@koreatech.ac.kr",
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "2021136012",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk());
-
-        Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
-
-        assertSoftly(
-            softly -> {
-                softly.assertThat(student).isNotNull();
-                softly.assertThat(student.get().getNickname()).isEqualTo("koko");
-                softly.assertThat(student.get().getName()).isEqualTo("김철수");
-                softly.assertThat(student.get().getPhoneNumber()).isEqualTo("01000000000");
-                softly.assertThat(student.get().getEmail()).isEqualTo("koko123@koreatech.ac.kr");
-                softly.assertThat(student.get().getStudentNumber()).isEqualTo("2021136012");
-                softly.assertThat(student.get().getDepartment()).isEqualTo(Dept.COMPUTER_SCIENCE.getName());
-                forceVerify(() -> verify(studentEventListener).onStudentEmailRequest(any()));
-                clear();
-                setup();
-            }
-        );
-    }
-
-    @Test
-    void 이메일_요청을_확인_후_회원가입_이벤트가_발생하고_Redis에_저장된_정보가_삭제된다() throws Exception {
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "email": "koko123@koreatech.ac.kr",
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "2021136012",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk());
-
-        Optional<StudentTemporaryStatus> student = studentRedisRepository.findById("koko123@koreatech.ac.kr");
-        mockMvc.perform(
-                get("/user/authenticate")
-                    .queryParam("auth_token", student.get().getAuthToken())
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andReturn();
-
-        User user = userRepository.getByEmail("koko123@koreatech.ac.kr");
-        assertThat(studentRedisRepository.findById("koko123@koreatech.ac.kr")).isEmpty();
-
-        assertThat(user.isAuthed()).isTrue();
-        forceVerify(() -> verify(studentEventListener).onStudentRegister(any()));
-        clear();
-        setup();
-    }
-
-    @Test
-    void 회원_가입_필수_파라미터를_안넣을시_400에러코드를_반환한다() throws Exception {
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "account": null,
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "2021136012",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void 한기대_이메일이_아닐시_400에러코드를_반환한다() throws Exception {
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "account": "koko123@gmail.com",
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "2021136012",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void 유효한_학번의_형식이_아닐시_400에러코드를_반환한다() throws Exception {
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "account": "koko123@gmail.com",
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "20211360123324231",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-
-        mockMvc.perform(
-                post("/user/student/register")
-                    .content("""
-                        {
-                          "major": "컴퓨터공학부",
-                          "account": "koko123@gmail.com",
-                          "name": "김철수",
-                          "password": "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
-                          "nickname": "koko",
-                          "gender": "0",
-                          "is_graduated": false,
-                          "student_number": "19911360123",
-                          "phone_number": "01000000000"
-                        }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                post("/user/check/password")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "password": "1234"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다_비밀번호가_다르면_400_반환() throws Exception {
-        Student student = userFixture.준호_학생();
-        String token = userFixture.getToken(student.getUser());
-
-        mockMvc.perform(
-                post("/user/check/password")
-                    .header("Authorization", "Bearer " + token)
-                    .content("""
-                          {
-                            "password": "123"
-                          }
-                        """)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1081 

# 🚀 작업 내용

1. User, Student 패키지의 리팩토링을 진행했습니다.
- JsonNaming 통일(일부는 적용 X, 문제 가능성 있어서 수정 안 했으며 주석처리)
- UserService(Token, Validation), Student(Validation) Service 분리
- StudentUtil 패키지 추가
- 긴 메소드 분리 및 메소드명 명확하게 변경
- 안 쓰는 메소드 정리

# 💬 리뷰 중점사항
저번이랑 크게 달라진 건 없어용