### PR TITLE
feat: 일반인 유저타입 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.article.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import java.util.List;
@@ -160,7 +159,7 @@ public interface ArticleApi {
     @Operation(summary = "분실물 게시글 등록")
     @PostMapping("/lost-item")
     ResponseEntity<LostItemArticleResponse> createLostItemArticle(
-        @Auth(permit = {STUDENT, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId,
         @RequestBody @Valid LostItemArticlesRequest lostItemArticlesRequest
     );
 
@@ -177,6 +176,6 @@ public interface ArticleApi {
     @DeleteMapping("/lost-item/{id}")
     ResponseEntity<Void> deleteLostItemArticle(
         @PathVariable("id") Integer articleId,
-        @Auth(permit = {STUDENT, COUNCIL}) Integer councilId
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer councilId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/ArticleController.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.article.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.util.List;
 
@@ -119,7 +118,7 @@ public class ArticleController implements ArticleApi {
 
     @PostMapping("/lost-item")
     public ResponseEntity<LostItemArticleResponse> createLostItemArticle(
-        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @RequestBody @Valid LostItemArticlesRequest lostItemArticlesRequest
     ) {
         LostItemArticleResponse response = articleService.createLostItemArticle(studentId, lostItemArticlesRequest);
@@ -129,7 +128,7 @@ public class ArticleController implements ArticleApi {
     @DeleteMapping("/lost-item/{id}")
     public ResponseEntity<Void> deleteLostItemArticle(
         @PathVariable("id") Integer articleId,
-        @Auth(permit = {STUDENT, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId
     ) {
         articleService.deleteLostItemArticle(articleId, userId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/LostItemReportApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/LostItemReportApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.article.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.ResponseEntity;
@@ -24,6 +23,6 @@ public interface LostItemReportApi {
     ResponseEntity<Void> reportLostItemArticle(
         @Parameter(in = PATH) @PathVariable Integer id,
         @RequestBody @Valid LostItemReportRequest lostItemReportRequest,
-        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/controller/LostItemReportController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/controller/LostItemReportController.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.community.article.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,7 +24,7 @@ public class LostItemReportController implements LostItemReportApi{
     public ResponseEntity<Void> reportLostItemArticle(
         @PathVariable Integer id,
         @RequestBody @Valid LostItemReportRequest lostItemReportRequest,
-        @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer studentId
     ) {
         lostItemReportService.reportLostItemArticle(id, studentId, lostItemReportRequest);
         return ResponseEntity.noContent().build();

--- a/src/main/java/in/koreatech/koin/domain/dining/controller/DiningApi.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/controller/DiningApi.java
@@ -44,14 +44,14 @@ public interface DiningApi {
     @Operation(summary = "식단 좋아요")
     @PatchMapping("/dining/like")
     ResponseEntity<Void> likeDining(
-        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     );
 
     @Operation(summary = "식단 좋아요 취소")
     @PatchMapping("/dining/like/cancel")
     ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/dining/controller/DiningController.java
+++ b/src/main/java/in/koreatech/koin/domain/dining/controller/DiningController.java
@@ -38,7 +38,7 @@ public class DiningController implements DiningApi {
 
     @PatchMapping("/dining/like")
     public ResponseEntity<Void> likeDining(
-        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     ) {
         diningService.likeDining(userId, diningId);
@@ -47,7 +47,7 @@ public class DiningController implements DiningApi {
 
     @PatchMapping("/dining/like/cancel")
     public ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {STUDENT, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
         @RequestParam Integer diningId
     ) {
         diningService.likeDiningCancel(userId, diningId);

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import in.koreatech.koin.domain.shop.dto.search.response.RelatedKeywordResponse;
@@ -121,6 +120,6 @@ public interface ShopApi {
     @PostMapping("/shops/{shopId}/call-notification")
     ResponseEntity<Void> createCallNotification(
             @Parameter(in = PATH) @PathVariable("shopId") Integer shopId,
-            @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
+            @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import in.koreatech.koin.domain.shop.dto.search.response.RelatedKeywordResponse;
@@ -75,7 +74,7 @@ public class ShopController implements ShopApi {
     @PostMapping("/shops/{shopId}/call-notification")
     public ResponseEntity<Void> createCallNotification(
             @Parameter(in = PATH) @PathVariable("shopId") Integer shopId,
-            @Auth(permit = {STUDENT, COUNCIL}) Integer studentId
+            @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer studentId
     ) {
         shopService.publishCallNotification(shopId, studentId);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -58,7 +58,7 @@ public interface UserApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/user/logout")
     ResponseEntity<Void> logout(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -87,7 +87,7 @@ public interface UserApi {
     @Operation(summary = "사용자 권한 조회")
     @GetMapping("/user/auth")
     ResponseEntity<AuthResponse> getAuth(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -102,7 +102,7 @@ public interface UserApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @DeleteMapping("/user")
     ResponseEntity<Void> withdraw(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -149,7 +149,7 @@ public interface UserApi {
     @PostMapping("/user/check/password")
     ResponseEntity<Void> checkPassword(
         @Valid @RequestBody UserPasswordCheckRequest request,
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController implements UserApi {
 
     @PostMapping("/user/logout")
     public ResponseEntity<Void> logout(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userService.logout(userId);
         return ResponseEntity.ok().build();
@@ -62,7 +62,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/auth")
     public ResponseEntity<AuthResponse> getAuth(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         AuthResponse authResponse = userService.getAuth(userId);
         return ResponseEntity.ok().body(authResponse);
@@ -70,7 +70,7 @@ public class UserController implements UserApi {
 
     @DeleteMapping("/user")
     public ResponseEntity<Void> withdraw(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userService.withdraw(userId);
         return ResponseEntity.noContent().build();
@@ -106,7 +106,7 @@ public class UserController implements UserApi {
     @PostMapping("/user/check/password")
     public ResponseEntity<Void> checkPassword(
         @Valid @RequestBody UserPasswordCheckRequest request,
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         userValidationService.checkPassword(request, userId);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserType.java
@@ -4,10 +4,11 @@ import lombok.Getter;
 
 @Getter
 public enum UserType {
+    GENERAL("GENERAL", "일반"),
     STUDENT("STUDENT", "학생"),
-    OWNER("OWNER", "사장님"),
-    COOP("COOP", "영양사"),
     COUNCIL("COUNCIL", "총학생회"),
+    COOP("COOP", "영양사"),
+    OWNER("OWNER", "사장님"),
     ADMIN("ADMIN", "어드민"),
     ;
 

--- a/src/main/java/in/koreatech/koin/integration/fcm/notification/controller/NotificationApi.java
+++ b/src/main/java/in/koreatech/koin/integration/fcm/notification/controller/NotificationApi.java
@@ -37,7 +37,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 동의 여부 조회")
     @GetMapping("/notification")
     ResponseEntity<NotificationStatusResponse> checkNotificationStatus(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -52,7 +52,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 동의")
     @PostMapping("/notification")
     ResponseEntity<Void> permitNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @Valid @RequestBody NotificationPermitRequest request
     );
 
@@ -68,7 +68,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 알림 구독")
     @PostMapping("/notification/subscribe")
     ResponseEntity<Void> permitNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     );
 
@@ -84,7 +84,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 세부알림 구독")
     @PostMapping("/notification/subscribe/detail")
     ResponseEntity<Void> permitNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType notificationSubscribeType
     );
 
@@ -100,7 +100,7 @@ public interface NotificationApi {
     @Operation(summary = "푸쉬알림 거절")
     @DeleteMapping("/notification")
     ResponseEntity<Void> rejectNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     );
 
     @ApiResponses(
@@ -115,7 +115,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 알림 구독 취소")
     @DeleteMapping("/notification/subscribe")
     ResponseEntity<Void> rejectNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     );
 
@@ -131,7 +131,7 @@ public interface NotificationApi {
     @Operation(summary = "특정 세부알림 구독 취소")
     @DeleteMapping("/notification/subscribe/detail")
     ResponseEntity<Void> rejectNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType notificationSubscribeType
     );
 }

--- a/src/main/java/in/koreatech/koin/integration/fcm/notification/controller/NotificationController.java
+++ b/src/main/java/in/koreatech/koin/integration/fcm/notification/controller/NotificationController.java
@@ -28,14 +28,14 @@ public class NotificationController implements NotificationApi {
 
     @GetMapping("/notification")
     public ResponseEntity<NotificationStatusResponse> checkNotificationStatus(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         return ResponseEntity.ok(notificationService.checkNotification(userId));
     }
 
     @PostMapping("/notification")
     public ResponseEntity<Void> permitNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @Valid @RequestBody NotificationPermitRequest request
     ) {
         notificationService.permitNotification(userId, request.deviceToken());
@@ -44,7 +44,7 @@ public class NotificationController implements NotificationApi {
 
     @PostMapping("/notification/subscribe")
     public ResponseEntity<Void> permitNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     ) {
         notificationService.permitNotificationSubscribe(userId, notificationSubscribeType);
@@ -53,7 +53,7 @@ public class NotificationController implements NotificationApi {
 
     @PostMapping("/notification/subscribe/detail")
     public ResponseEntity<Void> permitNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType detailSubscribeType
     ) {
         notificationService.permitNotificationDetailSubscribe(userId, detailSubscribeType);
@@ -62,7 +62,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification")
     public ResponseEntity<Void> rejectNotification(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId
     ) {
         notificationService.rejectNotification(userId);
         return ResponseEntity.noContent().build();
@@ -70,7 +70,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification/subscribe")
     public ResponseEntity<Void> rejectNotificationSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "type") NotificationSubscribeType notificationSubscribeType
     ) {
         notificationService.rejectNotificationByType(userId, notificationSubscribeType);
@@ -79,7 +79,7 @@ public class NotificationController implements NotificationApi {
 
     @DeleteMapping("/notification/subscribe/detail")
     public ResponseEntity<Void> rejectNotificationDetailSubscribe(
-        @Auth(permit = {STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
+        @Auth(permit = {GENERAL, STUDENT, OWNER, COOP, COUNCIL}) Integer userId,
         @RequestParam(value = "detail_type") NotificationDetailSubscribeType detailSubscribeType
     ) {
         notificationService.rejectNotificationDetailSubscribe(userId, detailSubscribeType);

--- a/src/main/java/in/koreatech/koin/integration/s3/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/integration/s3/controller/UploadApi.java
@@ -57,7 +57,7 @@ public interface UploadApi {
     ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 
     @ApiResponses(
@@ -88,7 +88,7 @@ public interface UploadApi {
     ResponseEntity<UploadFileResponse> uploadFile(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 
     @ApiResponses(
@@ -119,6 +119,6 @@ public interface UploadApi {
     ResponseEntity<UploadFilesResponse> uploadFiles(
         @Parameter(in = PATH) @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     );
 }

--- a/src/main/java/in/koreatech/koin/integration/s3/controller/UploadController.java
+++ b/src/main/java/in/koreatech/koin/integration/s3/controller/UploadController.java
@@ -34,7 +34,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadUrlResponse> getPresignedUrl(
         @PathVariable ImageUploadDomain domain,
         @RequestBody @Valid UploadUrlRequest request,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.getPresignedUrl(domain, request);
         return ResponseEntity.ok(response);
@@ -48,7 +48,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFileResponse> uploadFile(
         @PathVariable ImageUploadDomain domain,
         @RequestPart MultipartFile multipartFile,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.uploadFile(domain, multipartFile);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -62,7 +62,7 @@ public class UploadController implements UploadApi {
     public ResponseEntity<UploadFilesResponse> uploadFiles(
         @PathVariable ImageUploadDomain domain,
         @RequestPart List<MultipartFile> files,
-        @Auth(permit = {OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
+        @Auth(permit = {GENERAL, OWNER, STUDENT, COOP, ADMIN, COUNCIL}, anonymous = true) Integer memberId
     ) {
         var response = uploadService.uploadFiles(domain, files);
         return new ResponseEntity<>(response, HttpStatus.CREATED);

--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/controller/ChatRestApi.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/controller/ChatRestApi.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.socket.domain.chatroom.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.COUNCIL;
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 
 import java.util.List;
 
@@ -62,7 +61,7 @@ public interface ChatRestApi {
     )
     @PostMapping("/lost-item/{articleId}")
     ResponseEntity<ChatRoomInfoResponse> createLostItemChatRoom(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId
     );
 
@@ -87,7 +86,7 @@ public interface ChatRestApi {
     )
     @PostMapping("/lost-item/{articleId}/{chatRoomId}/block")
     ResponseEntity<?> blockChatUser(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     );
@@ -113,7 +112,7 @@ public interface ChatRestApi {
     )
     @DeleteMapping("/lost-item/{articleId}/{chatRoomId}/unblock")
     ResponseEntity<?> unblockChatUser(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     );
@@ -151,7 +150,7 @@ public interface ChatRestApi {
     )
     @GetMapping("/lost-item/{articleId}/{chatRoomId}")
     ResponseEntity<?> getLostItemChatRoom(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     );
@@ -166,7 +165,7 @@ public interface ChatRestApi {
     )
     @GetMapping("/lost-item/{articleId}/{chatRoomId}/messages")
     ResponseEntity<List<ChatMessageResponse>> getAllMessages(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     );
@@ -189,6 +188,6 @@ public interface ChatRestApi {
     )
     @GetMapping("/lost-item/")
     ResponseEntity<List<ChatRoomListResponse>> getAllChatRoomInfo(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/controller/ChatRestController.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/controller/ChatRestController.java
@@ -33,7 +33,7 @@ public class ChatRestController implements ChatRestApi {
 
     @PostMapping("/lost-item/{articleId}")
     public ResponseEntity<ChatRoomInfoResponse> createLostItemChatRoom(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId
     ) {
         Integer chatRoomId = chatRoomInfoService.createLostItemChatRoom(articleId, studentId);
@@ -46,7 +46,7 @@ public class ChatRestController implements ChatRestApi {
 
     @GetMapping("/lost-item/{articleId}/{chatRoomId}")
     public ResponseEntity<?> getLostItemChatRoom(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     ) {
@@ -60,7 +60,7 @@ public class ChatRestController implements ChatRestApi {
 
     @PostMapping("/lost-item/{articleId}/{chatRoomId}/block")
     public ResponseEntity<?> blockChatUser(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     ) {
@@ -70,7 +70,7 @@ public class ChatRestController implements ChatRestApi {
 
     @DeleteMapping("/lost-item/{articleId}/{chatRoomId}/unblock")
     public ResponseEntity<?> unblockChatUser(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     ) {
@@ -80,7 +80,7 @@ public class ChatRestController implements ChatRestApi {
 
     @GetMapping("/lost-item/{articleId}/{chatRoomId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getAllMessages(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId,
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId,
         @PathVariable("articleId") Integer articleId,
         @PathVariable("chatRoomId") Integer chatRoomId
     ) {
@@ -92,7 +92,7 @@ public class ChatRestController implements ChatRestApi {
 
     @GetMapping("/lost-item")
     public ResponseEntity<List<ChatRoomListResponse>> getAllChatRoomInfo(
-        @Auth(permit= {STUDENT, COUNCIL}) Integer studentId
+        @Auth(permit= {GENERAL, STUDENT, COUNCIL}) Integer studentId
     ) {
         return ResponseEntity.ok(chatRoomInfoService.getAllChatRoomInfo(studentId));
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1404 

# 🚀 작업 내용

1. 일반인 UserType : `GENERAL` 을 추가했습니다.
2. 일반인은 `공지사항 알림, 학식 좋아요, 리뷰, 푸시알림, 주문 전화 리뷰 푸시알림, 파일업로드, 분실물, 분실물 쪽지` 권한을 가집니다.
3. 학생은 `졸업학점계산기, 학생 정보, 리뷰, 시간표, 학기정보` 권한을 추가로 갖고 있습니다.

