### PR TITLE
fix: 졸학계 계산 테이블 초기화 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -110,14 +110,16 @@ public class GraduationService {
     @Transactional
     public void resetStudentCourseCalculation(Student student, Major newMajor) {
         // 기존 학생 졸업요건 계산 정보 삭제
-        studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
+        if(!studentCourseCalculationRepository.findAllByUserId(student.getUser().getId()).isEmpty()) {
+            studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
 
-        initializeStudentCourseCalculation(student, newMajor);
+            initializeStudentCourseCalculation(student, newMajor);
 
-        detectGraduationCalculationRepository.findByUserId(student.getUser().getId())
-            .ifPresent(detectGraduationCalculation -> {
-                detectGraduationCalculation.updatedIsChanged(true);
-            });
+            detectGraduationCalculationRepository.findByUserId(student.getUser().getId())
+                .ifPresent(detectGraduationCalculation -> {
+                    detectGraduationCalculation.updatedIsChanged(true);
+                });
+        }
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1333

# 🚀 작업 내용

현재 agree api를 사용하지 않은상태에서 학생 정보를 수정했을때, 계산테이블의 정보만 초기화되고 detect테이블의 정보는 초기화가 되지 않아 추후 agree api를 사용할때 문제가 발생합니다.

그래서 학생 정보를 수정할때 데이터가 이미 존재하는지 확인 후 계산테이블의 정보 초기화시킬수 있도록 수정했습니다.

# 💬 리뷰 중점사항
