### PR TITLE
feat: s3 접근에 필요한 자격 증명 방식 단일화

### DIFF
--- a/src/main/java/in/koreatech/koin/global/config/S3Config.java
+++ b/src/main/java/in/koreatech/koin/global/config/S3Config.java
@@ -8,8 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -49,7 +48,8 @@ public class S3Config {
         return AmazonS3ClientBuilder.standard()
             .withRegion(Regions.AP_NORTHEAST_2)
             .withClientConfiguration(clientConfig)
-            .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+            //.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))) // IAM user 사용
+            .withCredentials(new EC2ContainerCredentialsProviderWrapper()) // IAM Role 사용
             .build();
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

## 기존
IAM user "s3"와 IAM role "EC2_to_S3"를 동시에 사용중이었습니다.

- IAM user "s3" -> accessKey, secretKey로 접근
- IAM role "EC2_to_S3" -> InstanceProfileCredentialsProvider로 접근(인스턴스에 부여된 역할에 기반한 임시 자격증명 발급)

presignedUrl은 IAM role 방식을 사용하기 때문에 권한 문제가 발생하지 않았으나, 이번에 추가된 #1175 와 기존(레거시) 이미지 업로드 방식은 IAM user 방식을 사용하여 권한없음 에러가 발생했습니다. 

# 🚀 작업 내용
자격 증명을 단일 방식으로 통일하기 위해 `s3Client` 빈 생성 시 `EC2ContainerCredentialsProviderWrapper`를 사용하도록 변경했습니다.

# 💬 리뷰 중점사항
