### PR TITLE
fix: handleHttpMessageNotReadable 메서드 오버라이딩을 통해 int overflow 에러 핸들링

### DIFF
--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -175,6 +176,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn("클라이언트가 연결을 중단했습니다: " + e.getMessage());
         requestLogging(request);
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "클라이언트에 의해 연결이 중단되었습니다");
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        log.warn(ex.getMessage());
+        requestLogging(((ServletWebRequest)request).getRequest());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "잘못된 입력 형식이거나, 값이 허용된 범위를 초과했습니다.");
     }
 
     @Override

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.Nullable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -180,12 +181,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
-        HttpMessageNotReadableException ex,
+        HttpMessageNotReadableException e,
         HttpHeaders headers,
         HttpStatusCode status,
         WebRequest request
     ) {
-        log.warn(ex.getMessage());
+        log.warn(e.getMessage());
         requestLogging(((ServletWebRequest)request).getRequest());
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "잘못된 입력 형식이거나, 값이 허용된 범위를 초과했습니다.");
     }
@@ -197,7 +198,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpStatusCode status,
         WebRequest request
     ) {
-        log.warn("유효하지 않은 API 경로입니다. " + e.getRequestURL());
+        log.warn("유효하지 않은 API 경로입니다. {}", e.getRequestURL());
         requestLogging(((ServletWebRequest)request).getRequest());
         return buildErrorResponse(HttpStatus.NOT_FOUND, "유효하지 않은 API 경로입니다.");
     }
@@ -224,7 +225,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String detail = String.format("""
                 Exception: *%s*
                 Location: *%s Line %d*
-                                
+                
                 ```%s```
                 """,
             errorName, errorFile, errorLine, errorMessage);
@@ -238,15 +239,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
-        MethodArgumentNotValidException ex,
+        MethodArgumentNotValidException e,
         HttpHeaders headers,
         HttpStatusCode status,
         WebRequest webRequest
     ) {
         HttpServletRequest request = ((ServletWebRequest)webRequest).getRequest();
-        log.warn("검증과정에서 문제가 발생했습니다. uri: {} {}, ", request.getMethod(), request.getRequestURI(), ex);
+        log.warn("검증과정에서 문제가 발생했습니다. uri: {} {}, ", request.getMethod(), request.getRequestURI(), e);
         requestLogging(request);
-        String errorMessages = ex.getBindingResult().getAllErrors().stream()
+        String errorMessages = e.getBindingResult().getAllErrors().stream()
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .collect(Collectors.joining(", "));
         return buildErrorResponse(HttpStatus.BAD_REQUEST, errorMessages);
@@ -255,13 +256,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 예외 메시지 구성 로직
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
-        Exception ex,
-        Object body,
+        Exception e,
+        @Nullable Object body,
         HttpHeaders headers,
         HttpStatusCode statusCode,
         WebRequest request
     ) {
-        return buildErrorResponse(HttpStatus.valueOf(statusCode.value()), ex.getMessage());
+        return buildErrorResponse(HttpStatus.valueOf(statusCode.value()), e.getMessage());
     }
 
     private ResponseEntity<Object> buildErrorResponse(

--- a/src/main/java/in/koreatech/koin/global/exception/package-info.java
+++ b/src/main/java/in/koreatech/koin/global/exception/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package in.koreatech.koin.global.exception;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1310 

# 🚀 작업 내용

## 숫자 범위 초과 (Overflow) 문제 발생

Java의 Integer 타입은 32비트 정수를 나타내며, 표현 가능한 범위는 -2,147,483,648 ~ 2,147,483,647
입력된 값 1232132132131231231은 이 범위를 초과하여 역직렬화(Deserialization) 중 오류가 발생
JSON 데이터에서 Integer 타입으로 매핑 시, 숫자가 너무 커서 overflow가 발생하여 역직렬화에 실패

### 해결방안
~1. `Integer` 대신 `Long, BigInteger, String` 사용을 고민했으나, 이보다 큰 숫자가 들어올 가능성 + 매번 정수값 처리 방식 필요.~
~2. `@Max` 과 같은 어노테이션은 JSON 역직렬화 시점에는 적용되지 않음.~

**3. GlobalExceptionHandler에 handleHttpMessageNotReadable 메서드 오버라이딩을 통해 적절하게 에러를 핸들링하도록 구현.**
   


## GlobalExceptionHandler에 23개의 경고메세지 발생

`Not annotated parameter overrides @NonNullApi parameter` 다수의 경고메세지 발생
부모 클래스에서 @NonNullApi로 인해 non-null로 간주되는 파라미터를 오버라이드할 때, 자식 메서드에 명시적 null 어노테이션이 없어 발생하는 경고

`package-info.java`는 해당 패키지의 문서화와 패키지 수준의 어노테이션을 선언하는 특수한 파일
`@NonNullApi`와 `@NonNullFields`를 붙이면, 해당 패키지 내의 모든 클래스에서 기본적으로 파라미터와 리턴값이 `non-null`로 간주됨
코드 일관성과 null 안전성이 향상되어 불필요한 어노테이션 반복을 줄이기 위해 사용함


+) 메게변수 이름 통일, 공백 제거

# 💬 리뷰 중점사항

메세지가 적절한지 체크 부탁드립니다.