### PR TITLE
feat: 채팅방 리스트 실시간 업데이트 기능

### DIFF
--- a/src/main/java/in/koreatech/koin/global/socket/domain/message/controller/ChatMessageSocketController.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/message/controller/ChatMessageSocketController.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.global.socket.domain.message.controller;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 

--- a/src/main/java/in/koreatech/koin/global/socket/domain/message/service/implement/MessageReader.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/message/service/implement/MessageReader.java
@@ -41,9 +41,8 @@ public class MessageReader {
         // 최근 메시지 내용 조회
         String lastMessageContent = messages.stream()
             .max(Comparator.comparing(ChatMessageEntity::getId))
-            .map(ChatMessageEntity::getContents)
+            .map(message -> message.getIsImage() ? "사진" : message.getContents())
             .orElse("");
-
 
         //최근 메시지 시간 조회
         LocalDateTime lastMessageTime = messages.stream()

--- a/src/main/java/in/koreatech/koin/global/socket/domain/notification/service/MessageReceivedEventListener.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/notification/service/MessageReceivedEventListener.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.global.socket.domain.notification.service;
 
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.domain.user.model.User;
@@ -8,15 +9,19 @@ import in.koreatech.koin.global.domain.notification.model.Notification;
 import in.koreatech.koin.global.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.global.domain.notification.service.NotificationService;
 import in.koreatech.koin.global.fcm.MobileAppPath;
+import in.koreatech.koin.global.socket.domain.chatroom.service.LostItemChatRoomInfoService;
 import in.koreatech.koin.global.socket.domain.chatroom.service.implement.ChatRoomInfoReader;
 import in.koreatech.koin.global.socket.domain.notification.model.MessageReceivedEvent;
+import in.koreatech.koin.global.socket.domain.session.model.UserSession;
 import in.koreatech.koin.global.socket.domain.session.model.UserSessionStatus;
 import in.koreatech.koin.global.socket.domain.session.service.UserSessionService;
 import in.koreatech.koin.global.socket.domain.session.service.implement.UserReader;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class MessageReceivedEventListener {
 
     private final NotificationService notificationService;
@@ -25,12 +30,18 @@ public class MessageReceivedEventListener {
     private final ChatRoomInfoReader chatRoomInfoReader;
     private final UserReader userReader;
     private final UserSessionService userSessionService;
+    private final SimpMessageSendingOperations simpMessageSendingOperations;
+    private final LostItemChatRoomInfoService chatRoomInfoService;
 
     @EventListener
     public void lostItemChatMessageReceived(MessageReceivedEvent event) {
         Integer partnerId = chatRoomInfoReader.getPartnerId(
             event.articleId(), event.chatRoomId(), event.userId()
         );
+
+        String destination = "/topic/chatroom/list/" + partnerId;
+        var chatRoomInfo = chatRoomInfoService.getAllChatRoomInfo(partnerId);
+        simpMessageSendingOperations.convertAndSend(destination, chatRoomInfo);
 
         if (!isNotificationEligible(partnerId)) {
             return;
@@ -65,7 +76,10 @@ public class MessageReceivedEventListener {
      */
     private boolean isActiveSession(Integer partnerId) {
         return userSessionService.read(partnerId)
-            .filter(session -> session.getStatus().equals(UserSessionStatus.ACTIVE_CHAT_ROOM))
+            .map(UserSession::getStatus)
+            .filter(session ->
+                UserSessionStatus.ACTIVE_CHAT_ROOM.equals(session) ||
+                UserSessionStatus.ACTIVE_CHAT_ROOM_LIST.equals(session))
             .isPresent();
     }
 

--- a/src/main/java/in/koreatech/koin/global/socket/domain/session/model/UserSessionStatus.java
+++ b/src/main/java/in/koreatech/koin/global/socket/domain/session/model/UserSessionStatus.java
@@ -7,9 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserSessionStatus {
 
-    ACTIVE_APP("1", "앱 활성화"),
+    ACTIVE_APP("1", "웹 소켓 연결"),
     ACTIVE_CHAT_ROOM("2", "채팅방 뷰"),
-    INACTIVE("3", "비활성화");
+    INACTIVE("3", "웹 소켓 연결 해제"),
+    ACTIVE_CHAT_ROOM_LIST("4", "채팅방 리스트");
 
     private final String code;
     private final String type;

--- a/src/main/java/in/koreatech/koin/global/socket/interceptor/SubscribeInterceptor.java
+++ b/src/main/java/in/koreatech/koin/global/socket/interceptor/SubscribeInterceptor.java
@@ -38,16 +38,22 @@ public class SubscribeInterceptor implements ChannelInterceptor {
             UserPrincipal principal = (UserPrincipal) accessor.getUser();
 
             if (principal != null) {
-                SubscribeDestination subscribeDestination = SubscribeDestination.extractDestinationInfo(accessor);
-
-                userSessionService.updateUserStatus(
-                    principal.getUserId(),
-                    subscribeDestination.articleId(),
-                    subscribeDestination.chatRoomId()
-                );
+                updateUserSessionByDestination(accessor, principal.getUserId());
             }
         }
 
         return message;
+    }
+
+    private void updateUserSessionByDestination(StompHeaderAccessor accessor, Integer userId) {
+        if (SubscribeDestination.isChatRoomSubscribe(accessor)) {
+            SubscribeDestination destination = SubscribeDestination.extractDestinationInfo(accessor);
+            userSessionService.updateUserStatus(userId, destination.articleId(), destination.chatRoomId());
+            return;
+        }
+
+        if (SubscribeDestination.isChatRoomListSubscribe(accessor)) {
+            userSessionService.updateUserStatus(userId, UserSessionStatus.ACTIVE_CHAT_ROOM_LIST);
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/global/socket/util/SubscribeDestination.java
+++ b/src/main/java/in/koreatech/koin/global/socket/util/SubscribeDestination.java
@@ -29,4 +29,14 @@ public record SubscribeDestination(
         Long chatRoomId = Long.valueOf(pathSegments[4]);
         return new SubscribeDestination(articleId, chatRoomId);
     }
+
+    public static boolean isChatRoomSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        return destination != null && destination.startsWith("/topic/chat/");
+    }
+
+    public static boolean isChatRoomListSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        return destination != null && destination.startsWith("/topic/chatroom/list");
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- #1185 

# 🚀 작업 내용

1. 채팅방 리스트 조회시 최근 메시지가 사진인 경우 정적 이미지 링크 대신 '사진' 문자열을 반환합니다.
2. 채팅방 리스트 실시간 업데이트 기능 추가
- 웹 소켓 경로 `/topic/chatroom/list/{userId}` 를 구독한 클라이언트는 자신에게 쪽지가 도착했을 때 업데이트 된 채팅방 리스트 데이터를 전달받습니다.

![채팅 리스트1](https://github.com/user-attachments/assets/e9a6e271-203b-4d16-8e68-d7855055da0f)

# 💬 리뷰 중점사항
