### PR TITLE
fix: abtest 데드락 발생 최소화

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
@@ -111,6 +111,7 @@ public class AccessHistory extends BaseEntity {
         );
     }
 
+    // TODO: 각 로그인 및 리프레시 요청에 추가 필요
     public void updateLastAccessedAt(Clock clock) {
         this.lastAccessedAt = LocalDateTime.now(clock);
     }

--- a/src/main/java/in/koreatech/koin/admin/abtest/service/AbtestService.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/service/AbtestService.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.admin.abtest.service;
 
-import java.time.Clock;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,7 +50,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class AbtestService {
 
-    private final Clock clock;
     private final EntityManager entityManager;
     private final AbtestVariableCountRepository abtestVariableCountRepository;
     private final AbtestRepository abtestRepository;
@@ -161,7 +159,6 @@ public class AbtestService {
         accessHistory.addAbtestVariable(variable);
         countCacheUpdate(variable);
         variableAssignCacheSave(variable, accessHistory.getId());
-        accessHistory.updateLastAccessedAt(clock);
         return AbtestAssignResponse.of(variable, accessHistory);
     }
 
@@ -217,7 +214,6 @@ public class AbtestService {
             abtestVariableAssignRepository.save(AbtestVariableAssign.of(dbVariable.getId(), accessHistory.getId()));
             return dbVariable;
         }
-        accessHistory.updateLastAccessedAt(clock);
         return cacheVariable.get();
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1074 

# 🚀 작업 내용

데드락(access_history 업데이트) 발생 가능성 최소화를 위해 중요도가 떨어지는 로직을 제거했습니다.
마지막 접속 시각 업데이트 로직을 제거했는데, 이 로직은 원래부터 여기가 아니라 로그인/리프레시 요청에 삽입하려고 설계했기에 급한대로 로직 제거만 선행했습니다. 각 로그인 요청에 적용하고 클라이언트에 요청하는 것은 추후 진행하겠습니다.

이 PR이 실제 환경에 미치는 영향은 "어드민페이지에서 AB테스트 실험군 수동 편입 시 기기 정보에 나타나는 마지막 접속 일시가 업데이트되지 않는다" 정도이기에 문제 해결을 먼저 진행하고자 합니다.

# 💬 리뷰 중점사항
