### PR TITLE
hotfix: error code string으로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/ErrorResponse.java
@@ -9,13 +9,13 @@ public class ErrorResponse {
 
     @JsonIgnore
     private final int status;
-    private final int code;
+    private final String code;
     private final String message;
     private final String errorTraceId;
 
     public ErrorResponse(int status, String message, String errorTraceId) {
         this.status = status;
-        this.code = 0;
+        this.code = "";
         this.message = message;
         this.errorTraceId = errorTraceId;
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1369 

# 🚀 작업 내용

1. 에러 코드 int -> String로 복구

