### PR TITLE
fix: ArticleApi deleteLostItemArticle auth의 STUDENT 누락 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -177,6 +177,6 @@ public interface ArticleApi {
     @DeleteMapping("/lost-item/{id}")
     ResponseEntity<Void> deleteLostItemArticle(
         @PathVariable("id") Integer articleId,
-        @Auth(permit = {COUNCIL}) Integer councilId
+        @Auth(permit = {STUDENT, COUNCIL}) Integer councilId
     );
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1374 

# 🚀 작업 내용

1. ArticleApi의 deleteLostItemArticle 메소드 auth의 STUDENT누락을 추가했습니다.

# 💬 리뷰 중점사항
- 7글자