### PR TITLE
chore: 분실물 게시글의 foundPlace 빈 값일 경우 "장소 미상"으로 저장하도록 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -233,27 +233,27 @@ public class Article extends BaseEntity {
     }
 
     public static Article createLostItemArticle(
-            LostItemArticleRequest request,
-            Board lostItemBoard,
-            User author
+        LostItemArticleRequest request,
+        Board lostItemBoard,
+        User author
     ) {
         List<LostItemImage> images = request.images().stream()
-                .map(image -> LostItemImage.builder()
-                        .imageUrl(image)
-                        .isDeleted(false)
-                        .build())
-                .toList();
+            .map(image -> LostItemImage.builder()
+                .imageUrl(image)
+                .isDeleted(false)
+                .build())
+            .toList();
 
         LostItemArticle lostItemArticle = LostItemArticle.builder()
-                .author(author)
-                .type(request.type())
-                .category(request.category())
-                .foundPlace(getValidatedFoundPlace(request.foundPlace()))
-                .foundDate(request.foundDate())
-                .images(images)
-                .isCouncil(false)
-                .isDeleted(false)
-                .build();
+            .author(author)
+            .type(request.type())
+            .category(request.category())
+            .foundPlace(getValidatedFoundPlace(request.foundPlace()))
+            .foundDate(request.foundDate())
+            .images(images)
+            .isCouncil(false)
+            .isDeleted(false)
+            .build();
 
         if (author.getUserType().equals(COUNCIL)) {
             lostItemArticle.setIsCouncil();
@@ -262,14 +262,14 @@ public class Article extends BaseEntity {
         images.forEach(image -> image.setArticle(lostItemArticle));
 
         Article article = Article.builder()
-                .board(lostItemBoard)
-                .title(lostItemArticle.generateTitle())
-                .content(request.content())
-                .koinArticle(null)
-                .koreatechArticle(null)
-                .lostItemArticle(lostItemArticle)
-                .isDeleted(false)
-                .build();
+            .board(lostItemBoard)
+            .title(lostItemArticle.generateTitle())
+            .content(request.content())
+            .koinArticle(null)
+            .koreatechArticle(null)
+            .lostItemArticle(lostItemArticle)
+            .isDeleted(false)
+            .build();
 
         lostItemArticle.setArticle(article);
         return article;

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -233,27 +233,27 @@ public class Article extends BaseEntity {
     }
 
     public static Article createLostItemArticle(
-        LostItemArticleRequest request,
-        Board lostItemBoard,
-        User author
+            LostItemArticleRequest request,
+            Board lostItemBoard,
+            User author
     ) {
         List<LostItemImage> images = request.images().stream()
-            .map(image -> LostItemImage.builder()
-                .imageUrl(image)
-                .isDeleted(false)
-                .build())
-            .toList();
+                .map(image -> LostItemImage.builder()
+                        .imageUrl(image)
+                        .isDeleted(false)
+                        .build())
+                .toList();
 
         LostItemArticle lostItemArticle = LostItemArticle.builder()
-            .author(author)
-            .type(request.type())
-            .category(request.category())
-            .foundPlace(request.foundPlace())
-            .foundDate(request.foundDate())
-            .images(images)
-            .isCouncil(false)
-            .isDeleted(false)
-            .build();
+                .author(author)
+                .type(request.type())
+                .category(request.category())
+                .foundPlace(getValidatedFoundPlace(request.foundPlace()))
+                .foundDate(request.foundDate())
+                .images(images)
+                .isCouncil(false)
+                .isDeleted(false)
+                .build();
 
         if (author.getUserType().equals(COUNCIL)) {
             lostItemArticle.setIsCouncil();
@@ -262,16 +262,20 @@ public class Article extends BaseEntity {
         images.forEach(image -> image.setArticle(lostItemArticle));
 
         Article article = Article.builder()
-            .board(lostItemBoard)
-            .title(lostItemArticle.generateTitle())
-            .content(request.content())
-            .koinArticle(null)
-            .koreatechArticle(null)
-            .lostItemArticle(lostItemArticle)
-            .isDeleted(false)
-            .build();
+                .board(lostItemBoard)
+                .title(lostItemArticle.generateTitle())
+                .content(request.content())
+                .koinArticle(null)
+                .koreatechArticle(null)
+                .lostItemArticle(lostItemArticle)
+                .isDeleted(false)
+                .build();
 
         lostItemArticle.setArticle(article);
         return article;
+    }
+
+    private static String getValidatedFoundPlace(String foundPlace) {
+        return (foundPlace == null || foundPlace.isBlank()) ? "장소 미상" : foundPlace;
     }
 }


### PR DESCRIPTION


# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

- `foundPlace` 빈 문자열이거나 공백만 포함된 경우 `장소 미상`으로 자동 설정되도록 변경
- 분실 장소 정보가 없는 경우에도 의미 있는 기본값을 제공하여 데이터 일관성 유지
# 💬 리뷰 중점사항
