### PR TITLE
feat : 학기와 이수구분으로 강의 찾기

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -64,7 +64,8 @@ public interface GraduationApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/graduation/course-type")
     ResponseEntity<CourseTypeLectureResponse> getCourseTypeLecture(
-        @RequestParam(name = "semester") String semester,
+        @RequestParam(name = "year") Integer year,
+        @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
         @Auth(permit = {STUDENT}) Integer userId
     );

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -3,10 +3,12 @@ package in.koreatech.koin.domain.graduation.controller;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -47,6 +49,23 @@ public interface GraduationApi {
     @PostMapping("/graduation/excel/upload")
     ResponseEntity<String> uploadStudentGradeExcelFile(
         @RequestParam(value = "file") MultipartFile file,
+        @Auth(permit = {STUDENT}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "학기에 따른 이수구분 강의 출력")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/graduation/course-type")
+    ResponseEntity<CourseTypeLectureResponse> getCourseTypeLecture(
+        @RequestParam(name = "semester") String semester,
+        @RequestParam(name = "name") String courseTypeName,
         @Auth(permit = {STUDENT}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -45,11 +45,12 @@ public class GraduationController implements GraduationApi {
 
     @GetMapping("/graduation/course-type")
     public ResponseEntity<CourseTypeLectureResponse> getCourseTypeLecture(
-        @RequestParam(name = "semester") String semester,
+        @RequestParam(name = "year") Integer year,
+        @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
         @Auth(permit = {STUDENT}) Integer userId
     ) {
-        CourseTypeLectureResponse response = graduationService.getLectureByCourseType(semester, courseTypeName);
+        CourseTypeLectureResponse response = graduationService.getLectureByCourseType(year, term, courseTypeName);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.graduation.controller;
 
 import java.io.IOException;
+
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import in.koreatech.koin.domain.graduation.dto.GraduationCourseCalculationResponse;
+import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
 import in.koreatech.koin.domain.graduation.service.GraduationService;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.auth.Auth;
@@ -24,8 +25,7 @@ public class GraduationController implements GraduationApi {
 
     @PostMapping("/graduation/agree")
     public ResponseEntity<Void> createStudentCourseCalculation(
-        @Auth(permit = {STUDENT}) Integer userId)
-    {
+        @Auth(permit = {STUDENT}) Integer userId) {
         graduationService.createStudentCourseCalculation(userId);
         return ResponseEntity.ok().build();
     }
@@ -43,10 +43,22 @@ public class GraduationController implements GraduationApi {
         }
     }
 
+    @GetMapping("/graduation/course-type")
+    public ResponseEntity<CourseTypeLectureResponse> getCourseTypeLecture(
+        @RequestParam(name = "semester") String semester,
+        @RequestParam(name = "name") String courseTypeName,
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        CourseTypeLectureResponse response = graduationService.getLectureByCourseType(semester, courseTypeName);
+        return ResponseEntity.ok(response);
+    }
+
+    /*
     @GetMapping("/graduation/course/calculation")
     public ResponseEntity<GraduationCourseCalculationResponse> getGraduationCourseCalculation(
         @Auth(permit = {STUDENT}) Integer userId) {
         GraduationCourseCalculationResponse response = graduationService.getGraduationCourseCalculationResponse(userId);
         return ResponseEntity.ok(response);
     }
+    */
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/CourseTypeLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/CourseTypeLectureResponse.java
@@ -10,9 +10,12 @@ public record CourseTypeLectureResponse(
     String semester,
 
     @Schema(description = "이수구분 충족강의")
-    List<Lecture> lectures
+    List<LecturePortionResponse> lectures
 ) {
     public static CourseTypeLectureResponse of(String semester, List<Lecture> lectures) {
-        return new CourseTypeLectureResponse(semester, lectures);
+        List<LecturePortionResponse> lectureList = lectures.stream()
+            .map(LecturePortionResponse::from)
+            .toList();
+        return new CourseTypeLectureResponse(semester, lectureList);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/CourseTypeLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/CourseTypeLectureResponse.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.graduation.dto;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.timetable.model.Lecture;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CourseTypeLectureResponse(
+    @Schema(description = "학기", example = "20192")
+    String semester,
+
+    @Schema(description = "이수구분 충족강의")
+    List<Lecture> lectures
+) {
+    public static CourseTypeLectureResponse of(String semester, List<Lecture> lectures) {
+        return new CourseTypeLectureResponse(semester, lectures);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/LecturePortionResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/LecturePortionResponse.java
@@ -1,15 +1,24 @@
 package in.koreatech.koin.domain.graduation.dto;
 
 import in.koreatech.koin.domain.timetable.model.Lecture;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record LecturePortionResponse
-    (
-        Integer id,
-        String code,
-        String name,
-        String grades,
-        String department
-    ) {
+public record LecturePortionResponse(
+    @Schema(description = "강의 ID", example = "1")
+    Integer id,
+
+    @Schema(description = "강의 코드", example = "ABC123")
+    String code,
+
+    @Schema(description = "강의 이름", example = "컴퓨터구조")
+    String name,
+
+    @Schema(description = "학점", example = "3")
+    String grades,
+
+    @Schema(description = "학과", example = "컴퓨터공학부")
+    String department
+) {
     public static LecturePortionResponse from(Lecture lecture) {
         return new LecturePortionResponse(
             lecture.getId(),

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/LecturePortionResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/LecturePortionResponse.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.graduation.dto;
+
+import in.koreatech.koin.domain.timetable.model.Lecture;
+
+public record LecturePortionResponse
+    (
+        Integer id,
+        String code,
+        String name,
+        String grades,
+        String department
+    ) {
+    public static LecturePortionResponse from(Lecture lecture) {
+        return new LecturePortionResponse(
+            lecture.getId(),
+            lecture.getCode(),
+            lecture.getName(),
+            lecture.getGrades(),
+            lecture.getDepartment()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
@@ -13,10 +13,18 @@ public interface CatalogRepository extends Repository<Catalog, Integer> {
 
     Optional<Catalog> findByDepartmentAndCode(Department department, String code);
 
+    // 이거 오류나요..
+    // List<Catalog> findByLectureNameAndYearAndDepartment(String lectureName, String studentYear, Department department);
+
+    Optional<List<Catalog>> findAllByCourseTypeId(Integer courseTypeId);
+
     default Catalog getByDepartmentAndCode(Department department, String code) {
         return findByDepartmentAndCode(department, code)
             .orElseThrow(() -> CatalogNotFoundException.withDetail("department: " + department + ", code: " + code));
     }
 
-    List<Catalog> findByLectureNameAndYearAndDepartment(String lectureName, String studentYear, Department department);
+    default List<Catalog> getAllByCourseTypeId(Integer courseTypeId) {
+        return findAllByCourseTypeId(courseTypeId)
+            .orElseThrow(() -> CatalogNotFoundException.withDetail("course_type_id" + courseTypeId));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CourseTypeRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CourseTypeRepository.java
@@ -19,4 +19,9 @@ public interface CourseTypeRepository extends Repository<CourseType, Integer> {
         return findById(id)
             .orElseThrow(() -> CourseTypeNotFoundException.withDetail("course_type_id: " + id));
     }
+
+    default CourseType getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> CourseTypeNotFoundException.withDetail("course_type_name: " + name));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/DetectGraduationCalculationRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/DetectGraduationCalculationRepository.java
@@ -8,8 +8,8 @@ import in.koreatech.koin.domain.graduation.model.DetectGraduationCalculation;
 
 public interface DetectGraduationCalculationRepository extends Repository<DetectGraduationCalculation, Integer> {
 
-    Optional<DetectGraduationCalculation> findByUserId(Integer userId);
-
     void save(DetectGraduationCalculation detectGraduationCalculation);
+
+    Optional<DetectGraduationCalculation> findByUserId(Integer userId);
 }
 

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/StudentCourseCalculationRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/StudentCourseCalculationRepository.java
@@ -8,13 +8,13 @@ import in.koreatech.koin.domain.graduation.model.StudentCourseCalculation;
 
 public interface StudentCourseCalculationRepository extends Repository<StudentCourseCalculation, Integer> {
 
-    Optional<StudentCourseCalculation> findByUserId(Integer userId);
-
-    void deleteAllByUserId(Integer userId);
-
     void save(StudentCourseCalculation studentCourseCalculation);
+
+    Optional<StudentCourseCalculation> findByUserId(Integer userId);
 
     StudentCourseCalculation findByUserIdAndStandardGraduationRequirementsId(Integer userId, Integer id);
 
     void delete(StudentCourseCalculation existingCalculation);
+
+    void deleteAllByUserId(Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/exception/NotFoundSemesterAndCourseTypeException.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/exception/NotFoundSemesterAndCourseTypeException.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.timetableV2.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class NotFoundSemesterAndCourseTypeException extends DataNotFoundException {
+    private static final String DEFAULT_MESSAGE = "학기나 이수구분을 찾을 수 없습니다.";
+
+    public NotFoundSemesterAndCourseTypeException(String message) {
+        super(message);
+    }
+
+    public NotFoundSemesterAndCourseTypeException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static NotFoundSemesterAndCourseTypeException withDetail(String detail) {
+        return new NotFoundSemesterAndCourseTypeException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/LectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/LectureRepositoryV2.java
@@ -3,12 +3,13 @@ package in.koreatech.koin.domain.timetableV2.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.timetable.exception.LectureNotFoundException;
 import in.koreatech.koin.domain.timetable.exception.SemesterNotFoundException;
 import in.koreatech.koin.domain.timetable.model.Lecture;
-import in.koreatech.koin.domain.timetable.model.Semester;
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface LectureRepositoryV2 extends Repository<Lecture, Integer> {
 
@@ -20,6 +21,9 @@ public interface LectureRepositoryV2 extends Repository<Lecture, Integer> {
 
     Optional<Lecture> findBySemesterAndCodeAndLectureClass(String semesterDate, String code, String classLecture);
 
+    @Query("SELECT l FROM Lecture l WHERE l.code IN :codes AND l.semester = :semesterDate")
+    Optional<List<Lecture>> findAllByCodesAndSemester(@Param("codes") List<String> codes, @Param("semesterDate") String semesterDate);
+
     default Lecture getBySemesterAndCodeAndLectureClass(String semesterDate, String code, String classLecture) {
         return findBySemesterAndCodeAndLectureClass(semesterDate, code, classLecture)
             .orElseThrow(() -> SemesterNotFoundException.withDetail(
@@ -30,4 +34,5 @@ public interface LectureRepositoryV2 extends Repository<Lecture, Integer> {
         return findById(id)
             .orElseThrow(() -> LectureNotFoundException.withDetail("lecture_id: " + id));
     }
+
 }

--- a/src/main/java/in/koreatech/koin/global/config/swagger/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/swagger/SwaggerGroupConfig.java
@@ -61,7 +61,8 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.student",
             "in.koreatech.koin.domain.timetable",
             "in.koreatech.koin.domain.timetableV2",
-            "in.koreatech.koin.domain.timetableV3"
+            "in.koreatech.koin.domain.timetableV3",
+            "in.koreatech.koin.domain.graduation"
         };
 
         return createGroupedOpenApi("4. User API", packagesPath);

--- a/src/main/resources/db/migration/V116__add_catalog.sql
+++ b/src/main/resources/db/migration/V116__add_catalog.sql
@@ -11,5 +11,5 @@ CREATE TABLE if not exists `koin`.`catalog`
     FOREIGN KEY (`course_type_id`) REFERENCES `course_type` (`id`),
     FOREIGN KEY (`department_id`) REFERENCES `department` (`id`),
     created_at       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP comment '생성 일자',
-    updated_at       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP comment '수정 일자',
+    updated_at       timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP comment '수정 일자'
 );

--- a/src/main/resources/db/migration/V117__add_detect_graduation_calculation.sql
+++ b/src/main/resources/db/migration/V117__add_detect_graduation_calculation.sql
@@ -1,5 +1,5 @@
 -- 졸업학점 계산 감지 테이블
-CREATE TABLE `detect_graduation_calculation`
+CREATE TABLE if not exists `koin`.`detect_graduation_calculation`
 (
     id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT comment '고유 id',
     user_id INT UNSIGNED NULL comment '유저 id',


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1140

# 🚀 작업 내용

1. 학기와 이수구분을 입력받아 그에 알맞는 강의들을 출력할 수 있도록 했습니다.
- 학기(년도, 학기), 이수구분를 아래의 사진처럼 입력합니다.
<img width="488" alt="image" src="https://github.com/user-attachments/assets/28d55087-262c-4451-b9a0-2f3725cd46c6" />

- 그러면 같은 이수구분을 가진 수업들이 일부 정보만을 가지고 출력됩니다.
<img width="252" alt="image" src="https://github.com/user-attachments/assets/3e0b7d5c-d564-433c-a7ea-dacfda67e924" />

# 💬 리뷰 중점사항
간단한 로직인데 머리에서 계속 꼬여서 여러 번 해멘 경우..
입력한 학기에서 이수구분을 확인하여 어떤 강의를 들어야하는지 출력하도록 했습니다.
## 추가적으로 !!!! year 관련된 로직 오류터져서 일단은 주석 처리 해놨습니다. 작업 끝나고 지울게요.
그 외 레포지토리 정리랑 flyway 오류 있어서 수정했습니다. 작업 시 확인해주세요.

로직은 학기(연도+학기)와 이수구분의 이름을 입력받으면 이수구분의 이름으로 이수구분의 아이디를 찾습니다.
이 이수구분의 아이디로 카탈로그에서 모든 강의를 가져옵니다.(현재 좀 무거운데, 중복 처리 된 거 빼면 가벼워 질 것 같습니다.)
카탈로그에서 강의 코드를 가져오고, 입력받은 학기와 강의코드를 통하여 그 학기의 이수구분에 맞는 강의들을 전체 반환합니다.

이상한 점 있으면 말씀해주세요 :D 