### PR TITLE
feat: 현재 이수한 교양 강의 API

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -111,7 +111,7 @@ public interface GraduationApi {
     )
     @Operation(summary = "현재 이수한 교양 강의 출력")
     @SecurityRequirement(name = "Jwt Authentication")
-    @GetMapping("/graduation/lecture/education")
+    @GetMapping("/graduation/lecture/general-education")
     ResponseEntity<EducationLectureResponse> getEducationLecture(
         @Auth(permit = {STUDENT}) Integer userId
     );

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
+import in.koreatech.koin.domain.graduation.dto.EducationLectureResponse;
 import in.koreatech.koin.domain.graduation.dto.GraduationCourseCalculationResponse;
 import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
 import in.koreatech.koin.global.auth.Auth;
@@ -97,6 +98,21 @@ public interface GraduationApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/graduation/course/calculation")
     ResponseEntity<GraduationCourseCalculationResponse> getGraduationCourseCalculation(
+        @Auth(permit = {STUDENT}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "현재 이수한 교양 강의 출력")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/graduation/lecture/education")
+    ResponseEntity<EducationLectureResponse> getEducationLecture(
         @Auth(permit = {STUDENT}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import in.koreatech.koin.domain.graduation.dto.CourseTypeLectureResponse;
+import in.koreatech.koin.domain.graduation.dto.EducationLectureResponse;
 import in.koreatech.koin.domain.graduation.dto.GraduationCourseCalculationResponse;
 import in.koreatech.koin.domain.graduation.model.GeneralEducationArea;
 import in.koreatech.koin.domain.graduation.service.GraduationService;
@@ -74,6 +75,14 @@ public class GraduationController implements GraduationApi {
     public ResponseEntity<GraduationCourseCalculationResponse> getGraduationCourseCalculation(
         @Auth(permit = {STUDENT}) Integer userId) {
         GraduationCourseCalculationResponse response = graduationService.getGraduationCourseCalculationResponse(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/graduation/lecture/education")
+    public ResponseEntity<EducationLectureResponse> getEducationLecture(
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        EducationLectureResponse response = graduationService.getEducationLecture(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/controller/GraduationController.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.graduation.controller;
 import java.io.IOException;
 import java.util.List;
 
+import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 
 import org.springframework.http.ResponseEntity;
@@ -78,9 +79,9 @@ public class GraduationController implements GraduationApi {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/graduation/lecture/education")
+    @GetMapping("/graduation/lecture/general-education")
     public ResponseEntity<EducationLectureResponse> getEducationLecture(
-        @Auth(permit = {STUDENT}) Integer userId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         EducationLectureResponse response = graduationService.getEducationLecture(userId);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/EducationLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/EducationLectureResponse.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.graduation.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record EducationLectureResponse(
+    List<RequiredEducationArea> requiredEducationArea
+) {
+    public record RequiredEducationArea(
+        String courseType,
+        boolean isCompleted,
+        String courseName
+    ) {
+        public static RequiredEducationArea of(String courseType, boolean isCompleted, String courseName) {
+            return new RequiredEducationArea(courseType, isCompleted, courseName);
+        }
+    }
+
+    public static EducationLectureResponse of(List<RequiredEducationArea> requiredEducationArea) {
+        return new EducationLectureResponse(requiredEducationArea);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/graduation/dto/EducationLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/dto/EducationLectureResponse.java
@@ -5,13 +5,19 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record EducationLectureResponse(
+    @Schema(description = "교양영역 이수 정보")
     List<RequiredEducationArea> requiredEducationArea
 ) {
     public record RequiredEducationArea(
+        @Schema(description = "이수구분", example = "사회와심리")
         String courseType,
+        @Schema(description = "수강여부", example = "true")
         boolean isCompleted,
+        @Schema(description = "강의명", example = "심리학의이해")
         String courseName
     ) {
         public static RequiredEducationArea of(String courseType, boolean isCompleted, String courseName) {

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
@@ -51,4 +51,6 @@ public interface CatalogRepository extends Repository<Catalog, Integer> {
     }
 
     List<Catalog> findByLectureNameAndDepartment(String lectureName, Department department);
+
+    List<Catalog> findAllByYearAndCourseTypeId(String year, Integer courseTypeId);
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -84,7 +84,7 @@ public class GraduationService {
     private static final String RETAKE = "Y";
     private static final String UNSATISFACTORY = "U";
     private static final String DEFAULTCOURSERTYPE = "이수구분선택";
-    private static final String EDUCATIONCOURSETYPE = "교양선택";
+    private static final String GENERALEDUCATIONCOURSETYPE = "교양선택";
 
     @Transactional
     public void createStudentCourseCalculation(Integer userId) {
@@ -523,7 +523,7 @@ public class GraduationService {
 
         List<GeneralEducationArea> generalEducationAreas = catalogRepository.findAllByYearAndCourseTypeId(
                 StudentUtil.parseStudentNumberYearAsString(studentRepository.getById(userId).getStudentNumber()),
-                courseTypeRepository.getByName(EDUCATIONCOURSETYPE).getId())
+                courseTypeRepository.getByName(GENERALEDUCATIONCOURSETYPE).getId())
             .stream()
             .filter(catalog -> catalog.getGeneralEducationArea() != null)
             .collect(Collectors.groupingBy(Catalog::getGeneralEducationArea))


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1210

# 🚀 작업 내용

1. 학생이 이수한 교양 강의에 대한 정보를 반환시켜주는 API입니다.

로직은 아래와 같습니다.
1. 학생이 들은 강의 목록(timetable_lecture)에서 geeral_education_area 필드가 null이 아닌 것들을 중복 제외
2. catalog 테이블에서 학생의 학번에 맞는 연도의 강의에서 geeral_education_area 필드가 중복 제외

위의 결과들을 조합해서 학생이 들어야할 교양과목중에서 어떤것을 들었는지 파악했습니다.

![image](https://github.com/user-attachments/assets/d1c7ee96-7118-43df-b16d-184c27503d1f)

# 💬 리뷰 중점사항 