### PR TITLE
fix: 단일 분실물 게시글 조회 NPE 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -134,8 +134,10 @@ public class Article extends BaseEntity {
         }
         if (lostItemArticle != null) {
             User user = lostItemArticle.getAuthor();
-            author = (user != null && user.getNickname() != null) ? user.getNickname() : ANONYMOUS_USER;
-            return;
+            if (user != null) {
+                author = user.getNickname() != null ? user.getNickname() : ANONYMOUS_USER;
+                return;
+            }
         }
         author = DELETED_USER;
     }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -19,6 +19,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin._common.auth.exception.AuthorizationException;
+import in.koreatech.koin._common.concurrent.ConcurrencyGuard;
+import in.koreatech.koin._common.event.ArticleKeywordEvent;
+import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
+import in.koreatech.koin._common.model.Criteria;
 import in.koreatech.koin.domain.community.article.dto.ArticleHotKeywordResponse;
 import in.koreatech.koin.domain.community.article.dto.ArticleResponse;
 import in.koreatech.koin.domain.community.article.dto.ArticlesResponse;
@@ -42,14 +47,9 @@ import in.koreatech.koin.domain.community.article.repository.redis.ArticleHitRep
 import in.koreatech.koin.domain.community.article.repository.redis.ArticleHitUserRepository;
 import in.koreatech.koin.domain.community.article.repository.redis.BusArticleRepository;
 import in.koreatech.koin.domain.community.article.repository.redis.HotArticleRepository;
-import in.koreatech.koin._common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.util.KeywordExtractor;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
-import in.koreatech.koin._common.auth.exception.AuthorizationException;
-import in.koreatech.koin._common.concurrent.ConcurrencyGuard;
-import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
-import in.koreatech.koin._common.model.Criteria;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -332,7 +332,7 @@ public class ArticleService {
 
         boolean isMine = false;
         User author = article.getLostItemArticle().getAuthor();
-        if (Objects.equals(author.getId(), userId)) {
+        if (author != null && Objects.equals(author.getId(), userId)) {
             isMine = true;
         }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1378 

# 🚀 작업 내용

- 탈퇴한 사용자의 분실물 게시글의 author에서 발생하는 NPE를 해결했습니다.
- 탈퇴한 사용자의 분실물 게시글의 반환값으로 "탈퇴한 사용자"를 반환하도록 로직을 수정했습니다.

# 💬 리뷰 중점사항
