### PR TITLE
feat : 분실물 게시글 쪽지(채팅) 사용자 차단 기능

### DIFF
--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestApi.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestApi.java
@@ -6,6 +6,7 @@ import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -86,6 +87,32 @@ public interface ChatRestApi {
     )
     @PostMapping("/lost-item/{articleId}/{chatRoomId}/block")
     ResponseEntity<?> blockChatUser(
+        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @PathVariable("articleId") Integer articleId,
+        @PathVariable("chatRoomId") Integer chatRoomId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "사용자 차단 해제 성공"
+            ),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "422", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(
+        summary = "채팅방에서 사용자 차단 해제(개발 편의용)",
+        description = """
+        ### articleId를 이용하여 사용자 차단을 해제
+        - 서버에서 글쓴이의 ID를 조회하여 차단을 해제합니다.
+        """
+    )
+    @DeleteMapping("/lost-item/{articleId}/{chatRoomId}/unblock")
+    ResponseEntity<?> unblockChatUser(
         @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestApi.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestApi.java
@@ -68,6 +68,32 @@ public interface ChatRestApi {
     @ApiResponses(
         value = {
             @ApiResponse(
+                responseCode = "201",
+                description = "사용자 차단 성공"
+            ),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "422", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(
+        summary = "채팅방 에서 사용자 차단",
+        description = """
+            ### articleId를 이용하여 사용자를 차단
+            - 서버에서 글쓴이의 ID를 조회하여 차단합니다.
+            """
+    )
+    @PostMapping("/lost-item/{articleId}/{chatRoomId}/block")
+    ResponseEntity<?> blockChatUser(
+        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @PathVariable("articleId") Integer articleId,
+        @PathVariable("chatRoomId") Integer chatRoomId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(
                 responseCode = "200",
                 description = "채팅방 정보 반환 성공",
                 content = @Content(

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestController.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/controller/ChatRestController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,6 +66,16 @@ public class ChatRestController implements ChatRestApi {
     ) {
         userBlockService.blockUser(articleId, chatRoomId, studentId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/lost-item/{articleId}/{chatRoomId}/unblock")
+    public ResponseEntity<?> unblockChatUser(
+        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @PathVariable("articleId") Integer articleId,
+        @PathVariable("chatRoomId") Integer chatRoomId
+    ) {
+        userBlockService.unBlockUser(articleId, chatRoomId, studentId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/lost-item/{articleId}/{chatRoomId}/messages")

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/exception/UserBlockException.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/exception/UserBlockException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.global.socket.domain.chatroom.exception;
+
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
+
+public class UserBlockException extends AuthorizationException {
+
+    private static final String DEFAULT_MESSAGE = "차단된 사용자 입니다.";
+
+    public UserBlockException(String message) {
+        super(message);
+    }
+
+    public UserBlockException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static UserBlockException withDetail(String detail) {
+        return new UserBlockException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/model/LostItemChatUserBlockEntity.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/model/LostItemChatUserBlockEntity.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.global.socket.domain.chatroom.model;
+
+import java.time.LocalDateTime;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Document(collection = "lost_item_chat_user_block")
+public class LostItemChatUserBlockEntity {
+
+    @Id
+    @Field("_id")
+    private ObjectId id;
+
+    @Field("blocker_user_id")
+    private Integer blockerUserId;
+
+    @Field("blocked_user_id")
+    private Integer blockedUserId;
+
+    @Field("is_active")
+    private Boolean isActive;
+
+    @Field("created_at")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public LostItemChatUserBlockEntity(Integer blockerUserId, Integer blockedUserId, Boolean isActive) {
+        this.blockerUserId = blockerUserId;
+        this.blockedUserId = blockedUserId;
+        this.isActive = isActive;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/repository/LostItemChatUserBlockRepository.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/repository/LostItemChatUserBlockRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
 import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatUserBlockEntity;
@@ -20,16 +21,30 @@ public class LostItemChatUserBlockRepository {
         return mongoTemplate.save(entity);
     }
 
-    public Optional<LostItemChatUserBlockEntity> findByBlockerUserAndBlockedUser(
+    public Optional<LostItemChatUserBlockEntity> findByBlockerUserAndBlockedUserAndIsActive(
         Integer blockerUserId,
-        Integer blockedUserId
+        Integer blockedUserId,
+        Boolean isActive
     ) {
         Query query = Query.query(Criteria.where("blocker_user_id").is(blockerUserId)
             .and("blocked_user_id").is(blockedUserId)
-            .and("is_active").is(true)
+            .and("is_active").is(isActive)
         );
 
         LostItemChatUserBlockEntity result = mongoTemplate.findOne(query, LostItemChatUserBlockEntity.class);
         return Optional.ofNullable(result);
+    }
+
+    public void updateIsActiveByBlockerAndBlockedUser(
+        Integer blockerUserId,
+        Integer blockedUserId,
+        Boolean isActive
+    ) {
+        Query query = Query.query(Criteria.where("blocker_user_id").is(blockerUserId)
+            .and("blocked_user_id").is(blockedUserId));
+
+        Update update = new Update().set("is_active", isActive);
+
+        mongoTemplate.updateFirst(query, update, LostItemChatUserBlockEntity.class);
     }
 }

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/repository/LostItemChatUserBlockRepository.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/repository/LostItemChatUserBlockRepository.java
@@ -1,0 +1,35 @@
+package in.koreatech.koin.global.socket.domain.chatroom.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatUserBlockEntity;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class LostItemChatUserBlockRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public LostItemChatUserBlockEntity save(LostItemChatUserBlockEntity entity) {
+        return mongoTemplate.save(entity);
+    }
+
+    public Optional<LostItemChatUserBlockEntity> findByBlockerUserAndBlockedUser(
+        Integer blockerUserId,
+        Integer blockedUserId
+    ) {
+        Query query = Query.query(Criteria.where("blocker_user_id").is(blockerUserId)
+            .and("blocked_user_id").is(blockedUserId)
+            .and("is_active").is(true)
+        );
+
+        LostItemChatUserBlockEntity result = mongoTemplate.findOne(query, LostItemChatUserBlockEntity.class);
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -109,8 +109,10 @@ public class LostItemChatRoomInfoService {
             otherUserId = articleAuthorId;
         }
 
-        boolean blockedByMe = userBlockReader.readByBlockerUserIdAndBlockedUserId(studentId, otherUserId).isPresent();
-        boolean blockedByOther = userBlockReader.readByBlockerUserIdAndBlockedUserId(otherUserId, studentId).isPresent();
+        boolean blockedByMe = userBlockReader.readByBlockerUserIdAndBlockedUserIdAndIsActive(
+            studentId, otherUserId, true).isPresent();
+        boolean blockedByOther = userBlockReader.readByBlockerUserIdAndBlockedUserIdAndIsActive(
+            otherUserId, studentId, true).isPresent();
 
         return blockedByMe || blockedByOther;
     }

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomUserBlockService.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomUserBlockService.java
@@ -22,6 +22,11 @@ public class LostItemChatRoomUserBlockService {
     @Transactional
     public void blockUser(Integer articleId, Integer chatRoomId, Integer userId) {
         Integer otherUserId = findOtherUserId(articleId, chatRoomId, userId);
+
+        if (userBlockReader.readByBlockerUserIdAndBlockedUserId(userId, otherUserId).isPresent()) {
+            return;
+        }
+
         userBlockAppender.save(userId, otherUserId);
     }
 

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomUserBlockService.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomUserBlockService.java
@@ -1,0 +1,51 @@
+package in.koreatech.koin.global.socket.domain.chatroom.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.global.socket.domain.chatroom.exception.UserBlockException;
+import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatRoomInfoEntity;
+import in.koreatech.koin.global.socket.domain.chatroom.service.implement.ChatRoomInfoReader;
+import in.koreatech.koin.global.socket.domain.chatroom.service.implement.UserBlockAppender;
+import in.koreatech.koin.global.socket.domain.chatroom.service.implement.UserBlockReader;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LostItemChatRoomUserBlockService {
+
+    private final ChatRoomInfoReader chatRoomInfoReader;
+    private final UserBlockReader userBlockReader;
+    private final UserBlockAppender userBlockAppender;
+
+    @Transactional
+    public void blockUser(Integer articleId, Integer chatRoomId, Integer userId) {
+        Integer otherUserId = findOtherUserId(articleId, chatRoomId, userId);
+        userBlockAppender.save(userId, otherUserId);
+    }
+
+    public void checkUserBlock(Integer articleId, Integer chatRoomId, Integer userId) {
+        Integer otherUserId = findOtherUserId(articleId, chatRoomId, userId);
+
+        boolean blockedByMe = userBlockReader.readByBlockerUserIdAndBlockedUserId(userId, otherUserId)
+            .isPresent();
+        boolean blockedByOther = userBlockReader.readByBlockerUserIdAndBlockedUserId(otherUserId, userId)
+            .isPresent();
+
+        if (blockedByMe || blockedByOther) {
+            throw new UserBlockException("차단된 사용자 입니다.");
+        }
+    }
+
+    private Integer findOtherUserId(Integer articleId, Integer chatRoomId, Integer userId) {
+        LostItemChatRoomInfoEntity chatRoomInfo = chatRoomInfoReader.readByArticleIdAndChatRoomId(
+            articleId, chatRoomId
+        );
+
+        Integer articleAuthorId = chatRoomInfo.getAuthorId();
+        Integer ownerId = chatRoomInfo.getOwnerId();
+
+        return userId.equals(articleAuthorId) ? ownerId : articleAuthorId;
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/ChatRoomInfoReader.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/ChatRoomInfoReader.java
@@ -21,6 +21,10 @@ public class ChatRoomInfoReader {
         return chatRoomInfoRepository.findByArticleIdAndOwnerId(articleId, ownerId);
     }
 
+    public LostItemChatRoomInfoEntity readByArticleIdAndChatRoomId(Integer articleId, Integer chatRoomId) {
+        return chatRoomInfoRepository.getByArticleIdAndChatRoomId(articleId, chatRoomId);
+    }
+
     public List<LostItemChatRoomInfoEntity> readByUserId(Integer userId) {
         return chatRoomInfoRepository.findByUserId(userId);
     }

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockAppender.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockAppender.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.global.socket.domain.chatroom.service.implement;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatUserBlockEntity;
+import in.koreatech.koin.global.socket.domain.chatroom.repository.LostItemChatUserBlockRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserBlockAppender {
+
+    private final LostItemChatUserBlockRepository userBlockRepository;
+
+    public LostItemChatUserBlockEntity save(Integer blockerUserId, Integer blockedUserId) {
+        LostItemChatUserBlockEntity entity = LostItemChatUserBlockEntity.builder()
+            .blockerUserId(blockerUserId)
+            .blockedUserId(blockedUserId)
+            .isActive(true)
+            .build();
+
+        return userBlockRepository.save(entity);
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockReader.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockReader.java
@@ -14,9 +14,9 @@ public class UserBlockReader {
 
     private final LostItemChatUserBlockRepository userBlockRepository;
 
-    public Optional<LostItemChatUserBlockEntity> readByBlockerUserIdAndBlockedUserId(
-        Integer blockerUserId, Integer blockedUserId
+    public Optional<LostItemChatUserBlockEntity> readByBlockerUserIdAndBlockedUserIdAndIsActive(
+        Integer blockerUserId, Integer blockedUserId, Boolean isActive
     ) {
-        return userBlockRepository.findByBlockerUserAndBlockedUser(blockerUserId, blockedUserId);
+        return userBlockRepository.findByBlockerUserAndBlockedUserAndIsActive(blockerUserId, blockedUserId, isActive);
     }
 }

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockReader.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockReader.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.global.socket.domain.chatroom.service.implement;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatUserBlockEntity;
+import in.koreatech.koin.global.socket.domain.chatroom.repository.LostItemChatUserBlockRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserBlockReader {
+
+    private final LostItemChatUserBlockRepository userBlockRepository;
+
+    public Optional<LostItemChatUserBlockEntity> readByBlockerUserIdAndBlockedUserId(
+        Integer blockerUserId, Integer blockedUserId
+    ) {
+        return userBlockRepository.findByBlockerUserAndBlockedUser(blockerUserId, blockedUserId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockUpdater.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/UserBlockUpdater.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.global.socket.domain.chatroom.service.implement;
+
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.global.socket.domain.chatroom.repository.LostItemChatUserBlockRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserBlockUpdater {
+
+    private final LostItemChatUserBlockRepository userBlockRepository;
+
+    public void block(Integer blockerUserId, Integer blockedUserId) {
+        userBlockRepository.updateIsActiveByBlockerAndBlockedUser(blockerUserId, blockedUserId, true);
+    }
+
+    public void unBlock(Integer blockerUserId, Integer blockedUserId) {
+        userBlockRepository.updateIsActiveByBlockerAndBlockedUser(blockerUserId, blockedUserId, false);
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- #1185

# 🚀 작업 내용
**REST 엔드포인트**
- **POST** /chatroom/lost-item/{articleId}/{chatRoomId}/block : 사용자 차단
- **DELETE** /chatroom/lost-item/{articleId}/{chatRoomId}/unblock : 사용자 차단 해제

- 채팅방 정보를 MongoDB에서 관리하기 때문에 통일성을 고려하여 MongoDB를 사용했습니다.
```mermaid
erDiagram
    LOST_ITEM_CHAT_USER_BLOCK {
        ObjectId id PK "MongoDB ObjectId"
        Integer blocker_user_id "차단을 수행한 사용자 ID"
        Integer blocked_user_id "차단된 사용자 ID"
        Boolean is_active "차단 상태 (활성/비활성)"
        LocalDateTime created_at "차단 생성 일시"
    }
```
- 차단을 해제하는 기능이 없기 때문에 is_active는 현재 유의미하게 사용되지 않습니다.
- 클라이언트 개발 편의를 위해 차단 해제 API를 제공하였습니다.
- 게시글 신고 기능이 스테이지에 적용되면 신고 완료 처리된 게시글에 대한 채팅방 접근이 불가능하도록 하는 기능을 별도의 PR로 개발하겠습니다.

# 💬 리뷰 중점사항
