### PR TITLE
fix : 학적 정보 중복 삽입 문제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -62,6 +62,7 @@ import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.concurrent.ConcurrencyGuard;
 import in.koreatech.koin.global.exception.DuplicationException;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -69,6 +70,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class GraduationService {
 
+    private final EntityManager entityManager;
     private final StudentRepository studentRepository;
     private final StudentCourseCalculationRepository studentCourseCalculationRepository;
     private final StandardGraduationRequirementsRepository standardGraduationRequirementsRepository;
@@ -132,7 +134,8 @@ public class GraduationService {
         // 기존 학생 졸업요건 계산 정보 삭제
         if(!studentCourseCalculationRepository.findAllByUserId(student.getUser().getId()).isEmpty()) {
             studentCourseCalculationRepository.deleteAllByUserId(student.getUser().getId());
-
+            entityManager.flush();
+            entityManager.clear();
             initializeStudentCourseCalculation(student, newMajor);
 
             detectGraduationCalculationRepository.findByUserId(student.getUser().getId())


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1345 

# 🚀 작업 내용

1. 학적 정보를 수정할 경우, 학생이 가지게 되는 기준 학점 테이블 내의 값이 중복 삽입되는 오류를 해결했습니다.
- 오류 값으로 처리해 본 결과, 로컬 내에서는 문제가 발생하지 않았습니다. 스테이지에서는 이러한 오류가 계속 발생하는 것으로 보아, 서버 -> DB 반영하는 과정에서 DELETE가 진행되지 않은 상황에 값이 삽입 됐다고 생각했습니다.
- 그 문제를 해결하기 위해 flush와 clear를 이용하여 즉시 DELETE 쿼리 실행 및 이전 데이터를 참조하지 않도록 했습니다.
<img width="330" alt="image" src="https://github.com/user-attachments/assets/ab66d06d-b6fd-4c60-b22f-637e4f04ac8a" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/f203cb1b-5103-4d09-8de1-9dd945c7f5c6" />


# 💬 리뷰 중점사항
서버가 너무 아파요