### PR TITLE
fix: 새로운 사장님 조회 로직 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
@@ -88,7 +88,7 @@ public class AdminOwnerService {
 
             if (ownerShopOptional.isPresent()) {
                 OwnerShop ownerShop = ownerShopOptional.get();
-                if (ownerShop.getShopId() != null) {
+                if (!Objects.isNull(ownerShop.getShopId())) {
                     shop = adminShopRepository.findById(ownerShop.getShopId()).orElse(null);
                 }
             }

--- a/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
@@ -2,6 +2,8 @@ package in.koreatech.koin.admin.owner.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +23,7 @@ import in.koreatech.koin.admin.owner.dto.OwnersCondition;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;
+import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.model.Criteria;
@@ -80,9 +83,15 @@ public class AdminOwnerService {
 
         List<OwnerIncludingShop> ownerIncludingShops = new ArrayList<>();
         for (Owner owner : result.getContent()) {
-            Shop shop = adminOwnerShopRedisRepository.findById(owner.getId())
-                .map(ownerShop -> adminShopRepository.findById(ownerShop.getShopId()).orElse(null))
-                .orElse(null);
+            Optional<OwnerShop> ownerShopOptional = adminOwnerShopRedisRepository.findById(owner.getId());
+            Shop shop = null;
+
+            if (ownerShopOptional.isPresent()) {
+                OwnerShop ownerShop = ownerShopOptional.get();
+                if (ownerShop.getShopId() != null) {
+                    shop = adminShopRepository.findById(ownerShop.getShopId()).orElse(null);
+                }
+            }
 
             OwnerIncludingShop ownerIncludingShop = OwnerIncludingShop.of(owner, shop);
             ownerIncludingShops.add(ownerIncludingShop);

--- a/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
@@ -2,8 +2,6 @@ package in.koreatech.koin.admin.owner.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,7 +21,6 @@ import in.koreatech.koin.admin.shop.repository.shop.AdminShopRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;
-import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.model.Criteria;
@@ -83,15 +80,12 @@ public class AdminOwnerService {
 
         List<OwnerIncludingShop> ownerIncludingShops = new ArrayList<>();
         for (Owner owner : result.getContent()) {
-            Optional<OwnerShop> ownerShopOptional = adminOwnerShopRedisRepository.findById(owner.getId());
-            Shop shop = null;
-
-            if (ownerShopOptional.isPresent()) {
-                OwnerShop ownerShop = ownerShopOptional.get();
-                if (!Objects.isNull(ownerShop.getShopId())) {
-                    shop = adminShopRepository.findById(ownerShop.getShopId()).orElse(null);
-                }
-            }
+            Shop shop = adminOwnerShopRedisRepository.findById(owner.getId())
+                .map(ownerShop -> {
+                    Integer shopId = ownerShop.getShopId();
+                    return shopId != null ? adminShopRepository.findById(shopId).orElse(null) : null;
+                })
+                .orElse(null);
 
             OwnerIncludingShop ownerIncludingShop = OwnerIncludingShop.of(owner, shop);
             ownerIncludingShops.add(ownerIncludingShop);

--- a/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
@@ -11,15 +11,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.admin.owner.repository.AdminOwnerRepository;
-import in.koreatech.koin.admin.owner.repository.AdminOwnerShopRedisRepository;
-import in.koreatech.koin.admin.shop.repository.shop.AdminShopRepository;
 import in.koreatech.koin.admin.owner.dto.AdminNewOwnersResponse;
 import in.koreatech.koin.admin.owner.dto.AdminOwnerResponse;
 import in.koreatech.koin.admin.owner.dto.AdminOwnerUpdateRequest;
 import in.koreatech.koin.admin.owner.dto.AdminOwnerUpdateResponse;
 import in.koreatech.koin.admin.owner.dto.AdminOwnersResponse;
 import in.koreatech.koin.admin.owner.dto.OwnersCondition;
+import in.koreatech.koin.admin.owner.repository.AdminOwnerRepository;
+import in.koreatech.koin.admin.owner.repository.AdminOwnerShopRedisRepository;
+import in.koreatech.koin.admin.shop.repository.shop.AdminShopRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.owner.model.OwnerIncludingShop;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1181 

# 🚀 작업 내용

- 새로운 사장님 조회 로직 버그를 수정했습니다.
  - 사장님 회원가입 과정에서 등록되지 않는 가게는 shopid가 null로 저장됩니다. 
  - findById 메소드에 null 값이 들어가서 어드민 페이지에서 500 에러가 발생했습니다.

# 💬 리뷰 중점사항
