### PR TITLE
fix: 영양사 이미지 압축 다운로드 예외처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -528,8 +528,6 @@ public class CoopService {
         }
     }
 
-
-
     public void removeDiningImageCompress(File zipFilePath) {
         new Thread(() -> remove(zipFilePath.getParentFile())).start();
     }


### PR DESCRIPTION
# 🔥 연관 이슈

서버에서 에러가 발생했습니다. uri: GET /coop/dining/image
Exception: AmazonS3Exception
Location: AmazonHttpClient.java Line 1879
```
The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: ~~; S3 Extended Request ID: ~~; Proxy: null)
```

# 🚀 작업 내용

1. 외부 이미지가 DB에 포함된 경우 다운로드를 시도하지 않도록 예외처리했습니다.
2. s3 이미지 다운로드 로직을 `s3Utils` 클래스로 분리했습니다.

# 💬 리뷰 중점사항
