### PR TITLE
feat: timetable API dto 유효성 검증 어노테이션 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
@@ -19,7 +19,6 @@ import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -40,7 +39,6 @@ public record TimetableLectureCreateRequest(
         String classTitle,
 
         @Valid
-        @NotEmpty(message = "강의 정보는 필수로 입력해야 합니다.")
         @Schema(description = "강의 정보", requiredMode = NOT_REQUIRED)
         List<ClassInfo> classInfos,
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/request/TimetableLectureCreateRequest.java
@@ -19,6 +19,7 @@ import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -39,6 +40,7 @@ public record TimetableLectureCreateRequest(
         String classTitle,
 
         @Valid
+        @NotEmpty(message = "강의 정보는 필수로 입력해야 합니다.")
         @Schema(description = "강의 정보", requiredMode = NOT_REQUIRED)
         List<ClassInfo> classInfos,
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureCreateRequest.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -36,6 +37,7 @@ public record TimetableCustomLectureCreateRequest(
         String classTitle,
 
         @Valid
+        @NotEmpty(message = "강의 시간 정보는 필수로 입력해야 합니다.")
         @Schema(description = "커스텀 강의 시간 정보", requiredMode = REQUIRED)
         List<LectureInfoRequest> lectureInfos,
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableCustomLectureUpdateRequest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -37,6 +38,7 @@ public record TimetableCustomLectureUpdateRequest(
         String classTitle,
 
         @Valid
+        @NotEmpty(message = "강의 시간 정보는 필수로 입력해야 합니다.")
         @Schema(description = "커스텀 강의 시간 정보", requiredMode = REQUIRED)
         List<LectureInfoRequest> lectureInfos,
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1235 

# 🚀 작업 내용

- timetable Api dto 중 강의 정보&시간을 리스트로 가지고 있는 필드에 NotEmpty 어노테이션을 작성했습니다.

# 💬 리뷰 중점사항
