### PR TITLE
fix: 중복된 여러개의 lecture_id 삭제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
@@ -26,12 +26,7 @@ public interface TimetableLectureRepositoryV2 extends Repository<TimetableLectur
 
     TimetableLecture save(TimetableLecture timetableLecture);
 
-    Optional<TimetableLecture> findByTimetableFrameIdAndLectureId(Integer frameId, Integer lectureId);
-
-    default TimetableLecture getByFrameIdAndLectureId(Integer frameId, Integer lectureId) {
-        return findByTimetableFrameIdAndLectureId(frameId, lectureId)
-            .orElseThrow(() -> TimetableLectureNotFoundException.withDetail("frameId: " + frameId + ", lectureId: " + lectureId));
-    }
+    List<TimetableLecture> findAllByTimetableFrameIdAndLectureId(Integer frameId, Integer lectureId);
 
     @Query(value = "SELECT * FROM timetable_lecture WHERE id = :id", nativeQuery = true)
     Optional<TimetableLecture> findByIdWithDeleted(@Param("id") Integer id);

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -82,8 +82,7 @@ public class TimetableLectureService {
     public void deleteTimetableLectureByFrameId(Integer frameId, Integer lectureId, Integer userId) {
         TimetableFrame frame = timetableFrameRepositoryV2.getById(frameId);
         validateUserAuthorization(frame.getUser().getId(), userId);
-        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getByFrameIdAndLectureId(frameId, lectureId);
-        timetableLecture.delete();
+        timetableLectureRepositoryV2.findAllByTimetableFrameIdAndLectureId(frameId, lectureId).forEach(TimetableLecture::delete);
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1127
기존 DB에 똑같은 lecture_id가 여러개 있을때 DELETE/v2/timetables/frame/{frameId}/lecture/{lectureId} API를 쓰게되면 오류가 발생했습니다.

# 🚀 작업 내용
1. JPA Repository에서 해당 쿼리반환타입을 List로 변경했습니다.

# 💬 리뷰 중점사항
