### PR TITLE
fix : 생협 운영장 추가 및 운영시간 오타 수정

### DIFF
--- a/src/main/resources/db/migration/V108__add_coopshops.sql
+++ b/src/main/resources/db/migration/V108__add_coopshops.sql
@@ -1,0 +1,18 @@
+UPDATE coop_opens AS co
+    JOIN coop_shop AS cs ON co.coop_shop_id = cs.id
+    SET co.day_of_week = 'WEEKEND'
+WHERE cs.name = '대즐';
+
+INSERT INTO `coop_shop` (`name`, `phone`, `location`, `remarks`, `semester_id`)
+VALUES ('우편취급국', '041-560-1758', '학생회관 1층', '점심시간 12:00-13:00', 2),
+       ('안경원', '041-560-1760', '복지관 1층', '점심시간 13:00-14:00', 2);
+
+SET @COOP_SHOP_ID = LAST_INSERT_ID();
+
+INSERT INTO `coop_opens` (`coop_shop_id`, `type`, `day_of_week`, `open_time`, `close_time`)
+VALUES (@COOP_SHOP_ID, NULL, 'WEEKDAYS', '09:00', '18:00'),
+       (@COOP_SHOP_ID, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@COOP_SHOP_ID + 1, NULL, 'WEEKDAYS', '11:00', '17:00'),
+       (@COOP_SHOP_ID + 1, NULL, 'WEEKEND', '휴점', '휴점'),
+       (@COOP_SHOP_ID + 1, NULL, 'FRIDAY', '휴점', '휴점');
+


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 생협 운영장 안경원, 우편취급국을 추가하였습니다.
2. 생협 운영장 운영시간 오타를 수정하였습니다.
    - 대즐: 평일/평일 -> 평일/주말
    - ![image](https://github.com/user-attachments/assets/4ff40ef7-d6aa-4d8a-bdbe-3257d3690cd6)


# 💬 리뷰 중점사항
