### PR TITLE
hotfix: timetableV2 온라인 강의 응답 오류 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -82,6 +83,10 @@ public record TimetableLectureResponse(
             public static List<ClassInfo> of(String classTime, String classPlace) {
                 // 강의 장소가 없는 경우 강의 시간과 매핑을 못하기 때문에 바로 반환
                 if (classPlace == null) {
+                    // 온라인 강의인 경우
+                    if (classTime.equals("[]")) {
+                        return Collections.emptyList();
+                    }
                     return List.of(new ClassInfo(parseClassTimes(classTime), null));
                 }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -81,12 +81,13 @@ public record TimetableLectureResponse(
             String classPlace
         ) {
             public static List<ClassInfo> of(String classTime, String classPlace) {
+                // 온라인 강의인 경우
+                if (Objects.equals(classTime, "[]")) {
+                    return Collections.emptyList();
+                }
+
                 // 강의 장소가 없는 경우 강의 시간과 매핑을 못하기 때문에 바로 반환
                 if (classPlace == null) {
-                    // 온라인 강의인 경우
-                    if (classTime.equals("[]")) {
-                        return Collections.emptyList();
-                    }
                     return List.of(new ClassInfo(parseClassTimes(classTime), null));
                 }
 


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

- timetableV2에서 온라인 강의(ex. 케이묵)을 반환 시 발생하는 오류를 수정했습니다.
  - 온라인 강의는 classTime이 `[]`
  - 앞뒤 괄호를 지우면 공백이 남고, 이를 Integer로 변환을 하게 되면 오류가 발생합니다.

# 💬 리뷰 중점사항
### **핫픽스 PR으로, 프로덕션 브랜치를 바라보고 있습니다.**