### PR TITLE
refactor: 배치 체리픽

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/config/RedisConfig.java
+++ b/src/main/java/in/koreatech/koin/_common/config/RedisConfig.java
@@ -2,9 +2,9 @@ package in.koreatech.koin._common.config;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
+import java.util.List;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,10 +15,15 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
@@ -41,10 +46,26 @@ public class RedisConfig {
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        /*
+        1. content-type: text/html
+        2. body는 json
+
+        위 조건일 경우, 파싱이 안되고 UnknownContentTypeException 발생하는 문제 해결하기 위해 text/html도 지원 목록에 추가
+        */
+        MappingJackson2HttpMessageConverter jacksonConverter = new MappingJackson2HttpMessageConverter();
+        jacksonConverter.setSupportedMediaTypes(List.of(
+            MediaType.TEXT_HTML,
+            MediaType.APPLICATION_JSON
+        ));
+
         return restTemplateBuilder.
             requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())).
             setConnectTimeout(Duration.ofMillis(5000))
             .setReadTimeout(Duration.ofMillis(5000))
-            .additionalMessageConverters(new StringHttpMessageConverter(UTF_8)).build();
+            .additionalMessageConverters(
+                jacksonConverter,
+                new StringHttpMessageConverter(UTF_8)
+            )
+            .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteApiResponse.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteApiResponse.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusRouteApiResponse(
+    List<CityBusRouteInfo> resultList
+) {
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusRouteInfo.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusRouteInfo(
+
+    @JsonProperty("ROUTE_ID")
+    Long routeId,
+
+    @JsonProperty("ROUTE_NAME")
+    String routeName,
+
+    @JsonProperty("ROUTE_DIRECTION")
+    String routeDirection,
+
+    @JsonProperty("RELAY_AREACODE")
+    String relayAreaCode,
+
+    @JsonProperty("ROUTE_EXPLAIN")
+    String routeExplain,
+
+    @JsonProperty("ST_STOP_NAME")
+    String stName,
+
+    @JsonProperty("ED_STOP_NAME")
+    String edName
+) {
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusTimetableApiResponse.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/dto/CityBusTimetableApiResponse.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.batch.campus.bus.city.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CityBusTimetableApiResponse(
+    List<InnerRoute> resultList
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record InnerRoute(
+        @JsonProperty("ROUTE_ID")
+        Long routeId
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
@@ -4,8 +4,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class BusInfo {
 
     @Field("number")

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/BusInfo.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BusInfo {
+
+    @Field("number")
+    private final Long number;
+
+    @Field("depart_node")
+    private final String departNode;
+
+    @Field("arrival_node")
+    private final String arrivalNode;
+
+    @Builder
+    private BusInfo(Long number, String departNode, String arrivalNode) {
+        this.number = number;
+        this.departNode = departNode;
+        this.arrivalNode = arrivalNode;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CityBusTimetable {
+
+    @Field("day_of_week")
+    private final String dayOfWeek;
+
+    @Field("depart_info")
+    private final List<String> departInfo;
+
+    @Builder
+    private CityBusTimetable(String dayOfWeek, List<String> departInfo) {
+        this.dayOfWeek = dayOfWeek;
+        this.departInfo = departInfo;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/CityBusTimetable.java
@@ -6,8 +6,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class CityBusTimetable {
 
     @Field("day_of_week")

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
-import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -31,15 +30,14 @@ public class TimetableDocument {
     private final LocalDateTime updatedAt;
 
     @Builder
-    private TimetableDocument(List<CityBusTimetable> busTimetables, CityBusRouteInfo routeInfo,
+    private TimetableDocument(
+        String routeId,
+        List<CityBusTimetable> busTimetables,
+        BusInfo busInfo,
         LocalDateTime updatedAt) {
-        this.routeId = routeInfo.routeId().toString();
+        this.routeId = routeId;
         this.busTimetables = busTimetables;
-        this.busInfo = BusInfo.builder()
-            .number(Long.parseLong(routeInfo.routeName()))
-            .departNode(routeInfo.stName())
-            .arrivalNode(routeInfo.edName())
-            .build();
+        this.busInfo = busInfo;
         this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
@@ -10,8 +10,10 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @Document(collection = "citybus_timetables")
 public class TimetableDocument {
 

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/model/TimetableDocument.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.batch.campus.bus.city.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Document(collection = "citybus_timetables")
+public class TimetableDocument {
+
+    @Id
+    @Field("_id")
+    private final String routeId;
+
+    @Field("bus_info")
+    private final BusInfo busInfo;
+
+    @Field("bus_timetables")
+    private final List<CityBusTimetable> busTimetables;
+
+    @Field("updated_at")
+    private final LocalDateTime updatedAt;
+
+    @Builder
+    private TimetableDocument(List<CityBusTimetable> busTimetables, CityBusRouteInfo routeInfo,
+        LocalDateTime updatedAt) {
+        this.routeId = routeInfo.routeId().toString();
+        this.busTimetables = busTimetables;
+        this.busInfo = BusInfo.builder()
+            .number(Long.parseLong(routeInfo.routeName()))
+            .departNode(routeInfo.stName())
+            .arrivalNode(routeInfo.edName())
+            .build();
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
-import com.mongodb.bulk.BulkWriteResult;
-
 import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
 import lombok.RequiredArgsConstructor;
 
@@ -37,12 +35,6 @@ public class BatchCityBusTimetableRepository {
             bulkOps.upsert(query, update);
         });
 
-        BulkWriteResult result = bulkOps.execute();
-
-        // log.info("Bulk upsert completed - Upserted: {}, Modified: {}, Matched: {}",
-        //     result.getUpserts().size(),
-        //     result.getModifiedCount(),
-        //     result.getMatchedCount()
-        // );
+        bulkOps.execute();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/repository/BatchCityBusTimetableRepository.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.batch.campus.bus.city.repository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import com.mongodb.bulk.BulkWriteResult;
+
+import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BatchCityBusTimetableRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public void saveAll(List<TimetableDocument> timetables) {
+        BulkOperations bulkOps = mongoTemplate.bulkOps(
+            BulkOperations.BulkMode.UNORDERED,
+            TimetableDocument.class
+        );
+
+        timetables.forEach(timetable -> {
+            Query query = Query.query(Criteria.where("_id").is(timetable.getRouteId()));
+
+            Update update = new Update()
+                .set("updatedAt", timetable.getUpdatedAt())
+                .set("busInfo", timetable.getBusInfo())
+                .set("busTimetables", timetable.getBusTimetables());
+
+            bulkOps.upsert(query, update);
+        });
+
+        BulkWriteResult result = bulkOps.execute();
+
+        // log.info("Bulk upsert completed - Upserted: {}, Modified: {}, Matched: {}",
+        //     result.getUpserts().size(),
+        //     result.getModifiedCount(),
+        //     result.getMatchedCount()
+        // );
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -20,6 +20,7 @@ import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteApiResponse;
 import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
 import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse;
 import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse.InnerRoute;
+import in.koreatech.koin.batch.campus.bus.city.model.BusInfo;
 import in.koreatech.koin.batch.campus.bus.city.model.CityBusTimetable;
 import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
 import in.koreatech.koin.batch.campus.bus.city.repository.BatchCityBusTimetableRepository;
@@ -65,6 +66,7 @@ public class BatchCityBusService {
 
     private List<Long> getAvailableBus() {
         return List.of(400L, 402L, 405L);
+        // TODO : 정적으로 반환해주는거 open api로 한기대 오는 버스 번호 조회해서 반환해주기
     }
 
     private List<Long> getRouteIds(Long busNumber) {
@@ -138,8 +140,15 @@ public class BatchCityBusService {
         }
 
         return TimetableDocument.builder()
+            .routeId(cityBusRouteInfo.routeId().toString())
             .busTimetables(timetables)
-            .routeInfo(cityBusRouteInfo)
+            .busInfo(
+                BusInfo.builder()
+                    .number(Long.parseLong(cityBusRouteInfo.routeName()))
+                    .departNode(cityBusRouteInfo.stName())
+                    .arrivalNode(cityBusRouteInfo.edName())
+                    .build()
+            )
             .updatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
             .build();
     }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -40,7 +40,6 @@ public class BatchCityBusService {
 
         batchCityBusTimetableRepository.saveAll(timetables);
 
-        // TODO : Save Timetables using Bulk Write
         // TODO : Remove Duplicate Entities
         // TODO : Change System.out.println to Logger
     }
@@ -118,6 +117,7 @@ public class BatchCityBusService {
                 .get();
 
         } catch (IOException e) {
+            // TODO : Exception 커스텀하기
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -40,26 +40,25 @@ public class BatchCityBusService {
 
         batchCityBusTimetableRepository.saveAll(timetables);
 
-        // TODO : Remove Duplicate Entities
-        // TODO : Change System.out.println to Logger
+        // TODO : Remove Duplicate Entities (CityBusRouteInfo, BusInfo, CityBusTimetable, TimetableDocument, ...)
     }
 
     private List<TimetableDocument> crawling() {
         List<Long> availableBuses = getAvailableBus();
-        System.out.println(availableBuses);
+        log.info(availableBuses.toString());
 
         List<Long> routeIds = availableBuses.stream()
             .flatMap(busNumber -> getRouteIds(busNumber).stream())
             .toList();
-        System.out.println(routeIds);
+        log.info(routeIds.toString());
 
         List<CityBusRouteInfo> routeInfos = routeIds.stream()
             .flatMap(routeId -> getRouteInfo(routeId).stream())
             .toList();
-        System.out.println(routeInfos);
+        log.info(routeInfos.toString());
 
         List<TimetableDocument> timetables = routeInfos.stream().map(this::getTimetable).toList();
-        System.out.println(timetables);
+        timetables.forEach(timetable -> log.info(timetable.toString()));
 
         return timetables;
     }

--- a/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/bus/city/service/BatchCityBusService.java
@@ -1,0 +1,147 @@
+package in.koreatech.koin.batch.campus.bus.city.service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteApiResponse;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusRouteInfo;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse;
+import in.koreatech.koin.batch.campus.bus.city.dto.CityBusTimetableApiResponse.InnerRoute;
+import in.koreatech.koin.batch.campus.bus.city.model.CityBusTimetable;
+import in.koreatech.koin.batch.campus.bus.city.model.TimetableDocument;
+import in.koreatech.koin.batch.campus.bus.city.repository.BatchCityBusTimetableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BatchCityBusService {
+
+    private final RestTemplate restTemplate;
+    private final BatchCityBusTimetableRepository batchCityBusTimetableRepository;
+
+    public void update() {
+        List<TimetableDocument> timetables = crawling();
+
+        batchCityBusTimetableRepository.saveAll(timetables);
+
+        // TODO : Save Timetables using Bulk Write
+        // TODO : Remove Duplicate Entities
+        // TODO : Change System.out.println to Logger
+    }
+
+    private List<TimetableDocument> crawling() {
+        List<Long> availableBuses = getAvailableBus();
+        System.out.println(availableBuses);
+
+        List<Long> routeIds = availableBuses.stream()
+            .flatMap(busNumber -> getRouteIds(busNumber).stream())
+            .toList();
+        System.out.println(routeIds);
+
+        List<CityBusRouteInfo> routeInfos = routeIds.stream()
+            .flatMap(routeId -> getRouteInfo(routeId).stream())
+            .toList();
+        System.out.println(routeInfos);
+
+        List<TimetableDocument> timetables = routeInfos.stream().map(this::getTimetable).toList();
+        System.out.println(timetables);
+
+        return timetables;
+    }
+
+    private List<Long> getAvailableBus() {
+        return List.of(400L, 402L, 405L);
+    }
+
+    private List<Long> getRouteIds(Long busNumber) {
+        ResponseEntity<CityBusTimetableApiResponse> response = restTemplate.getForEntity(
+            "https://its.cheonan.go.kr/bis/getBusTimeTable.do?thisPage=1&searchKeyword={busNumber}",
+            CityBusTimetableApiResponse.class,
+            busNumber
+        );
+
+        if (!response.hasBody()) {
+            return Collections.emptyList();
+        }
+
+        return Objects.requireNonNull(response.getBody())
+            .resultList()
+            .stream()
+            .map(InnerRoute::routeId)
+            .toList();
+    }
+
+    private List<CityBusRouteInfo> getRouteInfo(Long routeId) {
+        ResponseEntity<CityBusRouteApiResponse> response = restTemplate.getForEntity(
+            "https://its.cheonan.go.kr/bis/getRouteList.do?searchKeyword={routeId}",
+            CityBusRouteApiResponse.class,
+            routeId
+        );
+
+        if (!response.hasBody()) {
+            return Collections.emptyList();
+        }
+
+        return Objects.requireNonNull(response.getBody()).resultList();
+    }
+
+    private TimetableDocument getTimetable(CityBusRouteInfo cityBusRouteInfo) {
+        String url = "https://its.cheonan.go.kr/bis/showBusTimeTable.do";
+
+        Document document;
+        try {
+            document = Jsoup.connect(url)
+                .data("routeName", cityBusRouteInfo.routeName())
+                .data("routeDirection", cityBusRouteInfo.routeDirection())
+                .data("relayAreacode", cityBusRouteInfo.relayAreaCode())
+                .data("routeExplain", cityBusRouteInfo.routeExplain())
+                .data("stName", cityBusRouteInfo.stName())
+                .data("edName", cityBusRouteInfo.edName())
+                .ignoreContentType(true)
+                .timeout(5000)
+                .get();
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<String> dayOfWeeks = List.of("평일", "주말", "공휴일", "임시");
+        List<CityBusTimetable> timetables = new ArrayList<>();
+        for (int i = 0; i < dayOfWeeks.size(); i++) {
+            String selector =
+                "body > div.timeTalbeWrap > div > div.timeTable-wrap > div:nth-child(" + (i + 1) + ") > dl > dd";
+            Elements departInfoElem = document.select(selector);
+
+            List<String> departInfo = departInfoElem.stream()
+                .map(element -> element.text().substring(0, 5))
+                .toList();
+
+            String dayOfWeek = dayOfWeeks.get(i);
+            timetables.add(
+                CityBusTimetable.builder().dayOfWeek(dayOfWeek).departInfo(departInfo).build()
+            );
+        }
+
+        return TimetableDocument.builder()
+            .busTimetables(timetables)
+            .routeInfo(cityBusRouteInfo)
+            .updatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
 import in.koreatech.koin.batch.campus.koreatech.service.BatchKoreatechLoginService;
-import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin._common.auth.Auth;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -12,6 +12,7 @@ import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
 import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
 import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
+import in.koreatech.koin.batch.campus.service.BatchPortalLoginService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class BatchCampusController implements BatchCampusControllerApi {
 
     private final SchoolBusService schoolBusService;
     private final BatchCityBusService batchCityBusService;
+    private final BatchPortalLoginService batchPortalLoginService;
     private final BatchDiningService batchDiningService;
 
     @Override
@@ -49,6 +51,7 @@ public class BatchCampusController implements BatchCampusControllerApi {
     public ResponseEntity<Void> updateDining(
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
+        batchPortalLoginService.login();
         batchDiningService.update();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.batch.campus.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
+import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
+import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
+import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/batch/campus")
+public class BatchCampusController implements BatchCampusControllerApi {
+
+    private final SchoolBusService schoolBusService;
+    private final BatchCityBusService batchCityBusService;
+
+    @Override
+    @PostMapping("/bus/school")
+    public ResponseEntity<Void> updateSchoolBus(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
+    ) {
+        schoolBusService.update(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PostMapping("/bus/city")
+    public ResponseEntity<Void> updateCityBus(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        batchCityBusService.update();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -12,7 +12,7 @@ import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
 import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
 import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
-import in.koreatech.koin.batch.campus.service.BatchPortalLoginService;
+import in.koreatech.koin.batch.campus.koreatech.service.BatchKoreatechLoginService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class BatchCampusController implements BatchCampusControllerApi {
 
     private final SchoolBusService schoolBusService;
     private final BatchCityBusService batchCityBusService;
-    private final BatchPortalLoginService batchPortalLoginService;
+    private final BatchKoreatechLoginService batchKoreatechLoginService;
     private final BatchDiningService batchDiningService;
 
     @Override
@@ -51,7 +51,7 @@ public class BatchCampusController implements BatchCampusControllerApi {
     public ResponseEntity<Void> updateDining(
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
-        batchPortalLoginService.login();
+        batchKoreatechLoginService.login();
         batchDiningService.update();
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
 import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
+import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class BatchCampusController implements BatchCampusControllerApi {
 
     private final SchoolBusService schoolBusService;
     private final BatchCityBusService batchCityBusService;
+    private final BatchDiningService batchDiningService;
 
     @Override
     @PostMapping("/bus/school")
@@ -39,6 +41,15 @@ public class BatchCampusController implements BatchCampusControllerApi {
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         batchCityBusService.update();
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PostMapping("/dining")
+    public ResponseEntity<Void> updateDining(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        batchDiningService.update();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusController.java
@@ -4,17 +4,13 @@ import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
-import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
-import in.koreatech.koin.batch.campus.bus.school.service.SchoolBusService;
 import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
 import in.koreatech.koin.batch.campus.koreatech.service.BatchKoreatechLoginService;
 import in.koreatech.koin.global.auth.Auth;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -22,20 +18,9 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/batch/campus")
 public class BatchCampusController implements BatchCampusControllerApi {
 
-    private final SchoolBusService schoolBusService;
     private final BatchCityBusService batchCityBusService;
     private final BatchKoreatechLoginService batchKoreatechLoginService;
     private final BatchDiningService batchDiningService;
-
-    @Override
-    @PostMapping("/bus/school")
-    public ResponseEntity<Void> updateSchoolBus(
-        @Auth(permit = {ADMIN}) Integer adminId,
-        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
-    ) {
-        schoolBusService.update(request);
-        return ResponseEntity.ok().build();
-    }
 
     @Override
     @PostMapping("/bus/city")

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -4,10 +4,8 @@ import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,26 +13,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 
 @Tag(name = "(Admin) Batch: 배치", description = "Campus 팀 배치 작업을 관리한다.")
 @RequestMapping("/batch/campus")
 public interface BatchCampusControllerApi {
-
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
-        }
-    )
-    @Operation(summary = "학교버스 시간표 업데이트")
-    @PostMapping("/bus/school")
-    ResponseEntity<Void> updateSchoolBus(
-        @Auth(permit = {ADMIN}) Integer adminId,
-        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
-    );
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -40,7 +40,7 @@ public interface BatchCampusControllerApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "시내버스 시간표 업데이트")
+    @Operation(summary = "식단 업데이트")
     @PostMapping("/dining")
     ResponseEntity<Void> updateDining(
         @Auth(permit = {ADMIN}) Integer adminId

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin._common.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -1,0 +1,52 @@
+package in.koreatech.koin.batch.campus.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin.batch.campus.bus.school.dto.BatchSchoolBusVersionUpdateRequest;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Admin) Batch: 배치", description = "Campus 팀 배치 작업을 관리한다.")
+@RequestMapping("/batch/campus")
+public interface BatchCampusControllerApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "학교버스 시간표 업데이트")
+    @PostMapping("/bus/school")
+    ResponseEntity<Void> updateSchoolBus(
+        @Auth(permit = {ADMIN}) Integer adminId,
+        @RequestBody @Valid BatchSchoolBusVersionUpdateRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "시내버스 시간표 업데이트")
+    @PostMapping("/bus/city")
+    ResponseEntity<Void> updateCityBus(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/controller/BatchCampusControllerApi.java
@@ -49,4 +49,18 @@ public interface BatchCampusControllerApi {
     ResponseEntity<Void> updateCityBus(
         @Auth(permit = {ADMIN}) Integer adminId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "시내버스 시간표 업데이트")
+    @PostMapping("/dining")
+    ResponseEntity<Void> updateDining(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/dining/service/BatchDiningService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/dining/service/BatchDiningService.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.batch.campus.koreatech.dining.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@ToString
+@RequiredArgsConstructor
+public class BatchDiningService {
+
+    public void update() {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/model/HttpCookieJar.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/model/HttpCookieJar.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.batch.campus.koreatech.model;
+
+import java.net.HttpCookie;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash("HttpCookieJar")
+public class HttpCookieJar {
+
+    @Id
+    private String id;
+
+    private List<String> cookies;
+
+    // 아우누리 포탈 로그인 세션이 6시간임
+    @TimeToLive(unit = TimeUnit.MINUTES)
+    private Long expiration = (5 * 60) + 30L;  // 5시간 30분
+
+    @Builder
+    private HttpCookieJar(String id, List<String> cookies, Long expiration) {
+        this.id = id;
+        this.cookies = cookies;
+        this.expiration = expiration;
+    }
+
+    public static HttpCookieJar of(String id, List<HttpCookie> cookies) {
+        return HttpCookieJar.builder()
+            .id(id)
+            .cookies(cookies.stream().map(HttpCookie::toString).toList())
+            .expiration((5 * 60) + 30L)
+            .build();
+    }
+
+    public List<HttpCookie> getCookies() {
+        return cookies.stream().flatMap(s -> HttpCookie.parse(s).stream()).toList();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/repository/HttpCookieJarRepository.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/repository/HttpCookieJarRepository.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.batch.campus.koreatech.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.batch.campus.koreatech.model.HttpCookieJar;
+
+public interface HttpCookieJarRepository extends Repository<HttpCookieJar, String> {
+
+    HttpCookieJar save(HttpCookieJar cookies);
+
+    Optional<HttpCookieJar> findById(String id);
+
+    default HttpCookieJar getById(String id) {
+        return findById(id)
+            .orElseThrow(() -> new RuntimeException("Cookie not found"));
+    }
+
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
@@ -1,0 +1,135 @@
+package in.koreatech.koin.batch.campus.koreatech.service;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.batch.campus.koreatech.BatchKoreatechCookieRepository;
+import in.koreatech.koin.global.exception.KoinIllegalStateException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Transactional
+public class BatchKoreatechLoginService {
+
+    private final BatchKoreatechCookieRepository koreatechCookieRepository;
+
+    private final String userId;
+    private final String userPwd;
+    private final String[] headers;
+
+    private final CookieManager cookieManager;
+    private final HttpClient httpClient;
+
+    public BatchKoreatechLoginService(
+        BatchKoreatechCookieRepository koreatechCookieRepository,
+        @Value("${portal.koreatech.id}") String userId,
+        @Value("${portal.koreatech.password}") String userPwd,
+        @Value("${portal.koreatech.ip}") String ip
+    ) {
+        this.koreatechCookieRepository = koreatechCookieRepository;
+
+        this.userId = userId;
+        this.userPwd = userPwd;
+        this.headers = new String[] {
+            "X-Forwarded-For", ip,
+            "X-Real-IP", ip,
+        };
+
+        cookieManager = new CookieManager();
+        cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+
+        this.httpClient = HttpClient.newBuilder()
+            .cookieHandler(cookieManager)
+            .followRedirects(HttpClient.Redirect.ALWAYS)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    }
+
+    public void login() {
+        List<HttpCookie> cookies;
+        try {
+            checkLoginId();
+
+            setCookie("kut_login_type", "id", "/", "portal.koreatech.ac.kr");
+            checkSecondLoginCert();
+
+            ssoAssert();
+            ssoLogin();
+
+            cookies = new ArrayList<>(cookieManager.getCookieStore().getCookies());
+        } catch (IOException e) {
+            throw new KoinIllegalStateException("");
+        } catch (InterruptedException e) { // TODO : 잘못된 에러 처리 수정하기
+            throw new RuntimeException(e);
+        } finally {
+            cookieManager.getCookieStore().removeAll();
+        }
+
+        koreatechCookieRepository.save(cookies);
+    }
+
+    private void checkLoginId() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://portal.koreatech.ac.kr/ktp/login/checkLoginId.do"))
+            .header("content-type", "application/x-www-form-urlencoded; charset=UTF-8")
+            .headers(headers)
+            .POST(HttpRequest.BodyPublishers.ofString("login_id=" + userId + "&login_pwd=" + userPwd))
+            .build();
+
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void checkSecondLoginCert() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://portal.koreatech.ac.kr/ktp/login/checkSecondLoginCert.do"))
+            .header("content-type", "application/x-www-form-urlencoded; charset=UTF-8")
+            .headers(headers)
+            .POST(HttpRequest.BodyPublishers.ofString("login_id=" + userId))
+            .build();
+
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void ssoAssert() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://portal.koreatech.ac.kr/exsignon/sso/sso_assert.jsp"))
+            .headers(headers)
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void ssoLogin() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("https://kut90.koreatech.ac.kr/ssoLogin_ext.jsp?&PGM_ID=CO::CO0998W&locale=ko"))
+            .headers(headers)
+            .GET()
+            .build();
+
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private void setCookie(String name, String value, String path, String domain) {
+        CookieStore cookieStore = cookieManager.getCookieStore();
+
+        HttpCookie cookie = new HttpCookie(name, value);
+        cookie.setPath(path);
+        cookieStore.add(URI.create("https://" + domain), cookie);
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
@@ -82,7 +82,7 @@ public class BatchKoreatechLoginService {
             // 식단 로드
             requestGet("https://kut90.koreatech.ac.kr/ssoLogin_ext.jsp?&PGM_ID=CO::CO0998W&locale=ko");
 
-            // 학생종합경력개 로드
+            // 학생종합경력개발 로드
             jobLogin();
 
             cookies = new ArrayList<>(cookieManager.getCookieStore().getCookies());

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin._common.exception.custom.KoinIllegalStateException;
 import in.koreatech.koin.batch.campus.koreatech.model.HttpCookieJar;
 import in.koreatech.koin.batch.campus.koreatech.repository.HttpCookieJarRepository;
-import in.koreatech.koin.global.exception.KoinIllegalStateException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/koreatech/service/BatchKoreatechLoginService.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.batch.campus.koreatech.BatchKoreatechCookieRepository;
+import in.koreatech.koin.batch.campus.koreatech.model.HttpCookieJar;
+import in.koreatech.koin.batch.campus.koreatech.repository.HttpCookieJarRepository;
 import in.koreatech.koin.global.exception.KoinIllegalStateException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,7 +27,9 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class BatchKoreatechLoginService {
 
-    private final BatchKoreatechCookieRepository koreatechCookieRepository;
+    private static final String COOKIE_JAR_ID = "KOREATECH";
+
+    private final HttpCookieJarRepository httpCookieJarRepository;
 
     private final String userId;
     private final String userPwd;
@@ -36,12 +39,12 @@ public class BatchKoreatechLoginService {
     private final HttpClient httpClient;
 
     public BatchKoreatechLoginService(
-        BatchKoreatechCookieRepository koreatechCookieRepository,
+        HttpCookieJarRepository httpCookieJarRepository,
         @Value("${portal.koreatech.id}") String userId,
         @Value("${portal.koreatech.password}") String userPwd,
         @Value("${portal.koreatech.ip}") String ip
     ) {
-        this.koreatechCookieRepository = koreatechCookieRepository;
+        this.httpCookieJarRepository = httpCookieJarRepository;
 
         this.userId = userId;
         this.userPwd = userPwd;
@@ -80,7 +83,7 @@ public class BatchKoreatechLoginService {
             cookieManager.getCookieStore().removeAll();
         }
 
-        koreatechCookieRepository.save(cookies);
+        httpCookieJarRepository.save(HttpCookieJar.of(COOKIE_JAR_ID, cookies));
     }
 
     private void checkLoginId() throws IOException, InterruptedException {

--- a/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
@@ -4,6 +4,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
+import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
+import in.koreatech.koin.batch.campus.service.BatchPortalLoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,9 +15,20 @@ import lombok.extern.slf4j.Slf4j;
 public class BatchCampusScheduler {
 
     private final BatchCityBusService batchCityBusService;
+    private final BatchPortalLoginService batchPortalLoginService;
+    private final BatchDiningService batchDiningService;
 
     @Scheduled(cron = "0 0 0 * * 0")
     public void updateCityBusTimetables() {
         batchCityBusService.update();
+    }
+
+    @Scheduled(cron = "0 0 5,15 * * *")
+    @Scheduled(cron = "0 15,30 17,18 * * *")
+    @Scheduled(cron = "0 */30 8-11 * * *")
+    @Scheduled(cron = "0 15 11 * * *")
+    public void updateDining() {
+        batchPortalLoginService.login();
+        batchDiningService.update();
     }
 }

--- a/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.batch.campus.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchCampusScheduler {
+
+    private final BatchCityBusService batchCityBusService;
+
+    @Scheduled(cron = "0 0 0 * * 0")
+    public void updateCityBusTimetables() {
+        batchCityBusService.update();
+    }
+}

--- a/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
+++ b/src/main/java/in/koreatech/koin/batch/campus/scheduler/BatchCampusScheduler.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.batch.campus.bus.city.service.BatchCityBusService;
 import in.koreatech.koin.batch.campus.koreatech.dining.service.BatchDiningService;
-import in.koreatech.koin.batch.campus.service.BatchPortalLoginService;
+import in.koreatech.koin.batch.campus.koreatech.service.BatchKoreatechLoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BatchCampusScheduler {
 
     private final BatchCityBusService batchCityBusService;
-    private final BatchPortalLoginService batchPortalLoginService;
+    private final BatchKoreatechLoginService batchKoreatechLoginService;
     private final BatchDiningService batchDiningService;
 
     @Scheduled(cron = "0 0 0 * * 0")
@@ -28,7 +28,7 @@ public class BatchCampusScheduler {
     @Scheduled(cron = "0 */30 8-11 * * *")
     @Scheduled(cron = "0 15 11 * * *")
     public void updateDining() {
-        batchPortalLoginService.login();
+        batchKoreatechLoginService.login();
         batchDiningService.update();
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -98,6 +98,11 @@ naver:
     serviceId: ncp:sms:kr:test
     fromNumber: "01012331234"
 
+portal:
+  koreatech:
+    id: test
+    password: test
+    ip: 203.255.221.0
 
 OPEN_API_KEY_PUBLIC: testck
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1247 

# 🚀 작업 내용

- 시내 버스 크롤링 마이그레이션(Python → Java)
- 식단 & 공지사항 크롤링을 위한 로그인 로직 구현

1. [KOIN_BATCH](https://github.com/BCSDLab/KOIN_BATCH)의 [시내버스 크롤링](https://github.com/BCSDLab/KOIN_BATCH/blob/master/crawling/city_bus/city_bus_timetable.py)을 마이그레이션 했습니다. (Python → Java)
2. RestTemplate과 Jsoup를 사용했습니다.
    - RestTemplate는 기본적으로 content-type이 text/html이면 body가 json 형태라도 파싱되지 않는 문제가 있었습니다.
    - 그래서 text/html도 파싱할 수 있도록 지원 목록에 추가했습니다.
    
1. 크롤링을 위한 로그인 로직을 구현했습니다.
방금 막 발견한 따끈따끈한 '통합로그인' 방식으로 로그인 했습니다.
헤더를 수정하는 방식보다 더 안정적으로 로그인 할 수 있습니다. 

# 💬 리뷰 중점사항

체리픽 뭔가 쉬운거 같으면서 어려운거 같기도...
체리픽 처음 써본거 같아요.

궁금증: 왜 restTemplate이 RedisConfig에 들어있는거죠?????

코드 정리 없이 냅다 옮기기만 했습니다. 코드가 많이 더러워요..
스무스하게 넘어갈줄 알았는데 뭔가 난관이 많네요...

**정리 안된것:**
- Exception 정리
- 중복 엔티티 제거
- Test 작성