### PR TITLE
refactor: loginId 필드명 및 회원가입 API URI 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentApi.java
@@ -140,7 +140,7 @@ public interface StudentApi {
     )
     @Operation(summary = "학생 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
-    @PostMapping("/v2/user/student/register")
+    @PostMapping("/v2/users/students/register")
     ResponseEntity<Void> studentRegisterV2(
         @RequestBody @Valid StudentRegisterRequestV2 request
     );

--- a/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
+++ b/src/main/java/in/koreatech/koin/domain/student/controller/StudentController.java
@@ -104,7 +104,7 @@ public class StudentController implements StudentApi {
         return studentService.authenticate(request);
     }
 
-    @PostMapping("/v2/user/student/register")
+    @PostMapping("/v2/users/students/register")
     public ResponseEntity<Void> studentRegisterV2(
         @RequestBody @Valid StudentRegisterRequestV2 request
     ) {

--- a/src/main/java/in/koreatech/koin/domain/student/dto/StudentRegisterRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/StudentRegisterRequestV2.java
@@ -34,7 +34,7 @@ public record StudentRegisterRequestV2(
     @NotBlank(message = "아이디는 필수입니다.")
     @Size(max = 50, message = "아이디는 50자 이내여야 합니다.")
     @Schema(description = "사용자 아이디", example = "example123", requiredMode = REQUIRED)
-    String userId,
+    String loginId,
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
@@ -63,7 +63,7 @@ public record StudentRegisterRequestV2(
         User user = User.builder()
             .name(name)
             .phoneNumber(phoneNumber)
-            .userId(userId)
+            .userId(loginId)
             .password(passwordEncoder.encode(password))
             .email(email)
             .gender(gender)

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -57,7 +57,7 @@ public interface UserApi {
     )
     @Operation(summary = "일반인 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
-    @PostMapping("/v2/user/general/register")
+    @PostMapping("/v2/user/register")
     ResponseEntity<Void> generalUserRegisterV2(
         @RequestBody @Valid GeneralUserRegisterRequest request
     );

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -57,7 +57,7 @@ public interface UserApi {
     )
     @Operation(summary = "일반인 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
-    @PostMapping("/v2/user/register")
+    @PostMapping("/v2/users/register")
     ResponseEntity<Void> generalUserRegisterV2(
         @RequestBody @Valid GeneralUserRegisterRequest request
     );
@@ -71,7 +71,7 @@ public interface UserApi {
         }
     )
     @Operation(summary = "로그인")
-    @PostMapping("/v2/user/login")
+    @PostMapping("/v2/users/login")
     ResponseEntity<UserLoginResponse> loginV2(
         @RequestBody @Valid UserLoginRequestV2 request
     );
@@ -295,7 +295,7 @@ public interface UserApi {
         summary = "로그인 ID와 전화번호 일치 여부 확인",
         description = "입력한 로그인 ID와 전화번호가 일치하는지 확인합니다."
     )
-    @PostMapping("/user/id/match/phone")
+    @PostMapping("/users/id/match/phone")
     ResponseEntity<Void> matchUserIdWithPhoneNumber(@Valid @RequestBody MatchUserIdWithPhoneNumberRequest request);
 
     @ApiResponses({
@@ -307,7 +307,7 @@ public interface UserApi {
         summary = "로그인 ID와 이메일 일치 여부 확인",
         description = "입력한 로그인 ID와 이메일 주소가 일치하는지 확인합니다."
     )
-    @PostMapping("/user/id/match/email")
+    @PostMapping("/users/id/match/email")
     ResponseEntity<Void> matchUserIdWithEmail(@Valid @RequestBody MatchUserIdWithEmailRequest request);
 
     @ApiResponses({
@@ -320,7 +320,7 @@ public interface UserApi {
         summary = "SMS 인증으로 로그인 ID 찾기",
         description = "SMS 인증 완료 후 1시간 이내에 ID를 찾을 수 있습니다."
     )
-    @PostMapping("/user/id/find/sms")
+    @PostMapping("/users/id/find/sms")
     ResponseEntity<FindIdResponse> findIdBySmsVerification(@Valid @RequestBody FindIdBySmsRequest request);
 
     @ApiResponses({
@@ -333,7 +333,7 @@ public interface UserApi {
         summary = "이메일 인증으로 로그인 ID 찾기",
         description = "이메일 인증 완료 후 1시간 이내에 ID를 찾을 수 있습니다."
     )
-    @PostMapping("/user/id/find/email")
+    @PostMapping("/users/id/find/email")
     ResponseEntity<FindIdResponse> findIdByEmailVerification(@Valid @RequestBody FindIdByEmailRequest request);
 
     @ApiResponses({
@@ -346,7 +346,7 @@ public interface UserApi {
         summary = "SMS 인증으로 패스워드 리셋",
         description = "SMS 인증 완료 후 1시간 이내에 비밀번호를 재설정할 수 있습니다."
     )
-    @PostMapping("/user/password/reset/sms")
+    @PostMapping("/users/password/reset/sms")
     ResponseEntity<Void> resetPasswordBySmsVerification(@Valid @RequestBody ResetPasswordBySmsRequest request);
 
     @ApiResponses({
@@ -359,6 +359,6 @@ public interface UserApi {
         summary = "이메일 인증으로 패스워드 리셋",
         description = "이메일 인증 완료 후 1시간 이내에 비밀번호를 재설정할 수 있습니다."
     )
-    @PostMapping("/user/password/reset/email")
+    @PostMapping("/users/password/reset/email")
     ResponseEntity<Void> resetPasswordByEmailVerification(@Valid @RequestBody ResetPasswordByEmailRequest request);
 }

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController implements UserApi {
     private final UserService userService;
     private final UserValidationService userValidationService;
 
-    @PostMapping("/v2/user/register")
+    @PostMapping("/v2/users/register")
     public ResponseEntity<Void> generalUserRegisterV2(
         @RequestBody @Valid GeneralUserRegisterRequest request
     ) {
@@ -58,7 +58,7 @@ public class UserController implements UserApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("/v2/user/login")
+    @PostMapping("/v2/users/login")
     public ResponseEntity<UserLoginResponse> loginV2(
         @RequestBody @Valid UserLoginRequestV2 request
     ) {
@@ -185,7 +185,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/user/id/match/phone")
+    @PostMapping("/users/id/match/phone")
     public ResponseEntity<Void> matchUserIdWithPhoneNumber(
         @Valid @RequestBody MatchUserIdWithPhoneNumberRequest request
     ) {
@@ -193,7 +193,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/user/id/match/email")
+    @PostMapping("/users/id/match/email")
     public ResponseEntity<Void> matchUserIdWithEmail(
         @Valid @RequestBody MatchUserIdWithEmailRequest request
     ) {
@@ -201,7 +201,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/user/id/find/sms")
+    @PostMapping("/users/id/find/sms")
     public ResponseEntity<FindIdResponse> findIdBySmsVerification(
         @Valid @RequestBody FindIdBySmsRequest request
     ) {
@@ -209,7 +209,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().body(FindIdResponse.from(userId));
     }
 
-    @PostMapping("/user/id/find/email")
+    @PostMapping("/users/id/find/email")
     public ResponseEntity<FindIdResponse> findIdByEmailVerification(
         @Valid @RequestBody FindIdByEmailRequest request
     ) {
@@ -217,7 +217,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().body(FindIdResponse.from(userId));
     }
 
-    @PostMapping("/user/password/reset/sms")
+    @PostMapping("/users/password/reset/sms")
     public ResponseEntity<Void> resetPasswordBySmsVerification(
         @Valid @RequestBody ResetPasswordBySmsRequest request
     ) {
@@ -225,7 +225,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/user/password/reset/email")
+    @PostMapping("/users/password/reset/email")
     public ResponseEntity<Void> resetPasswordByEmailVerification(
         @Valid @RequestBody ResetPasswordByEmailRequest request
     ) {

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -165,7 +165,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> existsByUserId(
         @Valid @RequestBody ExistsByUserIdRequest request
     ) {
-        userValidationService.existsByUserId(request.userId());
+        userValidationService.existsByUserId(request.loginId());
         return ResponseEntity.ok().build();
     }
 
@@ -189,7 +189,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> matchUserIdWithPhoneNumber(
         @Valid @RequestBody MatchUserIdWithPhoneNumberRequest request
     ) {
-        userValidationService.matchUserIdWithPhoneNumber(request.userId(), request.phoneNumber());
+        userValidationService.matchUserIdWithPhoneNumber(request.loginId(), request.phoneNumber());
         return ResponseEntity.ok().build();
     }
 
@@ -197,7 +197,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> matchUserIdWithEmail(
         @Valid @RequestBody MatchUserIdWithEmailRequest request
     ) {
-        userValidationService.matchUserIdWithEmail(request.userId(), request.email());
+        userValidationService.matchUserIdWithEmail(request.loginId(), request.email());
         return ResponseEntity.ok().build();
     }
 
@@ -221,7 +221,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> resetPasswordBySmsVerification(
         @Valid @RequestBody ResetPasswordBySmsRequest request
     ) {
-        userService.resetPasswordBySms(request.userId(), request.phoneNumber(), request.newPassword());
+        userService.resetPasswordBySms(request.loginId(), request.phoneNumber(), request.newPassword());
         return ResponseEntity.ok().build();
     }
 
@@ -229,7 +229,7 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> resetPasswordByEmailVerification(
         @Valid @RequestBody ResetPasswordByEmailRequest request
     ) {
-        userService.resetPasswordByEmail(request.userId(), request.email(), request.newPassword());
+        userService.resetPasswordByEmail(request.loginId(), request.email(), request.newPassword());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController implements UserApi {
     private final UserService userService;
     private final UserValidationService userValidationService;
 
-    @PostMapping("/v2/user/general/register")
+    @PostMapping("/v2/user/register")
     public ResponseEntity<Void> generalUserRegisterV2(
         @RequestBody @Valid GeneralUserRegisterRequest request
     ) {

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserVerificationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserVerificationApi.java
@@ -19,7 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @Tag(name = "(Normal) User(본인인증): 회원", description = "본인인증 기반으로 회원 정보를 관리한다.")
-@RequestMapping("/user/verification")
+@RequestMapping("/users/verification")
 public interface UserVerificationApi {
 
     @ApiResponses({

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserVerificationController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserVerificationController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user/verification")
+@RequestMapping("/users/verification")
 public class UserVerificationController implements UserVerificationApi {
 
     private final UserVerificationService userVerificationService;

--- a/src/main/java/in/koreatech/koin/domain/user/dto/FindIdResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/FindIdResponse.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record FindIdResponse(
     @Schema(description = "로그인 ID", example = "user3452", requiredMode = REQUIRED)
-    String userId
+    String loginId
 ) {
 
     public static FindIdResponse from(String userId) {

--- a/src/main/java/in/koreatech/koin/domain/user/dto/GeneralUserRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/GeneralUserRegisterRequest.java
@@ -31,8 +31,8 @@ public record GeneralUserRegisterRequest(
 
     @NotBlank(message = "아이디는 필수입니다.")
     @Size(max = 50, message = "아이디는 50자 이내여야 합니다.")
-    @Schema(description = "사용자 아이디", example = "example123", requiredMode = REQUIRED)
-    String userId,
+    @Schema(description = "로그인 아이디", example = "example123", requiredMode = REQUIRED)
+    String loginId,
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
@@ -53,7 +53,7 @@ public record GeneralUserRegisterRequest(
         return User.builder()
             .name(name)
             .phoneNumber(phoneNumber)
-            .userId(userId)
+            .userId(loginId)
             .password(passwordEncoder.encode(password))
             .email(email)
             .gender(gender)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/ResetPasswordByEmailRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/ResetPasswordByEmailRequest.java
@@ -15,7 +15,7 @@ public record ResetPasswordByEmailRequest(
     @Schema(description = "로그인 ID", example = "user123", requiredMode = REQUIRED)
     @NotBlank(message = "로그인 ID는 필수입니다.")
     @Pattern(regexp = "^[a-z0-9_.-]{1,13}$", message = "로그인 ID는 영소문자, 숫자, 밑줄(_), 하이픈(-), 마침표(.)로 이루어진 1~13자여야 합니다.")
-    String userId,
+    String loginId,
 
     @Schema(description = "이메일", example = "user@example.com", requiredMode = REQUIRED)
     @NotBlank(message = "이메일은 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/ResetPasswordBySmsRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/ResetPasswordBySmsRequest.java
@@ -14,7 +14,7 @@ public record ResetPasswordBySmsRequest(
     @Schema(description = "로그인 ID", example = "user123", requiredMode = REQUIRED)
     @NotBlank(message = "로그인 ID는 필수입니다.")
     @Pattern(regexp = "^[a-z0-9_.-]{1,13}$", message = "로그인 ID는 영소문자, 숫자, 밑줄(_), 하이픈(-), 마침표(.)로 이루어진 1~13자여야 합니다.")
-    String userId,
+    String loginId,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = REQUIRED)
     @NotBlank(message = "전화번호는 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/validation/ExistsByUserIdRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/validation/ExistsByUserIdRequest.java
@@ -14,7 +14,7 @@ public record ExistsByUserIdRequest(
     @Schema(description = "로그인 ID", example = "user123", requiredMode = REQUIRED)
     @NotBlank(message = "로그인 ID는 필수입니다.")
     @Pattern(regexp = "^[a-z0-9_.-]{1,13}$", message = "로그인 ID는 영소문자, 숫자, 밑줄(_), 하이픈(-), 마침표(.)로 이루어진 1~13자여야 합니다.")
-    String userId
+    String loginId
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/validation/MatchUserIdWithEmailRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/validation/MatchUserIdWithEmailRequest.java
@@ -15,7 +15,7 @@ public record MatchUserIdWithEmailRequest(
     @Schema(description = "로그인 ID", example = "user123", requiredMode = REQUIRED)
     @NotBlank(message = "로그인 ID는 필수입니다.")
     @Pattern(regexp = "^[a-z0-9_.-]{1,13}$", message = "로그인 ID는 영소문자, 숫자, 밑줄(_), 하이픈(-), 마침표(.)로 이루어진 1~13자여야 합니다.")
-    String userId,
+    String loginId,
 
     @Schema(description = "이메일", example = "user@example.com", requiredMode = REQUIRED)
     @NotBlank(message = "이메일은 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/dto/validation/MatchUserIdWithPhoneNumberRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/validation/MatchUserIdWithPhoneNumberRequest.java
@@ -14,7 +14,7 @@ public record MatchUserIdWithPhoneNumberRequest(
     @Schema(description = "로그인 ID", example = "user123", requiredMode = REQUIRED)
     @NotBlank(message = "로그인 ID는 필수입니다.")
     @Pattern(regexp = "^[a-z0-9_.-]{1,13}$", message = "로그인 ID는 영소문자, 숫자, 밑줄(_), 하이픈(-), 마침표(.)로 이루어진 1~13자여야 합니다.")
-    String userId,
+    String loginId,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = REQUIRED)
     @NotBlank(message = "전화번호는 필수입니다.")

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -53,11 +53,6 @@ public interface UserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
     }
 
-    default User getById(String id, UserType userType) {
-        return findByEmailAndUserType(id, userType)
-            .orElseThrow(() -> UserNotFoundException.withDetail("id: " + id));
-    }
-
     default User getByUserId(String loginId) {
         return findByUserId(loginId)
             .orElseThrow(() -> UserNotFoundException.withDetail("loginId: " + loginId));

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -60,9 +60,9 @@ public interface UserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("id: " + id));
     }
 
-    default User getByUserId(String userId) {
-        return findByUserId(userId)
-            .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
+    default User getByUserId(String loginId) {
+        return findByUserId(loginId)
+            .orElseThrow(() -> UserNotFoundException.withDetail("loginId: " + loginId));
     }
 
     boolean existsByNickname(String nickname);
@@ -96,6 +96,6 @@ public interface UserRepository extends Repository<User, Integer> {
 
     default User getByUserIdAndUserTypeIn(String userId, List<UserType> userTypes) {
         return findByUserIdAndUserTypeIn(userId, userTypes)
-            .orElseThrow(() -> UserNotFoundException.withDetail("userId: " + userId));
+            .orElseThrow(() -> UserNotFoundException.withDetail("loginId: " + userId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -94,8 +94,8 @@ public interface UserRepository extends Repository<User, Integer> {
             .orElseThrow(() -> UserNotFoundException.withDetail("phoneNumber: " + phoneNumber));
     }
 
-    default User getByUserIdAndUserTypeIn(String userId, List<UserType> userTypes) {
-        return findByUserIdAndUserTypeIn(userId, userTypes)
-            .orElseThrow(() -> UserNotFoundException.withDetail("loginId: " + userId));
+    default User getByUserIdAndUserTypeIn(String loginId, List<UserType> userTypes) {
+        return findByUserIdAndUserTypeIn(loginId, userTypes)
+            .orElseThrow(() -> UserNotFoundException.withDetail("loginId: " + loginId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -93,11 +93,11 @@ public class UserValidationService {
         }
     }
 
-    public void existsByUserId(String userId) {
-        if (userRepository.existsByUserId(userId)) {
+    public void existsByUserId(String loginId) {
+        if (userRepository.existsByUserId(loginId)) {
             return;
         }
-        throw UserNotFoundException.withDetail("userId: " + userId);
+        throw UserNotFoundException.withDetail("loginId: " + loginId);
     }
 
     public void existsByPhoneNumber(String phoneNumber) {

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -392,7 +392,7 @@ class UserApiTest extends AcceptanceTest {
         // when
         // SMS 인증번호 전송
         mockMvc.perform(
-                post("/user/verification/sms/send")
+                post("/users/verification/sms/send")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -409,7 +409,7 @@ class UserApiTest extends AcceptanceTest {
         // then
         // SMS 인증번호 검증
         mockMvc.perform(
-                post("/user/verification/sms/verify")
+                post("/users/verification/sms/verify")
                     .content("""
                         {
                           "phone_number": "%s",
@@ -430,7 +430,7 @@ class UserApiTest extends AcceptanceTest {
         // when
         // SMS 인증번호 전송
         mockMvc.perform(
-                post("/user/verification/sms/send")
+                post("/users/verification/sms/send")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -448,7 +448,7 @@ class UserApiTest extends AcceptanceTest {
         // then
         // 잘못된 인증번호로 검증
         mockMvc.perform(
-                post("/user/verification/sms/verify")
+                post("/users/verification/sms/verify")
                     .content("""
                         {
                           "phone_number": "%s",
@@ -471,7 +471,7 @@ class UserApiTest extends AcceptanceTest {
         // 5번까지 정상 발송
         for (int i = 0; i < maxDailyLimit; i++) {
             mockMvc.perform(
-                    post("/user/verification/sms/send")
+                    post("/users/verification/sms/send")
                         .content("""
                             {
                               "phone_number": "%s"
@@ -485,7 +485,7 @@ class UserApiTest extends AcceptanceTest {
         // then
         // 6번째 발송 시도시 400 반환
         mockMvc.perform(
-                post("/user/verification/sms/send")
+                post("/users/verification/sms/send")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -506,7 +506,7 @@ class UserApiTest extends AcceptanceTest {
         // when
         // SMS 인증번호 전송
         mockMvc.perform(
-                post("/user/verification/sms/send")
+                post("/users/verification/sms/send")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -522,7 +522,7 @@ class UserApiTest extends AcceptanceTest {
 
         // 인증번호 검증
         mockMvc.perform(
-                post("/user/verification/sms/verify")
+                post("/users/verification/sms/verify")
                     .content("""
                         {
                           "phone_number": "%s",
@@ -535,7 +535,7 @@ class UserApiTest extends AcceptanceTest {
 
         // ID 찾기
         mockMvc.perform(
-                post("/user/id/find/sms")
+                post("/users/id/find/sms")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -558,7 +558,7 @@ class UserApiTest extends AcceptanceTest {
         // when
         // SMS 인증번호 전송
         mockMvc.perform(
-                post("/user/verification/sms/send")
+                post("/users/verification/sms/send")
                     .content("""
                         {
                           "phone_number": "%s"
@@ -574,7 +574,7 @@ class UserApiTest extends AcceptanceTest {
 
         // 인증번호 검증
         mockMvc.perform(
-                post("/user/verification/sms/verify")
+                post("/users/verification/sms/verify")
                     .content("""
                         {
                           "phone_number": "%s",
@@ -587,7 +587,7 @@ class UserApiTest extends AcceptanceTest {
 
         // 비밀번호 변경
         mockMvc.perform(
-                post("/user/password/reset/sms")
+                post("/users/password/reset/sms")
                     .content("""
                         {
                           "login_id": "%s",

--- a/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/UserApiTest.java
@@ -544,7 +544,7 @@ class UserApiTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.user_id").value(user.getUserId()));
+            .andExpect(jsonPath("$.login_id").value(user.getUserId()));
     }
 
     @Test
@@ -590,7 +590,7 @@ class UserApiTest extends AcceptanceTest {
                 post("/user/password/reset/sms")
                     .content("""
                         {
-                          "user_id": "%s",
+                          "login_id": "%s",
                           "phone_number": "%s",
                           "new_password": "%s"
                         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 1차 스프린트에서 사용된 로그인 id의 필드명을 `userId` -> `loginId`로 수정하였습니다.
2. 1차 스프린트에서 작성한 회원가입 api의 uri를 `/v2/user/general` -> `/v2/user`로 수정하였습니다.

# 💬 리뷰 중점사항
