### PR TITLE
fix: timetable NPE 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/LectureInfoResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/LectureInfoResponse.java
@@ -72,6 +72,10 @@ public record LectureInfoResponse(
 
     // 역정규화 된 커스텀 강의 정보를 정규화 하는 메소드
     public static List<LectureInfoResponse> getCustomLectureInfo(String classTime, String classPlace) {
+        if (classTime == null || classPlace == null) {
+            return Collections.emptyList();
+        }
+
         List<Integer> classTimes = parseToIntegerList(classTime);
         List<LectureInfoResponse> response = new ArrayList<>();
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/utils/ClassTimeUtils.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/utils/ClassTimeUtils.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.timetableV3.utils;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -14,6 +15,11 @@ public class ClassTimeUtils {
 
     // 문자열 강의 시간 리스트로 변환
     public static List<Integer> parseToIntegerList(String classTime) {
+        // 온라인 강의 혹은 졸학계로 생성된 강의 중 classTime이 null인 경우
+        if (classTime == null || classTime.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         return Stream.of(classTime.replaceAll("[\\[\\]]", "").split(","))
             .map(String::strip)
             .filter(time -> !time.isEmpty())


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1295 

# 🚀 작업 내용

- 졸학계로 생긴 timetableLecture 중 강의 시간이 null인 강의에서 생긴 NPE를 해결했습니다.
- 강의 시간과 강의 장소가 null인 경우 빈 리스트를 반환하도록 수정했습니다.

# 💬 리뷰 중점사항
