### PR TITLE
fix: 학생 정보 수정 NPE 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -105,11 +105,7 @@ public class GraduationService {
     @Transactional
     public void resetStudentCourseCalculation(Student student, Major newMajor) {
         // 기존 학생 졸업요건 계산 정보 삭제
-        List<StudentCourseCalculation> studentCourseCalculations = studentCourseCalculationRepository.findAllByUserId(
-            student.getUser().getId());
-        if (!studentCourseCalculations.isEmpty()) {
-            studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
-        }
+        studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
 
         initializeStudentCourseCalculation(student, newMajor);
 

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -105,7 +105,8 @@ public class GraduationService {
     @Transactional
     public void resetStudentCourseCalculation(Student student, Major newMajor) {
         // 기존 학생 졸업요건 계산 정보 삭제
-        List<StudentCourseCalculation> studentCourseCalculations = studentCourseCalculationRepository.findAllByUserId(student.getUser().getId());
+        List<StudentCourseCalculation> studentCourseCalculations = studentCourseCalculationRepository.findAllByUserId(
+            student.getUser().getId());
         if (!studentCourseCalculations.isEmpty()) {
             studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
         }
@@ -547,7 +548,8 @@ public class GraduationService {
             }
 
             requiredEducationAreaMap.put(generalEducationArea.getName(),
-                EducationLectureResponse.RequiredEducationArea.of(generalEducationArea.getName(), isCompleted, lectureName));
+                EducationLectureResponse.RequiredEducationArea.of(generalEducationArea.getName(), isCompleted,
+                    lectureName));
         }
 
         return EducationLectureResponse.of(new ArrayList<>(requiredEducationAreaMap.values()));

--- a/src/main/java/in/koreatech/koin/domain/student/dto/StudentUpdateResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/StudentUpdateResponse.java
@@ -55,7 +55,7 @@ public record StudentUpdateResponse(
             student.getAnonymousNickname(),
             user.getEmail(),
             user.getGender() != null ? user.getGender().ordinal() : null,
-            student.getDepartment().getName(),
+            student.getDepartment() != null ? student.getDepartment().getName() : null,
             user.getName(),
             user.getNickname(),
             user.getPhoneNumber(),

--- a/src/main/java/in/koreatech/koin/domain/student/model/StudentDepartment.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/StudentDepartment.java
@@ -14,6 +14,7 @@ public enum StudentDepartment {
     ENERGY("에너지신소재공학부"),
     INDUSTRIAL("산업경영학부"),
     EMPLOYMENT("고용서비스정책학과"),
+    APPLIED_CHEMICAL("응용화학공학부"),
     ;
 
     private final String value;

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -138,18 +138,11 @@ public class StudentService {
          * 2. 학생의 학번이 변경이 안되고, 학부 변경이 있는 경우 (학번이 있냐 / 학번이 없냐)
          * 3. 학생의 학번도 변경되고, 학부 변경도 있는 경우
          */
-        if (updateStudentNumber && updateDepartment) {
-            if (student.getStudentNumber() != null && student.getDepartment() != null) {
-                graduationService.resetStudentCourseCalculation(student, newMajor);
-            }
-        } else if (updateDepartment) {
-            if (student.getStudentNumber() != null && student.getDepartment() != null) {
-                graduationService.resetStudentCourseCalculation(student, newMajor);
-            }
-        } else if (updateStudentNumber) {
-            if (student.getDepartment() != null && student.getStudentNumber() != null) {
-                graduationService.resetStudentCourseCalculation(student, newMajor);
-            }
+        if ((updateStudentNumber || updateDepartment)
+            && student.getStudentNumber() != null
+            && student.getDepartment() != null
+        ) {
+            graduationService.resetStudentCourseCalculation(student, newMajor);
         }
 
         user.update(request.nickname(), request.name(), request.phoneNumber(), request.gender());


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1285

# 🚀 작업 내용

- 학번, 전공을 넣지 않았을 때 발생하는 NPE를 수정했습니다.
  - 졸학계 로직에서 학번을 필요로 하는데, 학번이 null인 상태에서 로직을 호출했을 때 NPE가 발생하는 부분을 수정했습니다.
  - 전공과 학번의 경우 변경 여부를 확인할 때 NPE가 발생하는 부분을 Objects.equals 메소드로 변경했습니다.

# 💬 리뷰 중점사항
