### PR TITLE
fix: 권한 추가 및 분실물 게시글 작성 response 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -137,14 +137,14 @@ public interface ArticleApi {
     )
     @Operation(summary = "분실물 게시글 등록")
     @PostMapping("/lost-item")
-    ResponseEntity<Void> createLostItemArticle(
+    ResponseEntity<LostItemArticleResponse> createLostItemArticle(
         @Auth(permit = {COUNCIL}) Integer councilId,
         @RequestBody @Valid LostItemArticlesRequest lostItemArticlesRequest
     );
 
     @ApiResponses(
         value = {
-            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "204"),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -2,8 +2,10 @@ package in.koreatech.koin.domain.community.article.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.*;
 
+import java.net.URI;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -97,12 +99,12 @@ public class ArticleController implements ArticleApi {
     }
 
     @PostMapping("/lost-item")
-    public ResponseEntity<Void> createLostItemArticle(
+    public ResponseEntity<LostItemArticleResponse> createLostItemArticle(
         @Auth(permit = {COUNCIL}) Integer councilId,
         @RequestBody @Valid LostItemArticlesRequest lostItemArticlesRequest
     ) {
-        articleService.createLostItemArticle(councilId, lostItemArticlesRequest);
-        return ResponseEntity.ok().build();
+        LostItemArticleResponse response = articleService.createLostItemArticle(councilId, lostItemArticlesRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @DeleteMapping("/lost-item/{id}")

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -319,7 +319,7 @@ public class ArticleService {
     }
 
     @Transactional
-    public void createLostItemArticle(Integer userId, LostItemArticlesRequest requests) {
+    public LostItemArticleResponse createLostItemArticle(Integer userId, LostItemArticlesRequest requests) {
         Board lostItemBoard = boardRepository.getById(LOST_ITEM_BOARD_ID);
         List<Article> newArticles = new ArrayList<>();
         User user = userRepository.getById(userId);
@@ -331,6 +331,7 @@ public class ArticleService {
                 }
             );
         sendKeywordNotification(newArticles);
+        return LostItemArticleResponse.from(newArticles.get(0));
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -40,7 +39,7 @@ public interface KeywordApi {
     @PostMapping("/articles/keyword")
     ResponseEntity<ArticleKeywordResponse> createKeyword(
         @Valid @RequestBody ArticleKeywordCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -56,7 +55,7 @@ public interface KeywordApi {
     @DeleteMapping("/articles/keyword/{id}")
     ResponseEntity<Void> deleteKeyword(
         @PathVariable(value = "id") Integer keywordUserMapId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -68,7 +67,7 @@ public interface KeywordApi {
     @Operation(summary = "자신의 알림 키워드 전체 조회")
     @GetMapping("/articles/keyword/me")
     ResponseEntity<ArticleKeywordsResponse> getMyKeywords(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +31,7 @@ public class KeywordController implements KeywordApi{
     @PostMapping()
     public ResponseEntity<ArticleKeywordResponse> createKeyword(
         @Valid @RequestBody ArticleKeywordCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         ArticleKeywordResponse response = keywordService.createKeyword(userId, request);
         return ResponseEntity.ok(response);
@@ -41,7 +40,7 @@ public class KeywordController implements KeywordApi{
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteKeyword(
         @PathVariable(value = "id") Integer keywordUserMapId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         keywordService.deleteKeyword(userId, keywordUserMapId);
         return ResponseEntity.noContent().build();
@@ -49,7 +48,7 @@ public class KeywordController implements KeywordApi{
 
     @GetMapping("/me")
     public ResponseEntity<ArticleKeywordsResponse> getMyKeywords(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         ArticleKeywordsResponse response = keywordService.getMyKeywords(userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/dining/controller/DiningApi.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/controller/DiningApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.dining.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -45,14 +44,14 @@ public interface DiningApi {
     @Operation(summary = "식단 좋아요")
     @PatchMapping("/dining/like")
     ResponseEntity<Void> likeDining(
-        @Auth(permit = {STUDENT, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     );
 
     @Operation(summary = "식단 좋아요 취소")
     @PatchMapping("/dining/like/cancel")
     ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {STUDENT, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/dining/controller/DiningController.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/controller/DiningController.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.dining.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -39,7 +38,7 @@ public class DiningController implements DiningApi {
 
     @PatchMapping("/dining/like")
     public ResponseEntity<Void> likeDining(
-        @Auth(permit = {STUDENT, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     ) {
         diningService.likeDining(userId, diningId);
@@ -48,7 +47,7 @@ public class DiningController implements DiningApi {
 
     @PatchMapping("/dining/like/cancel")
     public ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {STUDENT, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     ) {
         diningService.likeDiningCancel(userId, diningId);

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
@@ -120,6 +121,6 @@ public interface ShopApi {
     @PostMapping("/shops/{shopId}/call-notification")
     ResponseEntity<Void> createCallNotification(
             @Parameter(in = PATH) @PathVariable("shopId") Integer shopId,
-            @Auth(permit = {STUDENT}) Integer studentId
+            @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
@@ -74,7 +75,7 @@ public class ShopController implements ShopApi {
     @PostMapping("/shops/{shopId}/call-notification")
     public ResponseEntity<Void> createCallNotification(
             @Parameter(in = PATH) @PathVariable("shopId") Integer shopId,
-            @Auth(permit = {STUDENT}) Integer studentId
+            @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         shopService.publishCallNotification(shopId, studentId);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
@@ -60,7 +61,7 @@ public interface ShopReviewApi {
     ResponseEntity<ShopMyReviewsResponse> getMyReviews(
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 
     @ApiResponses(
@@ -90,7 +91,7 @@ public interface ShopReviewApi {
     ResponseEntity<Void> createReview(
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid CreateReviewRequest createReviewRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 
     @ApiResponses(
@@ -108,7 +109,7 @@ public interface ShopReviewApi {
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid ModifyReviewRequest modifyReviewRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 
     @ApiResponses(
@@ -124,7 +125,7 @@ public interface ShopReviewApi {
     ResponseEntity<Void> deleteReview(
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 
     @ApiResponses(
@@ -152,6 +153,6 @@ public interface ShopReviewApi {
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid ShopReviewReportRequest shopReviewReportRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewController.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
@@ -50,7 +51,7 @@ public class ShopReviewController implements ShopReviewApi {
     public ResponseEntity<ShopMyReviewsResponse> getMyReviews(
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestParam(name = "sorter", defaultValue = "LATEST") ReviewsSortCriteria sortBy,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         ShopMyReviewsResponse reviewsResponse = shopReviewService.getMyReviewsByShopId(shopId, studentId, sortBy);
         return ResponseEntity.ok(reviewsResponse);
@@ -60,7 +61,7 @@ public class ShopReviewController implements ShopReviewApi {
     public ResponseEntity<Void> createReview(
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid CreateReviewRequest createReviewRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         shopReviewService.createReview(createReviewRequest, studentId, shopId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -71,7 +72,7 @@ public class ShopReviewController implements ShopReviewApi {
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid ModifyReviewRequest modifyReviewRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         shopReviewService.modifyReview(modifyReviewRequest, reviewId, studentId);
         return ResponseEntity.noContent().build();
@@ -81,7 +82,7 @@ public class ShopReviewController implements ShopReviewApi {
     public ResponseEntity<Void> deleteReview(
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         shopReviewService.deleteReview(reviewId, studentId);
         return ResponseEntity.noContent().build();
@@ -99,7 +100,7 @@ public class ShopReviewController implements ShopReviewApi {
         @Parameter(in = PATH) @PathVariable Integer reviewId,
         @Parameter(in = PATH) @PathVariable Integer shopId,
         @RequestBody @Valid ShopReviewReportRequest shopReviewReportRequest,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
     ) {
         shopReviewService.reportReview(shopId, reviewId, studentId, shopReviewReportRequest);
         return ResponseEntity.noContent().build();

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.student.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,7 +43,7 @@ public interface StudentApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/user/student/me")
     ResponseEntity<StudentResponse> getStudent(
-        @Auth(permit = STUDENT) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -58,7 +59,7 @@ public interface StudentApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @PutMapping("/user/student/me")
     ResponseEntity<StudentUpdateResponse> updateStudent(
-        @Auth(permit = STUDENT) Integer userId,
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId,
         @Valid StudentUpdateRequest studentUpdateRequest
     );
 
@@ -120,6 +121,6 @@ public interface StudentApi {
     @PutMapping("/user/change/password")
     ResponseEntity<Void> changePassword(
         @RequestBody UserPasswordChangeRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.student.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.net.URI;
@@ -40,7 +41,7 @@ public class StudentController implements StudentApi{
 
     @GetMapping("/user/student/me")
     public ResponseEntity<StudentResponse> getStudent(
-        @Auth(permit = STUDENT) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         StudentResponse studentResponse = studentService.getStudent(userId);
         return ResponseEntity.ok().body(studentResponse);
@@ -48,7 +49,7 @@ public class StudentController implements StudentApi{
 
     @PutMapping("/user/student/me")
     public ResponseEntity<StudentUpdateResponse> updateStudent(
-        @Auth(permit = STUDENT) Integer userId,
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId,
         @Valid @RequestBody StudentUpdateRequest request
     ) {
         StudentUpdateResponse studentUpdateResponse = studentService.updateStudent(userId, request);
@@ -93,7 +94,7 @@ public class StudentController implements StudentApi{
     @PutMapping("/user/change/password")
     public ResponseEntity<Void> changePassword(
         @RequestBody UserPasswordChangeRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         studentService.changePassword(userId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/timetable/controller/TimetableApi.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/controller/TimetableApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetable.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public interface TimetableApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/semesters/check")
     ResponseEntity<SemesterCheckResponse> getStudentSemesters(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -82,7 +83,7 @@ public interface TimetableApi {
     @GetMapping("/timetables")
     ResponseEntity<TimetableResponse> getTimetables(
         @RequestParam(value = "semester") String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -98,7 +99,7 @@ public interface TimetableApi {
     @PostMapping("/timetables")
     ResponseEntity<TimetableResponse> createTimetables(
         @RequestBody TimetableCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -114,7 +115,7 @@ public interface TimetableApi {
     @PutMapping("/timetables")
     ResponseEntity<TimetableResponse> updateTimetable(
         @RequestBody TimetableUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -130,6 +131,6 @@ public interface TimetableApi {
     @DeleteMapping("/timetable")
     ResponseEntity<Void> deleteTimetableById(
         @RequestParam(value = "id") Integer id,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetable/controller/TimetableController.java
+++ b/src/main/java/in/koreatech/koin/domain/timetable/controller/TimetableController.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetable.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -48,7 +49,7 @@ public class TimetableController implements TimetableApi {
 
     @GetMapping("/semesters/check")
     public ResponseEntity<SemesterCheckResponse> getStudentSemesters(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         SemesterCheckResponse semesterCheckResponse = semesterService.getStudentSemesters(userId);
         return ResponseEntity.ok(semesterCheckResponse);
@@ -57,7 +58,7 @@ public class TimetableController implements TimetableApi {
     @GetMapping("/timetables")
     public ResponseEntity<TimetableResponse> getTimetables(
         @RequestParam(name = "semester") String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableResponse timetableResponse = timetableService.getTimetables(userId, semester);
         return ResponseEntity.ok(timetableResponse);
@@ -66,7 +67,7 @@ public class TimetableController implements TimetableApi {
     @PostMapping("/timetables")
     public ResponseEntity<TimetableResponse> createTimetables(
         @Valid @RequestBody TimetableCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableResponse timeTableResponse = timetableService.createTimetables(userId, request);
         return ResponseEntity.ok(timeTableResponse);
@@ -75,7 +76,7 @@ public class TimetableController implements TimetableApi {
     @PutMapping("/timetables")
     public ResponseEntity<TimetableResponse> updateTimetable(
         @Valid @RequestBody TimetableUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableResponse timetableResponse = timetableService.updateTimetables(userId, request);
         return ResponseEntity.ok(timetableResponse);
@@ -84,7 +85,7 @@ public class TimetableController implements TimetableApi {
     @DeleteMapping("/timetable")
     public ResponseEntity<Void> deleteTimetableById(
         @RequestParam(name = "id") Integer timetableId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         timetableService.deleteTimetableLecture(userId, timetableId);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableApiV2.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV2.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -46,7 +47,7 @@ public interface TimetableApiV2 {
     @PostMapping("/v2/timetables/frame")
     ResponseEntity<TimetableFrameResponse> createTimetablesFrame(
         @Valid @RequestBody TimetableFrameCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -63,7 +64,7 @@ public interface TimetableApiV2 {
     ResponseEntity<TimetableFrameUpdateResponse> updateTimetableFrame(
         @Valid @RequestBody TimetableFrameUpdateRequest request,
         @PathVariable(value = "id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -79,7 +80,7 @@ public interface TimetableApiV2 {
     @GetMapping("/v2/timetables/frames")
     ResponseEntity<Object> getTimetablesFrame(
         @RequestParam(name = "semester", required = false) String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -95,7 +96,7 @@ public interface TimetableApiV2 {
     @DeleteMapping("/v2/timetables/frame")
     ResponseEntity<Void> deleteTimetablesFrame(
         @RequestParam(name = "id") Integer frameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -110,7 +111,7 @@ public interface TimetableApiV2 {
     @DeleteMapping("/v2/all/timetables/frame")
     ResponseEntity<Void> deleteAllTimetablesFrame(
         @RequestParam(name = "semester") String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -130,7 +131,7 @@ public interface TimetableApiV2 {
     @PostMapping("/v2/timetables/lecture")
     ResponseEntity<TimetableLectureResponse> createTimetableLecture(
         @RequestBody TimetableLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -146,7 +147,7 @@ public interface TimetableApiV2 {
     @PutMapping("/v2/timetables/lecture")
     ResponseEntity<TimetableLectureResponse> updateTimetableLecture(
         @RequestBody TimetableLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -162,7 +163,7 @@ public interface TimetableApiV2 {
     @GetMapping("/v2/timetables/lecture")
     ResponseEntity<TimetableLectureResponse> getTimetableLecture(
         @RequestParam(value = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -177,7 +178,7 @@ public interface TimetableApiV2 {
     @DeleteMapping("/v2/timetables/lecture/{id}")
     ResponseEntity<Void> deleteTimetableLecture(
         @PathVariable(value = "id") Integer timetableLectureId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -192,7 +193,7 @@ public interface TimetableApiV2 {
     @DeleteMapping("/v2/timetables/lectures")
     ResponseEntity<Void> deleteTimetableLectures(
         @RequestParam(name = "timetable_lecture_ids") List<Integer> request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -208,7 +209,7 @@ public interface TimetableApiV2 {
     ResponseEntity<Void> deleteTimetableLectureByFrameId(
         @PathVariable(value = "frameId") Integer frameId,
         @PathVariable(value = "lectureId") Integer lectureId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -224,7 +225,7 @@ public interface TimetableApiV2 {
     @PostMapping("/v2/timetables/lecture/rollback")
     ResponseEntity<TimetableLectureResponse> rollbackTimetableLecture(
         @RequestParam(name = "timetable_lectures_id") List<Integer> timetableLecturesId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -244,6 +245,6 @@ public interface TimetableApiV2 {
     @PostMapping("/v2/timetables/frame/rollback")
     ResponseEntity<TimetableLectureResponse> rollbackTimetableFrame(
         @RequestParam(name = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/controller/TimetableControllerV2.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV2.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -38,7 +39,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @PostMapping("/v2/timetables/frame")
     public ResponseEntity<TimetableFrameResponse> createTimetablesFrame(
         @Valid @RequestBody TimetableFrameCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableFrameResponse response = frameServiceV2.createTimetablesFrame(userId, request);
         return ResponseEntity.ok(response);
@@ -48,7 +49,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     public ResponseEntity<TimetableFrameUpdateResponse> updateTimetableFrame(
         @Valid @RequestBody TimetableFrameUpdateRequest request,
         @PathVariable(value = "id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableFrameUpdateResponse response = frameServiceV2.updateTimetableFrame(request, timetableFrameId, userId);
         return ResponseEntity.ok(response);
@@ -57,7 +58,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @GetMapping("/v2/timetables/frames")
     public ResponseEntity<Object> getTimetablesFrame(
         @RequestParam(name = "semester", required = false) String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         Object response = frameServiceV2.getTimetablesFrame(userId, semester);
         return ResponseEntity.ok(response);
@@ -66,7 +67,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @DeleteMapping("/v2/timetables/frame")
     public ResponseEntity<Void> deleteTimetablesFrame(
         @RequestParam(name = "id") Integer frameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         frameServiceV2.deleteTimetablesFrame(userId, frameId);
         return ResponseEntity.noContent().build();
@@ -75,7 +76,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @DeleteMapping("/v2/all/timetables/frame")
     public ResponseEntity<Void> deleteAllTimetablesFrame(
         @RequestParam(name = "semester") String semester,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         frameServiceV2.deleteAllTimetablesFrame(userId, semester);
         return ResponseEntity.noContent().build();
@@ -84,7 +85,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @PostMapping("/v2/timetables/lecture")
     public ResponseEntity<TimetableLectureResponse> createTimetableLecture(
         @Valid @RequestBody TimetableLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponse response = lectureServiceV2.createTimetableLectures(userId, request);
         return ResponseEntity.ok(response);
@@ -93,7 +94,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @PutMapping("/v2/timetables/lecture")
     public ResponseEntity<TimetableLectureResponse> updateTimetableLecture(
         @Valid @RequestBody TimetableLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponse response = lectureServiceV2.updateTimetablesLectures(userId, request);
         return ResponseEntity.ok(response);
@@ -102,7 +103,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @GetMapping("/v2/timetables/lecture")
     public ResponseEntity<TimetableLectureResponse> getTimetableLecture(
         @RequestParam(name = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponse response = lectureServiceV2.getTimetableLectures(userId, timetableFrameId);
         return ResponseEntity.ok(response);
@@ -111,7 +112,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @DeleteMapping("/v2/timetables/lecture/{id}")
     public ResponseEntity<Void> deleteTimetableLecture(
         @PathVariable(value = "id") Integer timetableLectureId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         lectureServiceV2.deleteTimetableLecture(userId, timetableLectureId);
         return ResponseEntity.noContent().build();
@@ -120,7 +121,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @DeleteMapping("/v2/timetables/lectures")
     public ResponseEntity<Void> deleteTimetableLectures(
         @RequestParam(name = "timetable_lecture_ids") List<Integer> request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         lectureServiceV2.deleteTimetableLectures(request, userId);
         return ResponseEntity.noContent().build();
@@ -130,7 +131,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     public ResponseEntity<Void> deleteTimetableLectureByFrameId(
         @PathVariable(value = "frameId") Integer frameId,
         @PathVariable(value = "lectureId") Integer lectureId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         lectureServiceV2.deleteTimetableLectureByFrameId(frameId, lectureId, userId);
         return ResponseEntity.noContent().build();
@@ -139,7 +140,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @PostMapping("/v2/timetables/lecture/rollback")
     public ResponseEntity<TimetableLectureResponse> rollbackTimetableLecture(
         @RequestParam(name = "timetable_lectures_id") List<Integer> timetableLecturesId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponse response = timetableLectureService.rollbackTimetableLecture(timetableLecturesId, userId);
         return ResponseEntity.ok(response);
@@ -148,7 +149,7 @@ public class TimetableControllerV2 implements TimetableApiV2 {
     @PostMapping("/v2/timetables/frame/rollback")
     public ResponseEntity<TimetableLectureResponse> rollbackTimetableFrame(
         @RequestParam(name = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponse response = timetableLectureService.rollbackTimetableFrame(timetableFrameId, userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/SemesterApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/SemesterApiV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -42,6 +43,6 @@ public interface SemesterApiV3 {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/v3/semesters/check")
     ResponseEntity<SemesterCheckResponseV3> getStudentSemesters(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/SemesterControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/SemesterControllerV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -28,7 +29,7 @@ public class SemesterControllerV3 implements SemesterApiV3 {
 
     @GetMapping("/v3/semesters/check")
     public ResponseEntity<SemesterCheckResponseV3> getStudentSemesters(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         SemesterCheckResponseV3 semesterCheckResponseV3 = semesterServiceV3.getStudentSemesters(userId);
         return ResponseEntity.ok(semesterCheckResponseV3);

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableCustomLectureApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableCustomLectureApiV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -37,7 +38,7 @@ public interface TimetableCustomLectureApiV3 {
     @PostMapping("/v3/timetables/lecture/custom")
     ResponseEntity<TimetableLectureResponseV3> createTimetablesCustomLecture(
         @Valid @RequestBody TimetableCustomLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -54,6 +55,6 @@ public interface TimetableCustomLectureApiV3 {
     @PutMapping("/v3/timetables/lecture/custom")
     ResponseEntity<TimetableLectureResponseV3> updateTimetablesCustomLecture(
         @Valid @RequestBody TimetableCustomLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableCustomLectureControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableCustomLectureControllerV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class TimetableCustomLectureControllerV3 implements TimetableCustomLectur
     @PostMapping("/v3/timetables/lecture/custom")
     public ResponseEntity<TimetableLectureResponseV3> createTimetablesCustomLecture(
         @Valid @RequestBody TimetableCustomLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = customLectureServiceV3.createTimetablesCustomLecture(request, userId);
         return ResponseEntity.ok(response);
@@ -34,7 +35,7 @@ public class TimetableCustomLectureControllerV3 implements TimetableCustomLectur
     @PutMapping("/v3/timetables/lecture/custom")
     public ResponseEntity<TimetableLectureResponseV3> updateTimetablesCustomLecture(
         @Valid @RequestBody TimetableCustomLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = customLectureServiceV3.updateTimetablesCustomLecture(request, userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableFrameApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableFrameApiV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -43,7 +44,7 @@ public interface TimetableFrameApiV3 {
     @PostMapping("/v3/timetables/frame")
     ResponseEntity<List<TimetableFrameResponseV3>> createTimetablesFrame(
         @Valid @RequestBody TimetableFrameCreateRequestV3 request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -60,7 +61,7 @@ public interface TimetableFrameApiV3 {
     ResponseEntity<List<TimetableFrameResponseV3>> updateTimetableFrame(
         @Valid @RequestBody TimetableFrameUpdateRequestV3 request,
         @PathVariable(value = "id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -77,7 +78,7 @@ public interface TimetableFrameApiV3 {
     ResponseEntity<List<TimetableFrameResponseV3>> getTimetablesFrame(
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -92,7 +93,7 @@ public interface TimetableFrameApiV3 {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/v3/timetables/frames")
     ResponseEntity<List<TimetableFramesResponseV3>> getTimetablesFrames(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -108,6 +109,6 @@ public interface TimetableFrameApiV3 {
     ResponseEntity<Void> deleteTimetablesFrames(
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableFrameControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableFrameControllerV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class TimetableFrameControllerV3 implements TimetableFrameApiV3 {
     @PostMapping("/v3/timetables/frame")
     public ResponseEntity<List<TimetableFrameResponseV3>> createTimetablesFrame(
         @Valid @RequestBody TimetableFrameCreateRequestV3 request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         List<TimetableFrameResponseV3> response = timetableFrameServiceV3.createTimetablesFrame(request, userId);
         return ResponseEntity.ok(response);
@@ -42,7 +43,7 @@ public class TimetableFrameControllerV3 implements TimetableFrameApiV3 {
     public ResponseEntity<List<TimetableFrameResponseV3>> updateTimetableFrame(
         @Valid @RequestBody TimetableFrameUpdateRequestV3 request,
         @PathVariable(value = "id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         List<TimetableFrameResponseV3> response = timetableFrameServiceV3.updateTimetableFrame(request,
             timetableFrameId, userId);
@@ -53,7 +54,7 @@ public class TimetableFrameControllerV3 implements TimetableFrameApiV3 {
     public ResponseEntity<List<TimetableFrameResponseV3>> getTimetablesFrame(
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         List<TimetableFrameResponseV3> response = timetableFrameServiceV3.getTimetablesFrame(year, term, userId);
         return ResponseEntity.ok(response);
@@ -61,7 +62,7 @@ public class TimetableFrameControllerV3 implements TimetableFrameApiV3 {
 
     @GetMapping("/v3/timetables/frames")
     public ResponseEntity<List<TimetableFramesResponseV3>> getTimetablesFrames(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         List<TimetableFramesResponseV3> response = timetableFrameServiceV3.getTimetablesFrames(userId);
         return ResponseEntity.ok(response);
@@ -71,7 +72,7 @@ public class TimetableFrameControllerV3 implements TimetableFrameApiV3 {
     public ResponseEntity<Void> deleteTimetablesFrames(
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         timetableFrameServiceV3.deleteTimetablesFrames(year, term, userId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureApiV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -35,7 +36,7 @@ public interface TimetableLectureApiV3 {
     @GetMapping("/v3/timetables/lecture")
     ResponseEntity<TimetableLectureResponseV3> getTimetableLecture(
         @RequestParam(value = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -51,7 +52,7 @@ public interface TimetableLectureApiV3 {
     @PostMapping("/v3/timetables/lecture/rollback")
     ResponseEntity<TimetableLectureResponseV3> rollbackTimetableLecture(
         @RequestParam(name = "timetable_lectures_id") List<Integer> timetableLecturesId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -71,6 +72,6 @@ public interface TimetableLectureApiV3 {
     @PostMapping("/v3/timetables/frame/rollback")
     ResponseEntity<TimetableLectureResponseV3> rollbackTimetableFrame(
         @RequestParam(name = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class TimetableLectureControllerV3 implements TimetableLectureApiV3 {
     @GetMapping("/v3/timetables/lecture")
     public ResponseEntity<TimetableLectureResponseV3> getTimetableLecture(
         @RequestParam(value = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = lectureServiceV3.getTimetableLecture(timetableFrameId, userId);
         return ResponseEntity.ok(response);
@@ -33,7 +34,7 @@ public class TimetableLectureControllerV3 implements TimetableLectureApiV3 {
     @PostMapping("/v3/timetables/lecture/rollback")
     public ResponseEntity<TimetableLectureResponseV3> rollbackTimetableLecture(
         @RequestParam(name = "timetable_lectures_id") List<Integer> timetableLecturesId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = lectureServiceV3.rollbackTimetableLecture(timetableLecturesId, userId);
         return ResponseEntity.ok(response);
@@ -42,7 +43,7 @@ public class TimetableLectureControllerV3 implements TimetableLectureApiV3 {
     @PostMapping("/v3/timetables/frame/rollback")
     public ResponseEntity<TimetableLectureResponseV3> rollbackTimetableFrame(
         @RequestParam(name = "timetable_frame_id") Integer timetableFrameId,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = lectureServiceV3.rollbackTimetableFrame(timetableFrameId, userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableRegularLectureApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableRegularLectureApiV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -37,7 +38,7 @@ public interface TimetableRegularLectureApiV3 {
     @PostMapping("/v3/timetables/lecture/regular")
     ResponseEntity<TimetableLectureResponseV3> createTimetablesRegularLecture(
         @Valid @RequestBody TimetableRegularLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -54,6 +55,6 @@ public interface TimetableRegularLectureApiV3 {
     @PutMapping("/v3/timetables/lecture/regular")
     ResponseEntity<TimetableLectureResponseV3> updateTimetablesRegularLecture(
         @Valid @RequestBody TimetableRegularLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableRegularLectureControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableRegularLectureControllerV3.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.timetableV3.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class TimetableRegularLectureControllerV3 implements TimetableRegularLect
     @PostMapping("/v3/timetables/lecture/regular")
     public ResponseEntity<TimetableLectureResponseV3> createTimetablesRegularLecture(
         @Valid @RequestBody TimetableRegularLectureCreateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = timetableLectureV3.createTimetablesRegularLecture(request, userId);
         return ResponseEntity.ok(response);
@@ -34,7 +35,7 @@ public class TimetableRegularLectureControllerV3 implements TimetableRegularLect
     @PutMapping("/v3/timetables/lecture/regular")
     public ResponseEntity<TimetableLectureResponseV3> updateTimetablesRegularLecture(
         @Valid @RequestBody TimetableRegularLectureUpdateRequest request,
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = timetableLectureV3.updateTimetablesRegularLecture(request, userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.domain.user.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import in.koreatech.koin.domain.user.dto.*;
 import org.springdoc.core.annotations.ParameterObject;
@@ -52,7 +50,7 @@ public interface UserApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/user/logout")
     ResponseEntity<Void> logout(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -81,7 +79,7 @@ public interface UserApi {
     @Operation(summary = "사용자 권한 조회")
     @GetMapping("/user/auth")
     ResponseEntity<AuthResponse> getAuth(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -96,7 +94,7 @@ public interface UserApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @DeleteMapping("/user")
     ResponseEntity<Void> withdraw(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -143,7 +141,7 @@ public interface UserApi {
     @PostMapping("/user/check/password")
     ResponseEntity<Void> checkPassword(
         @Valid @RequestBody UserPasswordCheckRequest request,
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -1,8 +1,6 @@
 package in.koreatech.koin.domain.user.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.net.URI;
 
@@ -41,7 +39,7 @@ public class UserController implements UserApi {
 
     @PostMapping("/user/logout")
     public ResponseEntity<Void> logout(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userService.logout(userId);
         return ResponseEntity.ok().build();
@@ -58,7 +56,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/auth")
     public ResponseEntity<AuthResponse> getAuth(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         AuthResponse authResponse = userService.getAuth(userId);
         return ResponseEntity.ok().body(authResponse);
@@ -66,7 +64,7 @@ public class UserController implements UserApi {
 
     @DeleteMapping("/user")
     public ResponseEntity<Void> withdraw(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userService.withdraw(userId);
         return ResponseEntity.noContent().build();
@@ -102,7 +100,7 @@ public class UserController implements UserApi {
     @PostMapping("/user/check/password")
     public ResponseEntity<Void> checkPassword(
         @Valid @RequestBody UserPasswordCheckRequest request,
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userValidationService.checkPassword(request, userId);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationApi.java
@@ -37,7 +37,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 동의 여부 조회")
     @GetMapping("/notification")
     ResponseEntity<NotificationStatusResponse> checkNotificationStatus(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -52,7 +52,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 동의")
     @PostMapping("/notification")
     ResponseEntity<Void> permitNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @Valid @RequestBody NotificationPermitRequest request
     );
 
@@ -68,7 +68,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 알림 구독")
     @PostMapping("/notification/subscribe")
     ResponseEntity<Void> permitNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     );
 
@@ -84,7 +84,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 세부알림 구독")
     @PostMapping("/notification/subscribe/detail")
     ResponseEntity<Void> permitNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType notificationSubscribeType
     );
 
@@ -100,7 +100,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 거절")
     @DeleteMapping("/notification")
     ResponseEntity<Void> rejectNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -115,7 +115,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 알림 구독 취소")
     @DeleteMapping("/notification/subscribe")
     ResponseEntity<Void> rejectNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     );
 
@@ -131,7 +131,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 세부알림 구독 취소")
     @DeleteMapping("/notification/subscribe/detail")
     ResponseEntity<Void> rejectNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType notificationSubscribeType
     );
 }

--- a/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/controller/NotificationController.java
@@ -28,14 +28,14 @@ public class NotificationController implements NotificationApi {
 
     @GetMapping("/notification")
     public ResponseEntity<NotificationStatusResponse> checkNotificationStatus(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         return ResponseEntity.ok(notificationService.checkNotification(userId));
     }
 
     @PostMapping("/notification")
     public ResponseEntity<Void> permitNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @Valid @RequestBody NotificationPermitRequest request
     ) {
         notificationService.permitNotification(userId, request.deviceToken());
@@ -44,7 +44,7 @@ public class NotificationController implements NotificationApi {
 
     @PostMapping("/notification/subscribe")
     public ResponseEntity<Void> permitNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     ) {
         notificationService.permitNotificationSubscribe(userId, notificationSubscribeType);
@@ -53,7 +53,7 @@ public class NotificationController implements NotificationApi {
 
     @PostMapping("/notification/subscribe/detail")
     public ResponseEntity<Void> permitNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType detailSubscribeType
     ) {
         notificationService.permitNotificationDetailSubscribe(userId, detailSubscribeType);
@@ -62,7 +62,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification")
     public ResponseEntity<Void> rejectNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         notificationService.rejectNotification(userId);
         return ResponseEntity.noContent().build();
@@ -70,7 +70,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification/subscribe")
     public ResponseEntity<Void> rejectNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     ) {
         notificationService.rejectNotificationByType(userId, notificationSubscribeType);
@@ -79,7 +79,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification/subscribe/detail")
     public ResponseEntity<Void> rejectNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP}) Integer userId,
+        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType detailSubscribeType
     ) {
         notificationService.rejectNotificationDetailSubscribe(userId, detailSubscribeType);

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadApi.java
@@ -57,7 +57,7 @@ public interface UploadApi {
     ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 
     @ApiResponses(
@@ -88,7 +88,7 @@ public interface UploadApi {
     ResponseEntity<UploadFileResponse> uploadFile(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 
     @ApiResponses(
@@ -119,6 +119,6 @@ public interface UploadApi {
     ResponseEntity<UploadFilesResponse> uploadFiles(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 }

--- a/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/controller/UploadController.java
@@ -1,9 +1,6 @@
 package in.koreatech.koin.global.domain.upload.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
-import static in.koreatech.koin.domain.user.model.UserType.COOP;
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.util.List;
 
@@ -37,7 +34,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.getPresignedUrl(domain, request);
         return ResponseEntity.ok(response);
@@ -51,7 +48,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFileResponse> uploadFile(
         @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.uploadFile(domain, multipartFile);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -65,7 +62,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFilesResponse> uploadFiles(
         @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN}, anonymous = true) Integer memberId
+        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.uploadFiles(domain, files);
         return new ResponseEntity<>(response, HttpStatus.CREATED);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. STUDENT 접근 권한의 모든 API에 COUNCIL 권한을 추가하였습니다.
2. 분실물 게시글 작성 응답을 수정하였습니다.

# 💬 리뷰 중점사항
