### PR TITLE
fix: 분실물 게시글 조회 시 is_deleted 미적용 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.domain.shop.model.review.ReportStatus;
 import in.koreatech.koin.domain.user.model.User;
@@ -33,6 +34,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Where(clause = "is_deleted=0")
 @Table(name = "lost_item_articles", schema = "koin")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LostItemArticle extends BaseEntity {
@@ -74,6 +76,7 @@ public class LostItemArticle extends BaseEntity {
     private Boolean isCouncil = false;
 
     @NotNull
+    @ColumnDefault("0")
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -45,8 +45,8 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     }
 
     @Query(
-        value = "SELECT a.* FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type",
-        countQuery = "SELECT COUNT(*) FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type",
+        value = "SELECT a.* FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type AND a.is_deleted = 0",
+        countQuery = "SELECT COUNT(*) FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type AND a.is_deleted = 0",
         nativeQuery = true
     )
     Page<Article> findAllByLostItemArticleType(@Param("type") String type, PageRequest pageRequest);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 분실물 게시글 조회 시 is_deleted=1(삭제된 게시글)도 함께 조회되는 버그를 수정했습니다.
    - type이 있는 경우 네이티브 쿼리를 통해 조회하는데, 이 때 @Where(is_deleted=0) 어노테이션이 동작하지 않아 발생했습니다.

# 💬 리뷰 중점사항
