### PR TITLE
fix: V1 시간표에서 6시 이후 시간은 제외하고 조회되도록 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
@@ -119,10 +119,7 @@ public record TimetableResponse(
         }
 
         private static boolean isValidClassTime(int classTime) {
-            if (classTime < 100) {
-                return classTime < 19;
-            }
-            return classTime % 100 < 19;
+            return classTime < 19 || classTime % 100 < 19;
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
@@ -121,10 +121,8 @@ public record TimetableResponse(
         private static boolean isValidClassTime(int classTime) {
             if (classTime < 100) {
                 return classTime < 19;
-            } else {
-                int lastTwoDigits = classTime % 100;
-                return lastTwoDigits < 19;
             }
+            return classTime % 100 < 19;
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/dto/TimetableResponse.java
@@ -73,22 +73,29 @@ public record TimetableResponse(
 
         public static List<InnerTimetableResponse> from(List<TimetableLecture> timetableLectures) {
             return timetableLectures.stream()
+                .filter(timeTableLecture -> {
+                    if (timeTableLecture.getLecture() == null) {
+                        List<Integer> classTimes = parseIntegerClassTimesFromString(timeTableLecture.getClassTime());
+                        return classTimes.stream().allMatch(InnerTimetableResponse::isValidClassTime);
+                    }
+                    return true;
+                })
                 .map(timeTableLecture -> {
                     if (timeTableLecture.getLecture() == null) {
                         return new InnerTimetableResponse(
-                            timeTableLecture.getId(),
-                            null,
-                            null,
-                            null,
-                            null,
-                            timeTableLecture.getClassPlace(),
-                            timeTableLecture.getMemo(),
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            null
+                                timeTableLecture.getId(),
+                                null,
+                                null,
+                                null,
+                                parseIntegerClassTimesFromString(timeTableLecture.getClassTime()),
+                                timeTableLecture.getClassPlace(),
+                                timeTableLecture.getMemo(),
+                                null,
+                                timeTableLecture.getClassTitle(),
+                                null,
+                                null,
+                                timeTableLecture.getProfessor(),
+                                null
                         );
                     } else {
                         return new InnerTimetableResponse(
@@ -109,6 +116,15 @@ public record TimetableResponse(
                     }
                 })
                 .toList();
+        }
+
+        private static boolean isValidClassTime(int classTime) {
+            if (classTime < 100) {
+                return classTime < 19;
+            } else {
+                int lastTwoDigits = classTime % 100;
+                return lastTwoDigits < 19;
+            }
         }
     }
 


### PR DESCRIPTION
# 🚀 작업 내용
`GET /timetables`에서 6시 이후 시간은 제외하고 조회되도록 수정하였습니다.

- 문제상황
1. 커스텀 시간표 기능에서 6시 이후 시간을 만듦
2. 커스텀 시간표 기능이 아직 없는 안드로이드 폰에서 시간표를 조회
3. 시간표를 조회했을 때 6시 이후 시간이 조회되면 문제가 생김

- 작업
`TimetableResponse`에서 List<InnerTimetableResponse>에 들어갈 값을 추가하기 전에 filter를 추가하였습니다.
filter에서는 커스텀 시간표일 경우 강의 시간들을 가져와 6시 이후일 경우 추가하지 않도록 하였습니다. 

6시 이전인지 확인하는 코드
```java
if (classTime < 100) {
    return classTime < 19;
} else {
    int lastTwoDigits = classTime % 100;
    return lastTwoDigits < 19;
}
```
- 세자리 숫자일 경우 (ex. [211, 212])
  - 맨 첫글자는 요일을 의미해서 0은 월, 1은 화, 2는 수 ...
  - 뒤의 두자리는 시간을 의미// 9시: 1 ~ 2,  10시: 3 ~ 4 , ... , 18시: 17~18 
- 두자리 이하 숫자일 경우 (ex. [11, 12])
  - 맨 앞에 월요일을 의미하는 0이 있음
  - 따라서 11, 12는 월요일 14:00~15:00를 의미

# 💬 리뷰 중점사항
