### PR TITLE
fix: 탈퇴한 사용자의 분실물 채팅에서 발생하는 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -110,11 +110,7 @@ public class LostItemChatRoomInfoService {
 
     @Transactional(readOnly = true)
     public String getChatPartnerProfileImage(Integer articleId) {
-        User author = lostItemArticleReader.readByArticleId(articleId).getAuthor();
-        if (author == null) {
-            return null;
-        }
-        return author.getProfileImageUrl();
+        return lostItemArticleReader.readByArticleId(articleId).getAuthor().getProfileImageUrl();
     }
 
     private void checkSelfChat(Integer ownerId, Integer articleAuthorId) {

--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -104,7 +104,11 @@ public class LostItemChatRoomInfoService {
 
     @Transactional(readOnly = true)
     public String getChatPartnerProfileImage(Integer articleId) {
-        return lostItemArticleReader.readByArticleId(articleId).getAuthor().getProfileImageUrl();
+        User author = lostItemArticleReader.readByArticleId(articleId).getAuthor();
+        if (author == null) {
+            return null;
+        }
+        return author.getProfileImageUrl();
     }
 
     private void checkSelfChat(Integer ownerId, Integer articleAuthorId) {

--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.article.model.LostItemArticle;
+import in.koreatech.koin.domain.user.exception.UserNotFoundException;
+import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.socket.domain.chatroom.dto.ChatRoomListResponse;
 import in.koreatech.koin.socket.domain.chatroom.exception.SelfChatNotAllowedException;
 import in.koreatech.koin.socket.domain.chatroom.model.LostItemChatRoomInfoEntity;
@@ -38,7 +40,11 @@ public class LostItemChatRoomInfoService {
         }
 
         LostItemArticle lostItemArticle = lostItemArticleReader.readByArticleId(articleId);
-        Integer articleAuthorId = lostItemArticle.getAuthor().getId();
+        User author = lostItemArticle.getAuthor();
+        if (author == null) {
+            throw UserNotFoundException.withDetail("탈퇴한 사용자입니다.");
+        }
+        Integer articleAuthorId = author.getId();
 
         checkSelfChat(ownerId, articleAuthorId);
 

--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -19,6 +19,7 @@ import in.koreatech.koin.socket.domain.chatroom.service.implement.ChatRoomInfoRe
 import in.koreatech.koin.socket.domain.chatroom.service.implement.LostItemArticleReader;
 import in.koreatech.koin.socket.domain.chatroom.service.implement.UserBlockReader;
 import in.koreatech.koin.socket.domain.message.service.implement.MessageReader;
+import in.koreatech.koin.socket.domain.session.service.implement.UserReader;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -29,6 +30,7 @@ public class LostItemChatRoomInfoService {
     private final ChatRoomInfoReader chatRoomInfoReader;
     private final ChatRoomInfoAppender chatRoomInfoAppender;
     private final LostItemArticleReader lostItemArticleReader;
+    private final UserReader userReader;
     private final UserBlockReader userBlockReader;
     private static final String DEFAULT_MESSAGE = "대화를 시작해보세요!";
 
@@ -65,6 +67,10 @@ public class LostItemChatRoomInfoService {
 
         return chatRoomInfoList.stream()
             .flatMap(entity -> {
+                if (userReader.readUser(entity.getOwnerId()) == null) {
+                    return Stream.empty();
+                }
+
                 var articleSummary = lostItemArticleReader.getArticleSummary(entity.getArticleId());
                 if (articleSummary == null || isUserBlocked(entity.getArticleId(), entity.getChatRoomId(), userId)) {
                     return Stream.empty();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1390 

# 🚀 작업 내용

- 채팅방을 모두 조회할 때, 탈퇴한 사용자의 채팅방은 출력하지 않도록 로직을 추가했습니다.
- 탈퇴한 사용자의 분실물 게시글에서 쪽지 보내기를 눌렀을 때, 예외 처리를 했습니다.

# 💬 리뷰 중점사항
