### PR TITLE
fix: 계절학기 삽입을 위한 lecture 컬럼 크기 변경

### DIFF
--- a/src/main/resources/db/migration/V105__alter_lecture_semester_date_size.sql
+++ b/src/main/resources/db/migration/V105__alter_lecture_semester_date_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lectures MODIFY semester_date VARCHAR(10) NOT NULL;

--- a/src/main/resources/db/migration/V106__alter_lecture_class_time_size.sql
+++ b/src/main/resources/db/migration/V106__alter_lecture_class_time_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lectures MODIFY class_time VARCHAR(255) NOT NULL;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1141 

# 🚀 작업 내용

- 계절학기 삽입을 위한 lecture 컬럼 크기 변경을 했습니다. 
  - semester_date의 크기를 기존 6에서 10으로 늘렸습니다 ex) `2024-여름`
  - class_time의 크기를 기존 100에서 255으로 늘렸습니다,

# 💬 리뷰 중점사항
