### PR TITLE
fix: 리뷰어 자동 지정이 PR이 열렸을 때도 동작되도록 수정한다.

### DIFF
--- a/.github/workflows/pr-reviewers-by-label.yml
+++ b/.github/workflows/pr-reviewers-by-label.yml
@@ -1,7 +1,7 @@
 name: "Assign Reviewers by Label"
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, labeled, unlabeled]
 
 jobs:
   assign:

--- a/src/main/java/in/koreatech/koin/admin/benefit/service/AdminBenefitService.java
+++ b/src/main/java/in/koreatech/koin/admin/benefit/service/AdminBenefitService.java
@@ -51,8 +51,8 @@ public class AdminBenefitService {
             throw BenefitLimitException.withDetail("최대 혜택 수는 " + BenefitCategory.MAX_BENEFIT_CATEGORIES + "개 입니다.");
         }
 
-        boolean isExistCategory = adminBenefitCategoryRepository.existsByTitle(request.title());
-        if (isExistCategory) {
+        boolean existsCategory = adminBenefitCategoryRepository.existsByTitle(request.title());
+        if (existsCategory) {
             throw BenefitDuplicationException.withDetail("이미 존재하는 혜택 카테고리입니다.");
         }
 
@@ -66,8 +66,8 @@ public class AdminBenefitService {
         Integer categoryId,
         AdminModifyBenefitCategoryRequest request
     ) {
-        boolean isExistCategory = adminBenefitCategoryRepository.existsByTitleAndIdNot(request.title(), categoryId);
-        if (isExistCategory) {
+        boolean existsCategory = adminBenefitCategoryRepository.existsByTitleAndIdNot(request.title(), categoryId);
+        if (existsCategory) {
             throw BenefitDuplicationException.withDetail("이미 존재하는 혜택 카테고리입니다.");
         }
         BenefitCategory benefitCategory = adminBenefitCategoryRepository.getById(categoryId);

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -131,6 +131,7 @@ public interface UserApi {
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", content = @Content(schema = @Schema(hidden = true))),
         }
     )
     @Operation(summary = "전화번호 중복 체크")

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -100,7 +100,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/user/check/phone")
+    @GetMapping("/user/check/phone")
     public ResponseEntity<Void> checkPhoneNumberExist(
         @ModelAttribute(value = "phone")
         @Valid PhoneCheckExistsRequest request

--- a/src/main/java/in/koreatech/koin/socket/domain/session/service/UserSessionService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/session/service/UserSessionService.java
@@ -24,7 +24,7 @@ public class UserSessionService {
         return userSessionRepository.findUserSession(userId);
     }
 
-    public boolean isExists(Integer userId) {
+    public boolean exists(Integer userId) {
         return userSessionRepository.exists(userId);
     }
 

--- a/src/main/java/in/koreatech/koin/socket/interceptor/ConnectInterceptor.java
+++ b/src/main/java/in/koreatech/koin/socket/interceptor/ConnectInterceptor.java
@@ -65,7 +65,7 @@ public class ConnectInterceptor implements ChannelInterceptor {
                 accessor.setUser(principal);
 
                 // 사용자 세션 활성화
-                if (userSessionService.isExists(principal.getUserId())) {
+                if (userSessionService.exists(principal.getUserId())) {
                     userSessionService.updateUserStatus(principal.getUserId(), UserSessionStatus.ACTIVE_APP);
                 } else {
                     userSessionService.save(

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -187,7 +187,7 @@ class UserApiTest extends AcceptanceTest {
         String phoneNumber = "01012345678";
 
         mockMvc.perform(
-                post("/user/check/phone")
+                get("/user/check/phone")
                     .param("phone", phoneNumber)
                     .contentType(MediaType.APPLICATION_JSON)
             )
@@ -201,7 +201,7 @@ class UserApiTest extends AcceptanceTest {
         User user = userFixture.코인_유저();
 
         mockMvc.perform(
-                post("/user/check/phone")
+                get("/user/check/phone")
                     .param("phone", user.getPhoneNumber())
                     .contentType(MediaType.APPLICATION_JSON)
             )


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1434 

# 🚀 작업 내용

1. 리뷰어 자동 지정이 PR이 열렸을 때도 동작되도록 수정한다.
2. 잘못된 요청 매핑 수정
