### PR TITLE
feat: 회원가입 인증 시 major 지정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/model/redis/StudentTemporaryStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/student/model/redis/StudentTemporaryStatus.java
@@ -1,15 +1,20 @@
 package in.koreatech.koin.domain.student.model.redis;
 
-import in.koreatech.koin.domain.student.model.Department;
-import in.koreatech.koin.domain.student.model.Student;
-import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
-import in.koreatech.koin.domain.user.model.*;
-import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import in.koreatech.koin.domain.student.dto.StudentRegisterRequest;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Major;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserGender;
+import in.koreatech.koin.domain.user.model.UserIdentity;
+import in.koreatech.koin.domain.user.model.UserType;
+import lombok.Getter;
 
 @Getter
 @RedisHash(value = "StudentTemporaryStatus")
@@ -45,7 +50,7 @@ public class StudentTemporaryStatus {
     private Long expiration;
 
     public StudentTemporaryStatus(String email, String authToken, String nickname, String name, String password,
-                                  UserGender gender, boolean isGraduated, String department, String studentNumber, String phoneNumber) {
+        UserGender gender, boolean isGraduated, String department, String studentNumber, String phoneNumber) {
         this.email = email;
         this.authToken = authToken;
         this.nickname = nickname;
@@ -60,30 +65,32 @@ public class StudentTemporaryStatus {
     }
 
     public static StudentTemporaryStatus of(StudentRegisterRequest request, String authToken) {
-        return new StudentTemporaryStatus(request.email(), authToken, request.nickname(), request.name(), request.password(), request.gender(),
-                request.isGraduated(), request.major(), request.studentNumber(), request.phoneNumber());
+        return new StudentTemporaryStatus(request.email(), authToken, request.nickname(), request.name(),
+            request.password(), request.gender(),
+            request.isGraduated(), request.major(), request.studentNumber(), request.phoneNumber());
     }
 
-    public Student toStudent(PasswordEncoder passwordEncoder, Department department) {
+    public Student toStudent(PasswordEncoder passwordEncoder, Department department, Major major) {
         User user = User.builder()
-                .password(passwordEncoder.encode(password))
-                .email(email)
-                .name(name)
-                .nickname(nickname)
-                .gender(gender)
-                .phoneNumber(phoneNumber)
-                .isAuthed(true)
-                .isDeleted(false)
-                .userType(UserType.STUDENT)
-                .build();
+            .password(passwordEncoder.encode(password))
+            .email(email)
+            .name(name)
+            .nickname(nickname)
+            .gender(gender)
+            .phoneNumber(phoneNumber)
+            .isAuthed(true)
+            .isDeleted(false)
+            .userType(UserType.STUDENT)
+            .build();
 
         return Student.builder()
-                .user(user)
-                .anonymousNickname("익명_" + (System.currentTimeMillis()))
-                .isGraduated(isGraduated)
-                .userIdentity(UserIdentity.UNDERGRADUATE)
-                .department(department)
-                .studentNumber(studentNumber)
-                .build();
+            .user(user)
+            .anonymousNickname("익명_" + (System.currentTimeMillis()))
+            .isGraduated(isGraduated)
+            .userIdentity(UserIdentity.UNDERGRADUATE)
+            .department(department)
+            .major(major)
+            .studentNumber(studentNumber)
+            .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -258,7 +258,11 @@ public class StudentService {
         if (studentTemporaryStatus.get().getDepartment() != null) {
             department = departmentRepository.getByName(studentTemporaryStatus.get().getDepartment());
         }
-        Student student = studentTemporaryStatus.get().toStudent(passwordEncoder, department);
+        Major major = null;
+        if (department != null) {
+            major = majorRepository.findByDepartmentId(department.getId()).get(0);
+        }
+        Student student = studentTemporaryStatus.get().toStudent(passwordEncoder, department, major);
         studentRepository.save(student);
         userRepository.save(student.getUser());
         studentRedisRepository.deleteById(student.getUser().getEmail());

--- a/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/StudentApiTest.java
@@ -372,7 +372,7 @@ public class StudentApiTest extends AcceptanceTest {
 
     @Test
     void 이메일_요청을_확인_후_회원가입_이벤트가_발생하고_Redis에_저장된_정보가_삭제된다() throws Exception {
-        departmentFixture.전체학부();
+        majorFixture.컴퓨터공학전공(departmentFixture.컴퓨터공학부());
         mockMvc.perform(
                 post("/user/student/register")
                     .content("""


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1350 

# 🚀 작업 내용

- 회원 가입 시, major를 지정해주는 로직을 추가 했습니다.
  - 인증 api에서 department가 존재할 경우, department와 연관된 major 중 첫 번째를 지정해줍니다.
- 관련 테스트 코드 수정했습니다.

# 💬 리뷰 중점사항
