### PR TITLE
feat: 이메일 재전송 로직 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/global/domain/email/model/SesMailSender.java
+++ b/src/main/java/in/koreatech/koin/global/domain/email/model/SesMailSender.java
@@ -2,15 +2,19 @@ package in.koreatech.koin.global.domain.email.model;
 
 import org.springframework.stereotype.Component;
 
+import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsync;
 import com.amazonaws.services.simpleemail.model.Body;
 import com.amazonaws.services.simpleemail.model.Content;
 import com.amazonaws.services.simpleemail.model.Destination;
 import com.amazonaws.services.simpleemail.model.Message;
 import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendEmailResult;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SesMailSender {
@@ -25,6 +29,16 @@ public class SesMailSender {
                 .withBody(new Body().withHtml(new Content().withCharset("UTF-8").withData(htmlBody)))
                 .withSubject(new Content().withCharset("UTF-8").withData(subject)));
 
-        amazonSimpleEmailServiceAsync.sendEmailAsync(request);
+        amazonSimpleEmailServiceAsync.sendEmailAsync(request, new AsyncHandler<>() {
+            @Override
+            public void onError(Exception e) {
+                log.warn(e.getMessage());
+            }
+
+            @Override
+            public void onSuccess(SendEmailRequest request, SendEmailResult sendEmailResult) {
+                log.info("Email sent successfully");
+            }
+        });
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1293 

# 🚀 작업 내용

- 이메일 재전송 로직을 추가했습니다.

# 💬 리뷰 중점사항
[참고 자료](https://docs.aws.amazon.com/ko_kr/sdk-for-java/v1/developer-guide/basics-async.html) : 이메일에 대한 예제코드는 존재하지 않았습니다..

코인에서 사용 중인 이메일 전송은 AmazonSimpleEmailServiceAsync의 sendEmailAsync 메소드를 통해 전송되고 있습니다.
AmazonSimpleEmailServiceAsync은 AWS SES의 비동기 클라이언트 인터페이스로, 비동기로 메일을 전송한다고 생각하면 편할 것 같습니다.

sendEmailAsync 메소드는 파라미터로 다음과 같은 값을 가집니다.
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/8667af79-2c27-4b05-af04-65d538259106" />
- SendEmailRequest : 보낼 메일에 대한 정보를 가진 객체입니다.
- AsyncHandler<SendEmailRequest, SendEmailResult> : 비동기 요청의 성공 및 실패 처리를 위한 콜백 메커니즘을 제공해주는 인터페이스라고 합니다. 

기존에는 두 번째 파라미터를 설정하지 않고, 보낼 메일에 대한 정보만을 설정했습니다. aws ses으로 메일 전송을 요청한 이후 성공 혹은 실패에 대한 정보를 얻을 수 없는 문제점이 있습니다. 현재 회원가입 과정에서 이메일 전송이 안되는 상황도 aws ses으로 요청을 했지만 내부에서 오류가 발생하고, 오류값을 핸들링하고 있지 않습니다.

AsyncHandler 인터페이스는 두 개의 메소드를 제공합니다.
- onError : 비동기 작업 중에 오류가 발생했을 때 호출됩니다.
- onSuccess : 비동기 작업이 성공적으로 완료되었을 때 호출됩니다.

오류가 발생할 경우 재시도 로직을 넣었습니다. 재시도 카운트는 총 3번 간격은 0.5ms으로 설정했습니다.
관련해서 스테이지에서 먼저 테스트를 해보고, 프로덕션으로 핫픽스를 날리는 방향을 생각하고 있습니다. (처음 접해보는 내용이고, 비동기에 대한 추가 학습도 필요할 것 같습니다.)