### PR TITLE
fix: 삭제된 게시글 채팅방 정보 조회 시 404 에러 반환 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -60,7 +60,7 @@ public class LostItemChatRoomInfoService {
                 var messageSummary = messageReader.getMessageSummary(entity.getArticleId(), entity.getChatRoomId(), userId);
                 var articleSummary = lostItemArticleReader.getArticleSummary(entity.getArticleId());
 
-                if (messageSummary == null) {
+                if (messageSummary == null || articleSummary == null) {
                     return null;
                 }
 

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/LostItemArticleReader.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/LostItemArticleReader.java
@@ -25,16 +25,18 @@ public class LostItemArticleReader {
     }
 
     public ArticleSummary getArticleSummary(Integer articleId) {
-        LostItemArticle lostItemArticle = readByArticleId(articleId);
-        String title = lostItemArticle.getArticle().getTitle();
-        String imageUrl = (lostItemArticle.getImages() != null && !lostItemArticle.getImages().isEmpty())
-            ? lostItemArticle.getImages().get(0).getImageUrl()
-            : null;
-
-        return ArticleSummary.builder()
-            .articleTitle(title)
-            .itemImage(imageUrl)
-            .build();
+        return lostItemArticleRepository.findByArticleId(articleId)
+            .map(lostItemArticle -> {
+                String title = lostItemArticle.getArticle().getTitle();
+                String imageUrl = (lostItemArticle.getImages() != null && !lostItemArticle.getImages().isEmpty())
+                    ? lostItemArticle.getImages().get(0).getImageUrl()
+                    : null;
+                return ArticleSummary.builder()
+                    .articleTitle(title)
+                    .itemImage(imageUrl)
+                    .build();
+            })
+            .orElse(null);
     }
 
     @Getter


### PR DESCRIPTION
# 🔥 연관 이슈

- #1185

# 🚀 작업 내용

1. 게시글을 삭제한 경우 채팅방 정보 조회시 404 에러가 발생하는 오류 수정

# 💬 리뷰 중점사항
