### PR TITLE
feat: 어드민 배너 삭제 시 우선순위 조정 로직 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/banner/repository/AdminBannerRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/banner/repository/AdminBannerRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.admin.banner.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -10,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.admin.banner.exception.BannerNotFoundException;
 import in.koreatech.koin.domain.banner.model.Banner;
+import in.koreatech.koin.domain.banner.model.BannerCategory;
 
 public interface AdminBannerRepository extends Repository<Banner, Integer> {
 
@@ -51,4 +53,21 @@ public interface AdminBannerRepository extends Repository<Banner, Integer> {
     Page<Banner> findAllByBannerCategoryId(@Param("bannerCategoryId") Integer bannerCategoryId, Pageable pageable);
 
     void deleteById(Integer id);
+
+    @Query("SELECT MAX(b.priority) from Banner b WHERE b.bannerCategory = :category AND b.isActive = true")
+    Integer findMaxPriorityCategory(BannerCategory category);
+
+    Optional<Banner> findByBannerCategoryAndPriorityAndIsActiveTrue(BannerCategory category, Integer priority);
+
+    @Query(value = """
+        SELECT * FROM banners
+        WHERE banner_category_id = :bannerCategoryId
+        AND is_active = :isActive
+        AND priority > :priority
+        """, nativeQuery = true)
+    List<Banner> findLowerPriorityBannersInCategory(
+        @Param("isActive") Boolean isActive,
+        @Param("bannerCategoryId") Integer bannerCategoryId,
+        @Param("priority") Integer priority
+    );
 }

--- a/src/main/java/in/koreatech/koin/admin/banner/service/AdminBannerService.java
+++ b/src/main/java/in/koreatech/koin/admin/banner/service/AdminBannerService.java
@@ -58,9 +58,18 @@ public class AdminBannerService {
         adminBannerRepository.save(banner);
     }
 
-    // TODO. 우선순위 삭제 로직 추가
     @Transactional
     public void deleteBanner(Integer bannerId) {
+        Banner banner = adminBannerRepository.getById(bannerId);
+        BannerCategory bannerCategory = banner.getBannerCategory();
+
+        if (banner.getIsActive()) {
+            adminBannerRepository.findLowerPriorityBannersInCategory(true, bannerCategory.getId(), banner.getPriority())
+                .forEach(lowerPriorityBanner -> {
+                    Integer priority = lowerPriorityBanner.getPriority();
+                    lowerPriorityBanner.updatePriority(priority - 1);
+                });
+        }
         adminBannerRepository.deleteById(bannerId);
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/banner/service/AdminBannerService.java
+++ b/src/main/java/in/koreatech/koin/admin/banner/service/AdminBannerService.java
@@ -63,7 +63,7 @@ public class AdminBannerService {
         Banner banner = adminBannerRepository.getById(bannerId);
         BannerCategory bannerCategory = banner.getBannerCategory();
 
-        if (banner.getIsActive()) {
+        if (banner.getIsActive() && banner.getPriority() != null) {
             adminBannerRepository.findLowerPriorityBannersInCategory(true, bannerCategory.getId(), banner.getPriority())
                 .forEach(lowerPriorityBanner -> {
                     Integer priority = lowerPriorityBanner.getPriority();

--- a/src/main/java/in/koreatech/koin/domain/banner/model/Banner.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/model/Banner.java
@@ -80,4 +80,26 @@ public class Banner extends BaseEntity {
         this.isActive = isActive;
         this.bannerCategory = bannerCategory;
     }
+
+    public void modifyBanner(
+        String title,
+        String imageUrl,
+        String webRedirectLink,
+        String androidRedirectLink,
+        String iosRedirectLink
+    ) {
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.webRedirectLink = webRedirectLink;
+        this.androidRedirectLink = androidRedirectLink;
+        this.iosRedirectLink = iosRedirectLink;
+    }
+
+    public void updatePriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    public void updateIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
 }

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
@@ -174,26 +174,12 @@ public class AdminBannerApiTest extends AcceptanceTest {
             )
             .andExpect(status().isNoContent());
 
-        mockMvc.perform(
-                get("/admin/banners/2")
-                    .header("Authorization", "Bearer " + 어드민_토큰)
-            )
-            .andExpect(status().isOk())
-            .andExpect(content().json(String.format("""
-                    {
-                        "id": 2,
-                        "banner_category_id": 1,
-                        "banner_category": "메인 모달",
-                        "priority": 1,
-                        "title": "코인 이벤트",
-                        "image_url": "https://example.com/koin-event.jpg",
-                        "web_redirect_link": "https://example.com/koin-event",
-                        "android_redirect_link": "https://example.com/koin-event",
-                        "ios_redirect_link": "https://example.com/koin-event",
-                        "is_active": true,
-                        "create_at": "%s"
-                    }
-                """, 생성일)));
+        transactionTemplate.executeWithoutResult(status -> {
+            Banner priorityUpdatedBanner = adminBannerRepository.getById(메인_배너_2.getId());
+            assertSoftly(softly -> {
+                softly.assertThat(priorityUpdatedBanner.getPriority()).isEqualTo(1);
+            });
+        });
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminBannerApiTest.java
@@ -149,5 +149,26 @@ public class AdminBannerApiTest extends AcceptanceTest {
                     .header("Authorization", "Bearer " + 어드민_토큰)
             )
             .andExpect(status().isNoContent());
+
+        mockMvc.perform(
+                get("/admin/banners/2")
+                    .header("Authorization", "Bearer " + 어드민_토큰)
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json(String.format("""
+                    {
+                        "id": 2,
+                        "banner_category_id": 1,
+                        "banner_category": "메인 모달",
+                        "priority": 1,
+                        "title": "코인 이벤트",
+                        "image_url": "https://example.com/koin-event.jpg",
+                        "web_redirect_link": "https://example.com/koin-event",
+                        "android_redirect_link": "https://example.com/koin-event",
+                        "ios_redirect_link": "https://example.com/koin-event",
+                        "is_active": true,
+                        "create_at": "%s"
+                    }
+                """, 생성일)));
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1395 

# 🚀 작업 내용

### 어드민 배너 삭제 시 우선순위 조정 로직
- 배너 삭제 시 우선순위 조정 로직을 구현했습니다.
  - 삭제하는 배너가 활성화 상태이면서 우선순위가 있는 경우, 해당 배너와 같은 배너 카테고리에 있으면서 우선순위가 낮은 배너들의 우선순위를 수정합니다.
  - 관련해서 테스트 코드 작성했습니다.

# 💬 리뷰 중점사항
이전 PR에서 구현에 필요한 부분 긁어왔습니다. 이 부분 빼고 보시면 될 것 같습니다.