### PR TITLE
fix: 분실물 게시글 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -44,6 +44,7 @@ import lombok.NoArgsConstructor;
 public class Article extends BaseEntity {
 
     private static final String ADMIN_NOTICE_AUTHOR = "BCSD Lab";
+    private static final String UNKNOWN_AUTHOR = "탈퇴한 사용자";
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -123,18 +124,18 @@ public class Article extends BaseEntity {
             return;
         }
         if (koinArticle != null) {
-            author = (koinArticle.getUser() != null) ? koinArticle.getUser().getName() : "탈퇴한 사용자";
+            author = (koinArticle.getUser() != null) ? koinArticle.getUser().getName() : UNKNOWN_AUTHOR;
             return;
         }
         if (koreatechArticle != null) {
-            author = (koreatechArticle.getAuthor() != null) ? koreatechArticle.getAuthor() : "익명";
+            author = (koreatechArticle.getAuthor() != null) ? koreatechArticle.getAuthor() : UNKNOWN_AUTHOR;
             return;
         }
         if (lostItemArticle != null) {
-            author = (lostItemArticle.getAuthor() != null) ? lostItemArticle.getAuthor().getNickname() : "익명";
+            author = (lostItemArticle.getAuthor() != null) ? lostItemArticle.getAuthor().getNickname() : UNKNOWN_AUTHOR;
             return;
         }
-        author = "익명";
+        author = UNKNOWN_AUTHOR;
     }
 
     public void setAuthor(String author) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -132,7 +132,8 @@ public class Article extends BaseEntity {
             return;
         }
         if (lostItemArticle != null) {
-            author = (lostItemArticle.getAuthor() != null) ? lostItemArticle.getAuthor().getNickname() : UNKNOWN_AUTHOR;
+            User user = lostItemArticle.getAuthor();
+            author = (user != null && user.getNickname() != null) ? user.getNickname() : UNKNOWN_AUTHOR;
             return;
         }
         author = UNKNOWN_AUTHOR;

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -118,27 +118,23 @@ public class Article extends BaseEntity {
     @PostPersist
     @PostLoad
     public void updateAuthor() {
-        if (koreatechArticle == null && koinArticle == null && lostItemArticle == null) {
-            author = "익명";
-            return;
-        }
-        if (koreatechArticle != null) {
-            author = koreatechArticle.getAuthor();
-            return;
-        }
-        if (lostItemArticle != null) {
-            author = lostItemArticle.getAuthor().getNickname();
-            return;
-        }
         if (Objects.equals(board.getId(), KOIN_ADMIN_NOTICE_BOARD_ID)) {
             author = ADMIN_NOTICE_AUTHOR;
             return;
         }
-        if (Objects.equals(koinArticle.getUser(), null)) {
-            author = "탈퇴한 사용자";
+        if (koinArticle != null) {
+            author = (koinArticle.getUser() != null) ? koinArticle.getUser().getName() : "탈퇴한 사용자";
             return;
         }
-        author = koinArticle.getUser().getName();
+        if (koreatechArticle != null) {
+            author = (koreatechArticle.getAuthor() != null) ? koreatechArticle.getAuthor() : "익명";
+            return;
+        }
+        if (lostItemArticle != null) {
+            author = (lostItemArticle.getAuthor() != null) ? lostItemArticle.getAuthor().getNickname() : "익명";
+            return;
+        }
+        author = "익명";
     }
 
     public void setAuthor(String author) {

--- a/src/main/resources/db/migration/V134__alter_lost_item_author_cascade.sql
+++ b/src/main/resources/db/migration/V134__alter_lost_item_author_cascade.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `lost_item_articles`
+DROP FOREIGN KEY `lost_item_article_author_fk_id`;
+
+ALTER TABLE `lost_item_articles`
+ADD CONSTRAINT `lost_item_article_author_fk_id` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 분실물 게시글의 author가 null일 경우 '탈퇴한 사용자'로 수정 및 분기 처리 하였습니다.
    - author가 null로 작성된 게시글은 **로그인 사용자가 글 작성 후 회원 탈퇴한 경우**에만 가능한 상황이라서 '익명'에서 '탈퇴한 사용자'로 수정했습니다.
2. lostItemArticle과 User의 외래키 제약조건을 수정하였습니다.

# 💬 리뷰 중점사항
