### PR TITLE
feat: 시내 버스 크롤링 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,9 +104,6 @@ dependencies {
 
     // Zip Compress
     implementation 'net.lingala.zip4j:zip4j:2.6.1'
-
-    // jsoup HTML parser library @ https://jsoup.org/
-    implementation 'org.jsoup:jsoup:1.18.3'
 }
 
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ dependencies {
 
     // Zip Compress
     implementation 'net.lingala.zip4j:zip4j:2.6.1'
+
+    // jsoup HTML parser library @ https://jsoup.org/
+    implementation 'org.jsoup:jsoup:1.18.3'
 }
 
 clean {

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteApiResponse.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteApiResponse.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusRouteApiResponse(
+    List<CityBusRouteInfo> resultList
+) {
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteInfo.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusRouteInfo(
+
+    @JsonProperty("ROUTE_ID")
+    Long routeId,
+
+    @JsonProperty("ROUTE_NAME")
+    String routeName,
+
+    @JsonProperty("ROUTE_DIRECTION")
+    String routeDirection,
+
+    @JsonProperty("RELAY_AREACODE")
+    String relayAreaCode,
+
+    @JsonProperty("ROUTE_EXPLAIN")
+    String routeExplain,
+
+    @JsonProperty("ST_STOP_NAME")
+    String stName,
+
+    @JsonProperty("ED_STOP_NAME")
+    String edName
+) {
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusTimetableApiResponse.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusTimetableApiResponse.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusTimetableApiResponse(
+    List<InnerRoute> resultList
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record InnerRoute(
+        @JsonProperty("ROUTE_ID")
+        Long routeId
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
@@ -4,8 +4,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class BusInfo {
 
     @Field("number")

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BusInfo {
+
+    @Field("number")
+    private final Long number;
+
+    @Field("depart_node")
+    private final String departNode;
+
+    @Field("arrival_node")
+    private final String arrivalNode;
+
+    @Builder
+    private BusInfo(Long number, String departNode, String arrivalNode) {
+        this.number = number;
+        this.departNode = departNode;
+        this.arrivalNode = arrivalNode;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CityBusTimetable {
+
+    @Field("day_of_week")
+    private final String dayOfWeek;
+
+    @Field("depart_info")
+    private final List<String> departInfo;
+
+    @Builder
+    private CityBusTimetable(String dayOfWeek, List<String> departInfo) {
+        this.dayOfWeek = dayOfWeek;
+        this.departInfo = departInfo;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
@@ -6,8 +6,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class CityBusTimetable {
 
     @Field("day_of_week")

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
@@ -10,8 +10,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @Document(collection = "citybus_timetables")
 public class TimetableDocument {
 

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Document(collection = "citybus_timetables")
+public class TimetableDocument {
+
+    @Id
+    @Field("_id")
+    private final String routeId;
+
+    @Field("bus_info")
+    private final BusInfo busInfo;
+
+    @Field("bus_timetables")
+    private final List<CityBusTimetable> busTimetables;
+
+    @Field("updated_at")
+    private final LocalDateTime updatedAt;
+
+    @Builder
+    private TimetableDocument(List<CityBusTimetable> busTimetables, CityBusRouteInfo routeInfo,
+        LocalDateTime updatedAt) {
+        this.routeId = routeInfo.routeId().toString();
+        this.busTimetables = busTimetables;
+        this.busInfo = BusInfo.builder()
+            .number(Long.parseLong(routeInfo.routeName()))
+            .departNode(routeInfo.stName())
+            .arrivalNode(routeInfo.edName())
+            .build();
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
-import com.mongodb.bulk.BulkWriteResult;
-
 import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
 import lombok.RequiredArgsConstructor;
 
@@ -37,12 +35,6 @@ public class BatchCityBusTimetableRepository {
             bulkOps.upsert(query, update);
         });
 
-        BulkWriteResult result = bulkOps.execute();
-
-        // log.info("Bulk upsert completed - Upserted: {}, Modified: {}, Matched: {}",
-        //     result.getUpserts().size(),
-        //     result.getModifiedCount(),
-        //     result.getMatchedCount()
-        // );
+        bulkOps.execute();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.batch.campus.bus.city.repository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import com.mongodb.bulk.BulkWriteResult;
+
+import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BatchCityBusTimetableRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public void saveAll(List<TimetableDocument> timetables) {
+        BulkOperations bulkOps = mongoTemplate.bulkOps(
+            BulkOperations.BulkMode.UNORDERED,
+            TimetableDocument.class
+        );
+
+        timetables.forEach(timetable -> {
+            Query query = Query.query(Criteria.where("_id").is(timetable.getRouteId()));
+
+            Update update = new Update()
+                .set("updatedAt", timetable.getUpdatedAt())
+                .set("busInfo", timetable.getBusInfo())
+                .set("busTimetables", timetable.getBusTimetables());
+
+            bulkOps.upsert(query, update);
+        });
+
+        BulkWriteResult result = bulkOps.execute();
+
+        // log.info("Bulk upsert completed - Upserted: {}, Modified: {}, Matched: {}",
+        //     result.getUpserts().size(),
+        //     result.getModifiedCount(),
+        //     result.getMatchedCount()
+        // );
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -40,7 +40,6 @@ public class BatchCityBusService {
 
         batchCityBusTimetableRepository.saveAll(timetables);
 
-        // TODO : Save Timetables using Bulk Write
         // TODO : Remove Duplicate Entities
         // TODO : Change System.out.println to Logger
     }
@@ -118,6 +117,7 @@ public class BatchCityBusService {
                 .get();
 
         } catch (IOException e) {
+            // TODO : Exception 커스텀하기
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -40,26 +40,25 @@ public class BatchCityBusService {
 
         batchCityBusTimetableRepository.saveAll(timetables);
 
-        // TODO : Remove Duplicate Entities
-        // TODO : Change System.out.println to Logger
+        // TODO : Remove Duplicate Entities (CityBusRouteInfo, BusInfo, CityBusTimetable, TimetableDocument, ...)
     }
 
     private List<TimetableDocument> crawling() {
         List<Long> availableBuses = getAvailableBus();
-        System.out.println(availableBuses);
+        log.info(availableBuses.toString());
 
         List<Long> routeIds = availableBuses.stream()
             .flatMap(busNumber -> getRouteIds(busNumber).stream())
             .toList();
-        System.out.println(routeIds);
+        log.info(routeIds.toString());
 
         List<CityBusRouteInfo> routeInfos = routeIds.stream()
             .flatMap(routeId -> getRouteInfo(routeId).stream())
             .toList();
-        System.out.println(routeInfos);
+        log.info(routeInfos.toString());
 
         List<TimetableDocument> timetables = routeInfos.stream().map(this::getTimetable).toList();
-        System.out.println(timetables);
+        timetables.forEach(timetable -> log.info(timetable.toString()));
 
         return timetables;
     }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -1,0 +1,147 @@
+package in.koreatech.koin.batch.campus.bus.city.service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteApiResponse;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse.InnerRoute;
+import in.koreatech.koin.batch.campus.bus.city.model.CityBusTimetable;
+import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
+import in.koreatech.koin.batch.campus.bus.city.repository.BatchCityBusTimetableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BatchCityBusService {
+
+    private final RestTemplate restTemplate;
+    private final BatchCityBusTimetableRepository batchCityBusTimetableRepository;
+
+    public void update() {
+        List<TimetableDocument> timetables = crawling();
+
+        batchCityBusTimetableRepository.saveAll(timetables);
+
+        // TODO : Save Timetables using Bulk Write
+        // TODO : Remove Duplicate Entities
+        // TODO : Change System.out.println to Logger
+    }
+
+    private List<TimetableDocument> crawling() {
+        List<Long> availableBuses = getAvailableBus();
+        System.out.println(availableBuses);
+
+        List<Long> routeIds = availableBuses.stream()
+            .flatMap(busNumber -> getRouteIds(busNumber).stream())
+            .toList();
+        System.out.println(routeIds);
+
+        List<CityBusRouteInfo> routeInfos = routeIds.stream()
+            .flatMap(routeId -> getRouteInfo(routeId).stream())
+            .toList();
+        System.out.println(routeInfos);
+
+        List<TimetableDocument> timetables = routeInfos.stream().map(this::getTimetable).toList();
+        System.out.println(timetables);
+
+        return timetables;
+    }
+
+    private List<Long> getAvailableBus() {
+        return List.of(400L, 402L, 405L);
+    }
+
+    private List<Long> getRouteIds(Long busNumber) {
+        ResponseEntity<CityBusTimetableApiResponse> response = restTemplate.getForEntity(
+            "https://its.cheonan.go.kr/bis/getBusTimeTable.do?thisPage=1&searchKeyword={busNumber}",
+            CityBusTimetableApiResponse.class,
+            busNumber
+        );
+
+        if (!response.hasBody()) {
+            return Collections.emptyList();
+        }
+
+        return Objects.requireNonNull(response.getBody())
+            .resultList()
+            .stream()
+            .map(InnerRoute::routeId)
+            .toList();
+    }
+
+    private List<CityBusRouteInfo> getRouteInfo(Long routeId) {
+        ResponseEntity<CityBusRouteApiResponse> response = restTemplate.getForEntity(
+            "https://its.cheonan.go.kr/bis/getRouteList.do?searchKeyword={routeId}",
+            CityBusRouteApiResponse.class,
+            routeId
+        );
+
+        if (!response.hasBody()) {
+            return Collections.emptyList();
+        }
+
+        return Objects.requireNonNull(response.getBody()).resultList();
+    }
+
+    private TimetableDocument getTimetable(CityBusRouteInfo cityBusRouteInfo) {
+        String url = "https://its.cheonan.go.kr/bis/showBusTimeTable.do";
+
+        Document document;
+        try {
+            document = Jsoup.connect(url)
+                .data("routeName", cityBusRouteInfo.routeName())
+                .data("routeDirection", cityBusRouteInfo.routeDirection())
+                .data("relayAreacode", cityBusRouteInfo.relayAreaCode())
+                .data("routeExplain", cityBusRouteInfo.routeExplain())
+                .data("stName", cityBusRouteInfo.stName())
+                .data("edName", cityBusRouteInfo.edName())
+                .ignoreContentType(true)
+                .timeout(5000)
+                .get();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<String> dayOfWeeks = List.of("평일", "주말", "공휴일", "임시");
+        List<CityBusTimetable> timetables = new ArrayList<>();
+        for (int i = 0; i < dayOfWeeks.size(); i++) {
+            String selector =
+                "body > div.timeTalbeWrap > div > div.timeTable-wrap > div:nth-child(" + (i + 1) + ") > dl > dd";
+            Elements departInfoElem = document.select(selector);
+
+            List<String> departInfo = departInfoElem.stream()
+                .map(element -> element.text().substring(0, 5))
+                .toList();
+
+            String dayOfWeek = dayOfWeeks.get(i);
+            timetables.add(
+                CityBusTimetable.builder().dayOfWeek(dayOfWeek).departInfo(departInfo).build()
+            );
+        }
+
+        return TimetableDocument.builder()
+            .busTimetables(timetables)
+            .routeInfo(cityBusRouteInfo)
+            .updatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/ArrivalInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/ArrivalInfo.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.batch.campus.bus.school.dto;
+
+import lombok.Setter;
+
+@Setter
+public class ArrivalInfo {
+    private String node_name;
+    private String arrival_time;
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/BatchSchoolBusVersionUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/BatchSchoolBusVersionUpdateRequest.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.batch.campus.bus.school.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record BatchSchoolBusVersionUpdateRequest(
+    @Schema(description = "업데이트 제목", example = "방학기간")
+    String title,
+
+    @Schema(description = "업데이트 내용", example = "2025-01-15~2025-02-28")
+    String content
+) {
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/Route.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/Route.java
@@ -1,0 +1,13 @@
+package in.koreatech.koin.batch.campus.bus.school.dto;
+
+import java.util.List;
+
+import lombok.Setter;
+
+@Setter
+public class Route {
+
+    private String route_name;
+    private List<String> running_days;
+    private List<ArrivalInfo> arrival_info;
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/SchoolBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/dto/SchoolBusTimetable.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.batch.campus.bus.school.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SchoolBusTimetable {
+
+    private List<String> nodes;
+    private List<Route> to_school;
+    private List<Route> from_school;
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/BusInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/BusInfo.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.batch.campus.bus.school.model;
+
+import lombok.Getter;
+
+@Getter
+public class BusInfo {
+    private final String region;
+    private final BusType busType;
+
+    public BusInfo(String region, BusType busType) {
+        this.region = region;
+        this.busType = busType;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/BusType.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/BusType.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.batch.campus.bus.school.model;
+
+import lombok.Getter;
+
+@Getter
+public enum BusType {
+    COMMUTING("commuting"),
+    SHUTTLE("shuttle"),
+    ;
+
+    private final String value;
+
+    BusType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/SchoolBus.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/model/SchoolBus.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.batch.campus.bus.school.model;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.batch.campus.bus.school.dto.Route;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Document(collection = "bus_timetables")
+@JsonNaming(value = SnakeCaseStrategy.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchoolBus {
+
+    @Id
+    @Field("_id")
+    private String id;
+
+    @Field("region")
+    private String region;
+
+    @Field("bus_type")
+    private String busType;
+
+    @Field("direction")
+    private String direction;
+
+    @Field("routes")
+    private List<Route> routes;
+
+    @Builder
+    public SchoolBus(String id, String region, String busType, String direction, List<Route> routes) {
+        this.id = id;
+        this.region = region;
+        this.busType = busType;
+        this.direction = direction;
+        this.routes = routes;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/repository/SchoolBusRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/repository/SchoolBusRepository.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.batch.campus.bus.school.repository;
+
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import in.koreatech.koin.batch.campus.bus.school.model.SchoolBus;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SchoolBusRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public SchoolBus upsert(SchoolBus schoolBus) {
+        Query query = Query.query(
+            Criteria
+                .where("region").is(schoolBus.getRegion())
+                .and("bus_type").is(schoolBus.getBusType())
+                .and("direction").is(schoolBus.getDirection())
+        );
+
+        FindAndReplaceOptions options = new FindAndReplaceOptions().upsert();
+
+        return mongoTemplate.findAndReplace(query, schoolBus, options);
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/school/service/SchoolBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/school/service/SchoolBusService.java
@@ -1,0 +1,91 @@
+package in.koreatech.koin.batch.campus.bus.school.service;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.Clock;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
+import in.koreatech.koin.batch.campus.bus.school.dto.SchoolBusTimetable;
+import in.koreatech.koin.batch.campus.bus.school.model.BusInfo;
+import in.koreatech.koin.batch.campus.bus.school.model.BusType;
+import in.koreatech.koin.batch.campus.bus.school.model.SchoolBus;
+import in.koreatech.koin.batch.campus.bus.school.repository.SchoolBusRepository;
+import in.koreatech.koin.batch.campus.util.YamlParser;
+import in.koreatech.koin.domain.version.model.Version;
+import in.koreatech.koin.domain.version.model.VersionType;
+import in.koreatech.koin.domain.version.repository.VersionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SchoolBusService {
+
+    private final VersionRepository versionRepository;
+    private final SchoolBusRepository schoolBusRepository;
+    private final YamlParser yamlParser;
+    private final Clock clock;
+
+    private static final Map<String, BusInfo> fileMapper = Map.of(
+        "cheonan_commuting.yaml", new BusInfo("천안", BusType.COMMUTING),
+        "cheonan_shuttle.yaml", new BusInfo("천안", BusType.SHUTTLE),
+        "sejong_commuting.yaml", new BusInfo("세종", BusType.COMMUTING),
+        "daejeon_commuting.yaml", new BusInfo("대전", BusType.COMMUTING),
+        "seoul_commuting.yaml", new BusInfo("서울", BusType.COMMUTING),
+        "cheongju_shuttle.yaml", new BusInfo("청주", BusType.SHUTTLE),
+        "cheongju_commuting.yaml", new BusInfo("청주", BusType.COMMUTING)
+    );
+
+    public void update(BatchSchoolBusVersionUpdateRequest request) {
+        String currentPath = System.getProperty("user.dir");
+
+        fileMapper.forEach((fileName, busInfo) -> {
+            try {
+                SchoolBusTimetable timetable = yamlParser.parse(
+                    Paths.get(currentPath, "yaml", fileName).toString(),
+                    SchoolBusTimetable.class
+                );
+
+                updateTimetable(busInfo, timetable);
+
+            } catch (IOException e) {
+                throw new RuntimeException("error on reading: " + fileName, e);
+            }
+        });
+
+        updateVersion(request.title(), request.content());
+    }
+
+    private void updateTimetable(BusInfo busInfo, SchoolBusTimetable timetable) {
+        SchoolBus to = SchoolBus.builder()
+            .region(busInfo.getRegion())
+            .busType(busInfo.getBusType().getValue())
+            .direction("to")
+            .routes(timetable.getTo_school())
+            .build();
+
+        SchoolBus from = SchoolBus.builder()
+            .region(busInfo.getRegion())
+            .busType(busInfo.getBusType().getValue())
+            .direction("from")
+            .routes(timetable.getFrom_school())
+            .build();
+
+        schoolBusRepository.upsert(to);
+        schoolBusRepository.upsert(from);
+    }
+
+    private void updateVersion(String title, String content) {
+        Version version = versionRepository.findByType(VersionType.SHUTTLE.getValue())
+            .orElseGet(() -> {
+                Version newVersion = Version.of(VersionType.SHUTTLE, clock);
+                return versionRepository.save(newVersion);
+            });
+
+        version.update(clock, title, content);
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
 import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
 import in.koreatech.koin.global.auth.Auth;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class BatchCampusController implements BatchCampusControllerApi {
 
     private final SchoolBusService schoolBusService;
+    private final BatchCityBusService batchCityBusService;
 
     @Override
     @PostMapping("/bus/school")
@@ -28,6 +30,15 @@ public class BatchCampusController implements BatchCampusControllerApi {
         @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
     ) {
         schoolBusService.update(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PostMapping("/bus/city")
+    public ResponseEntity<Void> updateCityBus(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        batchCityBusService.update();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.batch.campus.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
+import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
+import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/batch/campus")
+public class BatchCampusController implements BatchCampusControllerApi {
+
+    private final SchoolBusService schoolBusService;
+
+    @Override
+    @PostMapping("/bus/school")
+    public ResponseEntity<Void> updateSchoolBus(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
+    ) {
+        schoolBusService.update(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.batch.campus.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Admin) Batch: 배치", description = "Campus 팀 배치 작업을 관리한다.")
+@RequestMapping("/batch/campus")
+public interface BatchCampusControllerApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "셔틀버스 시간표 업데이트")
+    @PostMapping("/bus/school")
+    ResponseEntity<Void> updateSchoolBus(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
+    );
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -35,4 +35,18 @@ public interface BatchCampusControllerApi {
         @Auth(permit = {ADMIN}) Integer adminId,
         @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "시내버스 시간표 업데이트")
+    @PostMapping("/bus/city")
+    ResponseEntity<Void> updateCityBus(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -29,7 +29,7 @@ public interface BatchCampusControllerApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "셔틀버스 시간표 업데이트")
+    @Operation(summary = "학교버스 시간표 업데이트")
     @PostMapping("/bus/school")
     ResponseEntity<Void> updateSchoolBus(
         @Auth(permit = {ADMIN}) Integer adminId,

--- a/src/main/java/in/koreatech/koin/batch/campus/util/YamlParser.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/util/YamlParser.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.batch.campus.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class YamlParser {
+
+    private final Yaml yaml;
+
+    public <T> T parse(String path, Class<T> clazz) throws IOException {
+        String content = Files.readString(Paths.get(path));
+        return yaml.loadAs(content, clazz);
+    }
+
+}

--- a/src/main/java/in/koreatech/koin/domain/version/model/Version.java
+++ b/src/main/java/in/koreatech/koin/domain/version/model/Version.java
@@ -68,6 +68,12 @@ public class Version extends BaseEntity {
         version = generateVersionName(clock);
     }
 
+    public void update(Clock clock, String title, String content) {
+        update(clock);
+        this.title = title;
+        this.content = content;
+    }
+
     private String generateVersionName(Clock clock) {
         String year = Integer.toString(LocalDate.now().getYear());
         String padding = "0_";
@@ -82,5 +88,16 @@ public class Version extends BaseEntity {
             .title(request.title())
             .content(request.content())
             .build();
+    }
+
+    public static Version of(VersionType type, Clock clock) {
+        Version version = Version.builder()
+            .type(type.getValue())
+            .version(clock.toString())
+            .build();
+
+        version.update(clock);
+
+        return version;
     }
 }

--- a/src/main/java/in/koreatech/koin/global/config/RedisConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/RedisConfig.java
@@ -2,9 +2,9 @@ package in.koreatech.koin.global.config;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
+import java.util.List;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,10 +15,15 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
@@ -41,10 +46,26 @@ public class RedisConfig {
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        /*
+        1. content-type: text/html
+        2. body는 json
+
+        위 조건일 경우, 파싱이 안되고 UnknownContentTypeException 발생하는 문제 해결하기 위해 text/html도 지원 목록에 추가
+        */
+        MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
+        jacksonConverter.setSupportedMediaTypes(List.of(
+            MediaType.TEXT_HTML,
+            MediaType.APPLICATION_JSON
+        ));
+
         return restTemplateBuilder.
             requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())).
             setConnectTimeout(Duration.ofMillis(5000))
             .setReadTimeout(Duration.ofMillis(5000))
-            .additionalMessageConverters(new StringHttpMessageConverter(UTF_8)).build();
+            .additionalMessageConverters(
+                jacksonConverter,
+                new StringHttpMessageConverter(UTF_8)
+            )
+            .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/global/config/YamlConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/YamlConfig.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.yaml.snakeyaml.Yaml;
+
+@Configuration
+public class YamlConfig {
+
+    @Bean
+    public Yaml yaml() {
+        return new Yaml();
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/config/swagger/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/swagger/SwaggerGroupConfig.java
@@ -49,7 +49,8 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.coop",
             "in.koreatech.koin.domain.coopshop",
             "in.koreatech.koin.domain.dining",
-            "in.koreatech.koin.global.socket.domain.chatroom"
+            "in.koreatech.koin.global.socket.domain.chatroom",
+            "in.koreatech.koin.batch.campus",
         };
 
         return createGroupedOpenApi("3. Campus API", packagesPath);

--- a/src/test/java/in/koreatech/koin/batch/acceptance/BatchSchoolBusApiTest.java
+++ b/src/test/java/in/koreatech/koin/batch/acceptance/BatchSchoolBusApiTest.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.batch.acceptance;
+
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+public class BatchSchoolBusApiTest {
+    // TODO : 배치 테스트 추가하기
+}

--- a/yaml/daejeon_commuting.yaml
+++ b/yaml/daejeon_commuting.yaml
@@ -1,0 +1,45 @@
+nodes:
+  - &koreatech "한기대"
+  - &daejeon_station "대전역"
+  - &compound_terminal "복합터미널"
+to_school:
+  - route_name: "일요일(18시 10분)"
+    running_days: [ "SUN" ]
+    arrival_info:
+      - node_name: *daejeon_station
+        arrival_time: "18:10"
+      - node_name: *compound_terminal
+        arrival_time: "18:15"
+      - node_name: *koreatech
+        arrival_time: "도착"
+
+  - route_name: "일요일(18시 20분)"
+    running_days: [ "SUN" ]
+    arrival_info:
+      - node_name: *daejeon_station
+        arrival_time: "18:20"
+      - node_name: *compound_terminal
+        arrival_time: "18:25"
+      - node_name: *koreatech
+        arrival_time: "도착"
+
+from_school:
+  - route_name: "금요일(14시)"
+    running_days: [ "FRI" ]
+    arrival_info:
+      - node_name: *koreatech
+        arrival_time: "14:00"
+      - node_name: *compound_terminal
+        arrival_time: "도착"
+      - node_name: *daejeon_station
+        arrival_time: "도착"
+
+  - route_name: "금요일(18시 20분)"
+    running_days: [ "FRI" ]
+    arrival_info:
+      - node_name: *koreatech
+        arrival_time: "18:20"
+      - node_name: *compound_terminal
+        arrival_time: "도착"
+      - node_name: *daejeon_station
+        arrival_time: "도착"


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1247 

# 🚀 작업 내용

1. [KOIN_BATCH](https://github.com/BCSDLab/KOIN_BATCH)의 [시내버스 크롤링](https://github.com/BCSDLab/KOIN_BATCH/blob/master/crawling/city_bus/city_bus_timetable.py)을 마이그레이션 했습니다. (Python → Java)
2. RestTemplate과 Jsoup를 사용했습니다.
    - RestTemplate는 기본적으로 content-type이 text/html이면 body가 json 형태라도 파싱되지 않는 문제가 있었습니다.
    - 그래서 text/html도 파싱할 수 있도록 지원 목록에 추가했습니다.

# 💬 리뷰 중점사항
코드 정리 없이 냅다 옮기기만 했습니다. 코드가 많이 더러워요..
스무스하게 넘어갈줄 알았는데 뭔가 난관이 많네요...

**정리 안된것:**
- Exception 정리
- 중복 엔티티 제거