### PR TITLE
refactor: 엑셀 다운로드 따닥 방지

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
@@ -16,6 +16,7 @@ public class DuplicateExcelRequestException extends DuplicationException {
     }
 
     public static DuplicateExcelRequestException withDetail(LocalDate startDate, LocalDate endDate) {
-        return new DuplicateExcelRequestException(DEFAULT_MESSAGE, "startDate: '" + startDate + "'" + "endDate: " + endDate);
+        return new DuplicateExcelRequestException(DEFAULT_MESSAGE,
+            "startDate: '" + startDate + "'" + "endDate: " + endDate);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import in.koreatech.koin.global.exception.DuplicationException;
 
 public class DuplicateExcelRequestException extends DuplicationException {
+
     private static final String DEFAULT_MESSAGE = "동일한 요청을 30초 안에 다시 보낼 수 없습니다!";
 
     public DuplicateExcelRequestException(String message) {

--- a/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/exception/DuplicateExcelRequestException.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.coop.exception;
+
+import java.time.LocalDate;
+
+import in.koreatech.koin.global.exception.DuplicationException;
+
+public class DuplicateExcelRequestException extends DuplicationException {
+    private static final String DEFAULT_MESSAGE = "동일한 요청을 30초 안에 다시 보낼 수 없습니다!";
+
+    public DuplicateExcelRequestException(String message) {
+        super(message);
+    }
+
+    public DuplicateExcelRequestException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DuplicateExcelRequestException withDetail(LocalDate startDate, LocalDate endDate) {
+        return new DuplicateExcelRequestException(DEFAULT_MESSAGE, "startDate: '" + startDate + "'" + "endDate: " + endDate);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Getter
 @RedisHash(value = "excelDownload")
 public class ExcelDownloadCache {
-    
+
     private static final long CACHE_EXPIRE_MINUTES = 30L;
 
     @Id
@@ -27,7 +27,7 @@ public class ExcelDownloadCache {
         this.expiration = expiration;
     }
 
-    public static ExcelDownloadCache from(String id){
+    public static ExcelDownloadCache from(String id) {
         return ExcelDownloadCache.builder()
             .id(id)
             .expiration(CACHE_EXPIRE_MINUTES)

--- a/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.coop.model;
 
+import java.time.LocalDate;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisHash;
@@ -27,9 +28,9 @@ public class ExcelDownloadCache {
         this.expiration = expiration;
     }
 
-    public static ExcelDownloadCache from(String id) {
+    public static ExcelDownloadCache from(LocalDate startDate, LocalDate endDate) {
         return ExcelDownloadCache.builder()
-            .id(id)
+            .id(startDate.toString() + endDate.toString())
             .expiration(CACHE_EXPIRE_SECONDS)
             .build();
     }

--- a/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @RedisHash(value = "excelDownload")
 public class ExcelDownloadCache {
 
-    private static final long CACHE_EXPIRE_MINUTES = 30L;
+    private static final long CACHE_EXPIRE_SECONDS = 30L;
 
     @Id
     private String id;
@@ -30,7 +30,7 @@ public class ExcelDownloadCache {
     public static ExcelDownloadCache from(String id) {
         return ExcelDownloadCache.builder()
             .id(id)
-            .expiration(CACHE_EXPIRE_MINUTES)
+            .expiration(CACHE_EXPIRE_SECONDS)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/model/ExcelDownloadCache.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.domain.coop.model;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash(value = "excelDownload")
+public class ExcelDownloadCache {
+    
+    private static final long CACHE_EXPIRE_MINUTES = 30L;
+
+    @Id
+    private String id;
+
+    @TimeToLive(unit = TimeUnit.SECONDS)
+    private final Long expiration;
+
+    @Builder
+    private ExcelDownloadCache(String id, Long expiration) {
+        this.id = id;
+        this.expiration = expiration;
+    }
+
+    public static ExcelDownloadCache from(String id){
+        return ExcelDownloadCache.builder()
+            .id(id)
+            .expiration(CACHE_EXPIRE_MINUTES)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/repository/ExcelDownloadCacheRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/repository/ExcelDownloadCacheRepository.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.coop.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.coop.model.ExcelDownloadCache;
+
+public interface ExcelDownloadCacheRepository extends Repository<ExcelDownloadCache, String> {
+
+    ExcelDownloadCache save(ExcelDownloadCache excelDownloadCache);
+
+    Optional<ExcelDownloadCache> findById(String id);
+
+    boolean existsById(String id);
+}

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -292,6 +292,6 @@ public class CoopService {
         if (isCacheExist) {
             throw DuplicateExcelRequestException.withDetail(startDate, endDate);
         }
-        excelDownloadCacheRepository.save(ExcelDownloadCache.from(startDate.toString() + endDate.toString()));
+        excelDownloadCacheRepository.save(ExcelDownloadCache.from(startDate, endDate));
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈


# 🚀 작업 내용

1. 엑셀 다운로드 중복 요청 방지 기능입니다
2. 동일한 인자로 30초 동안 재요청을 방지하는 로직을 만들었습니다

# 💬 리뷰 중점사항