### PR TITLE
fix: 졸학계 계산 테이블 유니크 제약조건 추가

### DIFF
--- a/src/main/resources/db/migration/V136__alter_graduation_calculation_unique_cascade.sql
+++ b/src/main/resources/db/migration/V136__alter_graduation_calculation_unique_cascade.sql
@@ -1,0 +1,5 @@
+ALTER TABLE student_course_calculation
+    ADD CONSTRAINT unique_user_standard_graduation_requirements UNIQUE (user_id, standard_graduation_requirements_id);
+
+ALTER TABLE detect_graduation_calculation
+    ADD CONSTRAINT unique_user UNIQUE (user_id);

--- a/src/main/resources/db/migration/V136__alter_user_and_standard_graduation_requirements_unique_cascade.sql
+++ b/src/main/resources/db/migration/V136__alter_user_and_standard_graduation_requirements_unique_cascade.sql
@@ -1,2 +1,0 @@
-ALTER TABLE student_course_calculation
-    ADD CONSTRAINT unique_user_standard_graduation_requirements UNIQUE (user_id, standard_graduation_requirements_id);

--- a/src/main/resources/db/migration/V136__alter_user_and_standard_graduation_requirements_unique_cascade.sql
+++ b/src/main/resources/db/migration/V136__alter_user_and_standard_graduation_requirements_unique_cascade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE student_course_calculation
+    ADD CONSTRAINT unique_user_standard_graduation_requirements UNIQUE (user_id, standard_graduation_requirements_id);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1335

# 🚀 작업 내용

동시 요청으로 인해 가끔 student_course_calculation과 detect_graduation_calculation에 중복으로 데이터가 들어오는 경우가 존재하기때문에, 중복 데이터를 방지하기 위해 유니크 제약조건을 걸었습니다.

# 💬 리뷰 중점사항
