### PR TITLE
fix: 졸업학점 계산 데이터 중복 삽입 방지

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -95,11 +95,17 @@ public class GraduationService {
 
         initializeStudentCourseCalculation(student, student.getMajor());
 
-        DetectGraduationCalculation detectGraduationCalculation = DetectGraduationCalculation.builder()
-            .user(student.getUser())
-            .isChanged(false)
-            .build();
-        detectGraduationCalculationRepository.save(detectGraduationCalculation);
+        detectGraduationCalculationRepository.findByUserId(student.getUser().getId())
+            .ifPresentOrElse(
+                existingCalculation -> existingCalculation.updatedIsChanged(false),
+                () -> {
+                    DetectGraduationCalculation newCalculation = DetectGraduationCalculation.builder()
+                        .user(student.getUser())
+                        .isChanged(false)
+                        .build();
+                    detectGraduationCalculationRepository.save(newCalculation);
+                }
+            );
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1283 

# 🚀 작업 내용

1. 이미 detectGraduationCalculation이 있을 경우 중복으로 생성하지 못하게 막았습니다.

# 💬 리뷰 중점사항
