### PR TITLE
feat: 이미지 업로드 도메인 분실물 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/upload/model/ImageUploadDomain.java
+++ b/src/main/java/in/koreatech/koin/global/domain/upload/model/ImageUploadDomain.java
@@ -17,6 +17,7 @@ public enum ImageUploadDomain {
     OWNERS,
     COOP,
     ADMIN,
+    LOST_ITEMS,
     ;
 
     public static ImageUploadDomain from(String domain) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1.이미지 업로드 도메인에 분실물 LOST_ITEM을 추가했습니다.

# 💬 리뷰 중점사항
