### PR TITLE
fix: 졸학계 catalog에 해당과목 없어도 계산 할 수 있게 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -247,7 +247,7 @@ public class GraduationService {
                             .credit(bestCatalog.getCredit())
                             .major(bestCatalog.getMajor())
                             .department(bestCatalog.getDepartment())
-                            .courseType(timetableLecture.getCourseType()) // 🎯 학생이 수정한 이수구분 적용
+                            .courseType(timetableLecture.getCourseType())
                             .generalEducationArea(bestCatalog.getGeneralEducationArea())
                             .build();
                     }
@@ -276,7 +276,17 @@ public class GraduationService {
             return catalogs.get(0);
         }
 
-        return null;
+        CourseType defaultCourseType = courseTypeRepository.getByName(DEFAULT_COURSER_TYPE);
+        return Catalog.builder()
+            .year(studentYear)
+            .code("UNKNOWN")
+            .lectureName(lectureName)
+            .credit(0)
+            .major(major)
+            .department(null)
+            .courseType(defaultCourseType)
+            .generalEducationArea(null)
+            .build();
     }
 
     private Map<Integer, Integer> calculateCourseTypeCredits(List<Catalog> catalogList, Student student) {
@@ -297,7 +307,17 @@ public class GraduationService {
                 .orElse(null);
 
             if (matchingCatalog == null) {
-                continue;
+                CourseType defaultCourseType = courseTypeRepository.getByName(DEFAULT_COURSER_TYPE);
+                matchingCatalog = Catalog.builder()
+                    .year(StudentUtil.parseStudentNumberYearAsString(student.getStudentNumber()))
+                    .code("UNKNOWN")
+                    .lectureName(lectureName)
+                    .credit(0)
+                    .major(student.getMajor())
+                    .department(null)
+                    .courseType(defaultCourseType)
+                    .generalEducationArea(null)
+                    .build();
             }
 
             CourseType appliedCourseType = matchingCatalog.getCourseType();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1360

# 🚀 작업 내용

1. 현재 학생이 들은 학점을 계산하는 방식이 학생이 들은 과목을 catalog에서 조회한 후 이수구분을 선택 해서 매핑 하는 형식이였습니다.
2. 따라서 catalog에 없는 과목들, ipp나 k-mooc 같은 경우는 계산에 반영이 되지 않았었습니다. 따라서 해당 과목들도 계산할 수 있게끔 수정하였습니다.

# 💬 리뷰 중점사항
