### PR TITLE
fix : 정적 파일 경로 설정 오류(학생 이메일 비밀번호 수정)

### DIFF
--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import in.koreatech.koin.domain.bus.controller.BusStationEnumConverter;
@@ -77,5 +78,11 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedHeaders("*")
             .allowCredentials(true)
             .maxAge(3600);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/static/**")
+            .addResourceLocations("classpath:/static/"); // 정적 파일 경로
     }
 }

--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -83,6 +83,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/static/**")
-            .addResourceLocations("classpath:/static/"); // 정적 파일 경로
+            .addResourceLocations("classpath:/static/");
     }
 }

--- a/src/main/resources/mail/change_password_config.html
+++ b/src/main/resources/mail/change_password_config.html
@@ -58,7 +58,7 @@
     </tr>
 </table>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script src="/js/sha256.min.js"></script>
-<script src="/js/password.check.js"></script>
+<script src="/static/js/sha256.min.js"></script>
+<script src="/static/js/password.check.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1100 

# 🚀 작업 내용

1. 학생이 이메일로 비밀번호를 변경 할 수 없었던 오류를 수정했습니다. 
<img width="452" alt="image" src="https://github.com/user-attachments/assets/79719e4e-8b4a-4241-84e4-30267360cbce">

# 💬 리뷰 중점사항
현재 정적파일을 사용하는 곳은 학생이 이메일을 통하여 비밀번호를 수정하는 로직이 있습니다. 예전 [존재하지 않는 API 응답 커스텀하기](https://velog.io/@songsunkook/%EC%A1%B4%EC%9E%AC%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94-API-%EC%9D%91%EB%8B%B5-%EC%BB%A4%EC%8A%A4%ED%85%80%ED%95%98%EA%B8%B0) 관련 yml 파일 수정(add-mappings = false)이 있었고, 이 과정에서 정적 파일의 경로를 찾을 수 없는 오류가 있었습니다.

WebConfig 중 `addResourceHandlers`를 추가하여 `/static`으로 통하는 정적 파일의 경로를 지정해줬습니다.
앞으로 정적 파일의 관리가 필요하다면 `/static`에 넣고 사용하시면 됩니다.

ㅜㅜ 빙빙 돌아서 오류는 해결했습니다.. 도와주신 분들 감사합니다.