### PR TITLE
fix: 시간표 프레임 롤백 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -14,6 +14,7 @@ import in.koreatech.koin.domain.timetableV2.exception.TimetableFrameNotFoundExce
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.LockModeType;
+import jakarta.validation.constraints.NotNull;
 
 public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, Integer> {
 
@@ -93,4 +94,6 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
     void deleteAllByUserAndSemester(User user, Semester semester);
 
     List<TimetableFrame> findAllByUserId(Integer userId);
+
+    boolean existsByUserAndSemester(User user, Semester semester);
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableFrameRepositoryV2.java
@@ -14,7 +14,6 @@ import in.koreatech.koin.domain.timetableV2.exception.TimetableFrameNotFoundExce
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.LockModeType;
-import jakarta.validation.constraints.NotNull;
 
 public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, Integer> {
 
@@ -61,21 +60,22 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
         """
-        SELECT t FROM TimetableFrame t
-        WHERE t.user.id = :userId
-        AND t.semester.id = :semesterId
-        AND t.isMain = false
-        ORDER BY t.createdAt ASC
-        LIMIT 1
-        """)
-    TimetableFrame findNextFirstTimetableFrame(@Param("userId") Integer userId, @Param("semesterId") Integer semesterId);
+            SELECT t FROM TimetableFrame t
+            WHERE t.user.id = :userId
+            AND t.semester.id = :semesterId
+            AND t.isMain = false
+            ORDER BY t.createdAt ASC
+            LIMIT 1
+            """)
+    TimetableFrame findNextFirstTimetableFrame(@Param("userId") Integer userId,
+        @Param("semesterId") Integer semesterId);
 
     @Query(
         """
-        SELECT COUNT(t) FROM TimetableFrame t
-        WHERE t.user.id = :userId
-        AND t.semester.id = :semesterId
-        """)
+            SELECT COUNT(t) FROM TimetableFrame t
+            WHERE t.user.id = :userId
+            AND t.semester.id = :semesterId
+            """)
     int countByUserIdAndSemesterId(@Param("userId") Integer userId, @Param("semesterId") Integer semesterId);
 
     void deleteById(Integer id);
@@ -91,6 +91,7 @@ public interface TimetableFrameRepositoryV2 extends Repository<TimetableFrame, I
         return findByIdWithDeleted(id)
             .orElseThrow(() -> TimetableFrameNotFoundException.withDetail("id: " + id));
     }
+
     void deleteAllByUserAndSemester(User user, Semester semester);
 
     List<TimetableFrame> findAllByUserId(Integer userId);

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureUpdateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.response.TimetableLectureResponse;
@@ -18,6 +19,8 @@ import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureCreator;
 import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureUpdater;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,7 @@ public class TimetableLectureService {
 
     @PersistenceContext
     private EntityManager entityManager;
+    private final UserRepository userRepository;
     private final TimetableLectureRepositoryV2 timetableLectureRepositoryV2;
     private final TimetableFrameRepositoryV2 timetableFrameRepositoryV2;
     private final TimetableLectureCreator timetableLectureCreator;
@@ -101,6 +105,14 @@ public class TimetableLectureService {
     public TimetableLectureResponse rollbackTimetableFrame(Integer frameId, Integer userId) {
         TimetableFrame timetableFrame = timetableFrameRepositoryV2.getByIdWithDeleted(frameId);
         validateUserAuthorization(timetableFrame.getUser().getId(), userId);
+
+        User user = userRepository.getById(userId);
+        List<TimetableFrame> frames = timetableFrameRepositoryV2.findAllByUserAndSemester(user,
+            timetableFrame.getSemester());
+
+        if (frames.isEmpty()) {
+            timetableFrame.updateMainFlag(true);
+        }
         timetableFrame.undelete();
 
         timetableLectureRepositoryV2.findAllByFrameIdWithDeleted(timetableFrame.getId()).stream()

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -9,16 +9,15 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureUpdateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.response.TimetableLectureResponse;
+import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureCreator;
+import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureUpdater;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
-import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureCreator;
-import in.koreatech.koin.domain.timetableV2.factory.TimetableLectureUpdater;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
@@ -107,10 +106,10 @@ public class TimetableLectureService {
         validateUserAuthorization(timetableFrame.getUser().getId(), userId);
 
         User user = userRepository.getById(userId);
-        List<TimetableFrame> frames = timetableFrameRepositoryV2.findAllByUserAndSemester(user,
+        boolean hasTimetableFrame = timetableFrameRepositoryV2.existsByUserAndSemester(user,
             timetableFrame.getSemester());
 
-        if (frames.isEmpty()) {
+        if (!hasTimetableFrame) {
             timetableFrame.updateMainFlag(true);
         }
         timetableFrame.undelete();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1125 

# 🚀 작업 내용

- 시간표 롤백 과정에서 발생하는 버그를 수정했습니다. [관련 스레드](https://bcsdlab.slack.com/archives/C06NEM6EY3W/p1733835482261379)
  - main 시간표 프레임과 main 시간표 프레임이 아닌 시간표 2개가 있음
  - main 시간표를 지우면 그 다음 시간표 프레임이 main이 됨
  - 그 시간표도 지우면 둘 다 main = false / is_deleted = 1 인 상태로 DB에 유지
  - 롤백 API 호출하면 is_delete = 0 으로만 복구되고, main은 여전히 false
  - 이때, 시간표 생성하면 다 main = false 으로 생성됨 (시간표 개수로 메인을 판단해서 생기는 문제)
  - 롤백 과정에서 현재 시간표의 개수를 바탕으로 main여부를 설정하는 로직을 넣었습니다. 

# 💬 리뷰 중점사항
