### PR TITLE
chore: 노선 지역 이름 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/model/enums/ShuttleBusRegion.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/model/enums/ShuttleBusRegion.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ShuttleBusRegion {
-    CHEONAN_ASAN("천안·아산"),
+    CHEONAN_ASAN("천안・아산"),
     CHEONGJU("청주"),
     SEOUL("서울"),
-    DAEJEON_SEJONG("대전·세종"),
+    DAEJEON_SEJONG("대전・세종"),
     ;
 
     private final String label;


### PR DESCRIPTION
# 🔥 연관 이슈
![image](https://github.com/user-attachments/assets/d4216ecb-1c12-43b2-918a-2b70fcbc7a47)
![image](https://github.com/user-attachments/assets/f63a4e01-0ada-4c68-a0b4-56d0f410ef83)

# 🚀 작업 내용

노선 지역 이름 반환 시 · 대신 ・사용 

ex: 천안·아산 -> 천안・아산

# 💬 리뷰 중점사항
