### PR TITLE
Chore : GET /semesters/check Response 내 user_id 삭제(졸학계)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/SemesterCheckResponseV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/SemesterCheckResponseV3.java
@@ -12,9 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record SemesterCheckResponseV3(
-    @Schema(description = "유저 id", example = "1", requiredMode = REQUIRED)
-    Integer userId,
-
     @Schema(description = "유저 학기", requiredMode = REQUIRED)
     List<InnerSemesterCheckResponse> semesters
 ) {
@@ -34,9 +31,8 @@ public record SemesterCheckResponseV3(
         }
     }
 
-    public static SemesterCheckResponseV3 of(Integer userId, List<Semester> semester) {
+    public static SemesterCheckResponseV3 of(List<Semester> semester) {
         return new SemesterCheckResponseV3(
-            userId,
             semester.stream()
                 .map(InnerSemesterCheckResponse::of)
                 .toList()

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/service/SemesterServiceV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/service/SemesterServiceV3.java
@@ -37,6 +37,6 @@ public class SemesterServiceV3 {
             .sorted(Comparator.comparing(Semester::getYear).reversed()
                 .thenComparing(semester -> semester.getTerm().getPriority()))
             .toList();
-        return SemesterCheckResponseV3.of(userId, semesters);
+        return SemesterCheckResponseV3.of(semesters);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1140

# 🚀 작업 내용

1. 클라이언트의 요청에 따라 GET v3/semesters/check의 Response 내의 user_id를 삭제했습니다.

# 💬 리뷰 중점사항
간단한.. 피알..