### PR TITLE
fix: 졸학계 aop 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/aop/GraduationAspect.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/aop/GraduationAspect.java
@@ -35,6 +35,7 @@ public class GraduationAspect {
 
         detectGraduationCalculationRepository.findByUserId(userId).ifPresent(detectGraduationCalculation -> {
             detectGraduationCalculation.updatedIsChanged(true);
+            detectGraduationCalculationRepository.save(detectGraduationCalculation);
         });
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1288

# 🚀 작업 내용

시간표 생성하거나 삭제해도 DB에 detectGraduationCalculation의 is_changed=1로 DB에 변경되지 않는 사항이 있어, DB에 반영될 수 있게 수정했습니다.

# 💬 리뷰 중점사항
