### PR TITLE
fix:  학생 정보 수정 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/model/Major.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/Major.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.domain.student.model;
 import static lombok.AccessLevel.PROTECTED;
 
 import in.koreatech.koin.global.domain.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,7 +34,7 @@ public class Major extends BaseEntity {
     private String name;
 
     @JoinColumn(name = "department_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Department department;
 
     @Builder

--- a/src/main/java/in/koreatech/koin/domain/student/model/Major.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/Major.java
@@ -39,9 +39,8 @@ public class Major extends BaseEntity {
     private Department department;
 
     @Builder
-    public Major(
-        String name
-    ) {
+    public Major(String name, Department department) {
         this.name = name;
+        this.department = department;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/model/Student.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/Student.java
@@ -1,15 +1,14 @@
 package in.koreatech.koin.domain.student.model;
 
+import static jakarta.persistence.FetchType.*;
 import static lombok.AccessLevel.PROTECTED;
 
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserIdentity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -40,11 +39,11 @@ public class Student {
     private String studentNumber;
 
     @JoinColumn(name = "department_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = LAZY)
     private Department department;
 
     @JoinColumn(name = "major_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = LAZY)
     private Major major;
 
     @Column(name = "identity", columnDefinition = "SMALLINT")

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -100,15 +100,16 @@ public class StudentService {
         User user = student.getUser();
 
         Department department = departmentRepository.getByName(request.major());
+        /*
         Major oldMajor = student.getMajor();
         Major newMajor = majorRepository.getByName(request.major());
         // 전공 변경 시 학생의 졸업 요건 계산 정보 초기화
         if (isChangedMajor(oldMajor, newMajor) && student.getStudentNumber() != null) {
             graduationService.resetStudentCourseCalculation(student, newMajor);
-        }
+        }*/
         user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());
         user.updateStudentPassword(passwordEncoder, request.password());
-        student.updateInfo(request.studentNumber(), newMajor);
+        // student.updateInfo(request.studentNumber(), newMajor);
         student.updateInfo(request.studentNumber(), department);
 
         return StudentUpdateResponse.from(student);

--- a/src/test/java/in/koreatech/koin/acceptance/AbtestApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/AbtestApiTest.java
@@ -27,8 +27,10 @@ import in.koreatech.koin.admin.abtest.repository.AbtestRepository;
 import in.koreatech.koin.admin.abtest.repository.DeviceRepository;
 import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.AbtestFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.DeviceFixture;
 import in.koreatech.koin.fixture.UserFixture;
 
@@ -54,14 +56,19 @@ class AbtestApiTest extends AcceptanceTest {
     @Autowired
     private DeviceRepository deviceRepository;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private Admin admin;
     private String adminToken;
+    private Department department;
 
     @BeforeAll
     void setUp() {
         clear();
         admin = userFixture.코인_운영자();
         adminToken = userFixture.getToken(admin.getUser());
+        department = departmentFixture.컴퓨터공학부();
     }
 
     @Test
@@ -366,7 +373,7 @@ class AbtestApiTest extends AcceptanceTest {
 
     @Test
     void 실험군_수동편입_이름으로_유저_목록을_조회한다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Student student = userFixture.성빈_학생(department);
         Owner owner = userFixture.성빈_사장님();
 
         mockMvc.perform(
@@ -396,7 +403,7 @@ class AbtestApiTest extends AcceptanceTest {
 
     @Test
     void 실험군_수동편입_유저_ID로_기기_목록을_조회한다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Student student = userFixture.성빈_학생(department);
         Device device1 = deviceFixture.아이폰(student.getUser().getId());
         Device device2 = deviceFixture.갤럭시(student.getUser().getId());
 
@@ -428,7 +435,7 @@ class AbtestApiTest extends AcceptanceTest {
 
     @Test
     void 특정_유저의_실험군을_수동으로_편입시킨다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Student student = userFixture.성빈_학생(department);
         Device device = deviceFixture.아이폰(student.getUser().getId());
         Abtest abtest = abtestFixture.식단_UI_실험();
 
@@ -463,7 +470,7 @@ class AbtestApiTest extends AcceptanceTest {
 
     @Test
     void 자신의_실험군을_조회한다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Student student = userFixture.성빈_학생(department);
         final Device device = deviceFixture.아이폰(student.getUser().getId());
         Abtest abtest = abtestFixture.식단_UI_실험();
 
@@ -512,7 +519,7 @@ class AbtestApiTest extends AcceptanceTest {
 
     @Test
     void 실험군_자동_편입_실험군에_최초로_편입된다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Student student = userFixture.성빈_학생(department);
         Device device1 = deviceFixture.아이폰(student.getUser().getId());
         Device device2 = deviceFixture.갤럭시(student.getUser().getId());
         Abtest abtest = abtestFixture.식단_UI_실험();

--- a/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ArticleApiTest.java
@@ -13,9 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.Board;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.ArticleFixture;
 import in.koreatech.koin.fixture.BoardFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.UserFixture;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -32,14 +34,19 @@ class ArticleApiTest extends AcceptanceTest {
     @Autowired
     private BoardFixture boardFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     Student student;
+    Department department;
     Board board, adminBoard;
     Article article1, article2, article3;
 
     @BeforeAll
     void givenBeforeEach() {
         clear();
-        student = userFixture.준호_학생();
+        department = departmentFixture.컴퓨터공학부();
+        student = userFixture.준호_학생(department, null);
         board = boardFixture.자유게시판();
         adminBoard = boardFixture.공지사항();
         article1 = articleFixture.자유글_1(board, student.getUser());

--- a/src/test/java/in/koreatech/koin/acceptance/BenefitApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/BenefitApiTest.java
@@ -17,9 +17,11 @@ import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.BenefitCategoryFixture;
 import in.koreatech.koin.fixture.BenefitCategoryMapFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
 import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
@@ -47,6 +49,9 @@ public class BenefitApiTest extends AcceptanceTest {
     UserFixture userFixture;
 
     @Autowired
+    DepartmentFixture departmentFixture;
+
+    @Autowired
     ShopCategoryFixture shopCategoryFixture;
 
     @Autowired
@@ -63,6 +68,7 @@ public class BenefitApiTest extends AcceptanceTest {
     Owner 현수_사장님;
 
     Student 성빈_학생;
+    Department 컴퓨터_공학부;
 
     Shop 마슬랜;
     Shop 김밥천국;
@@ -93,7 +99,7 @@ public class BenefitApiTest extends AcceptanceTest {
         shopCategory_치킨 = shopCategoryFixture.카테고리_치킨(shopParentCategory_가게);
         shopCategory_일반 = shopCategoryFixture.카테고리_일반음식(shopParentCategory_가게);
 
-        성빈_학생 = userFixture.성빈_학생();
+        성빈_학생 = userFixture.성빈_학생(departmentFixture.컴퓨터공학부());
 
         benefitCategoryMapFixture.설명이_포함된_혜택_추가(김밥천국, 배달비_무료, "무료");
         benefitCategoryMapFixture.혜택_추가(마슬랜, 배달비_무료);

--- a/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/KeywordApiTest.java
@@ -27,9 +27,11 @@ import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.fixture.ArticleFixture;
 import in.koreatech.koin.fixture.BoardFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.KeywordFixture;
 import in.koreatech.koin.fixture.UserFixture;
 
@@ -54,6 +56,9 @@ public class KeywordApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Autowired
+    private DepartmentFixture departmentFixture;
+
+    @Autowired
     private BoardFixture boardFixture;
 
     @Autowired
@@ -63,11 +68,13 @@ public class KeywordApiTest extends AcceptanceTest {
     private Admin 관리자;
     private String token;
     private String adminToken;
+    private Department department;
 
     @BeforeAll
     void setup() {
         clear();
-        준호_학생 = userFixture.준호_학생();
+        department = departmentFixture.컴퓨터공학부();
+        준호_학생 = userFixture.준호_학생(department, null);
         관리자 = userFixture.코인_운영자();
         token = userFixture.getToken(준호_학생.getUser());
         adminToken = userFixture.getToken(관리자.getUser());

--- a/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
@@ -5,7 +5,8 @@ import static in.koreatech.koin.global.domain.notification.model.NotificationSub
 import static in.koreatech.koin.global.domain.notification.model.NotificationSubscribeType.SHOP_EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -16,8 +17,10 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.global.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.global.domain.notification.model.NotificationSubscribe;
@@ -38,14 +41,19 @@ class NotificationApiTest extends AcceptanceTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     User user;
     String userToken;
     String deviceToken;
+    Department department;
 
     @BeforeAll
     void setUp() {
         clear();
-        user = userFixture.준호_학생().getUser();
+        department = departmentFixture.컴퓨터공학부();
+        user = userFixture.준호_학생(department, null).getUser();
         userToken = userFixture.getToken(user);
         deviceToken = "testToken";
     }

--- a/src/test/java/in/koreatech/koin/acceptance/SemesterApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/SemesterApiTest.java
@@ -13,10 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.graduation.model.CourseType;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.CourseTypeFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -41,6 +43,9 @@ public class SemesterApiTest extends AcceptanceTest {
 
     @Autowired
     private CourseTypeFixture courseTypeFixture;
+
+    @Autowired
+    private DepartmentFixture departmentFixture;
 
     @BeforeAll
     void setup() {
@@ -98,7 +103,8 @@ public class SemesterApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_가진_시간표의_학기를_조회한다() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester1 = semesterFixture.semester_2019년도_2학기();
         Semester semester2 = semesterFixture.semester_2020년도_1학기();
@@ -181,7 +187,8 @@ public class SemesterApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_가진_시간표의_학기를_조회한다_V3() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester1 = semesterFixture.semester_2019년도_2학기();
         Semester semester2 = semesterFixture.semester_2020년도_1학기();

--- a/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopApiTest.java
@@ -7,9 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import in.koreatech.koin.domain.benefit.model.BenefitCategory;
-import in.koreatech.koin.fixture.BenefitCategoryFixture;
-import in.koreatech.koin.fixture.BenefitCategoryMapFixture;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -19,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.benefit.model.BenefitCategory;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
@@ -26,7 +24,11 @@ import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.fixture.BenefitCategoryFixture;
+import in.koreatech.koin.fixture.BenefitCategoryMapFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.EventArticleFixture;
 import in.koreatech.koin.fixture.MenuCategoryFixture;
 import in.koreatech.koin.fixture.MenuFixture;
@@ -79,11 +81,15 @@ class ShopApiTest extends AcceptanceTest {
     @Autowired
     private ShopNotificationMessageFixture shopNotificationMessageFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private Shop 마슬랜;
     private Owner owner;
 
     private Student 익명_학생;
     private String token_익명;
+    private Department department;
 
     private ShopParentCategory shopParentCategory_가게;
     private ShopNotificationMessage notificationMessage_가게;
@@ -94,7 +100,7 @@ class ShopApiTest extends AcceptanceTest {
     void setUp() {
         clear();
         owner = userFixture.준영_사장님();
-        익명_학생 = userFixture.익명_학생();
+        익명_학생 = userFixture.익명_학생(department);
         token_익명 = userFixture.getToken(익명_학생.getUser());
         notificationMessage_가게 = shopNotificationMessageFixture.알림메시지_가게();
         shopParentCategory_가게 = shopParentCategoryFixture.상위_카테고리_가게(notificationMessage_가게);

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -1,11 +1,12 @@
 package in.koreatech.koin.acceptance;
 
-import static in.koreatech.koin.domain.shop.model.review.ReportStatus.*;
+import static in.koreatech.koin.domain.shop.model.review.ReportStatus.UNHANDLED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Optional;
 
@@ -27,7 +28,9 @@ import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.repository.review.ShopReviewReportCategoryRepository;
 import in.koreatech.koin.domain.shop.repository.review.ShopReviewReportRepository;
 import in.koreatech.koin.domain.shop.repository.review.ShopReviewRepository;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.ShopFixture;
 import in.koreatech.koin.fixture.ShopReviewFixture;
 import in.koreatech.koin.fixture.ShopReviewReportCategoryFixture;
@@ -44,6 +47,9 @@ class ShopReviewApiTest extends AcceptanceTest {
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
+    private DepartmentFixture departmentFixture;
 
     @Autowired
     private ShopReviewFixture shopReviewFixture;
@@ -64,6 +70,7 @@ class ShopReviewApiTest extends AcceptanceTest {
     private Student 준호_학생;
     private Student 익명_학생;
     private String token_준호;
+    private Department 컴퓨터_공학부;
     private ShopReviewReportCategory 신고_카테고리_1;
     private ShopReviewReportCategory 신고_카테고리_2;
     private ShopReviewReportCategory 신고_카테고리_3;
@@ -83,8 +90,9 @@ class ShopReviewApiTest extends AcceptanceTest {
     @BeforeAll
     void setUp() {
         clear();
-        준호_학생 = userFixture.준호_학생();
-        익명_학생 = userFixture.익명_학생();
+        컴퓨터_공학부 = departmentFixture.컴퓨터공학부();
+        준호_학생 = userFixture.준호_학생(컴퓨터_공학부, null);
+        익명_학생 = userFixture.익명_학생(컴퓨터_공학부);
         현수_사장님 = userFixture.현수_사장님();
         신전_떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(현수_사장님);
         token_준호 = userFixture.getToken(준호_학생.getUser());

--- a/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,6 +21,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.dept.model.Dept;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Major;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.student.model.redis.StudentTemporaryStatus;
 import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
@@ -69,7 +70,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_로그인을_진행한다_신규_API_student_login() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.성빈_학생(department);
         String email = student.getUser().getEmail();
         String password = "1234";
 
@@ -88,7 +91,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 올바른_학생계정인지_확인한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -113,7 +118,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 올바른_학생계정인지_확인한다_토큰_정보가_올바르지_않으면_401() throws Exception {
-        userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        userFixture.준호_학생(department, null);
         String token = "invalidToken";
 
         mockMvc.perform(
@@ -126,7 +133,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 올바른_학생계정인지_확인한다_회원을_찾을_수_없으면_404() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = jwtProvider.createToken(student.getUser());
         transactionTemplate.executeWithoutResult(status ->
             studentRepository.deleteByUserId(student.getId())
@@ -143,9 +152,9 @@ public class StudentApiTest extends AcceptanceTest {
     @Test
     void 학생이_정보를_수정한다() throws Exception {
         departmentFixture.전체학부();
-        majorFixture.컴퓨터공학전공();
-        majorFixture.기계공학전공();
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -194,7 +203,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_정보를_수정한다_학번의_형식이_맞지_않으면_400() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -217,7 +228,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_정보를_수정한다_학부의_형식이_맞지_않으면_400() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -240,7 +253,9 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_정보를_수정한다_토큰이_올바르지_않다면_401() throws Exception {
-        userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = "invalidToken";
 
         mockMvc.perform(
@@ -263,7 +278,10 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_정보를_수정한다_회원을_찾을_수_없다면_404() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Major major = majorFixture.컴퓨터공학전공(department);
+
+        Student student = userFixture.준호_학생(department, major);
         String token = userFixture.getToken(student.getUser());
         transactionTemplate.executeWithoutResult(status ->
             studentRepository.deleteByUserId(student.getId())
@@ -289,8 +307,10 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_정보를_수정한다_이미_있는_닉네임이라면_409() throws Exception {
-        Student 준호 = userFixture.준호_학생();
-        Student 성빈 = userFixture.성빈_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student 준호 = userFixture.준호_학생(department, null);
+        Student 성빈 = userFixture.성빈_학생(department);
         String token = userFixture.getToken(준호.getUser());
 
         mockMvc.perform(

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableApiTest.java
@@ -2,7 +2,8 @@ package in.koreatech.koin.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,10 +13,12 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetable.repository.TimetableRepository;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -40,6 +43,9 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Autowired
     private SemesterFixture semesterFixture;
+
+    @Autowired
+    private DepartmentFixture departmentFixture;
 
     @BeforeAll
     void setup() {
@@ -186,7 +192,8 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Test
     void 시간표를_조회한다() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester_2019년도_2학기();
 
@@ -245,7 +252,8 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Test
     void 시간표를_조회한다_시간표_프레임_없으면_생성() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester_2019년도_2학기();
 
@@ -269,7 +277,8 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Test
     void 시간표를_생성한다() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester_2019년도_2학기();
 
@@ -362,7 +371,8 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Test
     void 시간표를_단일_생성한다_전체_반환() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester_2019년도_2학기();
 
@@ -469,7 +479,8 @@ class TimetableApiTest extends AcceptanceTest {
 
     @Test
     void 시간표를_삭제한다() throws Exception {
-        User user = userFixture.준호_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.준호_학생(department, null).getUser();
         String token = userFixture.getToken(user);
         Semester semester = semesterFixture.semester_2019년도_2학기();
 

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiTest.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.graduation.model.CourseType;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
@@ -22,6 +23,7 @@ import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV
 import in.koreatech.koin.domain.timetableV2.repository.TimetableLectureRepositoryV2;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.CourseTypeFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -53,14 +55,19 @@ public class TimetableFrameApiTest extends AcceptanceTest {
     @Autowired
     private CourseTypeFixture courseTypeFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private User user;
     private String token;
     private Semester semester;
+    private Department department;
 
     @BeforeAll
     void setup() {
         clear();
-        user = userFixture.준호_학생().getUser();
+        department = departmentFixture.컴퓨터공학부();
+        user = userFixture.준호_학생(department, null).getUser();
         token = userFixture.getToken(user);
         semester = semesterFixture.semester_2019년도_2학기();
     }
@@ -206,7 +213,8 @@ public class TimetableFrameApiTest extends AcceptanceTest {
 
     @Test
     void 특정_시간표_frame을_삭제한다_본인_삭제가_아니면_403_반환() throws Exception {
-        User user1 = userFixture.성빈_학생().getUser();
+        Department department1 = departmentFixture.컴퓨터공학부();
+        User user1 = userFixture.성빈_학생(department1).getUser();
         String token = userFixture.getToken(user1);
 
         TimetableFrame frame1 = timetableV2Fixture.시간표1(user, semester);

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiV3Test.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableFrameApiV3Test.java
@@ -13,9 +13,11 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
 import in.koreatech.koin.fixture.UserFixture;
@@ -33,14 +35,19 @@ public class TimetableFrameApiV3Test extends AcceptanceTest {
     @Autowired
     private SemesterFixture semesterFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private User user;
     private String token;
     private Semester semester;
+    private Department department;
 
     @BeforeAll
     void setup() {
         clear();
-        user = userFixture.준호_학생().getUser();
+        department = departmentFixture.컴퓨터공학부();
+        user = userFixture.준호_학생(department, null).getUser();
         token = userFixture.getToken(user);
         semester = semesterFixture.semester_2019년도_2학기();
     }

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureApiTest.java
@@ -16,12 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.graduation.model.CourseType;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.CourseTypeFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -47,14 +49,19 @@ public class TimetableLectureApiTest extends AcceptanceTest {
     @Autowired
     private CourseTypeFixture courseTypeFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private User user;
     private String token;
     private Semester semester;
+    private Department department;
 
     @BeforeAll
     void setup() {
         clear();
-        user = userFixture.준호_학생().getUser();
+        department = departmentFixture.컴퓨터공학부();
+        user = userFixture.준호_학생(department, null).getUser();
         token = userFixture.getToken(user);
         semester = semesterFixture.semester_2019년도_2학기();
     }

--- a/src/test/java/in/koreatech/koin/acceptance/TimetableLectureV3ApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/TimetableLectureV3ApiTest.java
@@ -16,12 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.domain.graduation.model.CourseType;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.timetable.model.Lecture;
 import in.koreatech.koin.domain.timetable.model.Semester;
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.fixture.CourseTypeFixture;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.LectureFixture;
 import in.koreatech.koin.fixture.SemesterFixture;
 import in.koreatech.koin.fixture.TimeTableV2Fixture;
@@ -47,15 +49,20 @@ public class TimetableLectureV3ApiTest extends AcceptanceTest {
     @Autowired
     private CourseTypeFixture courseTypeFixture;
 
+    @Autowired
+    private DepartmentFixture departmentFixture;
+
     private User user;
     private String token;
     private Semester semester;
     private CourseType courseType;
+    private Department department;
 
     @BeforeAll
     void setup() {
         clear();
-        user = userFixture.준호_학생().getUser();
+        department = departmentFixture.컴퓨터공학부();
+        user = userFixture.준호_학생(department, null).getUser();
         token = userFixture.getToken(user);
         semester = semesterFixture.semester_2019년도_2학기();
         courseType = courseTypeFixture.이수_구분_선택();

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -52,7 +52,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 학생이_로그인을_진행한다_구_API_user_login() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.성빈_학생(department);
         String email = student.getUser().getEmail();
         String password = "1234";
 
@@ -104,7 +105,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 회원이_탈퇴한다() throws Exception {
-        Student student = userFixture.성빈_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.성빈_학생(department);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -154,7 +156,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 이메일이_중복인지_확인한다_중복이면_422() throws Exception {
-        User user = userFixture.성빈_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.성빈_학생(department).getUser();
 
         mockMvc.perform(
                 get("/user/check/email")
@@ -167,7 +170,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 닉네임_중복일때_상태코드_409를_반환한다() throws Exception {
-        User user = userFixture.성빈_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.성빈_학생(department).getUser();
 
         mockMvc.perform(
                 get("/user/check/nickname")
@@ -180,7 +184,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 닉네임_중복이_아닐시_상태코드_200을_반환한다() throws Exception {
-        User user = userFixture.성빈_학생().getUser();
+        Department department = departmentFixture.컴퓨터공학부();
+        User user = userFixture.성빈_학생(department).getUser();
 
         mockMvc.perform(
                 get("/user/check/nickname")
@@ -192,7 +197,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 사용자가_비밀번호를_통해_자신이_맞는지_인증한다_비밀번호가_다르면_400_반환() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -278,7 +284,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 사용자가_비밀번호를_변경하고_기존_비밀번호로_로그인하면_에러를_반환한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
         String accessToken = userFixture.getToken(student.getUser());
         String newPassword = "newPassword1234";
 
@@ -321,7 +328,8 @@ class UserApiTest extends AcceptanceTest {
 
     @Test
     void 사용자가_로그인상태인지_확인한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
         String accessToken = userFixture.getToken(student.getUser());
 
         mockMvc.perform(

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminShopReviewApiTest.java
@@ -27,7 +27,9 @@ import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.model.shop.ShopCategory;
 import in.koreatech.koin.domain.shop.model.shop.ShopNotificationMessage;
 import in.koreatech.koin.domain.shop.model.shop.ShopParentCategory;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.ShopCategoryFixture;
 import in.koreatech.koin.fixture.ShopFixture;
 import in.koreatech.koin.fixture.ShopNotificationMessageFixture;
@@ -46,6 +48,9 @@ class AdminShopReviewApiTest extends AcceptanceTest {
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
+    private DepartmentFixture departmentFixture;
 
     @Autowired
     private ShopReviewFixture shopReviewFixture;
@@ -71,6 +76,7 @@ class AdminShopReviewApiTest extends AcceptanceTest {
     private Admin admin;
     private Owner owner_현수;
     private Student student_익명;
+    private Department 컴퓨터_공학부;
     private ShopReview 준호_리뷰;
     private Shop shop_마슬랜;
     private String token_admin;
@@ -81,8 +87,9 @@ class AdminShopReviewApiTest extends AcceptanceTest {
     @BeforeAll
     void setUp() {
         clear();
+        컴퓨터_공학부 = departmentFixture.컴퓨터공학부();
         admin = userFixture.코인_운영자();
-        student_익명 = userFixture.익명_학생();
+        student_익명 = userFixture.익명_학생(컴퓨터_공학부);
         token_admin = userFixture.getToken(admin.getUser());
         owner_현수 = userFixture.현수_사장님();
         shop_마슬랜 = shopFixture.마슬랜(owner_현수, shopCategory_치킨);

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminStudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminStudentApiTest.java
@@ -59,7 +59,9 @@ public class AdminStudentApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_학생_리스트를_파라미터가_없이_조회한다_페이지네이션() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         Admin adminUser = userFixture.코인_운영자();
 
         String token = userFixture.getToken(adminUser.getUser());
@@ -150,8 +152,11 @@ public class AdminStudentApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_학생_리스트를_닉네임으로_조회한다_페이지네이션() throws Exception {
-        Student student1 = userFixture.성빈_학생();
-        Student student2 = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
+        Student student1 = userFixture.성빈_학생(department);
+
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
 
@@ -184,7 +189,9 @@ public class AdminStudentApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_특정_학생_정보를_조회한다_관리자가_아니면_403_반환() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(
@@ -197,7 +204,9 @@ public class AdminStudentApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_특정_학생_정보를_조회한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+
+        Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -232,10 +241,11 @@ public class AdminStudentApiTest extends AcceptanceTest {
     @Test
     void 관리자가_특정_학생_정보를_수정한다() throws Exception {
         departmentFixture.전체학부();
-        majorFixture.컴퓨터공학전공();
-        majorFixture.기계공학전공();
 
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        departmentFixture.기계공학부();
+
+        Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminStudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminStudentApiTest.java
@@ -23,6 +23,7 @@ import in.koreatech.koin.admin.student.repository.AdminStudentRepository;
 import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.student.repository.DepartmentRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.model.UserGender;
 import in.koreatech.koin.fixture.DepartmentFixture;
@@ -51,6 +52,9 @@ public class AdminStudentApiTest extends AcceptanceTest {
 
     @Autowired
     private MajorFixture majorFixture;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
 
     @BeforeAll
     void setup() {
@@ -154,8 +158,8 @@ public class AdminStudentApiTest extends AcceptanceTest {
     void 관리자가_학생_리스트를_닉네임으로_조회한다_페이지네이션() throws Exception {
         Department department = departmentFixture.컴퓨터공학부();
 
-        Student student = userFixture.준호_학생(department, null);
         Student student1 = userFixture.성빈_학생(department);
+        Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -242,9 +246,7 @@ public class AdminStudentApiTest extends AcceptanceTest {
     void 관리자가_특정_학생_정보를_수정한다() throws Exception {
         departmentFixture.전체학부();
 
-        Department department = departmentFixture.컴퓨터공학부();
-        departmentFixture.기계공학부();
-
+        Department department = departmentRepository.getByName("컴퓨터공학부");
         Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminTrackApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminTrackApiTest.java
@@ -18,7 +18,9 @@ import in.koreatech.koin.admin.member.repository.AdminTrackRepository;
 import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.domain.member.model.TechStack;
 import in.koreatech.koin.domain.member.model.Track;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.MemberFixture;
 import in.koreatech.koin.fixture.TechStackFixture;
 import in.koreatech.koin.fixture.TrackFixture;
@@ -42,6 +44,9 @@ public class AdminTrackApiTest extends AcceptanceTest {
     private UserFixture userFixture;
 
     @Autowired
+    private DepartmentFixture departmentFixture;
+
+    @Autowired
     private AdminTrackRepository adminTrackRepository;
 
     @Autowired
@@ -54,7 +59,8 @@ public class AdminTrackApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_BCSDLab_트랙_정보를_조회한다_관리자가_아니면_403_반환() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
         String token = userFixture.getToken(student.getUser());
 
         mockMvc.perform(

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminUserApiTest.java
@@ -18,8 +18,10 @@ import in.koreatech.koin.AcceptanceTest;
 import in.koreatech.koin.admin.user.model.Admin;
 import in.koreatech.koin.admin.user.repository.AdminRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.fixture.DepartmentFixture;
 import in.koreatech.koin.fixture.UserFixture;
 import in.koreatech.koin.support.JsonAssertions;
 
@@ -36,6 +38,9 @@ class AdminUserApiTest extends AcceptanceTest {
 
     @Autowired
     private UserFixture userFixture;
+
+    @Autowired
+    private DepartmentFixture departmentFixture;
 
     @BeforeAll
     void setup() {
@@ -63,7 +68,8 @@ class AdminUserApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_로그인_한다_관리자가_아니면_404_반환() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
         String email = student.getUser().getEmail();
         String password = "1234";
 
@@ -150,7 +156,8 @@ class AdminUserApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_회원을_조회한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());
@@ -168,7 +175,8 @@ class AdminUserApiTest extends AcceptanceTest {
 
     @Test
     void 관리자가_회원을_삭제한다() throws Exception {
-        Student student = userFixture.준호_학생();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
 
         Admin adminUser = userFixture.코인_운영자();
         String token = userFixture.getToken(adminUser.getUser());

--- a/src/test/java/in/koreatech/koin/fixture/MajorFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/MajorFixture.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.fixture;
 
 import org.springframework.stereotype.Component;
 
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Major;
 import in.koreatech.koin.domain.student.repository.MajorRepository;
 
@@ -15,16 +16,18 @@ public class MajorFixture {
         this.majorRepository = majorRepository;
     }
 
-    public void 기계공학전공() {
-        majorRepository.save(Major.builder()
-            .name("기계공학부")
+    public Major 기계공학전공(Department department) {
+        return majorRepository.save(Major.builder()
+            .name(null)
+            .department(department)
             .build()
         );
     }
 
-    public void 컴퓨터공학전공() {
-        majorRepository.save(Major.builder()
-            .name("컴퓨터공학전공")
+    public Major 컴퓨터공학전공(Department department) {
+        return majorRepository.save(Major.builder()
+            .name(null)
+            .department(department)
             .build()
         );
     }

--- a/src/test/java/in/koreatech/koin/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/UserFixture.java
@@ -134,13 +134,13 @@ public final class UserFixture {
         );
     }
 
-    public Student 준호_학생() {
+    public Student 준호_학생(Department department, Major major) {
         return studentRepository.save(
             Student.builder()
                 .studentNumber("2019136135")
                 .anonymousNickname("익명")
-                .department(new Department("컴퓨터공학부"))
-                .major(new Major("컴퓨터공학전공"))
+                .department(department)
+                .major(major)
                 .userIdentity(UNDERGRADUATE)
                 .isGraduated(false)
                 .user(
@@ -160,12 +160,12 @@ public final class UserFixture {
         );
     }
 
-    public Student 익명_학생() {
+    public Student 익명_학생(Department department) {
         return studentRepository.save(
             Student.builder()
                 .studentNumber("2020136111")
                 .anonymousNickname("익명111")
-                .department(new Department("컴퓨터공학부"))
+                .department(department)
                 .userIdentity(UNDERGRADUATE)
                 .isGraduated(false)
                 .user(
@@ -184,12 +184,12 @@ public final class UserFixture {
         );
     }
 
-    public Student 성빈_학생() {
+    public Student 성빈_학생(Department department) {
         return studentRepository.save(
             Student.builder()
                 .studentNumber("2023100514")
                 .anonymousNickname("익명123")
-                .department(new Department("컴퓨터공학부"))
+                .department(department)
                 .userIdentity(UNDERGRADUATE)
                 .isGraduated(false)
                 .user(


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1258 

# 🚀 작업 내용

- 현재 발생하고 있는 회원 탈퇴 오류를 수정했습니다.
  - Student와 major, department의 영속성 전의 설정을 삭제했습니다.
- 회원 정보 수정이 안되는 문제를 임시로 수정했습니다.
  - 졸학계 전용 수정 API를 추가하면서 수정할 계획입니다. 
  - [논의 스레드](https://bcsdlab.slack.com/archives/C06NEM6EY3W/p1739864891360629)
- 테스트 코드 중, 학생 관련 부분에 department를 추가했습니다.
  - Major은 null로 처리했습니다. 

# 💬 리뷰 중점사항
