### PR TITLE
feat: aws 자격 증명 방식 단일화 및 key 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/global/config/S3Config.java
+++ b/src/main/java/in/koreatech/koin/global/config/S3Config.java
@@ -16,7 +16,7 @@ import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvide
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 /**
- * Key 기반 인증 방식은 취약하므로 IAM Role 기반 인증 방식을 사용한다. (InstanceProfileCredentialsProvider)
+ * Key 기반 인증 방식은 취약하므로 IAM Role 기반 인증 방식을 사용한다. (EC2ContainerCredentialsProviderWrapper)
  * EC2 인스턴스에 부여된 "EC2_to_S3" IAM Role을 통해 인증을 수행한다.
  */
 @Configuration

--- a/src/main/java/in/koreatech/koin/global/config/S3Config.java
+++ b/src/main/java/in/koreatech/koin/global/config/S3Config.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.global.config;
 
 import static software.amazon.awssdk.regions.Region.AP_NORTHEAST_2;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,19 +15,12 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+/**
+ * Key 기반 인증 방식은 취약하므로 IAM Role 기반 인증 방식을 사용한다. (InstanceProfileCredentialsProvider)
+ * EC2 인스턴스에 부여된 "EC2_to_S3" IAM Role을 통해 인증을 수행한다.
+ */
 @Configuration
 public class S3Config {
-
-    private final String accessKey;
-    private final String secretKey;
-
-    public S3Config(
-        @Value("${s3.key}") String accessKey,
-        @Value("${s3.secret}") String secretKey
-    ) {
-        this.accessKey = accessKey;
-        this.secretKey = secretKey;
-    }
 
     /**
      * S3Presigner 사용 후 close()를 권장하므로, Builder 를 반환하여 필요 시 객체를 만들어 사용 후 close 되도록 구현.
@@ -48,7 +40,6 @@ public class S3Config {
         return AmazonS3ClientBuilder.standard()
             .withRegion(Regions.AP_NORTHEAST_2)
             .withClientConfiguration(clientConfig)
-            //.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))) // IAM user 사용
             .withCredentials(new EC2ContainerCredentialsProviderWrapper()) // IAM Role 사용
             .build();
     }

--- a/src/main/java/in/koreatech/koin/global/config/S3Config.java
+++ b/src/main/java/in/koreatech/koin/global/config/S3Config.java
@@ -8,8 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -49,7 +48,8 @@ public class S3Config {
         return AmazonS3ClientBuilder.standard()
             .withRegion(Regions.AP_NORTHEAST_2)
             .withClientConfiguration(clientConfig)
-            .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+            //.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))) // IAM user 사용
+            .withCredentials(new EC2ContainerCredentialsProviderWrapper()) // IAM Role 사용
             .build();
     }
 }


### PR DESCRIPTION
Reverts BCSDLab/KOIN_API_V2#1227

# 작업 내용

- 테스트 완료로 인한 롤백 (자격증명 수단: user key-> ec2 role)
- 불필요해진 accessKey, secretKey 필드 제거 

# 참고 자료
https://kim-jong-hyun.tistory.com/131