### PR TITLE
feat: 회원가입 시 아이디 중복 확인 api 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -12,28 +12,28 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
-import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
+import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
+import in.koreatech.koin.domain.user.dto.FindIdResponse;
 import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
+import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
-import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
+import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
+import in.koreatech.koin.domain.user.dto.validation.ExistsByEmailRequest;
 import in.koreatech.koin.domain.user.dto.validation.ExistsByPhoneRequest;
 import in.koreatech.koin.domain.user.dto.validation.ExistsByUserIdRequest;
-import in.koreatech.koin.domain.user.dto.validation.ExistsByEmailRequest;
 import in.koreatech.koin.domain.user.dto.validation.MatchUserIdWithEmailRequest;
 import in.koreatech.koin.domain.user.dto.validation.MatchUserIdWithPhoneNumberRequest;
-import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
-import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
-import in.koreatech.koin.domain.user.dto.FindIdResponse;
-import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
-import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -162,7 +162,7 @@ public interface UserApi {
     )
     @GetMapping("/user/check/email")
     ResponseEntity<Void> checkUserEmailExist(
-        @ModelAttribute("address")
+        @ParameterObject @ModelAttribute("address")
         @Valid CheckEmailDuplicationRequest request
     );
 
@@ -179,7 +179,7 @@ public interface UserApi {
     )
     @GetMapping("/user/check/phone")
     ResponseEntity<Void> checkPhoneNumberExist(
-        @ModelAttribute("phone")
+        @ParameterObject @ModelAttribute("phone")
         @Valid CheckPhoneDuplicationRequest request
     );
 
@@ -196,7 +196,7 @@ public interface UserApi {
     )
     @GetMapping("/user/check/id")
     ResponseEntity<Void> checkDuplicatedLoginId(
-        @ModelAttribute("id")
+        @ParameterObject @ModelAttribute("id")
         @Valid CheckLoginIdDuplicationRequest request
     );
 
@@ -213,7 +213,7 @@ public interface UserApi {
     )
     @GetMapping("/user/check/nickname")
     ResponseEntity<Void> checkDuplicationOfNickname(
-        @ModelAttribute("nickname")
+        @ParameterObject @ModelAttribute("nickname")
         @Valid CheckNicknameDuplicationRequest request
     );
 

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -14,6 +14,7 @@ import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
@@ -180,6 +181,23 @@ public interface UserApi {
     ResponseEntity<Void> checkPhoneNumberExist(
         @ModelAttribute("phone")
         @Valid CheckPhoneDuplicationRequest request
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", description = "아이디 양식 오류", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "아이디 중복", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(
+        summary = "아이디 중복 체크",
+        description = "입력한 아이디가 중복인지 확인합니다."
+    )
+    @GetMapping("/user/check/id")
+    ResponseEntity<Void> checkDuplicatedLoginId(
+        @ModelAttribute("id")
+        @Valid CheckLoginIdDuplicationRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
@@ -120,7 +121,7 @@ public class UserController implements UserApi {
         @ModelAttribute(value = "address")
         @Valid CheckEmailDuplicationRequest request
     ) {
-        userValidationService.checkExistsEmail(request);
+        userValidationService.checkDuplicatedEmail(request);
         return ResponseEntity.ok().build();
     }
 
@@ -129,7 +130,7 @@ public class UserController implements UserApi {
         @ModelAttribute(value = "phone")
         @Valid CheckPhoneDuplicationRequest request
     ) {
-        userValidationService.checkExistsPhoneNumber(request);
+        userValidationService.checkDuplicatedPhoneNumber(request);
         return ResponseEntity.ok().build();
     }
 
@@ -138,7 +139,16 @@ public class UserController implements UserApi {
         @ModelAttribute("nickname")
         @Valid CheckNicknameDuplicationRequest request
     ) {
-        userValidationService.checkUserNickname(request);
+        userValidationService.checkDuplicatedNickname(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/user/check/id")
+    public ResponseEntity<Void> checkDuplicatedLoginId(
+        @ModelAttribute("id")
+        @Valid CheckLoginIdDuplicationRequest request
+    ) {
+        userValidationService.checkDuplicatedLoginId(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -16,28 +16,28 @@ import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
-import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
-import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
+import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
+import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
+import in.koreatech.koin.domain.user.dto.FindIdResponse;
 import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
+import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshRequest;
 import in.koreatech.koin.domain.user.dto.UserTokenRefreshResponse;
+import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
 import in.koreatech.koin.domain.user.dto.validation.ExistsByEmailRequest;
 import in.koreatech.koin.domain.user.dto.validation.ExistsByPhoneRequest;
 import in.koreatech.koin.domain.user.dto.validation.ExistsByUserIdRequest;
-import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
-import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
-import in.koreatech.koin.domain.user.dto.FindIdResponse;
 import in.koreatech.koin.domain.user.dto.validation.MatchUserIdWithEmailRequest;
 import in.koreatech.koin.domain.user.dto.validation.MatchUserIdWithPhoneNumberRequest;
-import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
-import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.service.UserService;
 import in.koreatech.koin.domain.user.service.UserValidationService;
 import jakarta.validation.Valid;
@@ -118,7 +118,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/check/email")
     public ResponseEntity<Void> checkUserEmailExist(
-        @ModelAttribute(value = "address")
+        @ParameterObject @ModelAttribute(value = "address")
         @Valid CheckEmailDuplicationRequest request
     ) {
         userValidationService.checkDuplicatedEmail(request);
@@ -127,7 +127,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/check/phone")
     public ResponseEntity<Void> checkPhoneNumberExist(
-        @ModelAttribute(value = "phone")
+        @ParameterObject @ModelAttribute(value = "phone")
         @Valid CheckPhoneDuplicationRequest request
     ) {
         userValidationService.checkDuplicatedPhoneNumber(request);
@@ -136,7 +136,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/check/nickname")
     public ResponseEntity<Void> checkDuplicationOfNickname(
-        @ModelAttribute("nickname")
+        @ParameterObject @ModelAttribute("nickname")
         @Valid CheckNicknameDuplicationRequest request
     ) {
         userValidationService.checkDuplicatedNickname(request);
@@ -145,7 +145,7 @@ public class UserController implements UserApi {
 
     @GetMapping("/user/check/id")
     public ResponseEntity<Void> checkDuplicatedLoginId(
-        @ModelAttribute("id")
+        @ParameterObject @ModelAttribute("id")
         @Valid CheckLoginIdDuplicationRequest request
     ) {
         userValidationService.checkDuplicatedLoginId(request);

--- a/src/main/java/in/koreatech/koin/domain/user/dto/validation/CheckLoginIdDuplicationRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/validation/CheckLoginIdDuplicationRequest.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.user.dto.validation;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record CheckLoginIdDuplicationRequest(
+    @Schema(description = "로그인 Id", example = "example012", requiredMode = REQUIRED)
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String loginId
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/user/exception/DuplicationLoginIdException.java
+++ b/src/main/java/in/koreatech/koin/domain/user/exception/DuplicationLoginIdException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.user.exception;
+
+import in.koreatech.koin._common.exception.custom.DuplicationException;
+
+public class DuplicationLoginIdException extends DuplicationException {
+
+    private static final String DEFAULT_MESSAGE = "이미 존재하는 아이디입니다.";
+
+    public DuplicationLoginIdException(String message) {
+        super(message);
+    }
+
+    public DuplicationLoginIdException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DuplicationLoginIdException withDetail(String detail) {
+        return new DuplicationLoginIdException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -12,9 +12,11 @@ import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
 import in.koreatech.koin.domain.student.model.redis.UnAuthenticatedStudentInfo;
 import in.koreatech.koin.domain.student.repository.StudentRedisRepository;
 import in.koreatech.koin.domain.user.dto.validation.CheckEmailDuplicationRequest;
+import in.koreatech.koin.domain.user.dto.validation.CheckLoginIdDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckNicknameDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckPhoneDuplicationRequest;
 import in.koreatech.koin.domain.user.dto.validation.CheckUserPasswordRequest;
+import in.koreatech.koin.domain.user.exception.DuplicationLoginIdException;
 import in.koreatech.koin.domain.user.exception.DuplicationNicknameException;
 import in.koreatech.koin.domain.user.exception.DuplicationPhoneNumberException;
 import in.koreatech.koin.domain.user.exception.UserNotFoundException;
@@ -39,21 +41,27 @@ public class UserValidationService {
         }
     }
 
-    public void checkExistsEmail(CheckEmailDuplicationRequest request) {
+    public void checkDuplicatedEmail(CheckEmailDuplicationRequest request) {
         userRepository.findByEmail(request.email()).ifPresent(user -> {
             throw DuplicationEmailException.withDetail("email: " + user.getEmail());
         });
     }
 
-    public void checkExistsPhoneNumber(CheckPhoneDuplicationRequest request) {
+    public void checkDuplicatedPhoneNumber(CheckPhoneDuplicationRequest request) {
         userRepository.findByPhoneNumber(request.phone()).ifPresent(user -> {
             throw DuplicationPhoneNumberException.withDetail("phone: " + user.getPhoneNumber());
         });
     }
 
-    public void checkUserNickname(CheckNicknameDuplicationRequest request) {
+    public void checkDuplicatedNickname(CheckNicknameDuplicationRequest request) {
         userRepository.findByNickname(request.nickname()).ifPresent(user -> {
             throw DuplicationNicknameException.withDetail("nickname: " + request.nickname());
+        });
+    }
+
+    public void checkDuplicatedLoginId(CheckLoginIdDuplicationRequest request) {
+        userRepository.findByUserId(request.loginId()).ifPresent(user -> {
+            throw DuplicationLoginIdException.withDetail("loginId: " + request.loginId());
         });
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 회원가입 시 아이디 중복 확인 API를 추가하였습니다.
2. 아이디 중복 확인과 아이디 존재 여부 확인 메서드의 구분이 어려워 이름을 일부 수정했습니다.

# 💬 리뷰 중점사항
