### PR TITLE
refactor: 게시글 단건 조회 Lazy Loading, N+1 문제 해결 및 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/Article.java
@@ -113,13 +113,9 @@ public class Article extends BaseEntity {
         return this.hit;
     }
 
-    public void setPrevNextArticles(Article prev, Article next) {
-        if (prev != null) {
-            prevId = prev.getId();
-        }
-        if (next != null) {
-            nextId = next.getId();
-        }
+    public void setPrevNextArticles(Integer prevId, Integer nextId) {
+        this.prevId = prevId;
+        this.nextId = nextId;
     }
 
     @PostPersist

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -114,7 +114,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             ORDER BY id DESC
             LIMIT 1
         """, nativeQuery = true)
-    Optional<Integer> findPreviousArticleId(Integer articleId, Integer boardId);
+    Optional<Integer> findPreviousArticleIdWithBoardId(Integer articleId, Integer boardId);
 
     @Query(value = """
             SELECT id FROM new_articles
@@ -122,7 +122,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             ORDER BY id DESC
             LIMIT 1
         """, nativeQuery = true)
-    Optional<Integer> findPreviousAllArticleId(Integer articleId);
+    Optional<Integer> findPreviousArticleId(Integer articleId);
 
     @Query(value = """
             SELECT id FROM new_articles
@@ -138,7 +138,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             ORDER BY id ASC
             LIMIT 1
         """, nativeQuery = true)
-    Optional<Integer> findNextArticleId(Integer articleId, Integer boardId);
+    Optional<Integer> findNextArticleIdWithBoardId(Integer articleId, Integer boardId);
 
     @Query(value = """
             SELECT id FROM new_articles
@@ -146,28 +146,28 @@ public interface ArticleRepository extends Repository<Article, Integer> {
             ORDER BY id ASC
             LIMIT 1
         """, nativeQuery = true)
-    Optional<Integer> findNextAllArticleId(Integer articleId);
+    Optional<Integer> findNextArticleId(Integer articleId);
 
     default Integer getPreviousArticleId(Board board, Article article) {
         if (board.isNotice() && board.getId().equals(NOTICE_BOARD_ID)) {
             return findPreviousNoticeArticleId(article.getId()).orElse(null);
         }
-        return findPreviousArticleId(article.getId(), board.getId()).orElse(null);
+        return findPreviousArticleIdWithBoardId(article.getId(), board.getId()).orElse(null);
     }
 
     default Integer getPreviousAllArticleId(Article article) {
-        return findPreviousAllArticleId(article.getId()).orElse(null);
+        return findPreviousArticleId(article.getId()).orElse(null);
     }
 
     default Integer getNextArticleId(Board board, Article article) {
         if (board.isNotice() && board.getId().equals(NOTICE_BOARD_ID)) {
             return findNextNoticeArticleId(article.getId()).orElse(null);
         }
-        return findNextArticleId(article.getId(), board.getId()).orElse(null);
+        return findNextArticleIdWithBoardId(article.getId(), board.getId()).orElse(null);
     }
 
     default Integer getNextAllArticleId(Article article) {
-        return findNextAllArticleId(article.getId()).orElse(null);
+        return findNextArticleId(article.getId()).orElse(null);
     }
 
     @Query("""

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -97,46 +97,52 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Long countBy();
 
-    @Query("""
-                SELECT a.id FROM Article a
-                WHERE a.id < :articleId AND a.isNotice = true AND a.isDeleted = false
-                ORDER BY a.id DESC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id < :articleId AND is_notice = true AND is_deleted = false
+            ORDER BY id DESC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findPreviousNoticeArticleId(Integer articleId);
 
-    @Query("""
-            SELECT a.id FROM Article a
-            WHERE a.id < :articleId AND a.board.id = :boardId AND a.isDeleted = false
-            ORDER BY a.id DESC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id < :articleId AND board_id = :boardId AND is_deleted = false
+            ORDER BY id DESC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findPreviousArticleId(Integer articleId, Integer boardId);
 
-    @Query("""
-            SELECT a.id FROM Article a
-            WHERE a.id < :articleId AND a.isDeleted = false
-            ORDER BY a.id DESC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id < :articleId AND is_deleted = false
+            ORDER BY id DESC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findPreviousAllArticleId(Integer articleId);
 
-    @Query("""
-            SELECT a.id FROM Article a
-            WHERE a.id > :articleId AND a.isNotice = true AND a.isDeleted = false
-            ORDER BY a.id ASC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id > :articleId AND is_notice = true AND is_deleted = false
+            ORDER BY id ASC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findNextNoticeArticleId(Integer articleId);
 
-    @Query("""
-            SELECT a.id FROM Article a
-            WHERE a.id > :articleId AND a.board.id = :boardId AND a.isDeleted = false
-            ORDER BY a.id ASC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id > :articleId AND board_id = :boardId AND is_deleted = false
+            ORDER BY id ASC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findNextArticleId(Integer articleId, Integer boardId);
 
-    @Query("""
-            SELECT a.id FROM Article a
-            WHERE a.id > :articleId AND a.isDeleted = false
-            ORDER BY a.id ASC
-        """)
+    @Query(value = """
+            SELECT id FROM new_articles
+            WHERE id > :articleId AND is_deleted = false
+            ORDER BY id ASC
+            LIMIT 1
+        """, nativeQuery = true)
     Optional<Integer> findNextAllArticleId(Integer articleId);
 
     default Integer getPreviousArticleId(Board board, Article article) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -67,6 +67,9 @@ public interface ArticleRepository extends Repository<Article, Integer> {
         return found;
     }
 
+    @Query(value = "SELECT * FROM new_articles WHERE id = :articleId", nativeQuery = true)
+    Article findIncludingDeleted(Integer articleId);
+
     @Query(
         value = "SELECT a.* FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type AND a.is_deleted = 0",
         countQuery = "SELECT COUNT(*) FROM new_articles a JOIN lost_item_articles la ON a.id = la.article_id WHERE la.type = :type AND a.is_deleted = 0",

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -233,17 +233,16 @@ public class ArticleService {
     }
 
     private void setPrevNextArticle(Integer boardId, Article article) {
-        Article prevArticle;
-        Article nextArticle;
+        Integer prevId, nextId;
         if (boardId != null) {
             Board board = getBoard(boardId, article);
-            prevArticle = articleRepository.getPreviousArticle(board, article);
-            nextArticle = articleRepository.getNextArticle(board, article);
+            prevId = articleRepository.getPreviousArticleId(board, article);
+            nextId = articleRepository.getNextArticleId(board, article);
         } else {
-            prevArticle = articleRepository.getPreviousAllArticle(article);
-            nextArticle = articleRepository.getNextAllArticle(article);
+            prevId = articleRepository.getPreviousAllArticleId(article);
+            nextId = articleRepository.getNextAllArticleId(article);
         }
-        article.setPrevNextArticles(prevArticle, nextArticle);
+        article.setPrevNextArticles(prevId, nextId);
     }
 
     private Board getBoard(Integer boardId, Article article) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -86,7 +86,7 @@ public class ArticleService {
 
     public ArticlesResponse getArticles(Integer boardId, Integer page, Integer limit, Integer userId) {
         Long total = articleRepository.countBy();
-        Criteria criteria = Criteria.of(page, limit, total.intValue());
+        Criteria criteria = Criteria.of(page, limit);
         PageRequest pageRequest = PageRequest.of(criteria.getPage(), criteria.getLimit(), ARTICLES_SORT);
         if (boardId == null) {
             Page<Article> articles = articleRepository.findAll(pageRequest);

--- a/src/test/java/in/koreatech/koin/admin/acceptance/AdminNoticeApiTest.java
+++ b/src/test/java/in/koreatech/koin/admin/acceptance/AdminNoticeApiTest.java
@@ -128,7 +128,7 @@ public class AdminNoticeApiTest extends AcceptanceTest {
             )
             .andExpect(status().isNoContent());
 
-        Article deleteArticle = articleRepository.getById(noticeId);
+        Article deleteArticle = articleRepository.findIncludingDeleted(noticeId);
 
         assertSoftly(softly -> {
             softly.assertThat(deleteArticle.getTitle()).isEqualTo("[코인 캠퍼스팀] 공지사항 테스트");


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1467

# 🚀 작업 내용

### 문제상황
- 많은 데이터를 처리하는 작업이 아님에도 P95 LATENCY가 높은 것으로 보임
- 확인해보니 18개의 쿼리가 실행되고있음

<img width="638" alt="image" src="https://github.com/user-attachments/assets/f0ca50fa-00ed-4d88-b3ab-45aa0daa36ea" />

<img width="909" alt="image" src="https://github.com/user-attachments/assets/f0a05d35-f6e1-4197-830e-cd2d7881afa3" />


### 1. findById로 조회 시 Lazy Loading 문제로 불필요한 추가 쿼리 발생
- ToOne관계 페치조인, ToMany관계(attachment) 하나의 컬렉션이므로 같이 페치조인 진행
- 페이징 사용하지 않으므로 문제X
- getById 자체를 변경하였으므로 게시글 단건 조회와 관련된 다른 api들도 같이 개선될 것으로 보임

### 2. 이전과 이후 게시글을 불러오는 과정에서 Lazy Loading 문제로 불필요한 추가 쿼리 발생
- 해당 로직은 이전과 이후 게시글을 직접 사용하는 것이 아닌, 게시글의 id만 response로 전달하기위한 용도로 보임
- 따라서 article을 페치조인하여 엔티티를 가져오는 것보다 그냥 DB에서 id만 가져오는 로직으로 수정

### 3. 테스트 코드 수정
- 기존엔 getById가 findById를 호출하고 있었고, 같은 트랜잭션 내에서 수행되므로 soft delete를 수행해도 아직 flush(commit)되지 않아서 기존 테스트코드의 getById를 호출해도 1차캐시에 해당 ID가 있기때문에 isDeleted가 1으로 변경된 DB에 접근하지 않음. 따라서 Article 엔티티가 @Where(clause = "is_deleted=0")임에도 불구하고 해당 엔티티를 불러올 수 있었음.
- 하지만 JPQL로 getById로직을 변경하게 되면서, JPQL을 사용하였기 때문에 1차캐시를 거치지 않고 무조건적으로 DB에서 가져오게 됨. 따라서, is_deleted=1이 되어버린 deletedArticle은 조회되지 않아서 게시글을 찾을 수 없다는 예외가 발생하여 테스트 실패.
- is_deleted=1도 포함하여 조회하는 findIncludingDeleted를 추가하고 이 메소드를 사용하도록 테스트코드를 수정함

### 실행 시간 개선(stage 재확인 필요), 쿼리 18개 → 3개
# 💬 리뷰 중점사항
