### PR TITLE
refactor: 인기게시글 목록 조회 n+1, 지연로딩 문제해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -33,7 +33,18 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Page<Article> findAllByIdIn(List<Integer> articleIds, PageRequest pageRequest);
 
-    List<Article> findAllByIdIn(List<Integer> articleIds);
+    @Query("""
+        SELECT a
+        FROM Article a
+        LEFT JOIN FETCH a.koinArticle k
+        LEFT JOIN FETCH k.user
+        LEFT JOIN FETCH a.koreatechArticle
+        LEFT JOIN FETCH a.lostItemArticle l
+        LEFT JOIN FETCH l.author
+        WHERE a.id IN :ids
+        """)
+    List<Article> findAllForHotArticlesByIdIn(List<Integer> ids);
+
 
     default Article getById(Integer articleId) {
         Article found = findById(articleId)
@@ -128,15 +139,22 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         return findNextAllArticle(article.getId()).orElse(null);
     }
 
-    @Query(value = "SELECT a.* FROM new_articles a "
-        + "LEFT JOIN new_koreatech_articles ka ON ka.article_id = a.id "
-        + "WHERE ( "
-        + "    (ka.article_id IS NOT NULL AND ka.registered_at > :registeredAt) "
-        + "    OR (ka.article_id IS NULL AND a.created_at > :registeredAt) "
-        + ") "
-        + "AND a.is_deleted = false "
-        + "ORDER BY (a.hit + IFNULL(ka.portal_hit, 0)) DESC, a.id DESC LIMIT :limit", nativeQuery = true)
-    List<Article> findMostHitArticles(@Param("registeredAt") LocalDate registeredAt, @Param("limit") int limit);
+    @Query("""
+            SELECT a FROM Article a
+            LEFT JOIN FETCH a.koreatechArticle ka
+            LEFT JOIN FETCH a.koinArticle k
+            LEFT JOIN FETCH k.user
+            LEFT JOIN FETCH a.lostItemArticle l
+            LEFT JOIN FETCH l.author
+            WHERE (
+                (ka IS NOT NULL AND ka.registeredAt > :registeredAt)
+                OR (ka IS NULL AND a.createdAt > :registeredAt)
+            )
+            AND a.isDeleted = false
+            ORDER BY (a.hit + COALESCE(ka.portalHit, 0)) DESC, a.id DESC
+        """)
+    List<Article> findMostHitArticles(LocalDate registeredAt, Pageable pageable);
+
 
     @Query(value = "SELECT a.* FROM new_articles a "
         + "LEFT JOIN new_koreatech_articles ka ON ka.article_id = a.id "

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -45,7 +45,6 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         """)
     List<Article> findAllForHotArticlesByIdIn(List<Integer> ids);
 
-
     default Article getById(Integer articleId) {
         Article found = findById(articleId)
             .orElseThrow(() -> ArticleNotFoundException.withDetail("articleId: " + articleId));
@@ -154,7 +153,6 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             ORDER BY (a.hit + COALESCE(ka.portalHit, 0)) DESC, a.id DESC
         """)
     List<Article> findMostHitArticles(LocalDate registeredAt, Pageable pageable);
-
 
     @Query(value = "SELECT a.* FROM new_articles a "
         + "LEFT JOIN new_koreatech_articles ka ON ka.article_id = a.id "

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -33,6 +33,8 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Page<Article> findAllByIdIn(List<Integer> articleIds, PageRequest pageRequest);
 
+    List<Article> findAllByIdIn(List<Integer> articleIds);
+
     default Article getById(Integer articleId) {
         Article found = findById(articleId)
             .orElseThrow(() -> ArticleNotFoundException.withDetail("articleId: " + articleId));

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -111,7 +111,7 @@ public class ArticleService {
 
     public List<HotArticleItemResponse> getHotArticles() {
         List<Integer> hotArticlesIds = hotArticleRepository.getHotArticles(HOT_ARTICLE_LIMIT);
-        List<Article> articles = articleRepository.findAllByIdIn(hotArticlesIds);
+        List<Article> articles = articleRepository.findAllForHotArticlesByIdIn(hotArticlesIds);
 
         Map<Integer, Article> articleMap = articles.stream()
             .collect(Collectors.toMap(Article::getId, article -> article));
@@ -123,7 +123,9 @@ public class ArticleService {
 
         if (cacheList.size() < HOT_ARTICLE_LIMIT) {
             List<Article> highestHitArticles = articleRepository.findMostHitArticles(
-                LocalDate.now(clock).minusDays(HOT_ARTICLE_BEFORE_DAYS), HOT_ARTICLE_LIMIT);
+                LocalDate.now(clock).minusDays(HOT_ARTICLE_BEFORE_DAYS),
+                PageRequest.of(0, HOT_ARTICLE_LIMIT)
+            );
             cacheList.addAll(highestHitArticles);
             return cacheList.stream().limit(HOT_ARTICLE_LIMIT)
                 .map(HotArticleItemResponse::from)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1380 

# 🚀 작업 내용
<img width="752" alt="image" src="https://github.com/user-attachments/assets/fed1209a-41ef-49e9-94a0-9705a479ad1e" />

- 현재 /articles/hot api는 첫 화면에 표시되므로 한달기준으로 요청 수 6번 째에 해당할 정도로 많이 사용되는 api
- 하지만 기능 내용에 비해 latency가 높은 것으로 보임

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/94b3f60c-9379-4707-9d4a-56768e0444d2" />

- 여러 요청들을 확인해보니 41개의 쿼리가 나가고있음

- 기존 로직
```java
List<Article> cacheList = hotArticleRepository.getHotArticles(HOT_ARTICLE_LIMIT).stream()
             .map(articleRepository::getById)
             .collect(Collectors.toList());
```
list를 stream으로 돌며 getById를 호출하고있음
-> n+1문제 발생

- 이를 배치 쿼리를 통해 한번에 불러와서 n+1 문제를 해결하였음
- Map을 이용하여 id와 Article들을 재매핑하여 기존의 정렬 효과도 유지

하지만 이를 통해 해결해도 여전히 많은 쿼리가 발생함을 확인
-> 확인해보니 Article 엔티티에 LAZY로딩인 여러 엔티티들이 엮여있음
- 이들이 지연로딩되면서 많은 쿼리가 n+1으로 반복되는 것으로 확인

- LAZY로딩으로 연결된 엔티티들을 페치조인을 사용하여 한번에 가져옴
- 이를 통해 findAllByIdIn에서 발생하는 LAZY로딩 문제를 해결함
- ToOne 관계만 페치조인하므로 컬럼 개수가 기하급수적으로 증가하는 문제는 발생하지 않음

- findMostHitArticles 메소드에도 동일한 LAZY로딩 문제 발생
- 기존의 네이티브 쿼리에서 JPQL로 변경하고 LIMIT를 사용하지 못하는 부분은 페이징을 사용하여 해결
-> 페치조인을 사용하는 경우 페이징을 사용하면 안되지만, 이는 ToMany를 페치조인했을 때에 해당함
-> ToOne 관계만 페치조인하는경우 컬럼 개수가 늘어나지 않으므로 페이징에 영향을 미치지 않음

### 결과 
```java
[2025-03-22T18:10:37.128] INFO  74685 --- [nio-8080-exec-1] i.k.k.w.logging.RequestLoggingFilter     : : request start [uri: GET /articles/hot]
Hibernate: 
    select
        a1_0.id,
        a1_0.board_id,
        a1_0.content,
        a1_0.created_at,
        a1_0.hit,
        a1_0.is_deleted,
        a1_0.is_notice,
        k1_0.id,
        k1_0.article_id,
        k1_0.created_at,
        k1_0.is_deleted,
        k1_0.updated_at,
        u1_0.id,
        u1_0.created_at,
        u1_0.device_token,
        u1_0.email,
        u1_0.gender,
        u1_0.is_authed,
        u1_0.is_deleted,
        u1_0.last_logged_at,
        u1_0.name,
        u1_0.nickname,
        u1_0.password,
        u1_0.phone_number,
        u1_0.profile_image_url,
        u1_0.updated_at,
        u1_0.user_type,
        k2_0.id,
        k2_0.article_id,
        k2_0.author,
        k2_0.created_at,
        k2_0.is_deleted,
        k2_0.portal_hit,
        k2_0.portal_num,
        k2_0.registered_at,
        k2_0.updated_at,
        k2_0.url,
        l1_0.id,
        l1_0.article_id,
        a2_0.id,
        a2_0.created_at,
        a2_0.device_token,
        a2_0.email,
        a2_0.gender,
        a2_0.is_authed,
        a2_0.is_deleted,
        a2_0.last_logged_at,
        a2_0.name,
        a2_0.nickname,
        a2_0.password,
        a2_0.phone_number,
        a2_0.profile_image_url,
        a2_0.updated_at,
        a2_0.user_type,
        l1_0.category,
        l1_0.created_at,
        l1_0.found_date,
        l1_0.found_place,
        l1_0.is_council,
        l1_0.is_deleted,
        l1_0.type,
        l1_0.updated_at,
        a1_0.title,
        a1_0.updated_at 
    from
        new_articles a1_0 
    left join
        new_koin_articles k1_0 
            on a1_0.id=k1_0.article_id 
            and (
                k1_0.is_deleted=0
            ) 
    left join
        users u1_0 
            on u1_0.id=k1_0.user_id 
            and (
                u1_0.is_deleted=0
            ) 
    left join
        new_koreatech_articles k2_0 
            on a1_0.id=k2_0.article_id 
            and (
                k2_0.is_deleted=0
            ) 
    left join
        lost_item_articles l1_0 
            on a1_0.id=l1_0.article_id 
    left join
        users a2_0 
            on a2_0.id=l1_0.author_id 
            and (
                a2_0.is_deleted=0
            ) 
    where
        (
            a1_0.is_deleted=0
        ) 
        and a1_0.id in (?,?,?,?,?,?,?,?,?)
Hibernate: 
    select
        a1_0.id,
        a1_0.board_id,
        a1_0.content,
        a1_0.created_at,
        a1_0.hit,
        a1_0.is_deleted,
        a1_0.is_notice,
        k2_0.id,
        k2_0.article_id,
        k2_0.created_at,
        k2_0.is_deleted,
        k2_0.updated_at,
        u1_0.id,
        u1_0.created_at,
        u1_0.device_token,
        u1_0.email,
        u1_0.gender,
        u1_0.is_authed,
        u1_0.is_deleted,
        u1_0.last_logged_at,
        u1_0.name,
        u1_0.nickname,
        u1_0.password,
        u1_0.phone_number,
        u1_0.profile_image_url,
        u1_0.updated_at,
        u1_0.user_type,
        k1_0.id,
        k1_0.article_id,
        k1_0.author,
        k1_0.created_at,
        k1_0.is_deleted,
        k1_0.portal_hit,
        k1_0.portal_num,
        k1_0.registered_at,
        k1_0.updated_at,
        k1_0.url,
        l1_0.id,
        l1_0.article_id,
        a2_0.id,
        a2_0.created_at,
        a2_0.device_token,
        a2_0.email,
        a2_0.gender,
        a2_0.is_authed,
        a2_0.is_deleted,
        a2_0.last_logged_at,
        a2_0.name,
        a2_0.nickname,
        a2_0.password,
        a2_0.phone_number,
        a2_0.profile_image_url,
        a2_0.updated_at,
        a2_0.user_type,
        l1_0.category,
        l1_0.created_at,
        l1_0.found_date,
        l1_0.found_place,
        l1_0.is_council,
        l1_0.is_deleted,
        l1_0.type,
        l1_0.updated_at,
        a1_0.title,
        a1_0.updated_at 
    from
        new_articles a1_0 
    left join
        new_koreatech_articles k1_0 
            on a1_0.id=k1_0.article_id 
            and (
                k1_0.is_deleted=0
            ) 
    left join
        new_koin_articles k2_0 
            on a1_0.id=k2_0.article_id 
            and (
                k2_0.is_deleted=0
            ) 
    left join
        users u1_0 
            on u1_0.id=k2_0.user_id 
            and (
                u1_0.is_deleted=0
            ) 
    left join
        lost_item_articles l1_0 
            on a1_0.id=l1_0.article_id 
    left join
        users a2_0 
            on a2_0.id=l1_0.author_id 
            and (
                a2_0.is_deleted=0
            ) 
    where
        (
            a1_0.is_deleted=0
        ) 
        and (
            (
                k1_0.id is not null 
                and k1_0.registered_at>?
            ) 
            or (
                k1_0.id is null 
                and a1_0.created_at>?
            )
        ) 
        and a1_0.is_deleted=0 
    order by
        (a1_0.hit+coalesce(k1_0.portal_hit,0)) desc,
        a1_0.id desc 
    limit
        ?,?
[2025-03-22T18:10:37.608] INFO  74685 --- [nio-8080-exec-1] i.k.k.w.logging.RequestLoggingFilter     : : request end [time: 480ms]
```

- 쿼리 개수를 41개 -> 2개로 줄임
- 성능도 향상될 것으로 보이나 스테이지 환경에서 재확인 필요
    - 로컬 반복 테스트 결과 
    - 이전 로직 320~360ms 
    - 새 로직 230~250ms
        - 약 성능 30% 개선 확인
- dto등을 사용하여 가져오는 필드의 개수를 줄일 수 있으나 의존성이 생긴다는 문제가 있을 것으로 보임

# 💬 리뷰 중점사항
- 
