### PR TITLE
fix: 분실물 게시판 QA 이슈 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -59,7 +59,7 @@ public interface ArticleApi {
     @Operation(summary = "게시글 목록 조회")
     @GetMapping("")
     ResponseEntity<ArticlesResponse> getArticles(
-        @RequestParam Integer boardId,
+        @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit
     );

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -48,7 +48,7 @@ public class ArticleController implements ArticleApi {
 
     @GetMapping()
     public ResponseEntity<ArticlesResponse> getArticles(
-        @RequestParam Integer boardId,
+        @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit
     ) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticleRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticleRequest.java
@@ -9,21 +9,28 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record LostItemArticleRequest(
+    @NotNull(message = "분실물 종류는 필수로 입력해야 합니다.")
     @Schema(description = "분실물 종류", example = "신분증", requiredMode = REQUIRED)
     String category,
 
+    @NotNull(message = "분실물 습득 장소는 필수로 입력해야 합니다.")
     @Schema(description = "습득 장소", example = "학생회관 앞", requiredMode = REQUIRED)
-    String location,
+    String foundPlace,
 
+    @NotNull(message = "분실물 습득 날짜는 필수로 입력해야 합니다.")
     @Schema(description = "습득 날짜", example = "2025-01-01", requiredMode = REQUIRED)
     LocalDate foundDate,
 
+    @Size(max = 1000, message = "본문의 내용은 최대 1,000자까지만 입력할 수 있습니다.")
     @Schema(description = "본문", example = "학생회관 앞 계단에 …")
     String content,
 
+    @Size(max = 10, message = "이미지는 최대 10개까지만 업로드할 수 있습니다.")
     @Schema(description = "분실물 사진")
     List<String> images,
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticleResponse.java
@@ -38,7 +38,7 @@ public record LostItemArticleResponse(
     String author,
 
     @Schema(description = "분실물 사진")
-    List<InnerLostItemImageResponse> image,
+    List<InnerLostItemImageResponse> images,
 
     @Schema(description = "이전글 id", example = "17367")
     Integer prevId,

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticlesRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticlesRequest.java
@@ -5,8 +5,11 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import jakarta.validation.Valid;
+
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record LostItemArticlesRequest(
+    @Valid
     List<LostItemArticleRequest> articles
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -57,8 +57,7 @@ public class Article extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @NotNull
-    @Column(name = "content", nullable = false)
+    @Column(name = "content")
     private String content;
 
     @NotNull
@@ -246,7 +245,7 @@ public class Article extends BaseEntity {
         LostItemArticle lostItemArticle = LostItemArticle.builder()
             .author(author)
             .category(request.category())
-            .foundPlace(request.location())
+            .foundPlace(request.foundPlace())
             .foundDate(request.foundDate())
             .images(images)
             .isDeleted(false)

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
@@ -21,6 +21,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,13 +42,14 @@ public class LostItemArticle {
     private Article article;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = true)
+    @JoinColumn(name = "author_id")
     private User author;
 
     @NotNull
     @Column(name = "category", nullable = false)
     private String category;
 
+    @Size(max = 255)
     @NotNull
     @Column(name = "found_place", nullable = false)
     private String foundPlace;

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -27,7 +27,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Optional<Article> findById(Integer articleId);
 
-    List<Article> findAll(Pageable pageable);
+    Page<Article> findAll(Pageable pageable);
 
     Page<Article> findAllByBoardId(Integer boardId, PageRequest pageRequest);
 
@@ -76,6 +76,11 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     Optional<Article> findPreviousArticle(@Param("articleId") Integer articleId, @Param("boardId") Integer boardId);
 
     @Query(value = "SELECT * FROM new_articles a "
+        + "WHERE a.id < :articleId AND a.is_deleted = false "
+        + "ORDER BY a.id DESC LIMIT 1", nativeQuery = true)
+    Optional<Article> findPreviousAllArticle(@Param("articleId") Integer articleId);
+
+    @Query(value = "SELECT * FROM new_articles a "
         + "WHERE a.id > :articleId AND a.is_notice = true AND a.is_deleted = false "
         + "ORDER BY a.id DESC LIMIT 1", nativeQuery = true)
     Optional<Article> findNextNoticeArticle(@Param("articleId") Integer articleId);
@@ -85,6 +90,11 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         + "ORDER BY a.id ASC LIMIT 1", nativeQuery = true)
     Optional<Article> findNextArticle(@Param("articleId") Integer articleId, @Param("boardId") Integer boardId);
 
+    @Query(value = "SELECT * FROM new_articles a "
+        + "WHERE a.id > :articleId AND a.is_deleted = false "
+        + "ORDER BY a.id ASC LIMIT 1", nativeQuery = true)
+    Optional<Article> findNextAllArticle(@Param("articleId") Integer articleId);
+
     default Article getPreviousArticle(Board board, Article article) {
         if (board.isNotice() && board.getId().equals(NOTICE_BOARD_ID)) {
             return findPreviousNoticeArticle(article.getId()).orElse(null);
@@ -92,11 +102,19 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         return findPreviousArticle(article.getId(), board.getId()).orElse(null);
     }
 
+    default Article getPreviousAllArticle(Article article) {
+        return findPreviousAllArticle(article.getId()).orElse(null);
+    }
+
     default Article getNextArticle(Board board, Article article) {
         if (board.isNotice() && board.getId().equals(NOTICE_BOARD_ID)) {
             return findNextNoticeArticle(article.getId()).orElse(null);
         }
         return findNextArticle(article.getId(), board.getId()).orElse(null);
+    }
+
+    default Article getNextAllArticle(Article article) {
+        return findNextAllArticle(article.getId()).orElse(null);
     }
 
     @Query(value = "SELECT a.* FROM new_articles a "
@@ -122,7 +140,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     String getTitleById(@Param("id") Integer id);
 
     @Query(value = "SELECT * FROM new_articles a "
-            + "WHERE a.title REGEXP '통학버스|등교버스|셔틀버스|하교버스' AND a.is_notice = true "
-            + "ORDER BY a.created_at DESC LIMIT 5", nativeQuery = true)
+        + "WHERE a.title REGEXP '통학버스|등교버스|셔틀버스|하교버스' AND a.is_notice = true "
+        + "ORDER BY a.created_at DESC LIMIT 5", nativeQuery = true)
     List<Article> findBusArticlesTop5OrderByCreatedAtDesc();
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.article.model.Board;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.keyword.repository.UserNotificationStatusRepository;
 import in.koreatech.koin.domain.community.keyword.service.KeywordService;
@@ -35,7 +37,8 @@ public class ArticleKeywordEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onKeywordRequest(ArticleKeywordEvent event) {
-        String articleTitle = articleRepository.getTitleById(event.articleId());
+        Article article = articleRepository.getById(event.articleId());
+        Board board = article.getBoard();
 
         List<Notification> notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailType(ARTICLE_KEYWORD, null)
@@ -43,7 +46,7 @@ public class ArticleKeywordEventListener {
             .filter(this::hasDeviceToken)
             .filter(subscribe -> isKeywordRegistered(event, subscribe))
             .filter(subscribe -> isNewArticle(event, subscribe))
-            .map(subscribe -> createAndRecordNotification(event, articleTitle, subscribe))
+            .map(subscribe -> createAndRecordNotification(article, board, event.keyword(), subscribe))
             .toList();
 
         notificationService.push(notifications);
@@ -67,24 +70,25 @@ public class ArticleKeywordEventListener {
     }
 
     private Notification createAndRecordNotification(
-        ArticleKeywordEvent event,
-        String articleTitle,
+        Article article,
+        Board board,
+        ArticleKeyword keyword,
         NotificationSubscribe subscribe
     ) {
         Integer userId = subscribe.getUser().getId();
-        String keyword = event.keyword().getKeyword();
-        String description = generateDescription(keyword);
+        String description = generateDescription(keyword.getKeyword());
 
         Notification notification = notificationFactory.generateKeywordNotification(
             KEYWORD,
-            event.articleId(),
-            keyword,
-            articleTitle,
+            article.getId(),
+            keyword.getKeyword(),
+            article.getTitle(),
+            board.getId(),
             description,
             subscribe.getUser()
         );
 
-        keywordService.updateLastNotifiedArticle(userId, event.articleId());
+        keywordService.updateLastNotifiedArticle(userId, article.getId());
         return notification;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -1,0 +1,51 @@
+package in.koreatech.koin.domain.community.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordEvent;
+import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KeywordExtractor {
+
+    private static final int KEYWORD_BATCH_SIZE = 100;
+
+    private final ArticleKeywordRepository articleKeywordRepository;
+
+    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles) {
+        List<ArticleKeywordEvent> keywordEvents = new ArrayList<>();
+        int offset = 0;
+
+        while (true) {
+            Pageable pageable = PageRequest.of(offset / KEYWORD_BATCH_SIZE, KEYWORD_BATCH_SIZE);
+            List<ArticleKeyword> keywords = articleKeywordRepository.findAll(pageable);
+
+            if (keywords.isEmpty()) {
+                break;
+            }
+
+            for (Article article : articles) {
+                String title = article.getTitle();
+                for (ArticleKeyword keyword : keywords) {
+                    if (title.contains(keyword.getKeyword())) {
+                        keywordEvents.add(new ArticleKeywordEvent(article.getId(), keyword));
+                    }
+                }
+            }
+            offset += KEYWORD_BATCH_SIZE;
+        }
+
+        return keywordEvents;
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/global/domain/notification/model/NotificationFactory.java
@@ -85,12 +85,13 @@ public class NotificationFactory {
         Integer eventKeywordId,
         String keyword,
         String title,
+        Integer boardId,
         String description,
         User target
     ) {
         return new Notification(
             path,
-            generateKeywordSchemeUri(path, eventKeywordId, keyword),
+            generateKeywordSchemeUri(path, eventKeywordId, keyword, boardId),
             title,
             description,
             null,
@@ -112,10 +113,10 @@ public class NotificationFactory {
         return place + result;
     }
 
-    private String generateKeywordSchemeUri(MobileAppPath path, Integer eventId, String keyword) {
+    private String generateKeywordSchemeUri(MobileAppPath path, Integer eventId, String keyword, Integer boardId) {
         if (keyword == null) {
             return generateSchemeUri(path, eventId);
         }
-        return String.format("%s?id=%d&keyword=%s", path.getPath(), eventId, keyword);
+        return String.format("%s?id=%d&keyword=%s&board-id=%s", path.getPath(), eventId, keyword, boardId);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
@@ -82,9 +82,11 @@ class ArticleApiTest extends AcceptanceTest {
 
     @Test
     void 공지사항_크롤링_게시글을_단건_조회한다() throws Exception {
+        Board noticeBoard = article3.getBoard();
         mockMvc.perform(
                 get("/articles/{articleId}", article3.getId())
                     .contentType(MediaType.APPLICATION_JSON)
+                    .param("boardId", noticeBoard.getId().toString())
             )
             .andExpect(status().isOk())
             .andExpect(content().json("""


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. **분실물 게시판 QA 이슈 수정했습니다.**
    - 크기 제한, null 허용(분실물 내용 공백, 사진 개수 제한, 습득 장소 단어 수 에러)
2. **게시글 조회 시 게시판별 분기 처리를 추가했습니다.**
    - 웹과 모바일에서의 전체글 조회의 차이가 있어 분기를 추가했습니다.
        - **모바일**: 전체 게시글 = 전체 공지 | `boardId: 4`
        - **웹**: 전체 게시글 = 전체 공지 + 분실물 | `boardId: null`
3. **키워드 알림 추출 로직을 분리했습니다.**
    - `article`, `keyword` 모두에서 공통으로 쓰이는 `matchKeyword`를 `KeywordExtractor`로 분리
4. **키워드 알림 FCM 페이로드에 boardId를 추가했습니다.**
    - 분실물 게시글과 일반 게시글의 양식이 달라서 클라이언트측 분기 처리를 위해 추가하였습니다.

# 💬 리뷰 중점사항
