### PR TITLE
fix: shop softDelete시에 reviews도 softDelete 되도록 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -305,9 +305,11 @@ public class Shop extends BaseEntity {
 
     public void delete() {
         this.isDeleted = true;
+        reviews.forEach(ShopReview::deleteReview);
     }
 
     public void cancelDelete() {
         this.isDeleted = false;
+        reviews.forEach(ShopReview::cancelReview);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1097 

# 🚀 작업 내용
1. shop softDelete시에 해당 shop과 관련된 review들도 softdelete 되도록 변경하였습니다.
2. 삭제된 상점 복구시에 해당 shop과 관련된 review들도 복구되도록 변경하였습니다.

# 💬 리뷰 중점사항
- 간단한 변경입니다
