### PR TITLE
fix: 사장님 회원가입 에러 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/OwnerEventListener.java
@@ -49,7 +49,6 @@ public class OwnerEventListener {
      */
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onOwnerRegisterBySms(OwnerRegisterEvent event) {
-        ownerInVerificationRedisRepository.deleteByVerify(event.account());
         var notification = slackNotificationFactory.generateOwnerRegisterRequestNotification(
                 event.ownerName(),
                 shopsName(event.ownerId())

--- a/src/main/java/in/koreatech/koin/domain/owner/model/dto/OwnerRegisterEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/model/dto/OwnerRegisterEvent.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.owner.model.dto;
 
 public record OwnerRegisterEvent(
         String ownerName,
-        String account,
         Integer ownerId
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
@@ -17,6 +17,7 @@ import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerShopRedisRepository;
+import in.koreatech.koin.domain.owner.repository.redis.OwnerVerificationStatusRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.JwtProvider;
@@ -36,6 +37,7 @@ public class OwnerSmsService {
     private final UserRepository userRepository;
     private final OwnerRepository ownerRepository;
     private final OwnerShopRedisRepository ownerShopRedisRepository;
+    private final OwnerVerificationStatusRepository ownerInVerificationRedisRepository;
     private final OwnerValidator ownerValidator;
     private final OwnerUtilService ownerUtilService;
     private final OwnerVerificationService ownerVerificationService;
@@ -59,6 +61,7 @@ public class OwnerSmsService {
         OwnerShop.OwnerShopBuilder ownerShopBuilder = OwnerShop.builder().ownerId(saved.getId());
         ownerUtilService.setShopId(request.shopId(), ownerShopBuilder);
         ownerShopRedisRepository.save(ownerShopBuilder.build());
+        ownerInVerificationRedisRepository.deleteByVerify(saved.getUser().getPhoneNumber());
         ownerUtilService.sendSlackNotification(saved);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerUtilService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerUtilService.java
@@ -26,7 +26,6 @@ public class OwnerUtilService {
     public void sendSlackNotification(Owner owner) {
         eventPublisher.publishEvent(new OwnerRegisterEvent(
                 owner.getUser().getName(),
-                owner.getUser().getEmail(),
                 owner.getId()
         ));
     }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -257,7 +257,6 @@ class OwnerApiTest extends AcceptanceTest {
                                    "name": "최준호",
                                    "password": "a0240120305812krlakdsflsa;1235",
                                    "phone_number": "01012341234",
-                                   "shop_id": null,
                                    "shop_name": "기분좋은 뷔짱"
                                 }
                             """)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1176 

# 🚀 작업 내용
<img width="960" alt="image" src="https://github.com/user-attachments/assets/f8aacc45-b2a5-4624-9378-1779ce6b7ee0" />

1. redis에 있는 인증번호 삭제 로직을 email에서 phone으로 변경했습니다.

# 💬 리뷰 중점사항
회원가입시 phone을 이용해야 하는데 email을 이용해서 redis의 key값이 null로 들어가고 있었습니다. 때문에 레디스의 데이터를 이용하는 `GET /admin/users/new-owners`에서도 오류가 발생했습니다.
<img width="737" alt="image" src="https://github.com/user-attachments/assets/62d64275-6e01-4c44-a507-c71f17a28550" />
