### PR TITLE
fix: 시내버스 시간표 한기대 출발 시간 보정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/dto/CityBusTimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/dto/CityBusTimetableResponse.java
@@ -5,11 +5,13 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.bus.model.enums.CityBusDirection;
 import in.koreatech.koin.domain.bus.model.mongo.CityBusTimetable;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -51,41 +53,39 @@ public record CityBusTimetableResponse(
     List<BusTimetable> busTimetables
 ) {
 
-    public static CityBusTimetableResponse from(CityBusTimetable timetable) {
-        return new CityBusTimetableResponse(
-            timetable.getUpdatedAt(),
-            BusInfo.from(timetable.getBusInfo()),
-            timetable.getBusTimetables().stream()
-                .map(BusTimetable::from)
-                .toList()
-        );
-    }
-
     @JsonNaming(SnakeCaseStrategy.class)
-    public record BusInfo(
-        Long number,
-        String departNode,
-        String arrivalNode
-    ) {
-        public static BusInfo from(CityBusTimetable.BusInfo busInfo) {
+    public record BusInfo(Long number, String departNode, String arrivalNode) {
+
+        public static BusInfo of(Long busNumber, CityBusDirection direction) {
             return new BusInfo(
-                busInfo.getNumber(),
-                busInfo.getDepart(),
-                busInfo.getArrival()
+                busNumber,
+                direction.getDepartNode(),
+                direction.getApartNode()
             );
         }
     }
 
     @JsonNaming(SnakeCaseStrategy.class)
-    public record BusTimetable(
-        String dayOfWeek,
-        List<String> departInfo
-    ) {
-        public static BusTimetable from(CityBusTimetable.BusTimetable timetable) {
+    public record BusTimetable(String dayOfWeek, List<String> departInfo) {
+
+        public static BusTimetable of(Long busNumber, CityBusDirection direction,
+            CityBusTimetable.BusTimetable timetable) {
             return new BusTimetable(
                 timetable.getDayOfWeek(),
-                timetable.getDepartInfo()
+                timetable.applyTimeOffset(busNumber, direction).stream()
+                    .map(LocalTime::toString)
+                    .toList()
             );
         }
+    }
+
+    public static CityBusTimetableResponse of(Long busNumber, CityBusDirection direction, CityBusTimetable timetable) {
+        return new CityBusTimetableResponse(
+            timetable.getUpdatedAt(),
+            BusInfo.of(busNumber, direction),
+            timetable.getBusTimetables().stream()
+                .map(busTimetable -> BusTimetable.of(busNumber, direction, busTimetable))
+                .toList()
+        );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/bus/dto/CityBusTimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/dto/CityBusTimetableResponse.java
@@ -56,9 +56,9 @@ public record CityBusTimetableResponse(
     @JsonNaming(SnakeCaseStrategy.class)
     public record BusInfo(Long number, String departNode, String arrivalNode) {
 
-        public static BusInfo of(Long busNumber, CityBusDirection direction) {
+        public static BusInfo of(Long number, CityBusDirection direction) {
             return new BusInfo(
-                busNumber,
+                number,
                 direction.getDepartNode(),
                 direction.getApartNode()
             );

--- a/src/main/java/in/koreatech/koin/domain/bus/model/enums/CityBusDirection.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/model/enums/CityBusDirection.java
@@ -5,13 +5,19 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import in.koreatech.koin.domain.bus.exception.BusTypeNotFoundException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
+@Getter
 public enum CityBusDirection {
-    종합터미널,
-    병천3리,
-    황사동,
-    유관순열사사적지
-    ;
+    종합터미널("코리아텍", "천안 터미널"),
+    병천3리("천안 터미널", "코리아텍"),
+    황사동("천안 터미널", "코리아텍"),
+    유관순열사사적지("천안 터미널", "코리아텍");
+
+    private final String departNode;
+    private final String apartNode;
 
     @JsonCreator
     public static CityBusDirection from(String direction) {

--- a/src/main/java/in/koreatech/koin/domain/bus/model/mongo/CityBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/model/mongo/CityBusTimetable.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -13,6 +14,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import in.koreatech.koin.domain.bus.dto.BusScheduleResponse.ScheduleInfo;
 import in.koreatech.koin.domain.bus.model.enums.BusStation;
+import in.koreatech.koin.domain.bus.model.enums.CityBusDirection;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -124,6 +126,19 @@ public class CityBusTimetable {
                     }
                     return schedule;
                 })
+                .collect(Collectors.toList());
+        }
+
+        public List<LocalTime> applyTimeOffset(Long busNumber, CityBusDirection direction) {
+            Map<Long, Map<CityBusDirection, Integer>> timeOffsets = Map.of(
+                400L, Map.of(CityBusDirection.종합터미널, ADDITIONAL_TIME_DEPART_TO_KOREATECH_400),
+                402L, Map.of(CityBusDirection.종합터미널, ADDITIONAL_TIME_DEPART_TO_KOREATECH_402),
+                405L, Map.of(CityBusDirection.종합터미널, ADDITIONAL_TIME_DEPART_TO_KOREATECH_405)
+            );
+            int offset = timeOffsets.getOrDefault(busNumber, Map.of())
+                .getOrDefault(direction, 0);
+            return departInfo.stream()
+                .map(time -> LocalTime.parse(time).plusMinutes(offset))
                 .collect(Collectors.toList());
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/BusService.java
@@ -1,7 +1,33 @@
 package in.koreatech.koin.domain.bus.service;
 
-import in.koreatech.koin.domain.bus.dto.*;
+import static in.koreatech.koin.domain.bus.model.enums.BusStation.getDirection;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.bus.dto.BusCourseResponse;
+import in.koreatech.koin.domain.bus.dto.BusNoticeResponse;
+import in.koreatech.koin.domain.bus.dto.BusRemainTimeResponse;
+import in.koreatech.koin.domain.bus.dto.BusRouteCommand;
+import in.koreatech.koin.domain.bus.dto.BusScheduleResponse;
 import in.koreatech.koin.domain.bus.dto.BusScheduleResponse.ScheduleInfo;
+import in.koreatech.koin.domain.bus.dto.BusTimetableResponse;
+import in.koreatech.koin.domain.bus.dto.CityBusTimetableResponse;
+import in.koreatech.koin.domain.bus.dto.SingleBusTimeResponse;
 import in.koreatech.koin.domain.bus.exception.BusIllegalStationException;
 import in.koreatech.koin.domain.bus.exception.BusTypeNotFoundException;
 import in.koreatech.koin.domain.bus.exception.BusTypeNotSupportException;
@@ -26,14 +52,6 @@ import in.koreatech.koin.domain.version.dto.VersionResponse;
 import in.koreatech.koin.domain.version.service.VersionService;
 import in.koreatech.koin.global.exception.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.*;
-import java.time.format.TextStyle;
-import java.util.*;
-
-import static in.koreatech.koin.domain.bus.model.enums.BusStation.getDirection;
 
 @Service
 @Transactional(readOnly = true)
@@ -218,8 +236,7 @@ public class BusService {
     public CityBusTimetableResponse getCityBusTimetable(Long busNumber, CityBusDirection direction) {
         CityBusTimetable timetable = cityBusTimetableRepository
             .getByBusInfoNumberAndBusInfoArrival(busNumber, direction.getName());
-
-        return CityBusTimetableResponse.from(timetable);
+        return CityBusTimetableResponse.of(busNumber, direction, timetable);
     }
 
     public BusScheduleResponse getBusSchedule(BusRouteCommand request) {
@@ -250,8 +267,8 @@ public class BusService {
         }
 
         return BusNoticeResponse.of(
-                (Integer) article.get("id"),
-                (String) article.get("title")
+            (Integer)article.get("id"),
+            (String)article.get("title")
         );
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈
[슬랙](https://bcsdlab.slack.com/archives/C06NQT2TY9X/p1734775988419809)

1. 한기대 까지 오는 시간 보정
![image](https://github.com/user-attachments/assets/dcdf34a3-166b-4f27-8427-ecc90c198b5c)

2. - 병천방면: 출발 정류장 이름 ```천안 터미널``` 반환
    - 천안방면: 출발 정류장 이름 ```코리아텍``` 반환
![image](https://github.com/user-attachments/assets/5e04a390-5c50-4154-95cb-30cdfd135ec6)

# 🚀 작업 내용
![image](https://github.com/user-attachments/assets/99c2380f-3377-45bc-9957-fb99a105f897)

400, 402, 405 각각 기점에서 한기대까지 오는 시간 보정

# 💬 리뷰 중점사항
