### PR TITLE
fix: 대화가 없는 채팅방 정보도 출력

### DIFF
--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/model/LostItemChatRoomInfoEntity.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/model/LostItemChatRoomInfoEntity.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.global.socket.domain.chatroom.model;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,13 +37,18 @@ public class LostItemChatRoomInfoEntity {
     @Field("messages")
     private List<LostItemChatMessageEntity> messageList;
 
+    @Field("created_at")
+    private LocalDateTime createdAt;
+
     @Builder
-    public LostItemChatRoomInfoEntity(Integer articleId, Integer chatRoomId, Integer authorId, Integer ownerId) {
+    public LostItemChatRoomInfoEntity(Integer articleId, Integer chatRoomId, Integer authorId, Integer ownerId,
+        LocalDateTime createdAt) {
         this.articleId = articleId;
         this.chatRoomId = chatRoomId;
         this.authorId = authorId;
         this.ownerId = ownerId;
         this.messageList = new ArrayList<>();
+        this.createdAt = createdAt;
     }
 
     public void addMessage(LostItemChatMessageEntity message) {

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.global.socket.domain.chatroom.service;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -29,6 +28,7 @@ public class LostItemChatRoomInfoService {
     private final ChatRoomInfoAppender chatRoomInfoAppender;
     private final LostItemArticleReader lostItemArticleReader;
     private final UserBlockReader userBlockReader;
+    private static final String DEFAULT_MESSAGE = "대화를 시작해보세요!";
 
     public Integer createLostItemChatRoom(Integer articleId, Integer ownerId) {
         var existingChatRoom = chatRoomInfoReader.readByArticleIdAndOwnerId(articleId, ownerId);
@@ -73,9 +73,9 @@ public class LostItemChatRoomInfoService {
 
                 if(messageSummary == null) {
                     responseBuilder
-                        .recentMessageContent(null)
+                        .recentMessageContent(DEFAULT_MESSAGE)
                         .unreadMessageCount(0)
-                        .lastMessageAt(null);
+                        .lastMessageAt(entity.getCreatedAt());
                 } else {
                     responseBuilder
                         .recentMessageContent(messageSummary.getLastMessageContent())
@@ -85,18 +85,7 @@ public class LostItemChatRoomInfoService {
                 return responseBuilder.build();
             })
             .filter(Objects::nonNull)
-            .sorted((r1, r2) -> {
-                if (r1.lastMessageAt() != null && r2.lastMessageAt() != null) {
-                    return r2.lastMessageAt().compareTo(r1.lastMessageAt());
-                }
-                if (r1.lastMessageAt() == null && r2.lastMessageAt() != null) {
-                    return 1;
-                }
-                if (r1.lastMessageAt() != null) {
-                    return -1;
-                }
-                return 0;
-            })
+            .sorted(Comparator.comparing(ChatRoomListResponse::lastMessageAt, Comparator.reverseOrder()))
             .toList();
     }
 

--- a/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/ChatRoomInfoAppender.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/chatroom/service/implement/ChatRoomInfoAppender.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.global.socket.domain.chatroom.service.implement;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.global.socket.domain.chatroom.model.LostItemChatRoomInfoEntity;
@@ -23,6 +25,7 @@ public class ChatRoomInfoAppender {
             .chatRoomId(chatRoomId)
             .ownerId(ownerId)
             .authorId(authorId)
+            .createdAt(LocalDateTime.now())
             .build();
 
        return chatRoomInfoRepository.save(newInfo);


### PR DESCRIPTION
# 🔥 연관 이슈

- #1185

# 🚀 작업 내용

1. 채팅방 목록 데이터 반환에서 대화가 없는 채팅방도 출력하도록 수정했습니다.
2. 채팅방 목록 데이터 반환시 가장 최근 전달된 메시지 or 채팅방 기준으로 정렬하도록 수정했습니다.
3. mongodb에 채팅방 정보 저장시 `created_at` 필드를 추가했습니다. 향후 스테이지 적용 시 스테이지 mongodb에 직접 접속하여 이미 존재하는 데이터에 대해 shell로 직접  `created_at` 필드를 임의로 추가하는 작업을 진행할 예정입니다.

# 💬 리뷰 중점사항
