### PR TITLE
feat : 졸학계 엑셀 / 강의조회 로직 내 GeneralEducationArea 추가(졸학계)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -70,7 +70,7 @@ public interface GraduationApi {
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
-        @RequestParam(name = "generalEducationArea", required = false) String generalEducationAreaName,
+        @RequestParam(name = "general_education_area", required = false) String generalEducationAreaName,
         @Auth(permit = {STUDENT}) Integer userId
     );
 
@@ -81,6 +81,6 @@ public interface GraduationApi {
         }
     )
     @Operation(summary = "교양영역 전체 조회")
-    @GetMapping("/graduation/general-education-area")
+    @GetMapping("/general-education-area")
     ResponseEntity<List<GeneralEducationArea>> getCourseTypeLecture();
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -67,6 +67,7 @@ public interface GraduationApi {
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
+        @RequestParam(name = "generalEducationArea", required = false) String generalEducationAreaName,
         @Auth(permit = {STUDENT}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -2,6 +2,8 @@ package in.koreatech.koin.domain.graduation.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
+import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -70,4 +73,14 @@ public interface GraduationApi {
         @RequestParam(name = "generalEducationArea", required = false) String generalEducationAreaName,
         @Auth(permit = {STUDENT}) Integer userId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "교양영역 전체 조회")
+    @GetMapping("/graduation/general-education-area")
+    ResponseEntity<List<GeneralEducationArea>> getCourseTypeLecture();
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -48,9 +48,11 @@ public class GraduationController implements GraduationApi {
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
+        @RequestParam(name = "generalEducationArea", required = false) String generalEducationAreaName,
         @Auth(permit = {STUDENT}) Integer userId
     ) {
-        CourseTypeLectureResponse response = graduationService.getLectureByCourseType(year, term, courseTypeName);
+        CourseTypeLectureResponse response = graduationService.getLectureByCourseType(year, term,
+            courseTypeName, generalEducationAreaName);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.graduation.controller;
 
 import java.io.IOException;
+import java.util.List;
 
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
@@ -12,9 +13,15 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
+import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
 import in.koreatech.koin.domain.graduation.service.GraduationService;
 import in.koreatech.koin.domain.user.model.UserType;
 import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -55,6 +62,21 @@ public class GraduationController implements GraduationApi {
             courseTypeName, generalEducationAreaName);
         return ResponseEntity.ok(response);
     }
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "교양영역 전체 조회")
+    @GetMapping("/graduation/general-education-area")
+    public ResponseEntity<List<GeneralEducationArea>> getCourseTypeLecture() {
+        List<GeneralEducationArea> response = graduationService.getAllGeneralEducationArea();
+        return ResponseEntity.ok(response);
+    }
+
+    ;
 
     /*
     @GetMapping("/graduation/course/calculation")

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -55,7 +55,7 @@ public class GraduationController implements GraduationApi {
         @RequestParam(name = "year") Integer year,
         @RequestParam(name = "term") String term,
         @RequestParam(name = "name") String courseTypeName,
-        @RequestParam(name = "generalEducationArea", required = false) String generalEducationAreaName,
+        @RequestParam(name = "general_education_area", required = false) String generalEducationAreaName,
         @Auth(permit = {STUDENT}) Integer userId
     ) {
         CourseTypeLectureResponse response = graduationService.getLectureByCourseType(year, term,
@@ -70,7 +70,7 @@ public class GraduationController implements GraduationApi {
         }
     )
     @Operation(summary = "교양영역 전체 조회")
-    @GetMapping("/graduation/general-education-area")
+    @GetMapping("/general-education-area")
     public ResponseEntity<List<GeneralEducationArea>> getCourseTypeLecture() {
         List<GeneralEducationArea> response = graduationService.getAllGeneralEducationArea();
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/graduation/exception/GeneralEducationAreaNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/exception/GeneralEducationAreaNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.graduation.exception;
+
+import in.koreatech.koin.global.exception.DataNotFoundException;
+
+public class GeneralEducationAreaNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 교양 이수구분입니다.";
+
+    protected GeneralEducationAreaNotFoundException(String message) {
+        super(message);
+    }
+
+    protected GeneralEducationAreaNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static GeneralEducationAreaNotFoundException withDetail(String detail) {
+        return new GeneralEducationAreaNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/model/CatalogResult.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/model/CatalogResult.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin.domain.graduation.model;
+
+public record CatalogResult(
+    CourseType courseType,
+    GeneralEducationArea generalEducation
+) {}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/GeneralEducationAreaRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/GeneralEducationAreaRepository.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.graduation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.graduation.exception.GeneralEducationAreaNotFoundException;
+import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
+
+public interface GeneralEducationAreaRepository extends Repository<GeneralEducationArea, Integer> {
+
+    Optional<GeneralEducationArea> findGeneralEducationAreaByName(String name);
+
+    default GeneralEducationArea getGeneralEducationAreaByName(String name) {
+        return findGeneralEducationAreaByName(name)
+            .orElseThrow(() -> GeneralEducationAreaNotFoundException.withDetail("name" + name));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/GeneralEducationAreaRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/GeneralEducationAreaRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.graduation.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
@@ -10,6 +11,8 @@ import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
 public interface GeneralEducationAreaRepository extends Repository<GeneralEducationArea, Integer> {
 
     Optional<GeneralEducationArea> findGeneralEducationAreaByName(String name);
+
+    List<GeneralEducationArea> findAll();
 
     default GeneralEducationArea getGeneralEducationAreaByName(String name) {
         return findGeneralEducationAreaByName(name)

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -504,4 +504,8 @@ public class GraduationService {
 
         return CourseTypeLectureResponse.of(semester, lectures);
     }
+
+    public List<GeneralEducationArea> getAllGeneralEducationArea() {
+        return generalEducationAreaRepository.findAll();
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1140 

# 🚀 작업 내용

1. general_education_area 관련 로직 추가했습니다.
1-1 기존 GET /graduation/course-type 로직 내 추가
![스크린샷 2025-02-14 오전 1 22 08](https://github.com/user-attachments/assets/f33549b8-f138-4ad1-aa51-a748337c2ef1)
![스크린샷 2025-02-14 오전 1 22 13](https://github.com/user-attachments/assets/22260677-e6b8-482c-af06-c71ef879a522)

required를 빼놔서, 교양선택인 경우만 선택해서 드랍다운 형식으로 확인할 수 있도록 하면 괜찮을 것 같습니다.

1-2 기존 엑셀 코드 POST /graduation/excel/upload 내 추가
![image (1)](https://github.com/user-attachments/assets/af9030a1-b304-4cb5-82f0-1685f1a09c6f)

우리 Timetable_lecture가 드디어 교양영역을 보여줍니다.

# 💬 리뷰 중점사항
ㅠㅠ.. 최대한 빨리 한다고 했는데.. 영~.. 느렸네요.
확인 부탁드려용.