### PR TITLE
feat : 학부/전공 전체 조회(졸학계)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
@@ -48,6 +48,6 @@ public interface DeptApi {
         }
     )
     @Operation(summary = "학부/전공 목록 조회")
-    @GetMapping("/new/depts")
+    @GetMapping("/depts/major")
     ResponseEntity<List<DeptAndMajorResponse>> getAllDeptAndMajor();
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptApi.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.dept.dto.DeptAndMajorResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
 import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,4 +40,14 @@ public interface DeptApi {
     @Operation(summary = "학과 목록 조회")
     @GetMapping("/depts")
     ResponseEntity<List<DeptsResponse>> getAllDept();
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "학부/전공 목록 조회")
+    @GetMapping("/new/depts")
+    ResponseEntity<List<DeptAndMajorResponse>> getAllDeptAndMajor();
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
@@ -36,7 +36,7 @@ public class DeptController implements DeptApi {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/new/depts")
+    @GetMapping("/depts/major")
     public ResponseEntity<List<DeptAndMajorResponse>> getAllDeptAndMajor() {
         List<DeptAndMajorResponse> response = deptService.getAllDepartmentsWithMajors();
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/controller/DeptController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.dept.dto.DeptAndMajorResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
 import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import in.koreatech.koin.domain.dept.service.DeptService;
@@ -34,4 +35,11 @@ public class DeptController implements DeptApi {
         List<DeptsResponse> response = deptService.getAll();
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/new/depts")
+    public ResponseEntity<List<DeptAndMajorResponse>> getAllDeptAndMajor() {
+        List<DeptAndMajorResponse> response = deptService.getAllDepartmentsWithMajors();
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/in/koreatech/koin/domain/dept/dto/DeptAndMajorResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/dto/DeptAndMajorResponse.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.dept.dto;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Major;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeptAndMajorResponse(
+    @Schema(description = "학과", example = "기계공학부")
+    String department,
+
+    @Schema(description = "전공 리스트", example = """
+        ["친환경자동차･에너지트랙전공", "시스템설계제조전공", "생산시스템전공"]
+        """)
+    List<String> majors
+) {
+    public static DeptAndMajorResponse of(Department department, List<Major> majorList) {
+        return new DeptAndMajorResponse(
+            department.getName(),
+            majorList.stream().map(Major::getName).toList()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
+++ b/src/main/java/in/koreatech/koin/domain/dept/service/DeptService.java
@@ -7,12 +7,22 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import in.koreatech.koin.domain.dept.dto.DeptAndMajorResponse;
 import in.koreatech.koin.domain.dept.dto.DeptResponse;
 import in.koreatech.koin.domain.dept.dto.DeptsResponse;
 import in.koreatech.koin.domain.dept.model.Dept;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Major;
+import in.koreatech.koin.domain.student.repository.DepartmentRepository;
+import in.koreatech.koin.domain.student.repository.MajorRepository;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class DeptService {
+
+    private final DepartmentRepository departmentRepository;
+    private final MajorRepository majorRepository;
 
     public DeptResponse getById(String id) {
         Optional<Dept> dept = Dept.findByNumber(id);
@@ -25,5 +35,13 @@ public class DeptService {
             .filter(dept -> !NEW_ENERGY_MATERIALS_CHEMICAL_ENGINEERING.equals(dept))
             .map(DeptsResponse::from)
             .toList();
+    }
+
+    public List<DeptAndMajorResponse> getAllDepartmentsWithMajors() {
+        List<Department> departments = departmentRepository.getAll();
+        return departments.stream().map(department -> {
+            List<Major> majors = majorRepository.getAllByDepartmentId(department.getId());
+            return DeptAndMajorResponse.of(department, majors);
+        }).toList();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/repository/DepartmentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/student/repository/DepartmentRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.student.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
@@ -15,8 +16,14 @@ public interface DepartmentRepository extends Repository<Department, Integer> {
 
     Optional<Department> findByName(String name);
 
+    Optional<List<Department>> findAll();
+
     default Department getByName(String name) {
         return findByName(name)
             .orElseThrow(() -> DepartmentNotFoundException.withDetail("name: " + name));
+    }
+
+    default List<Department> getAll() {
+        return findAll().orElseThrow(() -> DepartmentNotFoundException.withDetail("all"));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/repository/MajorRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/student/repository/MajorRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.student.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
@@ -15,8 +16,15 @@ public interface MajorRepository extends Repository<Major, Integer> {
 
     Optional<Major> findByName(String name);
 
+    Optional<List<Major>> findAllByDepartmentId(Integer departmentId);
+
     default Major getByName(String name) {
         return findByName(name)
             .orElseThrow(() -> DepartmentNotFoundException.withDetail("name: " + name));
+    }
+
+    default List<Major> getAllByDepartmentId(Integer departmentId) {
+        return findAllByDepartmentId(departmentId)
+            .orElseThrow(() -> DepartmentNotFoundException.withDetail("departmentId: " + departmentId));
     }
 }

--- a/src/main/resources/db/migration/V118__add_catalog.sql
+++ b/src/main/resources/db/migration/V118__add_catalog.sql
@@ -3,6 +3,7 @@ CREATE TABLE if not exists `koin`.`catalog`
 (
     `id`             INT UNSIGNED NOT NULL AUTO_INCREMENT comment '고유 id',
     `code`           VARCHAR(20)  NOT NULL comment '강의 코드',
+    `year`           INT UNSIGNED NOT NULL comment '년도',
     `lecture_name`   VARCHAR(255) NOT NULL comment '강의 이름',
     `department_id`  INT UNSIGNED NOT NULL comment '학과 id',
     `major_id`       INT UNSIGNED NULL comment '전공 id',


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1140 
(이슈를 따로 안 팠네요..)

# 🚀 작업 내용

1. 학부와 전공을 전체 조회하는 API를 작성했습니다.
<img width="1245" alt="image" src="https://github.com/user-attachments/assets/a80b5580-39a1-4319-bc0c-a97e2a6b3f07" />
위의 사진처럼 출력됩니다.

# 💬 리뷰 중점사항
flyway 빠진 부분도 있어서 채워넣었습니다. 작업 간 확인 부탁드립니다.