### PR TITLE
fix: 식단 이미지 알림 롤백 

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +39,6 @@ import in.koreatech.koin.domain.coop.exception.DuplicateExcelRequestException;
 import in.koreatech.koin.domain.coop.exception.StartDateAfterEndDateException;
 import in.koreatech.koin.domain.coop.model.Coop;
 import in.koreatech.koin.domain.coop.model.DiningImageUploadEvent;
-import in.koreatech.koin.domain.coop.model.DiningNotifyCache;
 import in.koreatech.koin.domain.coop.model.DiningSoldOutEvent;
 import in.koreatech.koin.domain.coop.model.ExcelDownloadCache;
 import in.koreatech.koin.domain.coop.repository.CoopRepository;
@@ -50,7 +48,6 @@ import in.koreatech.koin.domain.coop.repository.ExcelDownloadCacheRepository;
 import in.koreatech.koin.domain.coopshop.model.CoopShopType;
 import in.koreatech.koin.domain.coopshop.service.CoopShopService;
 import in.koreatech.koin.domain.dining.model.Dining;
-import in.koreatech.koin.domain.dining.model.DiningType;
 import in.koreatech.koin.domain.dining.repository.DiningRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserToken;
@@ -100,9 +97,19 @@ public class CoopService {
     @Transactional
     public void saveDiningImage(DiningImageRequest imageRequest) {
         Dining dining = diningRepository.getById(imageRequest.menuId());
+
+        boolean isImageExist = diningRepository.existsByDateAndTypeAndImageUrlIsNotNull(dining.getDate(),
+            dining.getType());
+        LocalDateTime now = LocalDateTime.now(clock);
+        boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType(), true);
+        if (isOpened && !isImageExist) {
+            eventPublisher.publishEvent(new DiningImageUploadEvent(dining.getId(), dining.getImageUrl()));
+        }
+
         dining.setImageUrl(imageRequest.imageUrl());
     }
 
+    /* TODO: 알림 로직 테스트 후 주석 제거
     public void sendDiningNotify() {
         DiningType diningType = coopShopService.getDiningType();
         LocalDate nowDate = LocalDate.now(clock);
@@ -150,7 +157,7 @@ public class CoopService {
     private void sendNotify(String diningNotifyId, List<Dining> dinings) {
         diningNotifyCacheRepository.save(DiningNotifyCache.from(diningNotifyId));
         eventPublisher.publishEvent(new DiningImageUploadEvent(dinings.get(0).getId(), dinings.get(0).getImageUrl()));
-    }
+    }*/
 
     @Transactional
     public CoopLoginResponse coopLogin(CoopLoginRequest request) {

--- a/src/main/java/in/koreatech/koin/domain/coop/util/CoopScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/util/CoopScheduler.java
@@ -15,8 +15,10 @@ public class CoopScheduler {
     private final CoopService coopService;
 
     @Scheduled(cron = "0 0/6 7 * * *")
-    @Scheduled(cron = "0 30/6 10-11 * * *")
-    @Scheduled(cron = "0 30/6 16-17 * * *")
+    @Scheduled(cron = "0 30/6 10 * * *")
+    @Scheduled(cron = "0 0/6 11 * * *")
+    @Scheduled(cron = "0 30/6 16 * * *")
+    @Scheduled(cron = "0 0/6 17 * * *")
     public void notifyDiningImageUpload() {
         try {
             coopService.sendDiningNotify();

--- a/src/main/java/in/koreatech/koin/domain/coop/util/CoopScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/util/CoopScheduler.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.domain.coop.util;
 
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.domain.coop.service.CoopService;
@@ -14,6 +13,7 @@ public class CoopScheduler {
 
     private final CoopService coopService;
 
+    /* TODO: 알림 로직 테스트 후 주석 제거
     @Scheduled(cron = "0 0/6 7 * * *")
     @Scheduled(cron = "0 30/6 10 * * *")
     @Scheduled(cron = "0 0/6 11 * * *")
@@ -25,5 +25,5 @@ public class CoopScheduler {
         } catch (Exception e) {
             log.warn("식단 이미지 알림 과정에서 오류가 발생했습니다.");
         }
-    }
+    }*/
 }

--- a/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/DiningApiTest.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.acceptance;
 
-import static in.koreatech.koin.domain.dining.model.DiningType.LUNCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -20,7 +19,6 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
-import in.koreatech.koin.domain.coop.model.DiningNotifyCache;
 import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
 import in.koreatech.koin.domain.coop.repository.DiningNotifyCacheRepository;
 import in.koreatech.koin.domain.coop.repository.DiningSoldOutCacheRepository;
@@ -347,27 +345,6 @@ class DiningApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 특정_식단의_좋아요_중복해서_누르면_에러() throws Exception {
-        mockMvc.perform(
-                patch("/dining/like")
-                    .header("Authorization", "Bearer " + token_준기)
-                    .param("diningId", String.valueOf(1))
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isOk())
-            .andReturn();
-
-        mockMvc.perform(
-                patch("/dining/like")
-                    .header("Authorization", "Bearer " + token_준기)
-                    .param("diningId", String.valueOf(1))
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
-            .andExpect(status().isConflict())
-            .andReturn();
-    }
-
-    @Test
     void 좋아요_누른_식단은_isLiked가_true로_반환() throws Exception {
         mockMvc.perform(
                 patch("/dining/like")
@@ -517,6 +494,7 @@ class DiningApiTest extends AcceptanceTest {
         setUp();
     }
 
+    /* TODO: 알림 로직 테스트 후 주석 제거
     @Test
     void 이미지가_모두_존재하지_않으면_알림이_발송되지_않는다() throws Exception {
         coopService.sendDiningNotify();
@@ -546,7 +524,7 @@ class DiningApiTest extends AcceptanceTest {
         forceVerify(() -> verify(coopEventListener).onDiningImageUploadRequest(any()));
         clear();
         setUp();
-    }
+    }*/
 
     @Test
     void 특정_메뉴_특정_코너의_식단을_검색한다() throws Exception {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 식단 이미지 알림 로직 분리 작업을 롤백합니다
2. 안드로이드 스테이지 알림 테스트가 지금 안돼서 나중에 수정 되면 테스트 후 배포 예정입니다 

# 💬 리뷰 중점사항
