### PR TITLE
feat: 졸업학점 계산기 변경 감지 aop 포인트 컷 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/aop/GraduationAspect.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/aop/GraduationAspect.java
@@ -26,9 +26,13 @@ public class GraduationAspect {
         "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.createTimetableLecture(..)) || " +
         "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.updateTimetableLecture(..)) || " +
         "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.deleteTimetableLecture(..)) || " +
+        "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.deleteTimetableLectures(..)) || " +
+        "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.deleteTimetableLectureByFrameId(..)) ||" +
+        "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.deleteAllTimetablesFrame(..)) || " +
         "execution(* in.koreatech.koin.domain.timetableV2.controller.TimetableControllerV2.deleteTimetablesFrame(..)) ||" +
         "execution(* in.koreatech.koin.domain.timetableV3.controller.TimetableRegularLectureControllerV3.createTimetablesRegularLecture(..)) || " +
-        "execution(* in.koreatech.koin.domain.timetableV3.controller.TimetableRegularLectureControllerV3.updateTimetablesRegularLecture(..))",
+        "execution(* in.koreatech.koin.domain.timetableV3.controller.TimetableRegularLectureControllerV3.updateTimetablesRegularLecture(..)) || " +
+        "execution(* in.koreatech.koin.domain.graduation.controller.GraduationController.uploadStudentGradeExcelFile(..))",
     returning = "result")
     public void afterTimetableLecture(JoinPoint joinPoint, Object result) {
         Integer userId = authContext.getUserId();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1341 

# 🚀 작업 내용

- 변경 감지 aop의 포인트 컷을 추가했습니다.
  - timetableFrame을 모두 삭제하는 api, timetableLecture를 삭제하는 방식이 다른 api를 추가했습니다.
  - 엑셀 업로드 직후, 바로 계산되도록 추가했습니다.

# 💬 리뷰 중점사항
