### PR TITLE
fix: 특정 사장님 수정 gender null체크 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/owner/dto/AdminOwnerUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/owner/dto/AdminOwnerUpdateResponse.java
@@ -38,7 +38,7 @@ public record AdminOwnerUpdateResponse (
         return new AdminOwnerUpdateResponse(
             owner.getCompanyRegistrationNumber(),
             owner.getUser().getEmail(),
-            owner.getUser().getGender().ordinal(),
+            owner.getUser().getGender() == null ? null : owner.getUser().getGender().ordinal(),
             owner.isGrantShop(),
             owner.isGrantEvent(),
             owner.getUser().getName(),


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1271

# 🚀 작업 내용

1. AdminOwnerUpdateResponse의 gender null체크 로직 추가

# 💬 리뷰 중점사항
- 날먹