### PR TITLE
feat: 상점 리뷰 하루 한번으로 제한하기

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopReviewApi.java
@@ -17,6 +17,7 @@ import in.koreatech.koin._common.auth.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -80,7 +81,15 @@ public interface ShopReviewApi {
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "201"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "일일 리뷰 등록 횟수 초과", value = """
+                {
+                  "code": "",
+                  "message": "한 상점에 하루에 한번만 리뷰를 남길 수 있습니다.",
+                  "errorTraceId": "d4955051-bbc3-45fb-80d7-350eda9a81bd"
+                }
+                """)
+            }), description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),

--- a/src/main/java/in/koreatech/koin/domain/shop/exception/OneReviewPerDayException.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/exception/OneReviewPerDayException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.shop.exception;
+
+import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
+
+public class OneReviewPerDayException extends KoinIllegalArgumentException {
+
+    private static final String DEFAULT_MESSAGE = "한 상점에 하루에 한번만 리뷰를 남길 수 있습니다.";
+
+    public OneReviewPerDayException(String message) {
+        super(message);
+    }
+
+    public OneReviewPerDayException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static OneReviewPerDayException withDetail(String detail) {
+        return new OneReviewPerDayException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/review/ShopReviewRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/review/ShopReviewRepository.java
@@ -1,12 +1,15 @@
 package in.koreatech.koin.domain.shop.repository.review;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.shop.exception.ReviewNotFoundException;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
@@ -38,4 +41,15 @@ public interface ShopReviewRepository extends Repository<ShopReview, Integer> {
     Integer countByShopIdAndRatingAndIsDeletedFalse(Integer shopId, Integer rating);
 
     Optional<ShopReview> findById(Integer reviewId);
+
+    @Query(value = "SELECT * FROM shop_reviews "
+        + "WHERE reviewer_id = :studentId "
+        + "AND shop_id = :shopId "
+        + "AND created_at > :currentTime - INTERVAL 1 DAY "
+        + "ORDER BY created_at DESC LIMIT 1", nativeQuery = true)
+    Optional<ShopReview> findLatestReviewByStudentIdAndShopIdWithin24Hours(
+        @Param("studentId") Integer studentId,
+        @Param("shopId") Integer shopId,
+        @Param("currentTime") LocalDateTime currentTime
+    );
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.shop.service;
 import static in.koreatech.koin.domain.shop.dto.review.request.ShopReviewReportRequest.InnerShopReviewReport;
 import static in.koreatech.koin.domain.shop.model.review.ReportStatus.UNHANDLED;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -59,6 +60,7 @@ public class ShopReviewService {
     private final ShopReviewReportCategoryRepository shopReviewReportCategoryRepository;
     private final StudentRepository studentRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
 
     private final EntityManager entityManager;
 
@@ -195,7 +197,7 @@ public class ShopReviewService {
     }
 
     private void checkUserLatestReviewWithin24Hours(Integer studentId, Integer shopId) {
-        shopReviewRepository.findLatestReviewByStudentIdAndShopIdWithin24Hours(studentId, shopId, LocalDateTime.now())
+        shopReviewRepository.findLatestReviewByStudentIdAndShopIdWithin24Hours(studentId, shopId, LocalDateTime.now(clock))
             .ifPresent(review -> {
                 throw OneReviewPerDayException.withDetail("한 상점에 하루에 한번만 리뷰를 남길 수 있습니다.");
             });

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.shop.service;
 import static in.koreatech.koin.domain.shop.dto.review.request.ShopReviewReportRequest.InnerShopReviewReport;
 import static in.koreatech.koin.domain.shop.model.review.ReportStatus.UNHANDLED;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import in.koreatech.koin.domain.shop.dto.review.response.ShopReviewReportCategor
 import in.koreatech.koin.domain.shop.dto.review.request.ShopReviewReportRequest;
 import in.koreatech.koin.domain.shop.dto.review.response.ShopReviewResponse;
 import in.koreatech.koin.domain.shop.dto.review.response.ShopReviewsResponse;
+import in.koreatech.koin.domain.shop.exception.OneReviewPerDayException;
 import in.koreatech.koin.domain.shop.exception.ReviewNotFoundException;
 import in.koreatech.koin._common.event.ReviewRegisterEvent;
 import in.koreatech.koin._common.event.ReviewReportEvent;
@@ -84,6 +86,7 @@ public class ShopReviewService {
 
     @Transactional
     public void createReview(CreateReviewRequest createReviewRequest, Integer studentId, Integer shopId) {
+        checkUserLatestReviewWithin24Hours(studentId, shopId);
         Student student = studentRepository.getById(studentId);
         Shop shop = shopRepository.getById(shopId);
         ShopReview shopReview = ShopReview.builder()
@@ -189,5 +192,12 @@ public class ShopReviewService {
             sortBy.getSort()
         );
         return ShopMyReviewsResponse.from(reviews);
+    }
+
+    private void checkUserLatestReviewWithin24Hours(Integer studentId, Integer shopId) {
+        shopReviewRepository.findLatestReviewByStudentIdAndShopIdWithin24Hours(studentId, shopId, LocalDateTime.now())
+            .ifPresent(review -> {
+                throw OneReviewPerDayException.withDetail("한 상점에 하루에 한번만 리뷰를 남길 수 있습니다.");
+            });
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -66,6 +66,7 @@ class ShopReviewApiTest extends AcceptanceTest {
     private ShopReview 준호_학생_리뷰;
     private ShopReview 익명_학생_리뷰;
     private Shop 신전_떡볶이;
+    private Shop 티바;
     private Owner 현수_사장님;
     private Student 준호_학생;
     private Student 익명_학생;
@@ -95,6 +96,7 @@ class ShopReviewApiTest extends AcceptanceTest {
         익명_학생 = userFixture.익명_학생(컴퓨터_공학부);
         현수_사장님 = userFixture.현수_사장님();
         신전_떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(현수_사장님);
+        티바 = shopFixture._24시간_영업중인_티바(현수_사장님);
         token_준호 = userFixture.getToken(준호_학생.getUser());
         준호_학생_리뷰 = shopReviewFixture.리뷰_4점(준호_학생, 신전_떡볶이);
         익명_학생_리뷰 = shopReviewFixture.리뷰_4점(익명_학생, 신전_떡볶이);
@@ -107,7 +109,7 @@ class ShopReviewApiTest extends AcceptanceTest {
     @Test
     @DisplayName("사용자가 리뷰를 등록할 수 있다.")
     void createReview() throws Exception {
-        mockMvc.perform(post("/shops/{shopId}/reviews", 신전_떡볶이.getId())
+        mockMvc.perform(post("/shops/{shopId}/reviews", 티바.getId())
                 .header("Authorization", "Bearer " + token_준호)
                 .content(String.format("""
                 {
@@ -152,7 +154,7 @@ class ShopReviewApiTest extends AcceptanceTest {
 
     @Test
     void 리뷰_내용을_작성하지_않고_리뷰를_등록할_수_있다() throws Exception {
-        mockMvc.perform(post("/shops/{shopId}/reviews", 신전_떡볶이.getId())
+        mockMvc.perform(post("/shops/{shopId}/reviews", 티바.getId())
                 .header("Authorization", "Bearer " + token_준호)
                 .content(String.format("""
                 {

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -51,7 +51,7 @@ import in.koreatech.koin.fixture.UserFixture;
 class ShopReviewApiTest extends AcceptanceTest {
 
     @Autowired
-    private TransactionTemplate transactionTemplate;
+        private TransactionTemplate transactionTemplate;
 
     @Autowired
     private UserFixture userFixture;
@@ -1236,32 +1236,6 @@ class ShopReviewApiTest extends AcceptanceTest {
 
     @Test
     void 한_상점에_하루에_한번의_리뷰만_등록할_수_있다() throws Exception {
-        // 첫 번째 요청
-        transactionTemplate.execute(status -> {
-            try {
-                testTimeConfig.setCurrTime(LocalDateTime.of(2024, 1, 15, 12, 0, 0));
-                mockMvc.perform(post("/shops/{shopId}/reviews", 신전_떡볶이.getId())
-                        .header("Authorization", "Bearer " + token_준호)
-                        .content("""
-                        {
-                          "rating": 4,
-                          "content": "정말 맛있어요~!",
-                          "image_urls": ["https://static.koreatech.in/example.png"],
-                          "menu_names": ["치킨", "피자"]
-                        }
-                        """)
-                        .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isCreated());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        });
-
-        // 시간 이동
-        testTimeConfig.setCurrTime(LocalDateTime.of(2024, 1, 15, 12, 1));
-
-        System.out.println("테스트 시간(이동 후) : " + LocalDateTime.now());
         // 두 번째 요청
         mockMvc.perform(post("/shops/{shopId}/reviews", 신전_떡볶이.getId())
                 .header("Authorization", "Bearer " + token_준호)
@@ -1274,6 +1248,6 @@ class ShopReviewApiTest extends AcceptanceTest {
                 }
                 """)
                 .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/ShopReviewApiTest.java
@@ -4,12 +4,10 @@ import static in.koreatech.koin.domain.shop.model.review.ReportStatus.UNHANDLED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -18,15 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import groovy.util.logging.Slf4j;
 import in.koreatech.koin.AcceptanceTest;
-import in.koreatech.koin.config.FixedDate;
-import in.koreatech.koin.config.TestTimeConfig;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin.domain.shop.model.review.ShopReviewReport;
@@ -47,11 +40,10 @@ import in.koreatech.koin.fixture.UserFixture;
 @SuppressWarnings("NonAsciiCharacters")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
-@Slf4j
 class ShopReviewApiTest extends AcceptanceTest {
 
     @Autowired
-        private TransactionTemplate transactionTemplate;
+    private TransactionTemplate transactionTemplate;
 
     @Autowired
     private UserFixture userFixture;
@@ -92,9 +84,6 @@ class ShopReviewApiTest extends AcceptanceTest {
 
     @Autowired
     private ShopReviewReportCategoryRepository shopReviewReportCategoryRepository;
-
-    @Autowired
-    private TestTimeConfig testTimeConfig;
 
     private final int INITIAL_REVIEW_COUNT = 2;
 


### PR DESCRIPTION
# 🔥 연관 이슈

- #1398 

# 🚀 작업 내용

### 1. 리뷰 제한 로직 추가
- 사용자가 동일한 상점에 하루 내 최대 한 번만 리뷰를 남길 수 있도록 검증 로직을 구현했습니다.
- 검증 실패 시 400 Bad Request 예외를 반환합니다.

### 2. 테스트 코드 작성
- 기능 검증을 위한 테스트 코드를 추가했습니다.
- [테스트 관련 이슈](https://www.notion.so/1c09ae650b5980b8b21cdaad20a0d078)

# 💬 리뷰 중점사항
