### PR TITLE
fix: 커스텀 강의 생성 유효성 검증 추가 

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/LectureInfoRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/LectureInfoRequest.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,5 +26,11 @@ public record LectureInfoRequest(
     @Size(max = 30, message = "강의 장소의 최대 글자는 30글자입니다.")
     String place
 ) {
+    private static final String EMPTY_PLACE = "";
 
+    public LectureInfoRequest {
+        if (Objects.isNull(place)) {
+            place = EMPTY_PLACE;
+        }
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/LectureInfoRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/LectureInfoRequest.java
@@ -7,14 +7,17 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record LectureInfoRequest(
     @Schema(description = "시작 시간", example = "112", requiredMode = REQUIRED)
+    @NotNull(message = "강의 시작 시간을 입력해주세요.")
     Integer startTime,
 
     @Schema(description = "종료 시간", example = "115", requiredMode = REQUIRED)
+    @NotNull(message = "강의 종료 시간을 입력해주세요.")
     Integer endTime,
 
     @Schema(description = "장소", example = "2공학관314", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureCreateRequest.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -50,6 +51,11 @@ public record TimetableCustomLectureCreateRequest(
         @Size(max = 200, message = "메모는 200자 이하로 입력해주세요.")
         String memo
     ) {
+        public InnerTimeTableCustomLectureRequest {
+            if (Objects.isNull(grades)) {
+                grades = "0";
+            }
+        }
 
         // 커스텀 강의 장소 역정규화
         public String joinClassPlaces() {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1165 

# 🚀 작업 내용

- start_time과 end_time에 NotNull 어노테이션을 적용했습니다.
- 학점이 null인 경우 0으로 설정했습니다.

# 💬 리뷰 중점사항
