### PR TITLE
fix: 자신이 들은 학점 빈칸으로 보여주던 문제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/CatalogRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.Repository;
 import in.koreatech.koin.domain.graduation.exception.CatalogNotFoundException;
 import in.koreatech.koin.domain.graduation.model.Catalog;
 import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Major;
 
 public interface CatalogRepository extends Repository<Catalog, Integer> {
 
@@ -26,31 +27,20 @@ public interface CatalogRepository extends Repository<Catalog, Integer> {
 
     Optional<Catalog> findByDepartmentAndCode(Department department, String code);
 
-    List<Catalog> findByLectureNameAndMajorIdAndYear(String lectureName, Integer majorId, String year);
-
-    List<Catalog> findByLectureNameAndDepartmentIdAndYear(String lectureName, Integer departmentId, String year);
-
-    Optional<Catalog> findByCodeAndYear(String code, String year);
-
     Optional<List<Catalog>> findAllByCourseTypeId(Integer courseTypeId);
 
     List<Catalog> findByYearAndCode(String year, String code);
 
     List<Catalog> findByLectureNameAndYear(String lectureName, String year);
 
-    Optional<Catalog> findByYearAndCodeAndLectureName(String year, String code, String lectureName);
-
-    default Catalog getByDepartmentAndCode(Department department, String code) {
-        return findByDepartmentAndCode(department, code)
-            .orElseThrow(() -> CatalogNotFoundException.withDetail("department: " + department + ", code: " + code));
-    }
-
     default List<Catalog> getAllByCourseTypeId(Integer courseTypeId) {
         return findAllByCourseTypeId(courseTypeId)
             .orElseThrow(() -> CatalogNotFoundException.withDetail("course_type_id" + courseTypeId));
     }
 
-    List<Catalog> findByLectureNameAndDepartment(String lectureName, Department department);
-
     List<Catalog> findAllByYearAndCourseTypeId(String year, Integer courseTypeId);
+
+    List<Catalog> findByLectureNameAndYearAndMajor(String lectureName, String studentYear, Major major);
+
+    List<Catalog> findByLectureNameOrderByYearDesc(String lectureName);
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/repository/StandardGraduationRequirementsRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/repository/StandardGraduationRequirementsRepository.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.graduation.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
 
@@ -12,4 +13,8 @@ public interface StandardGraduationRequirementsRepository extends Repository<Sta
     List<StandardGraduationRequirements> findAllByMajorAndYear(Major major, String year);
 
     List<StandardGraduationRequirements> findByMajorIdAndCourseTypeIdAndYear(Integer id, Integer id1, String studentYear);
+
+    List<StandardGraduationRequirements> findByCourseTypeIdAndYear(Integer id, String studentYear);
+
+    Optional<StandardGraduationRequirements> findFirstByMajorIdAndCourseTypeIdAndYear(Integer id, Integer id1, String studentYear);
 }

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -17,8 +17,6 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -416,16 +414,19 @@ public class GraduationService {
     }
 
     private Catalog findBestMatchingCatalog(String lectureName, String studentYear, Major major) {
+        // 학생의 학번 연도와 전공이 모두 일치하는 Catalog 조회
         List<Catalog> catalogs = catalogRepository.findByLectureNameAndYearAndMajor(lectureName, studentYear, major);
         if (!catalogs.isEmpty()) {
             return catalogs.get(0);
         }
 
+        // 학생의 학번 연도만 일치하는 Catalog 조회 (전공 무관)
         catalogs = catalogRepository.findByLectureNameAndYear(lectureName, studentYear);
         if (!catalogs.isEmpty()) {
             return catalogs.get(0);
         }
 
+        // 강의명이 일치하는 모든 Catalog 조회
         catalogs = catalogRepository.findByLectureNameOrderByYearDesc(lectureName);
         if (!catalogs.isEmpty()) {
             return catalogs.get(0);
@@ -470,7 +471,7 @@ public class GraduationService {
 
         List<StandardGraduationRequirements> allRequirements =
             standardGraduationRequirementsRepository.findAllByMajorAndYear(student.getMajor(),
-                student.getStudentNumber().substring(0, 4));
+                StudentUtil.parseStudentNumberYearAsString(student.getStudentNumber()));
 
         Map<CourseType, Integer> groupedRequirements = new HashMap<>();
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1287

# 🚀 작업 내용

1. 자신이 들은 학점 빈칸으로 보여주던 문제를 해결했습니다.
2. 불필요한 재계산 방지 했습니다. (DetectGraduationCalculation 활용)
* 학생의 학번/전공 변경 여부(isChanged 필드)를 감지해 변경된 경우에만 학점 재계산 수행 → 성능 최적화.
``` java
if (!detectGraduationCalculation.isChanged()) {
    return getExistingGraduationCalculation(userId);
}
```
3. 중복 데이터 저장을 방지 했습니다.
* 기존 StudentCourseCalculation 데이터가 존재하면 삭제 후 새롭게 초기화하여 데이터 중복을 방지.
``` java
studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
```
4. 기존 데이터 즉시 반환
* getGraduationCourseCalculationResponse에서 변경 사항이 없으면 기존 데이터를 바로 반환해 불필요한 삭제 및 재계산 최소화.
* 기존 StudentCourseCalculation 데이터가 존재하면 삭제 후 새롭게 초기화하여 데이터 중복을 방지.
``` java
return GraduationCourseCalculationResponse.of(courseTypes);
```
5. 학점 매핑 연산 최적화 했습니다.
* Map<Integer, Integer>을 활용해 courseTypeId별 학점을 한 번의 매핑 과정에서 처리 → 연산 속도 개선.
``` java
courseTypeCreditsMap.put(courseTypeId, 
    courseTypeCreditsMap.getOrDefault(courseTypeId, 0) + catalog.getCredit());
```

# 💬 리뷰 중점사항
계속 변경사항이 많아서 수정 할것이 많았네요ㅠ 아직 계산 로직이 완벽하지는 않습니다. 예를 들어 다음과 같은 문제가 있습니다.
예를 들어 2020 대학요람 기준 미적분학이였던 것이 2022년도로 이름이 미분적분학으로 바뀌었고 이수구분 까지 바뀐 상황이라면 이것을 어떻게 계산해야 할 것인가..?
이런 고민들이 있습니다. 우선 프론트 분들이 많이 기다리고 계셔서 approve 해주시면 로직을 개선해 나가도록 하겠습니다.
고민 같이 해주시면 감사하겠습니다..
추가로 데이터 베이스에 standard_graduation_requirements에서 course_type_id가 잘못 들어가있는 경우가 많습니다. 이것도 수정해야 합니다.