### PR TITLE
fix: 인증 완료 후 잘못된 코드 요청 시 400 반환

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.user.model;
 
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,14 +28,14 @@ public class UserEventListener {
         slackClient.sendMessage(notification);
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onUserSmsVerificationSendEvent(UserSmsVerificationSendEvent userSmsVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserPhoneVerificationSendNotification(
             userSmsVerificationSendEvent.phoneNumber());
         slackClient.sendMessage(notification);
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void onUserEmailVerificationSendEvent(UserEmailVerificationSendEvent userEmailVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserEmailVerificationSendNotification(
             userEmailVerificationSendEvent.email());

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserEventListener.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.user.model;
 
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,14 +29,14 @@ public class UserEventListener {
         slackClient.sendMessage(notification);
     }
 
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @EventListener
     public void onUserSmsVerificationSendEvent(UserSmsVerificationSendEvent userSmsVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserPhoneVerificationSendNotification(
             userSmsVerificationSendEvent.phoneNumber());
         slackClient.sendMessage(notification);
     }
 
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @EventListener
     public void onUserEmailVerificationSendEvent(UserEmailVerificationSendEvent userEmailVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserEmailVerificationSendNotification(
             userEmailVerificationSendEvent.email());

--- a/src/main/java/in/koreatech/koin/domain/user/model/UserVerificationStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/UserVerificationStatus.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.user.model;
 
+import java.util.Objects;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -41,5 +43,9 @@ public class UserVerificationStatus {
     public void markAsVerified() {
         this.verified = true;
         this.expiration = VERIFIED_EXPIRATION_SECONDS;
+    }
+
+    public boolean isCodeMismatched(String inputCode) {
+        return !Objects.equals(this.verificationCode, inputCode);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.user.service;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin._common.auth.exception.AuthenticationException;
 import in.koreatech.koin._common.event.UserEmailVerificationSendEvent;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserVerificationService {
 
     private final UserVerificationStatusRedisRepository userVerificationStatusRedisRepository;

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
@@ -63,18 +63,9 @@ public class UserVerificationService {
 
     public void verifyCode(String phoneNumberOrEmail, String verificationCode) {
         UserVerificationStatus verificationStatus = userVerificationStatusRedisRepository.getById(phoneNumberOrEmail);
-
-        // 인증 코드가 틀릴 경우 (무조건 비교함)
         if (verificationStatus.isCodeMismatched(verificationCode)) {
             throw new KoinIllegalArgumentException("인증 번호가 일치하지 않습니다.");
         }
-
-        // 이미 인증 완료 상태라면 아무 작업도 하지 않음 (조기 리턴)
-        if (verificationStatus.isVerified()) {
-            return;
-        }
-
-        // 코드가 맞고, 아직 인증되지 않은 경우만 인증 처리
         verificationStatus.markAsVerified();
         userVerificationStatusRedisRepository.save(verificationStatus);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1465 

![image](https://github.com/user-attachments/assets/72e8426f-858c-4514-8764-03266112abdf)

# 🚀 작업 내용

1. 인증 번호 요청 시 슬랙 알림 정상적으로 전송하도록 버그 수정했습니다.
2. 인증 완료 후 잘못된 코드 요청 시 400 반환하도록 버그 수정했습니다.

### 변경된 인증코드 검증 로직
```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant RedisRepository as UserVerificationStatusRedisRepository

    Client->>Server: verifyCode(phoneNumberOrEmail, verificationCode)
    Server->>RedisRepository: getById(phoneNumberOrEmail)
    RedisRepository-->>Server: verificationStatus
    alt 상태가 없음 (404)
        Server->>Client: 404 Not Found (상태가 존재하지 않습니다.)
    else 상태 있음
        Server->>Server: isCodeMismatched(verificationCode)
        alt 인증 코드 일치하지 않음
            Server->>Client: KoinIllegalArgumentException("인증 번호가 일치하지 않습니다.")
        else 인증 코드 일치
            Server->>Server: isVerified()
            alt 이미 인증 완료
                Server->>Client: 아무 작업도 하지 않음
            else 인증 안됨
                Server->>Server: markAsVerified()
                Server->>RedisRepository: save(verificationStatus)
                RedisRepository-->>Server: 저장 완료
            end
        end
    end
    Client->>Server: 인증 처리 완료
```

# 💬 리뷰 중점사항
- 1번과 같은 경우 인증 요청 로직에서 트랜잭션을 사용하지 않지만 트랜잭션이벤트리스너를 사용해 발생한 문제로 비즈니스 로직에 트랜잭션 어노테이션 추가했습니다.
- 인증 요청의 경우 저장소로 REDIS만을 사용해 트랜잭션을 사용하지 않지만, 추후 확장 가능성과 일관성을 염두해 비즈니스 로직에 트랜잭션을 추가하는 방식으로 수정했습니다.