### PR TITLE
feat : 학생이 이수한 모든 수업 조회 / 엑셀로 추가한 수업 출력 오류 / 교양선택 매핑해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -178,7 +178,7 @@ public class GraduationService {
                 years.add(data.year());
             }
 
-            Map<String, Lecture> lectureMap = loadLectures(semesters, lectureCodes);
+            Map<String, List<Lecture>> lectureMap = loadLectures(semesters, lectureCodes);
             Map<String, Catalog> catalogByNameMap = loadCatalogByLectureName(lectureNames, studentYear);
             Map<String, Catalog> catalogByCodeMap = loadCatalogByCode(lectureCodes, years);
             /*
@@ -195,7 +195,10 @@ public class GraduationService {
                 }
 
                 String semester = getKoinSemester(data.semester(), data.year());
-                Lecture lecture = lectureMap.get(semester + "_" + data.code());
+
+                List<Lecture> lectures = lectureMap.get(semester + "_" + data.code());
+                Lecture lecture = findBestMatchingLecture(lectures, data.lectureClass());
+
                 CatalogResult catalogResult = findCourseType(lecture, data, studentYear, catalogByNameMap,
                     catalogByCodeMap);
                 CourseType courseType = catalogResult.courseType();
@@ -211,11 +214,21 @@ public class GraduationService {
         }
     }
 
-    // _를 넣은 이유는, 각각의 고유한 key 값을 갖게 하기 위해서(문제가 자주 생기길래..)
-    private Map<String, Lecture> loadLectures(Set<String> semesters, Set<String> lectureCodes) {
+    // 분반 문제를 해결하기 위해서, 강의들을 전부 가져오도록 했음
+    private Map<String, List<Lecture>> loadLectures(Set<String> semesters, Set<String> lectureCodes) {
         return lectureRepositoryV2.findAllBySemesterInAndCodeIn(semesters, lectureCodes)
-            .stream().collect(Collectors.toMap(l -> l.getSemester() + "_" + l.getCode(), Function.identity(),
-                (existing, duplicate) -> duplicate));
+            .stream().collect(Collectors.groupingBy(l -> l.getSemester() + "_" + l.getCode()));
+    }
+
+    private Lecture findBestMatchingLecture(List<Lecture> lectures, String lectureClass) {
+        if (lectures == null || lectures.isEmpty())
+            return null;
+        for (Lecture lecture : lectures) {
+            if (lecture.getLectureClass().equals(lectureClass)) {
+                return lecture;
+            }
+        }
+        return lectures.get(0);
     }
 
     // 1차 탐색 요소, 학번의 연도와 수업 이름으로 카탈로그를 가져옴
@@ -363,7 +376,8 @@ public class GraduationService {
     }
 
     private GraduationCourseCalculationResponse getExistingGraduationCalculation(Integer userId) {
-        List<StudentCourseCalculation> existingCalculations = studentCourseCalculationRepository.findAllByUserId(userId);
+        List<StudentCourseCalculation> existingCalculations = studentCourseCalculationRepository.findAllByUserId(
+            userId);
 
         List<GraduationCourseCalculationResponse.InnerCalculationResponse> courseTypes = existingCalculations.stream()
             .map(calc -> {
@@ -446,7 +460,8 @@ public class GraduationService {
         return courseTypeCreditsMap;
     }
 
-    private List<StandardGraduationRequirements> getGraduationRequirements(List<Catalog> catalogList, String studentYear) {
+    private List<StandardGraduationRequirements> getGraduationRequirements(List<Catalog> catalogList,
+        String studentYear) {
         return catalogList.stream()
             .map(catalog -> {
                 if (catalog.getMajor() == null) {

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -120,8 +120,7 @@ public class GraduationService {
 
     @Transactional
     public GraduationCourseCalculationResponse getGraduationCourseCalculationResponse(Integer userId) {
-        DetectGraduationCalculation detectGraduationCalculation = detectGraduationCalculationRepository.findByUserId(
-                userId)
+        DetectGraduationCalculation detectGraduationCalculation = detectGraduationCalculationRepository.findByUserId(userId)
             .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 GraduationCalculation 정보가 존재하지 않습니다."));
 
         if (!detectGraduationCalculation.isChanged()) {

--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -120,7 +120,8 @@ public class GraduationService {
 
     @Transactional
     public GraduationCourseCalculationResponse getGraduationCourseCalculationResponse(Integer userId) {
-        DetectGraduationCalculation detectGraduationCalculation = detectGraduationCalculationRepository.findByUserId(userId)
+        DetectGraduationCalculation detectGraduationCalculation = detectGraduationCalculationRepository.findByUserId(
+                userId)
             .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 GraduationCalculation 정보가 존재하지 않습니다."));
 
         if (!detectGraduationCalculation.isChanged()) {
@@ -324,8 +325,8 @@ public class GraduationService {
 
     private boolean skipRow(GradeExcelData gradeExcelData) {
         return gradeExcelData.classTitle().equals(MIDDLE_TOTAL) ||
-            gradeExcelData.retakeStatus().equals(RETAKE) ||
-            gradeExcelData.grade().equals(UNSATISFACTORY);
+               gradeExcelData.retakeStatus().equals(RETAKE) ||
+               gradeExcelData.grade().equals(UNSATISFACTORY);
     }
 
     private String getKoinSemester(String semester, String year) {
@@ -528,13 +529,20 @@ public class GraduationService {
         List<Catalog> catalogs = catalogRepository.getAllByCourseTypeId(courseType.getId());
 
         if (generalEducationAreaName != null) {
-            GeneralEducationArea generalEducationArea =
-                generalEducationAreaRepository.getGeneralEducationAreaByName(generalEducationAreaName);
+            if (generalEducationAreaName.equals("교양선택")) {
+                catalogs = catalogs.stream()
+                    .filter(catalog -> catalog.getGeneralEducationArea() == null)
+                    .toList();
+            } else {
+                GeneralEducationArea generalEducationArea =
+                    generalEducationAreaRepository.getGeneralEducationAreaByName(generalEducationAreaName);
 
-            catalogs = catalogs.stream()
-                .filter(catalog -> catalog.getGeneralEducationArea() != null
-                    && catalog.getGeneralEducationArea().getId().equals(generalEducationArea.getId()))
-                .toList();
+                catalogs = catalogs.stream()
+                    .filter(catalog -> catalog.getGeneralEducationArea() != null && catalog.getGeneralEducationArea()
+                        .getId()
+                        .equals(generalEducationArea.getId()))
+                    .toList();
+            }
         }
 
         List<String> codes = catalogs.stream().map(Catalog::getCode).toList();

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureApiV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureApiV3.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.timetableV3.dto.response.TakeAllTimetableLectureResponse;
 import in.koreatech.koin.domain.timetableV3.dto.response.TimetableLectureResponseV3;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +37,21 @@ public interface TimetableLectureApiV3 {
     @GetMapping("/v3/timetables/lecture")
     ResponseEntity<TimetableLectureResponseV3> getTimetableLecture(
         @RequestParam(value = "timetable_frame_id") Integer timetableFrameId,
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+        }
+    )
+    @Operation(summary = "수강한 강의 정보 전체 조회")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @GetMapping("/v3/timetables/main/lectures")
+    ResponseEntity<TakeAllTimetableLectureResponse> getTakeAllTimetableLectures(
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
@@ -36,7 +36,7 @@ public class TimetableLectureControllerV3 implements TimetableLectureApiV3 {
     public ResponseEntity<TakeAllTimetableLectureResponse> getTakeAllTimetableLectures(
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
-        TakeAllTimetableLectureResponse response = lectureServiceV3.getAllTakeTimetableLecture(userId);
+        TakeAllTimetableLectureResponse response = lectureServiceV3.getTakeAllTimetableLectures(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/controller/TimetableLectureControllerV3.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.timetableV3.dto.response.TakeAllTimetableLectureResponse;
 import in.koreatech.koin.domain.timetableV3.dto.response.TimetableLectureResponseV3;
 import in.koreatech.koin.domain.timetableV3.service.TimetableLectureServiceV3;
 import in.koreatech.koin.global.auth.Auth;
@@ -28,6 +29,14 @@ public class TimetableLectureControllerV3 implements TimetableLectureApiV3 {
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         TimetableLectureResponseV3 response = lectureServiceV3.getTimetableLecture(timetableFrameId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/v3/timetables/main/lectures")
+    public ResponseEntity<TakeAllTimetableLectureResponse> getTakeAllTimetableLectures(
+        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
+    ) {
+        TakeAllTimetableLectureResponse response = lectureServiceV3.getAllTakeTimetableLecture(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/TakeAllTimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/TakeAllTimetableLectureResponse.java
@@ -1,0 +1,144 @@
+package in.koreatech.koin.domain.timetableV3.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.timetable.model.Lecture;
+import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
+import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record TakeAllTimetableLectureResponse(
+    @Schema(description = "시간표 프레임 강의 정보")
+    List<TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3> timetable
+) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerTimetableLectureResponseV3(
+        @Schema(description = "시간표 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "강의 id", example = "1", requiredMode = NOT_REQUIRED)
+        Integer lectureId,
+
+        @Schema(description = "수강 정원", example = "38", requiredMode = NOT_REQUIRED)
+        String regularNumber,
+
+        @Schema(description = "과목 코드", example = "ARB244", requiredMode = NOT_REQUIRED)
+        String code,
+
+        @Schema(description = "설계 학점", example = "0", requiredMode = NOT_REQUIRED)
+        String designScore,
+
+        @Schema(description = "강의 정보", requiredMode = NOT_REQUIRED)
+        List<LectureInfoResponse> lectureInfos,
+
+        @Schema(description = "메모", example = "null", requiredMode = NOT_REQUIRED)
+        String memo,
+
+        @Schema(description = "학점", example = "3", requiredMode = REQUIRED)
+        String grades,
+
+        @Schema(description = "강의(커스텀) 이름", example = "한국사", requiredMode = REQUIRED)
+        String classTitle,
+
+        @Schema(description = "분반", example = "01", requiredMode = NOT_REQUIRED)
+        String lectureClass,
+
+        @Schema(description = "대상", example = "디자 1 건축", requiredMode = NOT_REQUIRED)
+        String target,
+
+        @Schema(description = "강의 교수", example = "이돈우", requiredMode = NOT_REQUIRED)
+        String professor,
+
+        @Schema(description = "학부", example = "디자인ㆍ건축공학부", requiredMode = NOT_REQUIRED)
+        String department,
+
+        @Schema(description = "이수구분", example = "전공필수", requiredMode = NOT_REQUIRED)
+        String courseType,
+
+        @Schema(description = "교양영역", example = "", requiredMode = NOT_REQUIRED)
+        String generalEducationArea
+    ) {
+        public static List<TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3> from(
+            List<TimetableLecture> timetableLectures) {
+            List<TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3> InnerTimetableLectureResponses = new ArrayList<>();
+
+            for (TimetableLecture timetableLecture : timetableLectures) {
+                Lecture lecture = timetableLecture.getLecture();
+                TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3 responseV3;
+
+                if (lecture == null) {
+                    responseV3 = new TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3(
+                        timetableLecture.getId(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        LectureInfoResponse.getCustomLectureInfo(timetableLecture.getClassTime(),
+                            timetableLecture.getClassPlace()),
+                        timetableLecture.getMemo(),
+                        timetableLecture.getGrades(),
+                        timetableLecture.getClassTitle(),
+                        null,
+                        null,
+                        timetableLecture.getProfessor(),
+                        null,
+                        getCourseType(timetableLecture),
+                        getGeneralEducationArea(timetableLecture)
+                    );
+                } else {
+                    responseV3 = new TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3(
+                        timetableLecture.getId(),
+                        lecture.getId(),
+                        lecture.getRegularNumber(),
+                        lecture.getCode(),
+                        lecture.getDesignScore(),
+                        LectureInfoResponse.getRegularLectureInfo(
+                            firstNonNull(timetableLecture.getClassTime(), lecture.getClassTime()),
+                            timetableLecture.getClassPlace()),
+                        timetableLecture.getMemo(),
+                        lecture.getGrades(),
+                        lecture.getName(),
+                        lecture.getLectureClass(),
+                        lecture.getTarget(),
+                        firstNonNull(timetableLecture.getProfessor(),lecture.getProfessor()),
+                        lecture.getDepartment(),
+                        getCourseType(timetableLecture),
+                        getGeneralEducationArea(timetableLecture)
+                    );
+                }
+                InnerTimetableLectureResponses.add(responseV3);
+            }
+            return InnerTimetableLectureResponses;
+        }
+
+        private static String getCourseType(TimetableLecture timetableLecture) {
+            if (Objects.isNull(timetableLecture.getCourseType())) {
+                return "이수구분선택";
+            }
+            return timetableLecture.getCourseType().getName();
+        }
+
+        private static String getGeneralEducationArea(TimetableLecture timetableLecture) {
+            if (timetableLecture.getGeneralEducationArea() == null) {
+                return "";
+            }
+            return timetableLecture.getGeneralEducationArea().getName();
+        }
+
+        public static TakeAllTimetableLectureResponse of(TimetableFrame frame) {
+            return new TakeAllTimetableLectureResponse(
+                TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3.from(frame.getTimetableLectures())
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/TimetableLectureResponseV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/TimetableLectureResponseV3.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.timetableV3.dto.response;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -109,14 +110,15 @@ public record TimetableLectureResponseV3(
                         lecture.getRegularNumber(),
                         lecture.getCode(),
                         lecture.getDesignScore(),
-                        LectureInfoResponse.getRegularLectureInfo(lecture.getClassTime(),
+                        LectureInfoResponse.getRegularLectureInfo(
+                            firstNonNull(timetableLecture.getClassTime(), lecture.getClassTime()),
                             timetableLecture.getClassPlace()),
                         timetableLecture.getMemo(),
                         lecture.getGrades(),
-                        timetableLecture.getClassTitle() == null ? lecture.getName() : timetableLecture.getClassTitle(),
+                        lecture.getName(),
                         lecture.getLectureClass(),
                         lecture.getTarget(),
-                        lecture.getProfessor(),
+                        firstNonNull(timetableLecture.getProfessor(),lecture.getProfessor()),
                         lecture.getDepartment(),
                         getCourseType(timetableLecture),
                         getGeneralEducationArea(timetableLecture)

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/repository/TimetableFrameRepositoryV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/repository/TimetableFrameRepositoryV3.java
@@ -24,6 +24,8 @@ public interface TimetableFrameRepositoryV3 extends Repository<TimetableFrame, I
 
     List<TimetableFrame> findByUserIdAndIsMainTrue(Integer userId);
 
+    List<TimetableFrame> findAllByUserIdAndIsMainTrue(Integer userId);
+
     @Query(value = "SELECT * FROM timetable_frame WHERE id = :id", nativeQuery = true)
     Optional<TimetableFrame> findByIdWithDeleted(@Param("id") Integer id);
 

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/service/TimetableLectureServiceV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/service/TimetableLectureServiceV3.java
@@ -44,7 +44,7 @@ public class TimetableLectureServiceV3 {
         return TimetableLectureResponseV3.of(timetableFrame, grades, totalGrades);
     }
 
-    public TakeAllTimetableLectureResponse getAllTakeTimetableLecture(Integer userId) {
+    public TakeAllTimetableLectureResponse getTakeAllTimetableLectures(Integer userId) {
         List<TimetableFrame> frames = timetableFrameRepositoryV3.findAllByUserIdAndIsMainTrue(userId);
 
         List<TimetableLecture> collectedLectures = frames.stream()

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/service/TimetableLectureServiceV3.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/service/TimetableLectureServiceV3.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.timetableV2.model.TimetableFrame;
 import in.koreatech.koin.domain.timetableV2.model.TimetableLecture;
+import in.koreatech.koin.domain.timetableV3.dto.response.TakeAllTimetableLectureResponse;
 import in.koreatech.koin.domain.timetableV3.dto.response.TimetableLectureResponseV3;
 import in.koreatech.koin.domain.timetableV3.repository.TimetableFrameRepositoryV3;
 import in.koreatech.koin.domain.timetableV3.repository.TimetableLectureRepositoryV3;
@@ -41,6 +42,18 @@ public class TimetableLectureServiceV3 {
         int grades = calculateGradesMainFrame(timetableFrame);
         int totalGrades = calculateTotalGrades(timetableFrameRepositoryV3.findByUserIdAndIsMainTrue(userId));
         return TimetableLectureResponseV3.of(timetableFrame, grades, totalGrades);
+    }
+
+    public TakeAllTimetableLectureResponse getAllTakeTimetableLecture(Integer userId) {
+        List<TimetableFrame> frames = timetableFrameRepositoryV3.findAllByUserIdAndIsMainTrue(userId);
+
+        List<TimetableLecture> collectedLectures = frames.stream()
+            .flatMap(frame -> frame.getTimetableLectures().stream())
+            .toList();
+
+        return new TakeAllTimetableLectureResponse(
+            TakeAllTimetableLectureResponse.InnerTimetableLectureResponseV3.from(collectedLectures)
+        );
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1308 

# 🚀 작업 내용
### 작업 한 번에 처리한 점 죄송합니다. 한 번에 몰려온 작업이라 한 PR 내에 처리했습니다.
1. 학생이 이수한 모든 수업 조회 API 추가했습니다. (**GET** `/v3/timetables/main/lectures`)
- `timetableFrame` - `isMain(true)`인 학생의 모든 수업을 조회합니다.

2. 엑셀로 추가한 수업 출력 오류 문제 해결했습니다.
- 기존엔 `Lecture`에서 코드가 같은 수업 중, 마지막으로 반환받는 강의만을 가져왔습니다. -> 이 과정에서 분반과 시간이 안 맞는 문제가 생겼습니다. (01분반을 수강했으나, 04분반을 수강했다고 함)
- `Lecture`를 가져오는 과정에서, 모든 `Lecture`를 가져오고 추후 분반으로 이를 가져와 학생의 수업에 맞는 수업을 가져오게 하였습니다. 분반을 찾지 못한 경우에는 첫 번째 `Lecture`를 가져옵니다.

3. 교양선택 - 교양선택 매핑 문제 해결했습니다.
- 현재 가지고 있는 교양선택에는 다양한 선택지가 있습니다.(`general_education_area`)
- 이 과정에서 `general_education_area`를 가진 수업들은, `course_type`이 "교양선택"으로 매핑되며 교양선택 - 자연과 인간처럼 선택할 수 있습니다.
- 그냥 교양선택인 수업들은 `general_education_area`가 `null`이므로, 이를 처리하기 위해 "교양선택" - "교양선택" 입력시 `general_education_area_id`가 `null`인 수업들을 출력하도록 했습니다.
- 그대로 교양선택만 입력하면, `course_type`이 "교양선택"인 수업들이 모두 출력됩니다.

# 💬 리뷰 중점사항
로컬 문제 생겨서 작업 조금 늦었습니다. QA 전 확인이 필요해서, 빠른 리뷰 감사하겠습니다.