### PR TITLE
feat: Normal Banner API 배너 이름 응답값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/banner/dto/response/BannersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/banner/dto/response/BannersResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.banner.dto.response;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
@@ -22,22 +23,26 @@ public record BannersResponse(
 
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerBannerResponse(
-        @Schema(description = "배너 ID", example = "1")
+        @Schema(description = "배너 ID", example = "1", requiredMode = REQUIRED)
         Integer id,
 
-        @Schema(description = "배너 이미지 링크", example = "https://example.com/1000won.jpg")
+        @Schema(description = "배너 이름", example = "천원의 아침 식사", requiredMode = REQUIRED)
+        String title,
+
+        @Schema(description = "배너 이미지 링크", example = "https://example.com/1000won.jpg", requiredMode = REQUIRED)
         String imageUrl,
 
-        @Schema(description = "플랫폼에 해당하는 리다이렉션 링크", example = "https://example.com/1000won")
+        @Schema(description = "플랫폼에 해당하는 리다이렉션 링크", example = "https://example.com/1000won", requiredMode = NOT_REQUIRED)
         String redirectLink,
 
-        @Schema(description = "플랫폼에 해당하는 최소 버전", example = "3.0.14")
+        @Schema(description = "플랫폼에 해당하는 최소 버전", example = "3.0.14", requiredMode = NOT_REQUIRED)
         String version
     ) {
 
         public static InnerBannerResponse of(Banner banner, PlatformType platformType) {
             return new InnerBannerResponse(
                 banner.getId(),
+                banner.getTitle(),
                 banner.getImageUrl(),
                 resolveRedirectLink(banner, platformType),
                 resolveVersion(banner, platformType)

--- a/src/test/java/in/koreatech/koin/acceptance/BannerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/BannerApiTest.java
@@ -15,7 +15,6 @@ import in.koreatech.koin.domain.banner.model.Banner;
 import in.koreatech.koin.domain.banner.model.BannerCategory;
 import in.koreatech.koin.fixture.BannerCategoryFixture;
 import in.koreatech.koin.fixture.BannerFixture;
-import in.koreatech.koin.fixture.UserFixture;
 
 @SuppressWarnings("NonAsciiCharacters")
 @Transactional
@@ -27,9 +26,6 @@ public class BannerApiTest extends AcceptanceTest {
 
     @Autowired
     private BannerCategoryFixture bannerCategoryFixture;
-
-    @Autowired
-    private UserFixture userFixture;
 
     private Banner 메인_배너_1;
     private Banner 메인_배너_2;
@@ -58,11 +54,13 @@ public class BannerApiTest extends AcceptanceTest {
                         "banners": [
                             {
                                 "id": 1,
+                                "title": "천원의 아침식사",
                                 "image_url": "https://example.com/1000won.jpg",
                                 "redirect_link": "https://example.com/1000won"
                             },
                             {
                                 "id": 2,
+                                "title": "코인 이벤트",
                                 "image_url": "https://example.com/koin-event.jpg",
                                 "redirect_link": "https://example.com/koin-event"
                             }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1436 

# 🚀 작업 내용

- 클라이언트 로깅을 위해 Normal Banner API 응답값에 배너 이름을 추가했습니다.
- 겸사겸사 Normal API에 requireMode를 설정했습니다.

# 💬 리뷰 중점사항
