### PR TITLE
fix : 정규 강의 수정 lecture NPE 문제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/model/TimetableLecture.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.domain.timetableV2.model;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.Optional;
+
 import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.domain.graduation.model.CourseType;
@@ -140,7 +142,11 @@ public class TimetableLecture extends BaseEntity {
 
     public void updateRegularLecture(String classTitle, String classPlace, CourseType courseType,
         GeneralEducationArea generalEducationArea) {
-        if (!lecture.getName().equals(classTitle)) {
+        String newClassTitle = Optional.ofNullable(lecture)
+            .map(Lecture::getName)
+            .orElse(this.classTitle);
+
+        if (!newClassTitle.equals(classTitle)) {
             this.classTitle = classTitle;
         }
         this.classPlace = classPlace;

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableRegularLectureUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/request/TimetableRegularLectureUpdateRequest.java
@@ -31,8 +31,7 @@ public record TimetableRegularLectureUpdateRequest(
         @NotNull(message = "시간표 id를 입력해주세요.")
         Integer id,
 
-        @Schema(description = "강의 id", example = "3015", requiredMode = REQUIRED)
-        @NotNull(message = "강의 id를 입력해주세요.")
+        @Schema(description = "강의 id", example = "3015", requiredMode = NOT_REQUIRED)
         Integer lectureId,
 
         @Schema(description = "정규 강의 이름", example = "정규 강의 이름", requiredMode = NOT_REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1330 

# 🚀 작업 내용

1. 정규 강의 수정시, lecture_id가 null인 경우 NPE가 발생하는 문제를 해결했습니다.
- lecture_id가 null이면 lecture.getName()을 가져오지 못하므로, 기존 classTitle을 사용하도록 했습니다.

# 💬 리뷰 중점사항
잘 부탁드립니당