### PR TITLE
feat: versions 테이블에 복합인덱스(type, is_previous)추가

### DIFF
--- a/src/main/resources/db/migration/V147__add_versions_type_isprevious_index.sql
+++ b/src/main/resources/db/migration/V147__add_versions_type_isprevious_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_versions_type_previous ON versions(type, is_previous);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1485 

# 🚀 작업 내용

## 상황
<img width="784" alt="image" src="https://github.com/user-attachments/assets/b84c0517-cd59-4940-95ee-e2bb98c8be68" />

- 프로덕션의 API 중 8번째로 자주 호출됨

<img width="971" alt="image" src="https://github.com/user-attachments/assets/66a3da74-d0ce-48da-974e-40c90de17dc7" />

- 로직은 단순히 type과 previous를 where 조건으로 사용해 조회하고있음
- 실제로 요청부터 응답까지의 시간이 병목이라고 할 만큼 오래걸리지는 않음

<img width="291" alt="image" src="https://github.com/user-attachments/assets/15839528-ff1f-4a18-a864-f304ff25b7d4" />

- 테이블의 행의 개수가 24개로 매우 적음 (프로덕션)

<img width="937" alt="image" src="https://github.com/user-attachments/assets/95f6d082-ba9a-4faa-997a-f08f1a611f0a" />

- 클러스터링 인덱스만 존재

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/f6ab975c-289a-45a0-9c9f-325aa32b9cae" />

- 자주 쓰는 다른 API 에서도 해당 쿼리 호출


### 1. 인덱스 추가 고려
- where 조건에 type과 previous를 사용하여 조회하지만 별도의 인덱스가 생성되어 있지 않음.
- type마다 previous가 0인 행은 단 하나임, 따라서 선택도가 매우 높음
- 하지만 행의 개수가 매우 적어서 full table scan이 index scan을 사용하는 것보다 빠를 수 있음.
- {type, previous}의 복합 인덱스를 생성하여 직접 비교확인해보기로 함

#### 1-1. 데이터가 10000개일 때 (더미데이터 삽입)
##### 인덱스가 없는 경우
![image](https://github.com/user-attachments/assets/139dd63c-8bbe-4b53-81bf-36aa5279b710)
- 풀 테이블 스캔 발생, 테이블 스캔 시간 약 9.59ms

##### 인덱스가 있는 경우
![image](https://github.com/user-attachments/assets/0a481e5b-c504-4edc-8655-038d55bf8cb2)
- 인덱스 사용, 약 0.006ms 소요

### → 약 1600배 빠름

#### 1-2. 데이터가 60개일 때
- 짧은 시간이므로 반복 수행하였음
##### 인덱스가 없는 경우
<img width="750" alt="image" src="https://github.com/user-attachments/assets/203cb656-e691-4abb-86b4-b140db435a2c" />

- 풀 테이블 스캔 발생, 테이블 스캔 시간 평균 0.105ms

##### 인덱스가 있는 경우
<img width="882" alt="image" src="https://github.com/user-attachments/assets/97b42538-615b-46e9-b30e-32bf7cdf4606" />

- 인덱스 사용, 평균 0.0069ms

### → 약 15배 빠름

## 인덱스를 사용하는 경우가 빠름을 확인

### 2. 기타 고려사항
- versions 테이블의 데이터의 cud가 자주 일어나지는 않으며, 따라서 cud 발생 시 인덱스 추가에 따른 비용은 크지 않을 것으로 보임.
- 인덱스의 크기가 크지않으므로 디스크 영향도 크지 않을 것임.
- 계속 데이터가 추가되어 누적되는 테이블이고, 이 인덱스의 효과는 행이 추가될 수록 기하급수적으로 커짐

## 결론 : versions테이블에 type, is_previous로 이루어진 복합 인덱스 추가

# 💬 리뷰 중점사항
