### PR TITLE
fix : 학생 학적 정보 수정 오류 해결 & feat : 학생 정보 조회(학적 포함)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -50,7 +50,7 @@ public interface StudentApi {
 
     @ApiResponses(
         value = {
-            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
@@ -67,7 +67,7 @@ public interface StudentApi {
 
     @ApiResponses(
         value = {
-            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -17,6 +17,7 @@ import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.student.dto.StudentResponse;
 import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
 import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
+import in.koreatech.koin.domain.student.dto.StudentWithAcademicResponse;
 import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
 import in.koreatech.koin.domain.user.dto.UserPasswordChangeRequest;
 import in.koreatech.koin.global.auth.Auth;
@@ -45,6 +46,21 @@ public interface StudentApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/user/student/me")
     ResponseEntity<StudentResponse> getStudent(
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "학생 정보 조회(학적 포함)")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/user/student/me/academic-info")
+    ResponseEntity<StudentWithAcademicResponse> getStudentWithAcademicInfo(
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
@@ -24,6 +24,7 @@ import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.student.dto.StudentResponse;
 import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
 import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
+import in.koreatech.koin.domain.student.dto.StudentWithAcademicResponse;
 import in.koreatech.koin.domain.student.service.StudentService;
 import in.koreatech.koin.domain.user.dto.AuthTokenRequest;
 import in.koreatech.koin.domain.user.dto.FindPasswordRequest;
@@ -47,6 +48,14 @@ public class StudentController implements StudentApi{
     ) {
         StudentResponse studentResponse = studentService.getStudent(userId);
         return ResponseEntity.ok().body(studentResponse);
+    }
+
+    @GetMapping("/user/student/me/academic-info")
+    public ResponseEntity<StudentWithAcademicResponse> getStudentWithAcademicInfo(
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
+    ) {
+        StudentWithAcademicResponse response = studentService.getStudentWithAcademicInfo(userId);
+        return ResponseEntity.ok().body(response);
     }
 
     @PutMapping("/user/student/me")

--- a/src/main/java/in/koreatech/koin/domain/student/dto/StudentWithAcademicResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/StudentWithAcademicResponse.java
@@ -1,0 +1,98 @@
+package in.koreatech.koin.domain.student.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record StudentWithAcademicResponse(
+    @Schema(example = "1", description = "학생 고유 id", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "익명 닉네임", example = "익명_1676688416361", requiredMode = NOT_REQUIRED)
+    String anonymousNickname,
+
+    @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = NOT_REQUIRED)
+    String email,
+
+    @Schema(description = "성별(남:0, 여:1)", example = "1", requiredMode = NOT_REQUIRED)
+    Integer gender,
+
+    @Schema(
+        description = """
+            학부
+            - 기계공학부
+            - 컴퓨터공학부
+            - 메카트로닉스공학부
+            - 전기전자통신공학부
+            - 디자인공학부
+            - 건축공학부
+            - 화학생명공학부
+            - 에너지신소재공학부
+            - 산업경영학부
+            - 고용서비스정책학과
+            """,
+        example = "컴퓨터공학부",
+        requiredMode = NOT_REQUIRED
+    )
+    String department,
+
+    @Schema(
+        description = """
+                전공:
+                - 컴퓨터공학부 (null)
+                - 기계공학부 (null)
+                - 메카트로닉스공학부 (생산시스템전공, 제어시스템전공, 디지털시스템전공)
+                - 전기전자통신공학부 (전기공학전공, 전자공학전공, 정보통신공학전공)
+                - 디자인공학부 (디자인공학전공)
+                - 건축공학부 (건축공학전공)
+                - 화학생명공학부 (화학생명공학전공)
+                - 에너지신소재공학부 (에너지신소재공학전공)
+                - 산업경영학부 (데이터경영전공, 산업경영전공, 혁신경영전공, 융합경영전공)
+                - 고용서비스정책학과 (null)
+                - 응용화학공학부 (응용화학공학전공)
+            """,
+        example = "null",
+        requiredMode = NOT_REQUIRED
+    )
+    String major,
+
+    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    String name,
+
+    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    String nickname,
+
+    @Schema(description = "휴대폰 번호", example = "010-0000-0000", requiredMode = NOT_REQUIRED)
+    String phoneNumber,
+
+    @Schema(description = "학번", example = "2029136012", requiredMode = NOT_REQUIRED)
+    String studentNumber
+) {
+
+    public static StudentWithAcademicResponse from(Student student) {
+        User user = student.getUser();
+        Integer userGender = null;
+        if (user.getGender() != null) {
+            userGender = user.getGender().ordinal();
+        }
+        return new StudentWithAcademicResponse(
+            student.getId(),
+            student.getAnonymousNickname(),
+            user.getEmail(),
+            userGender,
+            student.getDepartment() == null ? null : student.getDepartment().getName(),
+            student.getMajor() == null ? null : student.getMajor().getName(),
+            user.getName(),
+            user.getNickname(),
+            user.getPhoneNumber(),
+            student.getStudentNumber()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/student/repository/MajorRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/student/repository/MajorRepository.java
@@ -24,6 +24,8 @@ public interface MajorRepository extends Repository<Major, Integer> {
 
     Optional<Major> findByNameAndDepartmentId(String name, Integer departmentId);
 
+    Optional<Major> findFirstByDepartmentIdOrderByIdAsc(Integer departmentId);
+
     default Major getByName(String name) {
         return findByName(name)
             .orElseThrow(() -> DepartmentNotFoundException.withDetail("name: " + name));

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -168,7 +168,7 @@ public class StudentService {
         }
 
         Student student = studentRepository.getById(userId);
-        // 학번에 변경 사항이 생겼을 경우
+
         String oldStudentNumber = student.getStudentNumber();
         String newStudentNumber = student.getStudentNumber();
         String requestStudentNumber = request.studentNumber();
@@ -176,17 +176,17 @@ public class StudentService {
             newStudentNumber = requestStudentNumber;
         }
 
+        // 학번 변경 사항 감지
         boolean updateStudentNumber = false;
         if (requestStudentNumber != null && oldStudentNumber != null) {
             updateStudentNumber = isChangeStudentNumber(requestStudentNumber, oldStudentNumber);
         }
 
-        // 학부 변경이 생기는 경우 처리
         Department newStudentDepartment = student.getDepartment();
         if (request.department() != null) {
             newStudentDepartment = departmentRepository.getByName(request.department());
         }
-        // 전공에 변경 사항이 생겼을 경우
+
         Major oldMajor = student.getMajor();
         Major newMajor;
         if (request.major() != null) {
@@ -195,6 +195,7 @@ public class StudentService {
             newMajor = majorRepository.findFirstByDepartmentIdOrderByIdAsc(newStudentDepartment.getId())
                 .orElse(null);
         }
+        // 전공 변경 사항 감지
         boolean updateMajor = isChangedMajor(oldMajor, newMajor);
 
         student.updateStudentAcademicInfo(newStudentNumber, newStudentDepartment, newMajor);

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -170,16 +170,34 @@ public class StudentService {
         Student student = studentRepository.getById(userId);
         // 학번에 변경 사항이 생겼을 경우
         String oldStudentNumber = student.getStudentNumber();
-        String newStudentNumber = request.studentNumber();
-        boolean updateStudentNumber = isChangeStudentNumber(newStudentNumber, oldStudentNumber);
-        // 학부에 변경 사항이 생겼을 경우
-        Department newDepartment = departmentRepository.getByName(request.department());
+        String newStudentNumber = student.getStudentNumber();
+        String requestStudentNumber = request.studentNumber();
+        if (requestStudentNumber != null) {
+            newStudentNumber = requestStudentNumber;
+        }
+
+        boolean updateStudentNumber = false;
+        if (requestStudentNumber != null && oldStudentNumber != null) {
+            updateStudentNumber = isChangeStudentNumber(requestStudentNumber, oldStudentNumber);
+        }
+
+        // 학부 변경이 생기는 경우 처리
+        Department newStudentDepartment = student.getDepartment();
+        if (request.department() != null) {
+            newStudentDepartment = departmentRepository.getByName(request.department());
+        }
         // 전공에 변경 사항이 생겼을 경우
-        Major newMajor = majorRepository.getByNameAndDepartmentId(request.major(), student.getDepartment().getId());
         Major oldMajor = student.getMajor();
+        Major newMajor;
+        if (request.major() != null) {
+            newMajor = majorRepository.getByNameAndDepartmentId(request.major(), newStudentDepartment.getId());
+        } else {
+            newMajor = majorRepository.findFirstByDepartmentIdOrderByIdAsc(newStudentDepartment.getId())
+                .orElse(null);
+        }
         boolean updateMajor = isChangedMajor(oldMajor, newMajor);
 
-        student.updateStudentAcademicInfo(newStudentNumber, newDepartment, newMajor);
+        student.updateStudentAcademicInfo(newStudentNumber, newStudentDepartment, newMajor);
 
         /**
          * 해당 API에서는 Major를 수정할 수 있음 (여기서 그대로는 null이 아닌 경우)

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -20,6 +20,7 @@ import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
 import in.koreatech.koin.domain.student.dto.StudentResponse;
 import in.koreatech.koin.domain.student.dto.StudentUpdateRequest;
 import in.koreatech.koin.domain.student.dto.StudentUpdateResponse;
+import in.koreatech.koin.domain.student.dto.StudentWithAcademicResponse;
 import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Major;
 import in.koreatech.koin.domain.student.model.Student;
@@ -257,6 +258,11 @@ public class StudentService {
     public StudentResponse getStudent(Integer userId) {
         Student student = studentRepository.getById(userId);
         return StudentResponse.from(student);
+    }
+
+    public StudentWithAcademicResponse getStudentWithAcademicInfo(Integer userId) {
+        Student student = studentRepository.getById(userId);
+        return StudentWithAcademicResponse.from(student);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -182,23 +182,23 @@ public class StudentService {
             updateStudentNumber = isChangeStudentNumber(requestStudentNumber, oldStudentNumber);
         }
 
-        Department newStudentDepartment = student.getDepartment();
+        Department newDepartment = student.getDepartment();
         if (request.department() != null) {
-            newStudentDepartment = departmentRepository.getByName(request.department());
+            newDepartment = departmentRepository.getByName(request.department());
         }
 
         Major oldMajor = student.getMajor();
         Major newMajor;
         if (request.major() != null) {
-            newMajor = majorRepository.getByNameAndDepartmentId(request.major(), newStudentDepartment.getId());
+            newMajor = majorRepository.getByNameAndDepartmentId(request.major(), newDepartment.getId());
         } else {
-            newMajor = majorRepository.findFirstByDepartmentIdOrderByIdAsc(newStudentDepartment.getId())
+            newMajor = majorRepository.findFirstByDepartmentIdOrderByIdAsc(newDepartment.getId())
                 .orElse(null);
         }
         // 전공 변경 사항 감지
         boolean updateMajor = isChangedMajor(oldMajor, newMajor);
 
-        student.updateStudentAcademicInfo(newStudentNumber, newStudentDepartment, newMajor);
+        student.updateStudentAcademicInfo(newStudentNumber, newDepartment, newMajor);
 
         /**
          * 해당 API에서는 Major를 수정할 수 있음 (여기서 그대로는 null이 아닌 경우)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1302 

# 🚀 작업 내용

1. 학생 학적 정보 수정(`/user/student/academic-info`) 문제 해결 했습니다.
- 학번 / 학부 / 전공 수정시 생기는 오류들을 해결했습니다.
- department 수정시 major도 바뀌기 때문에, major를 입력하지 않고 department를 수정하는 경우에는 가장 위에 있는 major를 선택하도록 했습니다.
2. 학생 정보 조회(학적 포함) API 작성했습니다. (GET `/user/student/me/academic-info`)
- 기본 Response 수정 시 클라이언트 오류 발생 위험이 있어, 학적 정보를 포함한 API를 추가로 작성했습니다.

# 💬 리뷰 중점사항
생각보다 오래 걸렸네요.. 문제 있으면 말해주세여