### PR TITLE
fix: AB테스트 토큰 발급용 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestApi.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestApi.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.admin.abtest.dto.request.AbtestAdminAssignRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestAssignRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestCloseRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestRequest;
+import in.koreatech.koin.admin.abtest.dto.response.AbtestAccessHistoryResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestAssignResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestDevicesResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestResponse;
@@ -177,6 +178,20 @@ public interface AbtestApi {
         @Auth(permit = {ADMIN}) Integer adminId,
         @PathVariable(value = "id") Integer abtestId,
         @RequestBody @Valid AbtestAdminAssignRequest abtestAdminAssignRequest
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "(NORMAL) AB테스트 토큰(access_history_id) 발급")
+    @PostMapping("/assign/token")
+    ResponseEntity<AbtestAccessHistoryResponse> issueAccessHistoryId(
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestController.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/controller/AbtestController.java
@@ -19,6 +19,7 @@ import in.koreatech.koin.admin.abtest.dto.request.AbtestAdminAssignRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestAssignRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestCloseRequest;
 import in.koreatech.koin.admin.abtest.dto.request.AbtestRequest;
+import in.koreatech.koin.admin.abtest.dto.response.AbtestAccessHistoryResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestAssignResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestDevicesResponse;
 import in.koreatech.koin.admin.abtest.dto.response.AbtestResponse;
@@ -123,6 +124,15 @@ public class AbtestController implements AbtestApi {
     ) {
         abtestService.assignVariableByAdmin(abtestId, abtestAdminAssignRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/assign/token")
+    public ResponseEntity<AbtestAccessHistoryResponse> issueAccessHistoryId(
+        @UserAgent UserAgentInfo userAgentInfo,
+        @UserId Integer userId
+    ) {
+        AbtestAccessHistoryResponse response = abtestService.issueAccessHistoryId(userAgentInfo, userId);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/assign")

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/response/AbtestAccessHistoryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/response/AbtestAccessHistoryResponse.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.admin.abtest.dto.response;
+
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AbtestAccessHistoryResponse(
+    @Schema(description = "기기 식별자")
+    Integer accessHistoryId
+) {
+
+    public static AbtestAccessHistoryResponse from(AccessHistory accessHistory) {
+        return new AbtestAccessHistoryResponse(accessHistory.getId());
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/abtest/dto/response/AbtestDevicesResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/dto/response/AbtestDevicesResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.admin.abtest.model.AccessHistory;
 import in.koreatech.koin.admin.abtest.model.Device;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -37,11 +38,12 @@ public record AbtestDevicesResponse(
     ) {
 
         public static InnerDeviceResponse from(Device device) {
+            AccessHistory accessHistory = device.getAccessHistory();
             return new InnerDeviceResponse(
                 device.getId(),
                 device.getType(),
                 device.getModel(),
-                device.getAccessHistory().getLastAccessedAt().toLocalDate());
+                accessHistory != null ? accessHistory.getLastAccessedAt().toLocalDate() : null);
         }
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/model/AccessHistory.java
@@ -69,6 +69,12 @@ public class AccessHistory extends BaseEntity {
         this.lastAccessedAt = lastAccessedAt;
     }
 
+    public static AccessHistory create() {
+        return AccessHistory.builder()
+            .lastAccessedAt(LocalDateTime.now())
+            .build();
+    }
+
     public void connectDevice(Device device) {
         this.device = device;
         device.setAccessHistory(this);

--- a/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
+++ b/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
@@ -49,7 +49,8 @@ public class AdminActivityHistoryAspect {
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.refresh(..)) && "
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.createAdmin(..)) && "
         + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.adminPasswordChange(..)) && "
-        + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.assignOrGetAbtestVariable(..))")
+        + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.assignOrGetAbtestVariable(..)) &&"
+        + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.issueAccessHistoryId(..))")
     private void excludeSpecificMethods() {
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1103

# 🚀 작업 내용

1. AB테스트 자신의 실험군 조회 API에서 각종 이슈가 발생하고 있습니다. 원인은 최초 편입된 사용자에 대해 동시에 여러 AB테스트가 적용된 페이지에서 동시에 동일 인자로 API를 요청으로 인한 DEADLOCK 발생 및 Null 데이터 삽입으로 확인했습니다. 이를 개선하기 위해 AB테스트 토큰 발급용 API를 추가하였고, 이후 클라이언트 배포 전에 AB테스트 적용 과정을 변경할 것을 요청할 예정입니다. 자세한 내용은 이슈 내용 및 슬랙 확인해주시면 감사하겠습니다!

# 💬 리뷰 중점사항
