### PR TITLE
fix : 분실물 게시판 2차 QA 이슈 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -44,7 +44,8 @@ import lombok.NoArgsConstructor;
 public class Article extends BaseEntity {
 
     private static final String ADMIN_NOTICE_AUTHOR = "BCSD Lab";
-    private static final String UNKNOWN_AUTHOR = "탈퇴한 사용자";
+    private static final String DELETED_USER = "탈퇴한 사용자";
+    private static final String ANONYMOUS_USER = "익명";
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -124,19 +125,19 @@ public class Article extends BaseEntity {
             return;
         }
         if (koinArticle != null) {
-            author = (koinArticle.getUser() != null) ? koinArticle.getUser().getName() : UNKNOWN_AUTHOR;
+            author = (koinArticle.getUser() != null) ? koinArticle.getUser().getName() : DELETED_USER;
             return;
         }
         if (koreatechArticle != null) {
-            author = (koreatechArticle.getAuthor() != null) ? koreatechArticle.getAuthor() : UNKNOWN_AUTHOR;
+            author = (koreatechArticle.getAuthor() != null) ? koreatechArticle.getAuthor() : DELETED_USER;
             return;
         }
         if (lostItemArticle != null) {
             User user = lostItemArticle.getAuthor();
-            author = (user != null && user.getNickname() != null) ? user.getNickname() : UNKNOWN_AUTHOR;
+            author = (user != null && user.getNickname() != null) ? user.getNickname() : ANONYMOUS_USER;
             return;
         }
-        author = UNKNOWN_AUTHOR;
+        author = DELETED_USER;
     }
 
     public void setAuthor(String author) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -351,7 +351,7 @@ public class ArticleService {
             newArticles.add(lostItemArticle);
         }
 
-        sendKeywordNotification(newArticles);
+        sendKeywordNotification(newArticles, userId);
         return LostItemArticleResponse.of(newArticles.get(0), true);
     }
 
@@ -390,8 +390,8 @@ public class ArticleService {
         return boardRepository.getById(boardId);
     }
 
-    private void sendKeywordNotification(List<Article> articles) {
-        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles);
+    private void sendKeywordNotification(List<Article> articles, Integer authorId) {
+        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, authorId);
         if (!keywordEvents.isEmpty()) {
             for (ArticleKeywordEvent event : keywordEvents) {
                 eventPublisher.publishEvent(event);

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEvent.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.community.keyword.model;
 
 public record ArticleKeywordEvent(
     Integer articleId,
+    Integer authorId,
     ArticleKeyword keyword
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordEventListener.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.global.fcm.MobileAppPath.KEYWORD;
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -46,6 +47,7 @@ public class ArticleKeywordEventListener {
             .filter(this::hasDeviceToken)
             .filter(subscribe -> isKeywordRegistered(event, subscribe))
             .filter(subscribe -> isNewArticle(event, subscribe))
+            .filter(subscribe -> !isMyArticle(event, subscribe))
             .map(subscribe -> createAndRecordNotification(article, board, event.keyword(), subscribe))
             .toList();
 
@@ -67,6 +69,12 @@ public class ArticleKeywordEventListener {
             .findLastNotifiedArticleIdByUserId(userId)
             .orElse(0);
         return !lastNotifiedId.equals(event.articleId());
+    }
+
+    private boolean isMyArticle(ArticleKeywordEvent event, NotificationSubscribe subscribe) {
+        Integer authorId = event.authorId();
+        Integer subscriberId = subscribe.getUser().getId();
+        return Objects.equals(authorId, subscriberId);
     }
 
     private Notification createAndRecordNotification(

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -124,7 +124,7 @@ public class KeywordService {
                 articles.add(articleRepository.getById(id));
             }
 
-            List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles);
+            List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, null);
 
             if (!keywordEvents.isEmpty()) {
                 for (ArticleKeywordEvent event : keywordEvents) {

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -23,7 +23,7 @@ public class KeywordExtractor {
 
     private final ArticleKeywordRepository articleKeywordRepository;
 
-    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles) {
+    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
         List<ArticleKeywordEvent> keywordEvents = new ArrayList<>();
         int offset = 0;
 
@@ -39,7 +39,7 @@ public class KeywordExtractor {
                 String title = article.getTitle();
                 for (ArticleKeyword keyword : keywords) {
                     if (title.contains(keyword.getKeyword())) {
-                        keywordEvents.add(new ArticleKeywordEvent(article.getId(), keyword));
+                        keywordEvents.add(new ArticleKeywordEvent(article.getId(), authorId, keyword));
                     }
                 }
             }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. user의 nickname이 없을 경우 '익명'으로 표시되도록 수정했습니다.
2. 내 게시글의 경우 키워드 알림이 오지 않도록 수정했습니다.

# 💬 리뷰 중점사항
