### PR TITLE
feat: 분실물 게시글 검색 api 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -94,6 +94,11 @@ public interface ArticleApi {
         @UserId Integer userId
     );
 
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+        }
+    )
     @Operation(summary = "분실물 게시글 검색")
     @GetMapping("/lost-item/search")
     ResponseEntity<LostItemArticlesResponse> searchArticles(

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -94,6 +94,16 @@ public interface ArticleApi {
         @UserId Integer userId
     );
 
+    @Operation(summary = "분실물 게시글 검색")
+    @GetMapping("/lost-item/search")
+    ResponseEntity<LostItemArticlesResponse> searchArticles(
+        @RequestParam String query,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @IpAddress String ipAddress,
+        @UserId Integer userId
+    );
+
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "200")

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -77,6 +77,19 @@ public class ArticleController implements ArticleApi {
         return ResponseEntity.ok().body(foundArticles);
     }
 
+    @GetMapping("/lost-item/search")
+    public ResponseEntity<LostItemArticlesResponse> searchArticles(
+        @RequestParam String query,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer limit,
+        @IpAddress String ipAddress,
+        @UserId Integer userId
+    ) {
+        LostItemArticlesResponse foundArticles = articleService.searchLostItemArticles(query, page, limit, ipAddress,
+            userId);
+        return ResponseEntity.ok().body(foundArticles);
+    }
+
     @GetMapping("/hot/keyword")
     public ResponseEntity<ArticleHotKeywordResponse> getArticlesHotKeyword(
         @RequestParam Integer count

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -127,10 +127,7 @@ public class ArticleService {
     @Transactional
     public ArticlesResponse searchArticles(String query, Integer boardId, Integer page, Integer limit,
         String ipAddress, Integer userId) {
-        if (query.length() >= MAXIMUM_SEARCH_LENGTH) {
-            throw new KoinIllegalArgumentException("검색어의 최대 길이를 초과했습니다.");
-        }
-
+        verifyQueryLength(query);
         Criteria criteria = Criteria.of(page, limit);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), NATIVE_ARTICLES_SORT);
         Page<Article> articles;
@@ -141,10 +138,26 @@ public class ArticleService {
         } else {
             articles = articleRepository.findAllByBoardIdAndTitleContaining(boardId, query, pageRequest);
         }
-
         saveOrUpdateSearchLog(query, ipAddress);
-
         return ArticlesResponse.of(articles, criteria, userId);
+    }
+
+    @Transactional
+    public LostItemArticlesResponse searchLostItemArticles(String query, Integer page, Integer limit,
+        String ipAddress, Integer userId) {
+        verifyQueryLength(query);
+        Criteria criteria = Criteria.of(page, limit);
+        PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), NATIVE_ARTICLES_SORT);
+        Page<Article> articles = articleRepository.findAllByBoardIdAndTitleContaining(LOST_ITEM_BOARD_ID, query,
+            pageRequest);
+        saveOrUpdateSearchLog(query, ipAddress);
+        return LostItemArticlesResponse.of(articles, criteria, userId);
+    }
+
+    private void verifyQueryLength(String query) {
+        if (query.length() >= MAXIMUM_SEARCH_LENGTH) {
+            throw new KoinIllegalArgumentException("검색어의 최대 길이를 초과했습니다.");
+        }
     }
 
     public ArticleHotKeywordResponse getArticlesHotKeyword(Integer count) {


### PR DESCRIPTION
# 🔥 연관 이슈

일반 게시글 검색 응답과 분실물 게시글 검색 응답이 달라야한다.

# 🚀 작업 내용

1. `분실물 게시글 검색 api` 추가했습니다.

# 💬 리뷰 중점사항
