### PR TITLE
fix: timetableLecture 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -123,8 +123,8 @@ public interface TimetableApiV2 {
     )
     @Operation(summary = "시간표에 강의 정보 추가",
         description = """
-            lecture_id가 있는 경우 class_title, class_time, professor은 null, grades는 '0'으로 입력해야합니다.\n
-            lecture_id가 없는 경우 class_title, class_time, professor, grades을 선택적으로 입력합니다.
+            lecture_id가 있는 경우 class_infos, professor은 null, grades는 '0'으로 입력해야합니다.\n
+            lecture_id가 없는 경우 class_infos, professor, grades을 선택적으로 입력합니다.
             """)
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/timetables/lecture")

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
@@ -113,9 +114,15 @@ public record TimetableLectureCreateRequest(
 
         private String getClassPlaceToString() {
             if (classInfos != null) {
-                return classInfos.stream()
-                    .map(c -> c.classPlace)
-                    .collect(Collectors.joining(", "));
+                StringBuilder classPlaceSegment = new StringBuilder();
+                for (int i = 0; i < classInfos.size(); i++) {
+                    if (i > 0) classPlaceSegment.append(", ");
+                    if (Objects.equals(classInfos.get(i).classPlace,null)) {
+                        classPlaceSegment.append("");
+                    }
+                    else classPlaceSegment.append(classInfos.get(i).classPlace);
+                }
+                return classPlaceSegment.toString();
             }
             return null;
         }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
@@ -6,7 +6,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -98,7 +98,12 @@ public record TimetableLectureResponse(
                     int parseInt = Integer.parseInt(segment);
                     if (parseInt == -1) {
                         if (!currentTimes.isEmpty()) {
-                            classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index++]));
+                            if (classPlaceSegment.length <= index + 1) {
+                                classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
+                            }
+                            else {
+                                classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index++]));
+                            }
                             currentTimes.clear();
                         }
                     }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -15,7 +15,6 @@ import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record TimetableLectureResponse(
@@ -100,14 +99,13 @@ public record TimetableLectureResponse(
                         if (!currentTimes.isEmpty()) {
                             if (classPlaceSegment.length <= index + 1) {
                                 classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
-                            }
-                            else {
-                                classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index++]));
+                            } else {
+                                classInfos.add(
+                                    new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index++]));
                             }
                             currentTimes.clear();
                         }
-                    }
-                    else {
+                    } else {
                         currentTimes.add(parseInt);
                     }
                 }
@@ -120,7 +118,8 @@ public record TimetableLectureResponse(
             }
 
             private static List<Integer> parseClassTimes(String classTime) {
-                if (classTime == null) return null;
+                if (classTime == null)
+                    return null;
 
                 String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX, classTime.length() - 1);
                 return Arrays.stream(classTimeWithoutBrackets.split(SEPARATOR))

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -80,7 +80,7 @@ public record TimetableLectureResponse(
             String classPlace
         ) {
             public static List<ClassInfo> of(String classTime, String classPlace) {
-                // 정규 강의인 경우 강의 장소가 없기 때문에 바로 반환
+                // 강의 장소가 없는 경우 강의 시간과 매핑을 못하기 때문에 바로 반환
                 if (classPlace == null) {
                     return List.of(new ClassInfo(parseClassTimes(classTime), null));
                 }
@@ -111,7 +111,12 @@ public record TimetableLectureResponse(
                 }
 
                 if (!currentTimes.isEmpty()) {
-                    classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index]));
+                    if (classPlaceSegment.length <= index + 1) {
+                        classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
+                    } else {
+                        classInfos.add(
+                            new ClassInfo(new ArrayList<>(currentTimes), classPlaceSegment[index++]));
+                    }
                 }
 
                 return classInfos;

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -82,25 +82,7 @@ public record TimetableLectureResponse(
             public static List<ClassInfo> of(String classTime, String classPlace) {
                 // 정규 강의인 경우 강의 장소가 없기 때문에 바로 반환
                 if (classPlace == null) {
-                    String[] split = classTime.substring(1, classTime.length() - 1).trim().split(",\\s*");
-
-                    List<ClassInfo> classInfos = new ArrayList<>();
-                    List<Integer> currentTimes = new ArrayList<>();
-
-                    for (String str : split) {
-                        int num = Integer.parseInt(str);
-                        if (!currentTimes.isEmpty() && currentTimes.get(currentTimes.size() - 1) + 1 != num) {
-                            classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), null));
-                            currentTimes.clear();
-                        }
-                        currentTimes.add(num);
-                    }
-
-                    if (!currentTimes.isEmpty()) {
-                        classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), null));
-                    }
-
-                    return classInfos;
+                    return List.of(new ClassInfo(parseClassTimes(classTime), null));
                 }
 
                 // 구분자를 바탕으로 강의 시간과 강의 장소 분리
@@ -133,6 +115,17 @@ public record TimetableLectureResponse(
                 }
 
                 return classInfos;
+            }
+
+            private static List<Integer> parseClassTimes(String classTime) {
+                if (classTime == null)
+                    return null;
+
+                String classTimeWithoutBrackets = classTime.substring(INITIAL_BRACE_INDEX, classTime.length() - 1);
+                return Arrays.stream(classTimeWithoutBrackets.split(SEPARATOR))
+                    .map(String::strip)
+                    .map(Integer::parseInt)
+                    .toList();
             }
         }
 
@@ -211,6 +204,8 @@ public record TimetableLectureResponse(
     }
 
     private static final String GRADE_ZERO = "0";
+    private static final int INITIAL_BRACE_INDEX = 1;
+    private static final String SEPARATOR = ",";
 
     public static TimetableLectureResponse of(TimetableFrame timetableFrame, Integer grades, Integer totalGrades) {
         return new TimetableLectureResponse(

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -90,16 +90,14 @@ public record TimetableLectureResponse(
                     for (String str : split) {
                         int num = Integer.parseInt(str);
                         if (!currentTimes.isEmpty() && currentTimes.get(currentTimes.size() - 1) + 1 != num) {
-                            classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
+                            classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), null));
                             currentTimes.clear();
                         }
-                        else {
-                            currentTimes.add(num);
-                        }
+                        currentTimes.add(num);
                     }
 
                     if (!currentTimes.isEmpty()) {
-                        classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
+                        classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), null));
                     }
 
                     return classInfos;

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -97,7 +97,7 @@ public record TimetableLectureResponse(
                     int parseInt = Integer.parseInt(segment);
                     if (parseInt == -1) {
                         if (!currentTimes.isEmpty()) {
-                            if (classPlaceSegment.length <= index + 1) {
+                            if (classPlaceSegment.length < index + 1) {
                                 classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
                             } else {
                                 classInfos.add(
@@ -111,7 +111,7 @@ public record TimetableLectureResponse(
                 }
 
                 if (!currentTimes.isEmpty()) {
-                    if (classPlaceSegment.length <= index + 1) {
+                    if (classPlaceSegment.length < index + 1) {
                         classInfos.add(new ClassInfo(new ArrayList<>(currentTimes), ""));
                     } else {
                         classInfos.add(

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -86,6 +86,7 @@ public record TimetableLectureResponse(
                 }
 
                 // 구분자를 바탕으로 강의 시간과 강의 장소 분리
+                // TODO. StringBuilder으로 리펙토링
                 String[] classPlaceSegment = classPlace.split(",\\s*");
                 String[] classTimeSegment = classTime.substring(1, classTime.length() - 1).trim().split(",\\s*");
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.domain.timetableV2.util.GradeCalculator.calculat
 import static in.koreatech.koin.domain.timetableV2.validation.TimetableFrameValidate.validateUserAuthorization;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureCreator;
 import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureUpdater;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -70,7 +72,7 @@ public class TimetableLectureService {
     public void deleteTimetableLectures(List<Integer> request, Integer userId) {
         request.stream()
             .map(timetableLectureRepositoryV2::getById)
-            .peek(lecture -> validateUserAuthorization(lecture.getTimetableFrame().getId(), userId))
+            .peek(lecture -> validateUserAuthorization(lecture.getTimetableFrame().getUser().getId(), userId))
             .forEach(lecture -> timetableLectureRepositoryV2.deleteById(lecture.getId()));
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
@@ -286,7 +286,11 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "design_score": "0",
                             "class_infos": [
                               {
-                                "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
+                                "class_time": [12, 13, 14, 15],
+                                "class_place": null
+                              },
+                              {
+                                "class_time": [210, 211, 212, 213],
                                 "class_place": null
                               }
                             ],

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
@@ -286,11 +286,7 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "design_score": "0",
                             "class_infos": [
                               {
-                                "class_time": [12, 13, 14, 15],
-                                "class_place": null
-                              },
-                              {
-                                "class_time": [210, 211, 212, 213],
+                                "class_time": [12, 13, 14, 15, 210, 211, 212, 213],
                                 "class_place": null
                               }
                             ],


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1095 

# 🚀 작업 내용

- 기존 데이터에 `, , ,`와 같은 데이터가 있으면 인덱스가 터지는 버그를 고쳤습니다.
  - `,`구분자로 데이터를 자르고 공백을 지운 상태로 시간과 매핑을 하는데, 인덱스가 강의 장소 배열보다 넘치게 되는 경우가 발생해서 처리를 했습니다. 
- 리펙토링 과정에서 frame 권한 여부 확인을 frame id와 user id와 매칭하고 있어서 수정했습니다. 

# 💬 리뷰 중점사항
