### PR TITLE
feat: 어드민 히스토리 PATCH 요청 추가 및 도메인 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
+++ b/src/main/java/in/koreatech/koin/admin/history/enums/DomainType.java
@@ -31,7 +31,10 @@ public enum DomainType {
     USERS("User", "회원"),
     STUDENT("Student", "학생"),
     OWNER("Owner", "사장님"),
-    ADMIN("Admin", "어드민")
+    ADMIN("Admin", "어드민"),
+
+    BANNERS("Banner", "배너"),
+    BANNER_CATEGORIES("Banner Categories", "배너 카테고리"),
     ;
 
     private final String value;

--- a/src/main/java/in/koreatech/koin/admin/history/enums/HttpMethodType.java
+++ b/src/main/java/in/koreatech/koin/admin/history/enums/HttpMethodType.java
@@ -7,6 +7,7 @@ public enum HttpMethodType {
     POST("생성"),
     PUT("수정"),
     DELETE("삭제"),
+    PATCH("수정"),
     ;
 
     private final String value;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1428 

# 🚀 작업 내용

### 어드민 히스토리 PATCH 요청 추가
<img width="780" alt="image" src="https://github.com/user-attachments/assets/ffe00412-fb9b-426d-afdc-12211415c272" />

- 어드민 히스토리에는 API 요청 메소드를 통해 추가, 수정, 삭제를 반환합니다.
- PATCH 요청이 없어서 에러가 발생했고, 이를 추가했습니다.
### 어드민 히스토리 도메인 추가
<img width="240" alt="image" src="https://github.com/user-attachments/assets/bf300d46-4185-4816-a7c4-cb27ef839ece" />

- 어드민 히스토리는 도메인 enum과 API 요청 PATH를 비교해서 히스토리의 도메인을 반환합니다.
- 배너와 배너 카테고리의 enum이 존재하지 않아 히스토리에 어드민 도메인으로 처리됐습니다.
- 이를 추가하고, AOP에서 처리하도록 로직을 추가했습니다.

# 💬 리뷰 중점사항
히스토리 코드를 처음 보는 분이 계실텐데, 코드 자체가 쉽지 않습니다.
이후에 코드를 갈아 엎을 생각이라서, 수정된 부분만 확인해주시면 감사하겠습니다.