### PR TITLE
feat: 사장님 회원가입 시 redis에 임시 저장한 가게정보 조회 API

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/service/AdminOwnerService.java
@@ -47,7 +47,6 @@ public class AdminOwnerService {
                 shop.updateOwner(owner);
                 owner.setGrantShop(true);
             }
-            adminOwnerShopRedisRepository.deleteById(id);
         });
     }
 

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 import in.koreatech.koin.domain.owner.dto.CompanyNumberCheckRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerRegisteredInfoResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,5 +50,20 @@ public interface OwnerApi {
     ResponseEntity<Void> checkCompanyNumber(
         @ModelAttribute("company_number")
         @Valid CompanyNumberCheckRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "사장님 회원가입시 입력한 가게정보 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/owner/registered-store")
+    ResponseEntity<OwnerRegisteredInfoResponse> getOwnerRegisteredStoreInfo(
+        @Auth(permit = {OWNER}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/controller/OwnerController.java
@@ -8,9 +8,16 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.owner.dto.CompanyNumberCheckRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerRegisteredInfoResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
 import in.koreatech.koin.domain.owner.service.OwnerService;
 import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -35,5 +42,13 @@ public class OwnerController implements OwnerApi {
     ) {
         ownerService.checkCompanyNumber(request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/owner/registered-store")
+    public ResponseEntity<OwnerRegisteredInfoResponse> getOwnerRegisteredStoreInfo(
+        @Auth(permit = {OWNER}) Integer userId
+    ) {
+        OwnerRegisteredInfoResponse response = ownerService.getOwnerRegisteredStoreInfo(userId);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisteredInfoResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/OwnerRegisteredInfoResponse.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.domain.owner.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import in.koreatech.koin.domain.owner.model.OwnerShop;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OwnerRegisteredInfoResponse(
+    @Schema(description = "상점명", example = "교촌치킨", requiredMode = REQUIRED)
+    String shopName,
+
+    @Schema(description = "상점전화번호", example = "0514445555", requiredMode = REQUIRED)
+    String shopNumber
+) {
+
+    public static OwnerRegisteredInfoResponse from(OwnerShop ownerShop) {
+        if (ownerShop == null) {
+            return new OwnerRegisteredInfoResponse("", "");
+        }
+
+        return new OwnerRegisteredInfoResponse(
+            ownerShop.getShopName(),
+            ownerShop.getShopNumber()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerService.java
@@ -1,10 +1,13 @@
 package in.koreatech.koin.domain.owner.service;
 
 import in.koreatech.koin.domain.owner.dto.CompanyNumberCheckRequest;
+import in.koreatech.koin.domain.owner.dto.OwnerRegisteredInfoResponse;
 import in.koreatech.koin.domain.owner.dto.OwnerResponse;
 import in.koreatech.koin.domain.owner.exception.DuplicationCompanyNumberException;
 import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
+import in.koreatech.koin.domain.owner.repository.OwnerShopRedisRepository;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.repository.shop.ShopRepository;
 import java.util.List;
@@ -19,6 +22,7 @@ public class OwnerService {
 
     private final ShopRepository shopRepository;
     private final OwnerRepository ownerRepository;
+    private final OwnerShopRedisRepository ownerShopRedisRepository;
 
     public OwnerResponse getOwner(Integer ownerId) {
         Owner foundOwner = ownerRepository.getById(ownerId);
@@ -30,5 +34,10 @@ public class OwnerService {
         if (ownerRepository.findByCompanyRegistrationNumber(request.companyNumber()).isPresent()) {
             throw DuplicationCompanyNumberException.withDetail("companyNumber: " + request.companyNumber());
         }
+    }
+
+    public OwnerRegisteredInfoResponse getOwnerRegisteredStoreInfo(Integer userId) {
+        OwnerShop ownerShop = ownerShopRedisRepository.findById(userId);
+        return OwnerRegisteredInfoResponse.from(ownerShop);
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/OwnerApiTest.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.owner.model.OwnerShop;
 import in.koreatech.koin.domain.owner.model.redis.OwnerVerificationStatus;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.owner.repository.OwnerShopRedisRepository;
@@ -435,6 +436,32 @@ class OwnerApiTest extends AcceptanceTest {
                     softly.assertThat(ownerShop.getShopId()).isNull();
                 }
             );
+        }
+
+        @Test
+        void 사장님이_전화번호를_아이디로_회원가입을_했을_때_저장된_가게정보를_조회한다() throws Exception {
+            Owner owner = userFixture.현수_사장님();
+            String token = userFixture.getToken(owner.getUser());
+
+            OwnerShop ownerShop = OwnerShop.builder()
+                .ownerId(owner.getId())
+                .shopName("가게명")
+                .shopNumber("01012345678")
+                .build();
+
+            ownerShopRedisRepository.save(ownerShop);
+
+            mockMvc.perform(
+                    get("/owner/registered-store")
+                        .header("Authorization", "Bearer " + token)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                    {
+                        "shopName": "가게명",
+                        "shopNumber": "01012345678"
+                    }
+                    """));
         }
     }
 

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminOwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminOwnerApiTest.java
@@ -82,13 +82,11 @@ public class AdminOwnerApiTest extends AcceptanceTest {
 
         //영속성 컨테스트 동기화
         Owner updatedOwner = adminOwnerRepository.getById(owner.getId());
-        var resultOwnerShop = adminOwnerShopRedisRepository.findById(owner.getId());
 
         assertSoftly(
             softly -> {
                 softly.assertThat(updatedOwner.getUser().isAuthed()).isEqualTo(true);
                 softly.assertThat(updatedOwner.isGrantShop()).isEqualTo(true);
-                softly.assertThat(resultOwnerShop).isEmpty();
             }
         );
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1244

# 🚀 작업 내용

1. 기존에 사장님 승인이 진행될 때 redis에 저장해두었던 가게정보를 삭제하지 않도록 수정
2. 회원가입 시 redis에 임시 저장한 가게정보(가게명, 가게전화번호)를 조회하는 API 추가
3. 관련 테스트코드 수정

# 💬 리뷰 중점사항
