### PR TITLE
fix: 졸업학점 계산 agree api 유저 중복 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -517,10 +517,10 @@ public class GraduationService {
                 throw new DuplicationException("이미 졸업요건 계산이 초기화 되었습니다.") {
                 };
             });
-        studentCourseCalculationRepository.findByUserId(userId)
-            .ifPresent(studentCourseCalculation -> {
-                throw new DuplicationException("이미 졸업요건 계산이 초기화 되었습니다.") {
-                };
-            });
+        if (!studentCourseCalculationRepository.findAllByUserId(userId).isEmpty()) {
+            throw new DuplicationException("이미 졸업요건 계산이 초기화 되었습니다.") {
+            };
+        }
+
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -38,6 +38,7 @@ import in.koreatech.koin.domain.graduation.repository.DetectGraduationCalculatio
 import in.koreatech.koin.domain.graduation.repository.GeneralEducationAreaRepository;
 import in.koreatech.koin.domain.graduation.repository.StandardGraduationRequirementsRepository;
 import in.koreatech.koin.domain.graduation.repository.StudentCourseCalculationRepository;
+import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.student.exception.DepartmentNotFoundException;
 import in.koreatech.koin.domain.student.exception.StudentNumberNotFoundException;
 import in.koreatech.koin.domain.student.model.Major;
@@ -57,6 +58,8 @@ import in.koreatech.koin.domain.timetableV3.model.Term;
 import in.koreatech.koin.domain.timetableV3.repository.SemesterRepositoryV3;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.domain.email.exception.DuplicationEmailException;
+import in.koreatech.koin.global.exception.DuplicationException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -88,6 +91,7 @@ public class GraduationService {
     public void createStudentCourseCalculation(Integer userId) {
         Student student = studentRepository.getById(userId);
 
+        validateGraduationCalculatedDataExist(userId);
         validateStudentField(student.getMajor(), "전공을 추가하세요.");
         validateStudentField(student.getStudentNumber(), "학번을 추가하세요.");
 
@@ -505,5 +509,18 @@ public class GraduationService {
 
     public List<GeneralEducationArea> getAllGeneralEducationArea() {
         return generalEducationAreaRepository.findAll();
+    }
+
+    private void validateGraduationCalculatedDataExist(Integer userId) {
+        detectGraduationCalculationRepository.findByUserId(userId)
+            .ifPresent(detectGraduationCalculation -> {
+                throw new DuplicationException("이미 졸업요건 계산이 초기화 되었습니다.") {
+                };
+            });
+        studentCourseCalculationRepository.findByUserId(userId)
+            .ifPresent(studentCourseCalculation -> {
+                throw new DuplicationException("이미 졸업요건 계산이 초기화 되었습니다.") {
+                };
+            });
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1277

# 🚀 작업 내용

1. studentCourseCalculation과 detectGraduationCalculation에 userId중복을 방지하기위해 필터링 로직을 추가했습니다.

# 💬 리뷰 중점사항
