### PR TITLE
fix: 학생 비밀번호 수정 메소드 오류처리

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/student/service/AdminStudentService.java
+++ b/src/main/java/in/koreatech/koin/admin/student/service/AdminStudentService.java
@@ -54,7 +54,7 @@ public class AdminStudentService {
         validateDepartmentValid(adminRequest.major());
         user.update(adminRequest.nickname(), adminRequest.name(),
             adminRequest.phoneNumber(), UserGender.from(adminRequest.gender()));
-        user.updatePassword(passwordEncoder, adminRequest.password());
+        user.updateStudentPassword(passwordEncoder, adminRequest.password());
         student.updateInfo(adminRequest.studentNumber(), adminRequest.major());
         adminStudentRepository.save(student);
 

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -89,7 +89,7 @@ public class StudentService {
         User user = student.getUser();
 
         user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());
-        user.updatePassword(passwordEncoder, request.password());
+        user.updateStudentPassword(passwordEncoder, request.password());
         student.updateInfo(request.studentNumber(), request.major());
 
         return StudentUpdateResponse.from(student);

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -150,6 +150,11 @@ public class User extends BaseEntity {
         this.password = passwordEncoder.encode(password);
     }
 
+    public void updateStudentPassword(PasswordEncoder passwordEncoder, String password) {
+        if (password != null && !password.isEmpty())
+            this.password = passwordEncoder.encode(password);
+    }
+
     public boolean isSamePassword(PasswordEncoder passwordEncoder, String password) {
         return passwordEncoder.matches(password, this.password);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1088 

# 🚀 작업 내용

1. 학생 비밀번호 수정 메소드 추가했습니다.

# 💬 리뷰 중점사항
기존 유저들의 비밀번호 수정에는 null이 처리가 안 되어있고, 이를 통일하기 위해 학생 정보수정에서의 비밀번호 처리를 빼는 과정에서 if 처리를 하지않아 학생 정보 수정에서 오류가 발생했습니다. 