### PR TITLE
feat: 통합 로그인 API 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
@@ -86,7 +86,7 @@ public class OwnerSmsService {
 
     @Transactional
     public void sendResetPasswordBySms(OwnerSendSmsRequest request) {
-        User user = userRepository.getByPhoneNumber(request.phoneNumber(), OWNER);
+        User user = userRepository.getByPhoneNumberAndUserType(request.phoneNumber(), OWNER);
         ownerVerificationService.sendCertificationSms(user.getPhoneNumber());
     }
 
@@ -97,7 +97,7 @@ public class OwnerSmsService {
 
     @Transactional
     public void updatePasswordBySms(OwnerPasswordUpdateSmsRequest request) {
-        User user = userRepository.getByPhoneNumber(request.phoneNumber(), OWNER);
+        User user = userRepository.getByPhoneNumberAndUserType(request.phoneNumber(), OWNER);
         user.updatePassword(passwordEncoder, request.password());
     }
 

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -138,6 +138,7 @@ public interface StudentApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
         }
     )
+    @Operation(summary = "학생 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/user/student/register")
     ResponseEntity<Void> studentRegisterV2(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -54,20 +54,7 @@ public interface UserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
         }
     )
-    @Operation(
-        summary = "일반인 회원가입(문자 인증)",
-        description = """
-            ### 프로덕션
-            - 같은 번호 기준 하루 최대 5회 인증번호를 발송 가능.
-            - 문자로 인증번호 발송.
-            ### 스테이지
-            - 같은 번호 기준 하루 최대 5회 인증번호를 발송 가능.
-            - 슬랙으로 인증번호 발송.(발송채널: 코인_이벤트알림_stage)
-            ### 클라이언트 사용 설명
-            - 해당 api를 사용하면 위의 내용들이 자동으로 적용된다.
-            - 클라이언트는 해당 api를 사용하기만 하면 된다.
-            """
-    )
+    @Operation(summary = "일반인 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/user/general/register")
     ResponseEntity<Void> generalUserRegisterV2(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequ
 import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
+import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
@@ -53,10 +54,38 @@ public interface UserApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
         }
     )
+    @Operation(
+        summary = "일반인 회원가입(문자 인증)",
+        description = """
+            ### 프로덕션
+            - 같은 번호 기준 하루 최대 5회 인증번호를 발송 가능.
+            - 문자로 인증번호 발송.
+            ### 스테이지
+            - 같은 번호 기준 하루 최대 5회 인증번호를 발송 가능.
+            - 슬랙으로 인증번호 발송.(발송채널: 코인_이벤트알림_stage)
+            ### 클라이언트 사용 설명
+            - 해당 api를 사용하면 위의 내용들이 자동으로 적용된다.
+            - 클라이언트는 해당 api를 사용하기만 하면 된다.
+            """
+    )
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/user/general/register")
     ResponseEntity<Void> generalUserRegisterV2(
         @RequestBody @Valid GeneralUserRegisterRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "로그인")
+    @PostMapping("/v2/user/login")
+    ResponseEntity<UserLoginResponse> loginV2(
+        @RequestBody @Valid UserLoginRequestV2 request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -23,6 +23,7 @@ import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
 import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
+import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
@@ -54,6 +55,14 @@ public class UserController implements UserApi {
     ) {
         userService.generalUserRegister(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/v2/user/login")
+    public ResponseEntity<UserLoginResponse> loginV2(
+        @RequestBody @Valid UserLoginRequestV2 request
+    ) {
+        UserLoginResponse response = userService.loginV2(request);
+        return ResponseEntity.created(URI.create("/")).body(response);
     }
 
     @PostMapping("/user/login")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequestV2.java
@@ -1,0 +1,28 @@
+package in.koreatech.koin.domain.user.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin._common.validation.NotEmoji;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record UserLoginRequestV2(
+    @Schema(description = "로그인 id", example = "example1 or 01012345678", requiredMode = REQUIRED)
+    @NotBlank(message = "아이디 또는 전화번호를 입력해주세요.")
+    @NotEmoji
+    String userId,
+
+    @Schema(
+        description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
+        example = "cd06f8c2b0dd065faf6ef910c7f15934363df71c33740fd245590665286ed268",
+        requiredMode = REQUIRED
+    )
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserLoginRequestV2.java
@@ -14,7 +14,7 @@ public record UserLoginRequestV2(
     @Schema(description = "로그인 id", example = "example1 or 01012345678", requiredMode = REQUIRED)
     @NotBlank(message = "아이디 또는 전화번호를 입력해주세요.")
     @NotEmoji
-    String userId,
+    String loginId,
 
     @Schema(
         description = "SHA 256 해시 알고리즘으로 암호화된 비밀번호",
@@ -22,7 +22,7 @@ public record UserLoginRequestV2(
         requiredMode = REQUIRED
     )
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    String password
+    String loginPw
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -40,8 +40,13 @@ public interface UserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("account: " + email));
     }
 
-    default User getByPhoneNumber(String phoneNumber, UserType userType) {
+    default User getByPhoneNumberAndUserType(String phoneNumber, UserType userType) {
         return findByPhoneNumberAndUserType(phoneNumber, userType)
+            .orElseThrow(() -> UserNotFoundException.withDetail("account: " + phoneNumber));
+    }
+
+    default User getByPhoneNumber(String phoneNumber) {
+        return findByPhoneNumber(phoneNumber)
             .orElseThrow(() -> UserNotFoundException.withDetail("account: " + phoneNumber));
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -55,7 +55,7 @@ public class UserService {
 
     @Transactional
     public UserLoginResponse loginV2(UserLoginRequestV2 request) {
-        User user = userValidationService.checkLoginCredentialsV2(request.userId(), request.password());
+        User user = userValidationService.checkLoginCredentialsV2(request.loginId(), request.loginPw());
 
         return createLoginResponse(user);
     }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
+import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
@@ -53,10 +54,21 @@ public class UserService {
     }
 
     @Transactional
+    public UserLoginResponse loginV2(UserLoginRequestV2 request) {
+        User user = userValidationService.checkLoginCredentialsV2(request.userId(), request.password());
+
+        return createLoginResponse(user);
+    }
+
+    @Transactional
     public UserLoginResponse login(UserLoginRequest request) {
         User user = userValidationService.checkLoginCredentials(request.email(), request.password());
         userValidationService.checkUserAuthentication(request.email());
 
+        return createLoginResponse(user);
+    }
+
+    private UserLoginResponse createLoginResponse(User user) {
         String accessToken = jwtProvider.createToken(user);
         String refreshToken = refreshTokenService.createRefreshToken(user);
         UserToken savedToken = userTokenRedisRepository.save(UserToken.create(user.getId(), refreshToken));

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -65,6 +65,19 @@ public class UserValidationService {
         return user;
     }
 
+    public User checkLoginCredentialsV2(String userId, String password) {
+        User user;
+        if (userId.matches("^\\d{11}$")) {
+            user = userRepository.getByPhoneNumber(userId);
+        } else {
+            user = userRepository.getByUserId(userId);
+        }
+        if (!user.isSamePassword(passwordEncoder, password)) {
+            throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
+        }
+        return user;
+    }
+
     public void checkUserAuthentication(String email) {
         Optional<UnAuthenticatedStudentInfo> studentTemporaryStatus = studentRedisRepository.findById(email);
         if (studentTemporaryStatus.isPresent()) {

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -65,14 +65,14 @@ public class UserValidationService {
         return user;
     }
 
-    public User checkLoginCredentialsV2(String userId, String password) {
+    public User checkLoginCredentialsV2(String loginId, String loginPw) {
         User user;
-        if (userId.matches("^\\d{11}$")) {
-            user = userRepository.getByPhoneNumber(userId);
+        if (loginId.matches("^\\d{11}$")) {
+            user = userRepository.getByPhoneNumber(loginId);
         } else {
-            user = userRepository.getByUserId(userId);
+            user = userRepository.getByUserId(loginId);
         }
-        if (!user.isSamePassword(passwordEncoder, password)) {
+        if (!user.isSamePassword(passwordEncoder, loginPw)) {
             throw new KoinIllegalArgumentException("비밀번호가 틀렸습니다.");
         }
         return user;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1406 

# 🚀 작업 내용

1. 전화번호/Id 혼용 방식의 로그인 API를 추가하였습니다.
    - 전화번호 양식은 하이픈(-)을 제외한 형태입니다. ex) 01011112222
    - 에러코드
        - 404 에러: 아이디(전화번호)가 존재하지 않을 경우
        - 400 에러: 비밀번호가 일치하지 않을 경우

# 💬 리뷰 중점사항
