### PR TITLE
feat: 특정 카테고리의 활성화된 배너들을 플랫폼에 따라 조회하는 API

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/banner/dto/response/AdminBannerResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/banner/dto/response/AdminBannerResponse.java
@@ -44,7 +44,7 @@ public record AdminBannerResponse(
 
     @Schema(description = "배너 생성일", example = "25.03.23")
     @JsonFormat(pattern = "yy.MM.dd")
-    LocalDate createAt
+    LocalDate createdAt
 ) {
     public static AdminBannerResponse from(Banner banner) {
         return new AdminBannerResponse(

--- a/src/main/java/in/koreatech/koin/admin/banner/dto/response/AdminBannersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/banner/dto/response/AdminBannersResponse.java
@@ -66,7 +66,7 @@ public record AdminBannersResponse(
 
         @Schema(description = "배너 생성일", example = "25.03.23")
         @JsonFormat(pattern = "yy.MM.dd")
-        LocalDate createAt
+        LocalDate createdAt
     ) {
         public static InnerAdminBannerResponse from(Banner banner) {
             return new InnerAdminBannerResponse(

--- a/src/main/java/in/koreatech/koin/domain/banner/controller/BannerApi.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/controller/BannerApi.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.domain.banner.controller;
+
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.domain.banner.dto.response.BannersResponse;
+import in.koreatech.koin.domain.banner.enums.PlatformType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "(Normal) Banner: 배너", description = "배너 정보를 관리한다")
+@RequestMapping("/banners")
+public interface BannerApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 카테고리, 플랫폼의 활성화된 배너들을 조회한다.")
+    @GetMapping("/{categoryId}")
+    ResponseEntity<BannersResponse> getBannersByCategoryAndPlatform(
+        @Parameter(in = PATH) @PathVariable Integer categoryId,
+        @Parameter(description = "플랫폼 타입(web, android, ios)") @RequestParam PlatformType platform
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/banner/controller/BannerController.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/controller/BannerController.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.domain.banner.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.banner.dto.response.BannersResponse;
+import in.koreatech.koin.domain.banner.enums.PlatformType;
+import in.koreatech.koin.domain.banner.service.BannerService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/banners")
+public class BannerController implements BannerApi {
+
+    private final BannerService bannerService;
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<BannersResponse> getBannersByCategoryAndPlatform(
+        @PathVariable Integer categoryId,
+        @RequestParam PlatformType platform
+    ) {
+        BannersResponse response = bannerService.getBannerByCategoryAndPlatform(categoryId, platform);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/banner/dto/response/BannersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/dto/response/BannersResponse.java
@@ -1,0 +1,58 @@
+package in.koreatech.koin.domain.banner.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.banner.enums.PlatformType;
+import in.koreatech.koin.domain.banner.model.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record BannersResponse(
+    @Schema(example = "10", description = "해당 카테고리의 활성화된 배너 개수", requiredMode = REQUIRED)
+    Integer count,
+
+    @Schema(description = "해당 카테고리의 활성화된 배너 정보 리스트")
+    List<InnerBannerResponse> banners
+) {
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerBannerResponse(
+        @Schema(description = "배너 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "배너 이미지 링크", example = "https://example.com/1000won.jpg")
+        String imageUrl,
+
+        @Schema(description = "플랫폼에 해당하는 리다이렉션 링크", example = "https://example.com/1000won")
+        String redirectLink
+    ) {
+
+        public static InnerBannerResponse of(Banner banner, PlatformType platformType) {
+            return new InnerBannerResponse(
+                banner.getId(),
+                banner.getImageUrl(),
+                resolveRedirectLink(banner, platformType)
+            );
+        }
+
+        private static String resolveRedirectLink(Banner banner, PlatformType platformType) {
+            return switch (platformType) {
+                case WEB -> banner.getWebRedirectLink();
+                case ANDROID -> banner.getAndroidRedirectLink();
+                case IOS -> banner.getIosRedirectLink();
+            };
+        }
+    }
+
+    public static BannersResponse of(List<Banner> banners, PlatformType platformType) {
+        List<InnerBannerResponse> innerBannerResponses = banners.stream()
+            .map(banner -> InnerBannerResponse.of(banner, platformType))
+            .toList();
+        return new BannersResponse(innerBannerResponses.size(), innerBannerResponses);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/banner/enums/PlatformType.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/enums/PlatformType.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.banner.enums;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import in.koreatech.koin.domain.bus.exception.BusTypeNotFoundException;
+
+public enum PlatformType {
+    WEB,
+    ANDROID,
+    IOS,
+    ;
+
+    @JsonCreator
+    public static PlatformType from(String platform) {
+        return Arrays.stream(values())
+            .filter(platformType -> platformType.name().equalsIgnoreCase(platform))
+            .findAny()
+            .orElseThrow(() -> BusTypeNotFoundException.withDetail("platformType: " + platform));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.banner.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.banner.model.Banner;
+
+public interface BannerRepository extends Repository<Banner, Integer> {
+
+    List<Banner> findAllByBannerCategoryIdAndIsActiveTrueOrderByPriority(Integer categoryId);
+}

--- a/src/main/java/in/koreatech/koin/domain/banner/service/BannerService.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/service/BannerService.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.banner.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.banner.dto.response.BannersResponse;
+import in.koreatech.koin.domain.banner.enums.PlatformType;
+import in.koreatech.koin.domain.banner.model.Banner;
+import in.koreatech.koin.domain.banner.repository.BannerRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public BannersResponse getBannerByCategoryAndPlatform(Integer categoryId, PlatformType platform) {
+        List<Banner> banners = bannerRepository.findAllByBannerCategoryIdAndIsActiveTrueOrderByPriority(categoryId);
+        return BannersResponse.of(banners, platform);
+    }
+}

--- a/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
@@ -49,6 +49,7 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.coop",
             "in.koreatech.koin.domain.coopshop",
             "in.koreatech.koin.domain.dining",
+            "in.koreatech.koin.domain.banner",
             "in.koreatech.koin.global.socket.domain.chatroom"
         };
 

--- a/src/test/java/in/koreatech/koin/acceptance/BannerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/BannerApiTest.java
@@ -1,0 +1,73 @@
+package in.koreatech.koin.acceptance;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.AcceptanceTest;
+import in.koreatech.koin.domain.banner.model.Banner;
+import in.koreatech.koin.domain.banner.model.BannerCategory;
+import in.koreatech.koin.fixture.BannerCategoryFixture;
+import in.koreatech.koin.fixture.BannerFixture;
+import in.koreatech.koin.fixture.UserFixture;
+
+@SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BannerApiTest extends AcceptanceTest {
+
+    @Autowired
+    private BannerFixture bannerFixture;
+
+    @Autowired
+    private BannerCategoryFixture bannerCategoryFixture;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    private Banner 메인_배너_1;
+    private Banner 메인_배너_2;
+    private Banner 메인_배너_3;
+    private BannerCategory 배너_카테고리_메인_모달;
+
+    @BeforeAll
+    void setUp() {
+        clear();
+        배너_카테고리_메인_모달 = bannerCategoryFixture.메인_모달();
+        메인_배너_1 = bannerFixture.메인_배너_1(배너_카테고리_메인_모달);
+        메인_배너_2 = bannerFixture.메인_배너_2(배너_카테고리_메인_모달);
+        메인_배너_3 = bannerFixture.메인_배너_3(배너_카테고리_메인_모달);
+    }
+
+    @Test
+    void 특정_카테고리의_활성화된_배너들을_플랫폼에따라_조회한다() throws Exception {
+        mockMvc.perform(
+                get("/banners/{categoryId}", 배너_카테고리_메인_모달.getId())
+                    .param("platform", "ANDROID")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                    {
+                        "count": 2,
+                        "banners": [
+                            {
+                                "id": 1,
+                                "image_url": "https://example.com/1000won.jpg",
+                                "redirect_link": "https://example.com/1000won"
+                            },
+                            {
+                                "id": 2,
+                                "image_url": "https://example.com/koin-event.jpg",
+                                "redirect_link": "https://example.com/koin-event"
+                            }
+                        ]
+                    }
+                """));
+    }
+}

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
@@ -78,7 +78,7 @@ public class AdminBannerApiTest extends AcceptanceTest {
                                 "android_redirect_link": "https://example.com/1000won",
                                 "ios_redirect_link": "https://example.com/1000won",
                                 "is_active": true,
-                                "create_at": "%s"
+                                "created_at": "%s"
                             },
                             {
                                 "id": 2,
@@ -91,7 +91,7 @@ public class AdminBannerApiTest extends AcceptanceTest {
                                 "android_redirect_link": "https://example.com/koin-event",
                                 "ios_redirect_link": "https://example.com/koin-event",
                                 "is_active": true,
-                                "create_at": "%s"
+                                "created_at": "%s"
                             }
                         ]
                     }
@@ -117,7 +117,7 @@ public class AdminBannerApiTest extends AcceptanceTest {
                         "android_redirect_link": "https://example.com/1000won",
                         "ios_redirect_link": "https://example.com/1000won",
                         "is_active": true,
-                        "create_at": "%s"
+                        "created_at": "%s"
                     }
                 """, 생성일)));
     }

--- a/src/test/java/in/koreatech/koin/fixture/BannerFixture.java
+++ b/src/test/java/in/koreatech/koin/fixture/BannerFixture.java
@@ -43,4 +43,18 @@ public class BannerFixture {
             .build()
         );
     }
+
+    public Banner 메인_배너_3(BannerCategory bannerCategory) {
+        return bannerRepository.save(Banner.builder()
+            .bannerCategory(bannerCategory)
+            .priority(null)
+            .title("코인 이벤트 누누")
+            .imageUrl("https://example.com/nunu-event.jpg")
+            .webRedirectLink("https://example.com/nunu-event")
+            .androidRedirectLink("https://example.com/nunu-event")
+            .iosRedirectLink("https://example.com/nunu-event")
+            .isActive(false)
+            .build()
+        );
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1386 

# 🚀 작업 내용

- 카테고리ID와 플랫폼(WEB, ANDROID, IOS)을 요청
- 카테고리에 맞는 활성화된 배너들을 우선순위로 정렬하여 모두 가져옴
- DTO 매핑 과정에서 id, imageUrl, redirectLink만 남김
- redirectLink는 각 플랫폼에 해당하는 url과 매핑
- 총개수(count)와 배너 정보 리스트를 반환

# 💬 리뷰 중점사항
