### PR TITLE
fix : 웹 소켓 설정에서 sockjs 통신 설정 삭제

### DIFF
--- a/src/main/java/in/koreatech/koin/global/socket/config/WebSocketConfig.java
+++ b/src/main/java/in/koreatech/koin/global/socket/config/WebSocketConfig.java
@@ -32,8 +32,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
-            .setAllowedOriginPatterns("*")
-            .withSockJS();
+            .setAllowedOriginPatterns("*");
     }
 
     @Override


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 안드로이드 라이브러리에서 연결 오류가 나는 원인으로 추정되는 설정 (SockJS) 수정

# 💬 리뷰 중점사항