### PR TITLE
feat: 시간표 프레임 한번에 조회 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -77,7 +77,7 @@ public interface TimetableApiV2 {
     @Operation(summary = "시간표 프레임 조회")
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/v2/timetables/frame")
-    ResponseEntity<List<TimetableFrameResponse>> getTimetablesFrame(
+    ResponseEntity<Object> getTimetablesFrame(
         @RequestParam(name = "semester") String semester,
         @Auth(permit = {STUDENT}) Integer userId
     );

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -76,9 +76,9 @@ public interface TimetableApiV2 {
     )
     @Operation(summary = "시간표 프레임 조회")
     @SecurityRequirement(name = "Jwt Authentication")
-    @GetMapping("/v2/timetables/frame")
+    @GetMapping("/v2/timetables/frames")
     ResponseEntity<Object> getTimetablesFrame(
-        @RequestParam(name = "semester") String semester,
+        @RequestParam(name = "semester", required = false) String semester,
         @Auth(permit = {STUDENT}) Integer userId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
@@ -54,11 +54,11 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     }
 
     @GetMapping("/v2/timetables/frames")
-    public ResponseEntity<List<TimetableFrameResponse>> getTimetablesFrame(
-        @RequestParam(name = "semester") String semester,
+    public ResponseEntity<Object> getTimetablesFrame(
+        @RequestParam(name = "semester", required = false) String semester,
         @Auth(permit = {STUDENT}) Integer userId
     ) {
-        List<TimetableFrameResponse> response = frameServiceV2.getTimetablesFrame(userId, semester);
+        Object response = frameServiceV2.getTimetablesFrame(userId, semester);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableFramesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableFramesResponse.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.domain.timetableV2.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record TimetableFramesResponse(
+    @Schema(description = "학기별 시간표 프레임", example = """
+        {
+            "20241": [
+                {
+                    "id": 1,
+                    "timetable_name": "시간표1",
+                    "is_main": true
+                },
+                {
+                    "id": 2,
+                    "timetable_name": "시간표2",
+                    "is_main": false
+                }
+            ]
+        }
+        """, requiredMode = Schema.RequiredMode.REQUIRED)
+    Map<String, List<TimetableFrameResponse>> semesters
+) {
+    public static TimetableFramesResponse from(List<TimetableFrame> timetableFrames) {
+        Map<String, List<TimetableFrameResponse>> groupedBySemester = timetableFrames.stream()
+            .collect(Collectors.groupingBy(
+                frame -> frame.getSemester().getSemester(),
+                Collectors.mapping(TimetableFrameResponse::from, Collectors.toList())
+            ));
+        return new TimetableFramesResponse(groupedBySemester);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -82,4 +82,6 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
     void deleteAllByUser(User user);
 
     void deleteAllByUserAndSemester(User user, Semester semester);
+
+    List<TimetableFrame> findAllByUserId(Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableFrameService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableFrameService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.timetableV2.dto.request.TimetableFrameCreateRequ
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableFrameUpdateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.response.TimetableFrameResponse;
 import in.koreatech.koin.domain.timetableV2.dto.response.TimetableFrameUpdateResponse;
+import in.koreatech.koin.domain.timetableV2.dto.response.TimetableFramesResponse;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.repository.SemesterRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
@@ -68,16 +69,9 @@ public class TimetableFrameService {
             .toList();
     }
 
-    public Map<String, Map<String, List<TimetableFrameResponse>>> getAllTimetablesFrame(Integer userId) {
+    public TimetableFramesResponse getAllTimetablesFrame(Integer userId) {
         List<TimetableFrame> timetableFrames = timetableFrameRepositoryV2.findAllByUserId(userId);
-
-        Map<String, List<TimetableFrameResponse>> groupedBySemester = timetableFrames.stream()
-            .collect(Collectors.groupingBy(
-                frame -> frame.getSemester().getSemester(),
-                Collectors.mapping(TimetableFrameResponse::from, Collectors.toList())
-            ));
-
-        return Map.of("semesters", groupedBySemester);
+        return TimetableFramesResponse.from(timetableFrames);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableFrameService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableFrameService.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.timetableV2.validation.TimetableFrameVali
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -23,7 +22,6 @@ import in.koreatech.koin.domain.timetableV2.factory.TimetableFrameCreator;
 import in.koreatech.koin.domain.timetableV2.factory.TimetableFrameUpdater;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
-import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.global.concurrent.ConcurrencyGuard;
 import lombok.RequiredArgsConstructor;
 
@@ -70,7 +68,6 @@ public class TimetableFrameService {
             .toList();
     }
 
-    @Transactional(readOnly = true)
     public Map<String, Map<String, List<TimetableFrameResponse>>> getAllTimetablesFrame(Integer userId) {
         List<TimetableFrame> timetableFrames = timetableFrameRepositoryV2.findAllByUserId(userId);
 

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
@@ -234,4 +234,59 @@ public class TimetableFrameApiTest extends AcceptanceTest {
         assertThat(timetableFrameRepositoryV2.findById(frame2.getId())).isNotPresent();
         assertThat(timetableFrameRepositoryV2.findById(frame3.getId())).isNotPresent();
     }
+
+    @Test
+    void 모든_학기의_시간표_프레임을_조회한다() throws Exception {
+        Semester semester1 = semesterFixture.semester("20241");
+        Semester semester2 = semesterFixture.semester("20242");
+
+        timetableV2Fixture.시간표1(user, semester1);
+        timetableV2Fixture.시간표2(user, semester1);
+
+        timetableV2Fixture.시간표1(user, semester2);
+        timetableV2Fixture.시간표2(user, semester2);
+        timetableV2Fixture.시간표3(user, semester2);
+
+        mockMvc.perform(
+                get("/v2/timetables/frames")
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+            {
+                "semesters": {
+                    "20241": [
+                        {
+                            "id": 1,
+                            "timetable_name": "시간표1",
+                            "is_main": true
+                        },
+                        {
+                            "id": 2,
+                            "timetable_name": "시간표2",
+                            "is_main": false
+                        }
+                    ],
+                    "20242": [
+                        {
+                            "id": 3,
+                            "timetable_name": "시간표1",
+                            "is_main": true
+                        },
+                        {
+                            "id": 4,
+                            "timetable_name": "시간표2",
+                            "is_main": false
+                        },
+                        {
+                            "id": 5,
+                            "timetable_name": "시간표3",
+                            "is_main": false
+                        }
+                    ]
+                }
+            }
+            """));
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1106 

# 🚀 작업 내용

1. 시간표 프레임을 한번에 조회 할 수 있게 구조를 변경했습니다.
requestparam인 semester가 없을때는 아래와 같은 값을 반환하게 했습니다.
``` json
{
  "semesters": {
    "20242": [
      {
        "id": 1,
        "timetable_name": "시간표1",
        "is_main": false
      },
      {
        "id": 2,
        "timetable_name": "시간표2",
        "is_main": true
      },
      {
        "id": 3,
        "timetable_name": "시간표3",
        "is_main": false
      }
    ],
    "20241": [
      {
        "id": 4,
        "timetable_name": "시간표1",
        "is_main": false
      },
      {
        "id": 5,
        "timetable_name": "시간표2",
        "is_main": true
      },
      {
        "id": 6,
        "timetable_name": "시간표3",
        "is_main": false
      }
    ]
  }
}
```


# 💬 리뷰 중점사항
