### PR TITLE
chore: 게시글 목록 조회 응답에 is_reported 필드 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -63,7 +63,8 @@ public interface ArticleApi {
     ResponseEntity<ArticlesResponse> getArticles(
         @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
-        @RequestParam(required = false) Integer limit
+        @RequestParam(required = false) Integer limit,
+        @UserId Integer userId
     );
 
     @ApiResponses(
@@ -89,7 +90,8 @@ public interface ArticleApi {
         @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit,
-        @IpAddress String ipAddress
+        @IpAddress String ipAddress,
+        @UserId Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -51,9 +51,10 @@ public class ArticleController implements ArticleApi {
     public ResponseEntity<ArticlesResponse> getArticles(
         @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
-        @RequestParam(required = false) Integer limit
+        @RequestParam(required = false) Integer limit,
+        @UserId Integer userId
     ) {
-        ArticlesResponse foundArticles = articleService.getArticles(boardId, page, limit);
+        ArticlesResponse foundArticles = articleService.getArticles(boardId, page, limit, userId);
         return ResponseEntity.ok().body(foundArticles);
     }
 
@@ -69,9 +70,10 @@ public class ArticleController implements ArticleApi {
         @RequestParam(required = false) Integer boardId,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit,
-        @IpAddress String ipAddress
+        @IpAddress String ipAddress,
+        @UserId Integer userId
     ) {
-        ArticlesResponse foundArticles = articleService.searchArticles(query, boardId, page, limit, ipAddress);
+        ArticlesResponse foundArticles = articleService.searchArticles(query, boardId, page, limit, ipAddress, userId);
         return ResponseEntity.ok().body(foundArticles);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticlesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/LostItemArticlesResponse.java
@@ -15,7 +15,6 @@ import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.LostItemArticle;
 import in.koreatech.koin.global.model.Criteria;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record LostItemArticlesResponse(
@@ -76,7 +75,7 @@ public record LostItemArticlesResponse(
         @Schema(description = "등록일", example = "2025-01-10", requiredMode = REQUIRED)
         LocalDate registeredAt,
 
-        @Schema(description = "처리되지 않은 신고 존재 여부", example = "true", requiredMode = REQUIRED)
+        @Schema(description = "처리되지 않은 자신의 신고 존재 여부", example = "true", requiredMode = REQUIRED)
         Boolean isReported
     ) {
 


### PR DESCRIPTION
# 🔥 연관 이슈
1. 신고 기능은 분실물 게시글에만 존재
2. 모바일에서는 get /articles/lost-item 이용하여 분실물 게시글 조회
3. 웹사이트에서는 get /articles 이용하여 분실물 게시글 조회 (게시판 구분이 없음)
4. get /articles/lost-item 만 is_reported 필드 존재
5. 웹사이트에서 신고된 분실물을 판별하기 어려움

# 🚀 작업 내용

1. 게시글 목록 조회 응답(get /articles, get /articles/search)에 is_reported 필드 추가
2. is_reported: 게시글 중 자신의 미처리된 신고 존재 여부 반환, 게시글 블러처리 여부에 사용

# 💬 리뷰 중점사항
