### PR TITLE
feat: 시간표 조회 API 이수 구분 반환 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/exception/CatalogNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/exception/CatalogNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.graduation.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class CatalogNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 대학 요람입니다.";
+
+    protected CatalogNotFoundException(String message) {
+        super(message);
+    }
+
+    protected CatalogNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static CatalogNotFoundException withDetail(String detail) {
+        return new CatalogNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/exception/CourseTypeNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/exception/CourseTypeNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.graduation.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class CourseTypeNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 이수 구분입니다.";
+
+    protected CourseTypeNotFoundException(String message) {
+        super(message);
+    }
+
+    protected CourseTypeNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static CourseTypeNotFoundException withDetail(String detail) {
+        return new CourseTypeNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/exception/DepartmentNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/exception/DepartmentNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.graduation.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class DepartmentNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 학과입니다.";
+
+    protected DepartmentNotFoundException(String message) {
+        super(message);
+    }
+
+    protected DepartmentNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DepartmentNotFoundException withDetail(String detail) {
+        return new DepartmentNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.graduation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.graduation.exception.CatalogNotFoundException;
+import in.koreatech.koin.domain.graduation.model.Catalog;
+import in.koreatech.koin.domain.graduation.model.Department;
+
+public interface CatalogRepository extends Repository<Catalog, Integer> {
+    Optional<Catalog> findByYearAndDepartmentAndCode(String year, Department department, String code);
+
+    default Catalog getByYearAndDepartmentAndCode(String year, Department department, String code) {
+        return findByYearAndDepartmentAndCode(year, department, code)
+            .orElseThrow(() -> CatalogNotFoundException.withDetail(
+                "year: " + year + ", department: " + department + ", code: " + code));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CourseTypeRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CourseTypeRepository.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.graduation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.graduation.exception.CourseTypeNotFoundException;
+import in.koreatech.koin.domain.graduation.model.CourseType;
+
+public interface CourseTypeRepository extends Repository<CourseType, Integer> {
+
+    CourseType save(CourseType courseType);
+
+    Optional<CourseType> findById(Integer id);
+
+    default CourseType getCourseTypeById(Integer id) {
+        return findById(id)
+            .orElseThrow(() -> CourseTypeNotFoundException.withDetail("course_type_id: " + id));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/DepartmentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/DepartmentRepository.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.domain.graduation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.graduation.exception.DepartmentNotFoundException;
+import in.koreatech.koin.domain.graduation.model.Department;
+
+public interface DepartmentRepository extends Repository<Department, Integer> {
+    Optional<Department> findByName(String name);
+
+    default Department getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> DepartmentNotFoundException.withDetail("name: " + name));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.graduation.model.CourseType;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetableV2.exception.TimetableLectureClassTimeNullException;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
@@ -91,11 +92,13 @@ public record TimetableLectureCreateRequest(
                 memo,
                 false,
                 null,
-                timetableFrame
+                timetableFrame,
+                null
             );
         }
 
-        public TimetableLecture toTimetableLecture(TimetableFrame timetableFrame, Lecture lecture) {
+        public TimetableLecture toTimetableLecture(TimetableFrame timetableFrame, Lecture lecture,
+            CourseType courseType) {
             return new TimetableLecture(
                 classTitle,
                 getClassTimeToString(),
@@ -105,7 +108,8 @@ public record TimetableLectureCreateRequest(
                 memo,
                 false,
                 lecture,
-                timetableFrame
+                timetableFrame,
+                courseType
             );
         }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -69,7 +69,10 @@ public record TimetableLectureResponse(
         String professor,
 
         @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
-        String department
+        String department,
+
+        @Schema(description = "이수 구분", example = "전공필수", requiredMode = NOT_REQUIRED)
+        String courseType
     ) {
         @JsonNaming(value = SnakeCaseStrategy.class)
         public record ClassInfo(
@@ -156,6 +159,7 @@ public record TimetableLectureResponse(
                         null,
                         null,
                         timetableLecture.getProfessor(),
+                        null,
                         null
                     );
                 } else {
@@ -172,7 +176,8 @@ public record TimetableLectureResponse(
                         lecture.getLectureClass(),
                         lecture.getTarget(),
                         getProfessor(timetableLecture, lecture),
-                        lecture.getDepartment()
+                        lecture.getDepartment(),
+                        timetableLecture.getCourseType().getName()
                     );
                 }
                 timetableLectureList.add(response);

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 import org.hibernate.annotations.Where;
 
+import in.koreatech.koin.domain.graduation.model.CourseType;
 import in.koreatech.koin.domain.timetable.dto.TimetableUpdateRequest;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.global.domain.BaseEntity;
@@ -71,9 +72,14 @@ public class TimetableLecture extends BaseEntity {
     @JoinColumn(name = "frame_id")
     private TimetableFrame timetableFrame;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_type_id")
+    private CourseType courseType;
+
     @Builder
     public TimetableLecture(String classTitle, String classTime, String classPlace, String professor,
-        String grades, String memo, boolean isDeleted, Lecture lecture, TimetableFrame timetableFrame) {
+        String grades, String memo, boolean isDeleted, Lecture lecture, TimetableFrame timetableFrame,
+        CourseType courseType) {
         this.classTitle = classTitle;
         this.classTime = classTime;
         this.classPlace = classPlace;
@@ -83,6 +89,7 @@ public class TimetableLecture extends BaseEntity {
         this.isDeleted = isDeleted;
         this.lecture = lecture;
         this.timetableFrame = timetableFrame;
+        this.courseType = courseType;
     }
 
     public void update(

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -41,7 +41,7 @@ public class TimetableLectureService {
     public TimetableLectureResponse createTimetableLectures(Integer userId, TimetableLectureCreateRequest request) {
         TimetableFrame frame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
         validateUserAuthorization(frame.getUser().getId(), userId);
-        timetableLectureCreator.createTimetableLectures(request, frame);
+        timetableLectureCreator.createTimetableLectures(request, userId, frame);
         return getTimetableLectureResponse(userId, frame);
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -242,7 +242,7 @@ class TimetableApiTest extends AcceptanceTest {
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
 
-        timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+        timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론, null, null);
 
         mockMvc.perform(
                 get("/timetables")
@@ -324,8 +324,8 @@ class TimetableApiTest extends AcceptanceTest {
         Semester semester2 = semesterFixture.semester("20201");
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester1.getSemester());
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester2.getSemester());
-        timetableV2Fixture.시간표6(user, semester1, HRD_개론, null);
-        timetableV2Fixture.시간표6(user, semester2, 건축구조의_이해_및_실습, null);
+        timetableV2Fixture.시간표6(user, semester1, HRD_개론, null, null, null);
+        timetableV2Fixture.시간표6(user, semester2, 건축구조의_이해_및_실습, null, null, null);
 
         mockMvc.perform(
                 get("/semesters/check")
@@ -553,7 +553,7 @@ class TimetableApiTest extends AcceptanceTest {
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
 
-        timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+        timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론, null, null);
 
         mockMvc.perform(
                 delete("/timetable")

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
@@ -14,12 +14,14 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.graduation.model.CourseType;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.CourseTypeFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -47,6 +49,9 @@ public class TimetableFrameApiTest extends AcceptanceTest {
 
     @Autowired
     private TimetableLectureRepositoryV2 timetableLectureRepositoryV2;
+
+    @Autowired
+    private CourseTypeFixture courseTypeFixture;
 
     private User user;
     private String token;
@@ -165,8 +170,8 @@ public class TimetableFrameApiTest extends AcceptanceTest {
     @Test
     void 강의를_담고_있는_특정_시간표_frame을_삭제한다() throws Exception {
         Lecture lecture = lectureFixture.HRD_개론(semester.getSemester());
-
-        TimetableFrame frame1 = timetableV2Fixture.시간표5(user, semester, lecture);
+        CourseType courseType = courseTypeFixture.HRD_필수();
+        TimetableFrame frame1 = timetableV2Fixture.시간표5(user, semester, lecture, courseType);
 
         mockMvc.perform(
                 delete("/v2/timetables/frame")

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
@@ -310,7 +310,7 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "target": "기공1",
                             "professor": "박한수,최준호",
                             "department": "기계공학부",
-                            "course_type": "MSC 필수"
+                            "course_type": "HRD 필수"
                         }
                     ],
                     "grades": 6,

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
@@ -15,11 +15,13 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.graduation.model.CourseType;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.CourseTypeFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -41,6 +43,9 @@ public class TimetableLectureApiTest extends AcceptanceTest {
 
     @Autowired
     private LectureFixture lectureFixture;
+
+    @Autowired
+    private CourseTypeFixture courseTypeFixture;
 
     private User user;
     private String token;
@@ -75,7 +80,7 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                                     ],
                                     "professor" : "서정빈",
                                     "grades": "2",
-                                    "memo" : "메모"
+                                    "memo" : "메모",
                                 },
                                 {
                                     "class_title": "커스텀생성2",
@@ -117,7 +122,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": null,
                             "target": null,
                             "professor": "서정빈",
-                            "department": null
+                            "department": null,
+                            "course_type": null
                         },
                         {
                             "id": 2,
@@ -137,7 +143,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": null,
                             "target": null,
                             "professor": "감사 서정빈",
-                            "department": null
+                            "department": null,
+                            "course_type": null
                         }
                     ],
                     "grades": 3,
@@ -211,7 +218,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": null,
                             "target": null,
                             "professor": "서정빈",
-                            "department": null
+                            "department": null,
+                            "course_type": null
                         },
                         {
                             "id": 2,
@@ -231,7 +239,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": null,
                             "target": null,
                             "professor": "알바 서정빈",
-                            "department": null
+                            "department": null,
+                            "course_type": null
                         }
                     ],
                     "grades": 0,
@@ -245,7 +254,10 @@ public class TimetableLectureApiTest extends AcceptanceTest {
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
 
-        TimetableFrame frame = timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+        CourseType 전공_필수 = courseTypeFixture.전공_필수();
+        CourseType HRD_필수 = courseTypeFixture.HRD_필수();
+
+        TimetableFrame frame = timetableV2Fixture.시간표6(user, semester, 건축구조의_이해_및_실습, HRD_개론, 전공_필수, HRD_필수);
 
         mockMvc.perform(
                 get("/v2/timetables/lecture")
@@ -276,7 +288,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "01",
                             "target": "디자 1 건축",
                             "professor": "황현식",
-                            "department": "디자인ㆍ건축공학부"
+                            "department": "디자인ㆍ건축공학부",
+                            "course_type": "전공 필수"
                         },
                         {
                             "id": 2,
@@ -296,7 +309,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "06",
                             "target": "기공1",
                             "professor": "박한수,최준호",
-                            "department": "기계공학부"
+                            "department": "기계공학부",
+                            "course_type": "MSC 필수"
                         }
                     ],
                     "grades": 6,
@@ -309,7 +323,10 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     void 시간표에서_특정_강의를_삭제한다() throws Exception {
         Lecture lecture1 = lectureFixture.HRD_개론("20192");
         Lecture lecture2 = lectureFixture.영어청해("20192");
-        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2);
+        CourseType courseType1 = courseTypeFixture.HRD_필수();
+        CourseType courseType2 = courseTypeFixture.교양_필수();
+
+        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2, courseType1, courseType2);
 
         Integer lectureId = lecture1.getId();
 
@@ -326,7 +343,10 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     void 시간표에서_특정_강의를_삭제한다_V2() throws Exception {
         Lecture lecture1 = lectureFixture.HRD_개론("20192");
         Lecture lecture2 = lectureFixture.영어청해("20192");
-        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2);
+        CourseType courseType1 = courseTypeFixture.HRD_필수();
+        CourseType courseType2 = courseTypeFixture.교양_필수();
+
+        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2, courseType1, courseType2);
 
         Integer frameId = frame.getId();
         Integer lectureId = lecture1.getId();
@@ -343,7 +363,10 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     void 시간표에서_여러개의_강의를_한번에_삭제한다_V2() throws Exception {
         Lecture lecture1 = lectureFixture.HRD_개론("20192");
         Lecture lecture2 = lectureFixture.영어청해("20192");
-        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2);
+        CourseType courseType1 = courseTypeFixture.HRD_필수();
+        CourseType courseType2 = courseTypeFixture.교양_필수();
+
+        TimetableFrame frame = timetableV2Fixture.시간표4(user, semester, lecture1, lecture2, courseType1, courseType2);
 
         List<Integer> timetableLectureIds = frame.getTimetableLectures().stream()
             .map(TimetableLecture::getId)
@@ -364,7 +387,9 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     void 시간표에서_삭제된_강의를_복구한다_V2() throws Exception {
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
-        TimetableFrame frame = timetableV2Fixture.시간표8(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+        CourseType courseType1 = courseTypeFixture.전공_필수();
+        CourseType courseType2 = courseTypeFixture.교양_필수();
+        TimetableFrame frame = timetableV2Fixture.시간표8(user, semester, 건축구조의_이해_및_실습, HRD_개론, courseType1, courseType2);
 
         List<Integer> timetableLecturesId = frame.getTimetableLectures().stream()
             .map(TimetableLecture::getId)
@@ -401,7 +426,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "01",
                             "target": "디자 1 건축",
                             "professor": "황현식",
-                            "department": "디자인ㆍ건축공학부"
+                            "department": "디자인ㆍ건축공학부",
+                            "course_type": "전공 필수"
                         },
                         {
                             "id": 2,
@@ -421,7 +447,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "06",
                             "target": "기공1",
                             "professor": "박한수,최준호",
-                            "department": "기계공학부"
+                            "department": "기계공학부",
+                            "course_type": "MSC 필수"
                         }
                     ],
                     "grades": 6,
@@ -434,7 +461,9 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     void 삭제된_시간표프레임과_그에_해당하는_강의를_복구한다_V2() throws Exception {
         Lecture 건축구조의_이해_및_실습 = lectureFixture.건축구조의_이해_및_실습(semester.getSemester());
         Lecture HRD_개론 = lectureFixture.HRD_개론(semester.getSemester());
-        TimetableFrame frame = timetableV2Fixture.시간표7(user, semester, 건축구조의_이해_및_실습, HRD_개론);
+        CourseType courseType1 = courseTypeFixture.전공_필수();
+        CourseType courseType2 = courseTypeFixture.교양_필수();
+        TimetableFrame frame = timetableV2Fixture.시간표7(user, semester, 건축구조의_이해_및_실습, HRD_개론, courseType1, courseType2);
 
         mockMvc.perform(
                 post("/v2/timetables/frame/rollback")
@@ -465,7 +494,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "01",
                             "target": "디자 1 건축",
                             "professor": "황현식",
-                            "department": "디자인ㆍ건축공학부"
+                            "department": "디자인ㆍ건축공학부",
+                            "course_type": "전공 필수"
                         },
                         {
                             "id": 2,
@@ -485,7 +515,8 @@ public class TimetableLectureApiTest extends AcceptanceTest {
                             "lecture_class": "06",
                             "target": "기공1",
                             "professor": "박한수,최준호",
-                            "department": "기계공학부"
+                            "department": "기계공학부",
+                            "course_type": "MSC 필수"
                         }
                     ],
                     "grades": 6,

--- a/src/test/java/in/koreatech/koin/fixture/CourseTypeFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/CourseTypeFixture.java
@@ -1,0 +1,41 @@
+package in.koreatech.koin.fixture;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.domain.graduation.model.CourseType;
+import in.koreatech.koin.domain.graduation.repository.CourseTypeRepository;
+
+@Component
+@SuppressWarnings("NonAsciiCharacters")
+public class CourseTypeFixture {
+
+    private final CourseTypeRepository courseTypeRepository;
+
+    public CourseTypeFixture(CourseTypeRepository courseTypeRepository) {
+        this.courseTypeRepository = courseTypeRepository;
+    }
+
+    public CourseType 전공_필수() {
+        return courseTypeRepository.save(
+            CourseType.builder()
+                .name("전공 필수")
+                .build()
+        );
+    }
+
+    public CourseType HRD_필수() {
+        return courseTypeRepository.save(
+            CourseType.builder()
+                .name("MSC 필수")
+                .build()
+        );
+    }
+
+    public CourseType 교양_필수() {
+        return courseTypeRepository.save(
+            CourseType.builder()
+                .name("교양 필수")
+                .build()
+        );
+    }
+}

--- a/src/test/java/in/koreatech/koin/fixture/CourseTypeFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/CourseTypeFixture.java
@@ -26,7 +26,7 @@ public class CourseTypeFixture {
     public CourseType HRD_필수() {
         return courseTypeRepository.save(
             CourseType.builder()
-                .name("MSC 필수")
+                .name("HRD 필수")
                 .build()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/TimeTableV2Fixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/TimeTableV2Fixture.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import org.springframework.stereotype.Component;
 
+import in.koreatech.koin.domain.graduation.model.CourseType;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
@@ -81,7 +82,8 @@ public class TimeTableV2Fixture {
         return timetableFrameRepositoryV2.save(frame);
     }
 
-    public TimetableFrame 시간표4(User user, Semester semester, Lecture lecture1, Lecture lecture2) {
+    public TimetableFrame 시간표4(User user, Semester semester, Lecture lecture1, Lecture lecture2, CourseType courseType1,
+        CourseType courseType2) {
         TimetableFrame frame = TimetableFrame.builder()
             .user(user)
             .semester(semester)
@@ -95,6 +97,7 @@ public class TimeTableV2Fixture {
             .isDeleted(false)
             .lecture(lecture1)
             .timetableFrame(frame)
+            .courseType(courseType1)
             .build();
 
         TimetableLecture timetableLecture2 = TimetableLecture.builder()
@@ -102,6 +105,7 @@ public class TimeTableV2Fixture {
             .isDeleted(false)
             .lecture(lecture2)
             .timetableFrame(frame)
+            .courseType(courseType2)
             .build();
 
         frame.getTimetableLectures().add(timetableLecture1);
@@ -110,7 +114,7 @@ public class TimeTableV2Fixture {
         return timetableFrameRepositoryV2.save(frame);
     }
 
-    public TimetableFrame 시간표5(User user, Semester semester, Lecture lecture1) {
+    public TimetableFrame 시간표5(User user, Semester semester, Lecture lecture1, CourseType courseType1) {
         TimetableFrame frame = TimetableFrame.builder()
             .user(user)
             .semester(semester)
@@ -123,6 +127,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(false)
             .lecture(lecture1)
+            .courseType(courseType1)
             .timetableFrame(frame)
             .build();
 
@@ -143,7 +148,8 @@ public class TimeTableV2Fixture {
         return timetableFrameRepositoryV2.save(frame);
     }
 
-    public TimetableFrame 시간표6(User user, Semester semester, Lecture lecture1, Lecture lecture2) {
+    public TimetableFrame 시간표6(User user, Semester semester, Lecture lecture1, Lecture lecture2, CourseType courseType1,
+        CourseType courseType2) {
         TimetableFrame frame = TimetableFrame.builder()
             .user(user)
             .semester(semester)
@@ -156,6 +162,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(false)
             .lecture(lecture1)
+            .courseType(courseType1)
             .timetableFrame(frame)
             .build();
 
@@ -163,6 +170,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(false)
             .lecture(lecture2)
+            .courseType(courseType2)
             .timetableFrame(frame)
             .build();
 
@@ -172,7 +180,8 @@ public class TimeTableV2Fixture {
         return timetableFrameRepositoryV2.save(frame);
     }
 
-    public TimetableFrame 시간표7(User user, Semester semester, Lecture lecture1, Lecture lecture2) {
+    public TimetableFrame 시간표7(User user, Semester semester, Lecture lecture1, Lecture lecture2, CourseType courseType1,
+        CourseType courseType2) {
         TimetableFrame frame = TimetableFrame.builder()
             .user(user)
             .isDeleted(true)
@@ -186,6 +195,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(true)
             .lecture(lecture1)
+            .courseType(courseType1)
             .timetableFrame(frame)
             .build();
 
@@ -193,6 +203,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(true)
             .lecture(lecture2)
+            .courseType(courseType2)
             .timetableFrame(frame)
             .build();
 
@@ -202,7 +213,8 @@ public class TimeTableV2Fixture {
         return timetableFrameRepositoryV2.save(frame);
     }
 
-    public TimetableFrame 시간표8(User user, Semester semester, Lecture lecture1, Lecture lecture2) {
+    public TimetableFrame 시간표8(User user, Semester semester, Lecture lecture1, Lecture lecture2, CourseType courseType1,
+        CourseType courseType2) {
         TimetableFrame frame = TimetableFrame.builder()
             .user(user)
             .isDeleted(false)
@@ -216,6 +228,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(true)
             .lecture(lecture1)
+            .courseType(courseType1)
             .timetableFrame(frame)
             .build();
 
@@ -223,6 +236,7 @@ public class TimeTableV2Fixture {
             .grades("0")
             .isDeleted(true)
             .lecture(lecture2)
+            .courseType(courseType2)
             .timetableFrame(frame)
             .build();
 


### PR DESCRIPTION
# 🔥 연관 이슈

- #1140 

# 🚀 작업 내용

1. GET /v2/timetables/lecture의 응답에 이수 구분 추가
2. 이수 구분 관련 Repository, Exception 작업
3. POST /v2/timetables/lecture의 요청에서 year, department, code를 이용해서 이수 구분 id 저장
4. 테스트 코드 수정

# 💬 리뷰 중점사항
student 테이블의 year, department와 timetable_lecture의 code를 이용해서 catalog 테이블의 id를 얻습니다.
catalog의 id를 이용해서 course_type_id를 찾아서 timetable_lecture에 저장하도록 작성했습니다.

timetable_lecture의 course_type_id를 이용해서 이수 구분을 응답으로 반환하도록 작성했습니다.
[노후화 이전 PR](https://github.com/BCSDLab/KOIN_API_V2/pull/932)