### PR TITLE
fix: 유저 회원가입 실패 시 인증 캐시를 소모하는 오류를 해결한다.

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -285,12 +285,12 @@ public class StudentService {
 
     @Transactional
     public void studentRegisterV2(StudentRegisterRequestV2 request) {
-        userVerificationService.checkVerified(request.phoneNumber());
         studentValidationService.validateDepartment(request.department());
         Department department = departmentRepository.getByName(request.department());
         Student student = request.toStudent(passwordEncoder, department);
         studentRepository.save(student);
         userRepository.save(student.getUser());
+        userVerificationService.checkVerified(request.phoneNumber());
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -47,7 +47,6 @@ import in.koreatech.koin.domain.user.model.UserToken;
 import in.koreatech.koin.domain.user.repository.UserPasswordResetTokenRedisRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.repository.UserTokenRedisRepository;
-import in.koreatech.koin.domain.user.repository.UserVerificationStatusRedisRepository;
 import in.koreatech.koin.domain.user.service.RefreshTokenService;
 import in.koreatech.koin.domain.user.service.UserService;
 import in.koreatech.koin.domain.user.service.UserValidationService;
@@ -80,7 +79,6 @@ public class StudentService {
     private final ApplicationEventPublisher eventPublisher;
     private final UserPasswordResetTokenRedisRepository passwordResetTokenRepository;
     private final StandardGraduationRequirementsRepository standardGraduationRequirementsRepository;
-    private final UserVerificationStatusRedisRepository userVerificationStatusRedisRepository;
 
     @Transactional
     public void studentRegister(StudentRegisterRequest request, String serverURL) {

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -290,7 +290,7 @@ public class StudentService {
         Student student = request.toStudent(passwordEncoder, department);
         studentRepository.save(student);
         userRepository.save(student.getUser());
-        userVerificationService.checkVerified(request.phoneNumber());
+        userVerificationService.consumeVerification(request.phoneNumber());
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -15,7 +15,7 @@ import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
 import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
 import in.koreatech.koin.domain.user.dto.FindIdResponse;
-import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.RegisterUserRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
@@ -58,8 +58,8 @@ public interface UserApi {
     @Operation(summary = "일반인 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/users/register")
-    ResponseEntity<Void> userRegisterV2(
-        @RequestBody @Valid UserRegisterRequest request
+    ResponseEntity<Void> registerUserV2(
+        @RequestBody @Valid RegisterUserRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserApi.java
@@ -15,7 +15,7 @@ import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
 import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
 import in.koreatech.koin.domain.user.dto.FindIdResponse;
-import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
@@ -58,8 +58,8 @@ public interface UserApi {
     @Operation(summary = "일반인 회원가입(문자 인증)")
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/v2/users/register")
-    ResponseEntity<Void> generalUserRegisterV2(
-        @RequestBody @Valid GeneralUserRegisterRequest request
+    ResponseEntity<Void> userRegisterV2(
+        @RequestBody @Valid UserRegisterRequest request
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -19,7 +19,7 @@ import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
 import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
 import in.koreatech.koin.domain.user.dto.FindIdResponse;
-import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
@@ -51,10 +51,10 @@ public class UserController implements UserApi {
     private final UserValidationService userValidationService;
 
     @PostMapping("/v2/users/register")
-    public ResponseEntity<Void> generalUserRegisterV2(
-        @RequestBody @Valid GeneralUserRegisterRequest request
+    public ResponseEntity<Void> userRegisterV2(
+        @RequestBody @Valid UserRegisterRequest request
     ) {
-        userService.generalUserRegister(request);
+        userService.userRegister(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
+++ b/src/main/java/in/koreatech/koin/domain/user/controller/UserController.java
@@ -19,7 +19,7 @@ import in.koreatech.koin.domain.user.dto.AuthResponse;
 import in.koreatech.koin.domain.user.dto.FindIdByEmailRequest;
 import in.koreatech.koin.domain.user.dto.FindIdBySmsRequest;
 import in.koreatech.koin.domain.user.dto.FindIdResponse;
-import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.RegisterUserRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordByEmailRequest;
 import in.koreatech.koin.domain.user.dto.ResetPasswordBySmsRequest;
 import in.koreatech.koin.domain.user.dto.UserAccessTokenRequest;
@@ -51,8 +51,8 @@ public class UserController implements UserApi {
     private final UserValidationService userValidationService;
 
     @PostMapping("/v2/users/register")
-    public ResponseEntity<Void> userRegisterV2(
-        @RequestBody @Valid UserRegisterRequest request
+    public ResponseEntity<Void> registerUserV2(
+        @RequestBody @Valid RegisterUserRequest request
     ) {
         userService.userRegister(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
-public record UserRegisterRequest(
+public record RegisterUserRequest(
     @NotBlank(message = "이름은 필수입니다.")
     @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
@@ -43,6 +43,7 @@ public record UserRegisterRequest(
 
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
+    @Size(min = 1, message = "빈 문자열일 수 없습니다.")
     String email,
 
     @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
-public record GeneralUserRegisterRequest(
+public record UserRegisterRequest(
     @NotBlank(message = "이름은 필수입니다.")
     @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
@@ -43,7 +43,7 @@ public record UserRegisterRequest(
 
     @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
     @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
-    @Size(min = 1, message = "빈 문자열일 수 없습니다.")
+    @Pattern(regexp = "\\S+", message = "빈 문자열일 수 없습니다.")
     String email,
 
     @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/validation/CheckNicknameDuplicationRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/validation/CheckNicknameDuplicationRequest.java
@@ -6,14 +6,14 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record CheckNicknameDuplicationRequest(
-    @Schema(description = "닉네임", example = "홍길동", requiredMode = REQUIRED)
+    @Schema(description = "닉네임", example = "juno", requiredMode = REQUIRED)
     @Size(max = 10, message = "닉네임은 최대 10자입니다.")
-    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.user.model;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -141,6 +142,14 @@ public class User extends BaseEntity {
 
     public boolean isNotSamePassword(PasswordEncoder passwordEncoder, String password) {
         return !passwordEncoder.matches(password, this.password);
+    }
+
+    public boolean isNotSamePhoneNumber(String phoneNumber) {
+        return !Objects.equals(this.phoneNumber, phoneNumber);
+    }
+
+    public boolean isNotSameEmail(String email) {
+        return !Objects.equals(this.email, email);
     }
 
     public void auth() {

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -50,7 +50,7 @@ public class UserService {
         userValidationService.checkDuplicatedEmail(request.email());
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);
-        userVerificationService.checkVerified(request.phoneNumber());
+        userVerificationService.consumeVerification(request.phoneNumber());
     }
 
     @Transactional
@@ -119,14 +119,14 @@ public class UserService {
     public String findIdBySms(String phoneNumber) {
         User user = userRepository.getByPhoneNumberAndUserTypeIn(phoneNumber, List.of(UserType.GENERAL, UserType.STUDENT));
         String userId = user.getUserId();
-        userVerificationService.checkVerified(phoneNumber);
+        userVerificationService.consumeVerification(phoneNumber);
         return userId;
     }
 
     public String findIdByEmail(String email) {
         User user = userRepository.getByEmailAndUserTypeIn(email, List.of(UserType.GENERAL, UserType.STUDENT));
         String userId = user.getUserId();
-        userVerificationService.checkVerified(email);
+        userVerificationService.consumeVerification(email);
         return userId;
     }
 
@@ -138,7 +138,7 @@ public class UserService {
         }
         user.updatePassword(passwordEncoder, newPassword);
         userRepository.save(user);
-        userVerificationService.checkVerified(phoneNumber);
+        userVerificationService.consumeVerification(phoneNumber);
     }
 
     @Transactional
@@ -149,6 +149,6 @@ public class UserService {
         }
         user.updatePassword(passwordEncoder, newPassword);
         userRepository.save(user);
-        userVerificationService.checkVerified(email);
+        userVerificationService.consumeVerification(email);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.user.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -48,10 +47,10 @@ public class UserService {
 
     @Transactional
     public void generalUserRegister(GeneralUserRegisterRequest request) {
-        userVerificationService.checkVerified(request.phoneNumber());
         userValidationService.checkDuplicatedEmail(request.email());
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);
+        userVerificationService.checkVerified(request.phoneNumber());
     }
 
     @Transactional
@@ -118,39 +117,38 @@ public class UserService {
     }
 
     public String findIdBySms(String phoneNumber) {
+        User user = userRepository.getByPhoneNumberAndUserTypeIn(phoneNumber, List.of(UserType.GENERAL, UserType.STUDENT));
+        String userId = user.getUserId();
         userVerificationService.checkVerified(phoneNumber);
-        User user = userRepository.getByPhoneNumberAndUserTypeIn(phoneNumber,
-            List.of(UserType.GENERAL, UserType.STUDENT));
-        return user.getUserId();
+        return userId;
     }
 
     public String findIdByEmail(String email) {
-        userVerificationService.checkVerified(email);
         User user = userRepository.getByEmailAndUserTypeIn(email, List.of(UserType.GENERAL, UserType.STUDENT));
-        return user.getUserId();
+        String userId = user.getUserId();
+        userVerificationService.checkVerified(email);
+        return userId;
     }
 
     @Transactional
     public void resetPasswordBySms(String userId, String phoneNumber, String newPassword) {
-        userVerificationService.checkVerified(phoneNumber);
         User user = userRepository.getByUserIdAndUserTypeIn(userId, List.of(UserType.GENERAL, UserType.STUDENT));
-        if (Objects.equals(user.getPhoneNumber(), phoneNumber)) {
-            user.updatePassword(passwordEncoder, newPassword);
-            userRepository.save(user);
-            return;
+        if (user.isNotSamePhoneNumber(phoneNumber)) {
+            throw new KoinIllegalArgumentException("입력한 아이디와 인증된 사용자 정보가 일치하지 않습니다.");
         }
-        throw new KoinIllegalArgumentException("입력한 아이디와 인증된 사용자 정보가 일치하지 않습니다.");
+        user.updatePassword(passwordEncoder, newPassword);
+        userRepository.save(user);
+        userVerificationService.checkVerified(phoneNumber);
     }
 
     @Transactional
     public void resetPasswordByEmail(String userId, String email, String newPassword) {
-        userVerificationService.checkVerified(email);
         User user = userRepository.getByUserIdAndUserTypeIn(userId, List.of(UserType.GENERAL, UserType.STUDENT));
-        if (Objects.equals(user.getEmail(), email)) {
-            user.updatePassword(passwordEncoder, newPassword);
-            userRepository.save(user);
-            return;
+        if (user.isNotSameEmail(email)) {
+            throw new KoinIllegalArgumentException("입력한 아이디와 인증된 사용자 정보가 일치하지 않습니다.");
         }
-        throw new KoinIllegalArgumentException("입력한 아이디와 인증된 사용자 정보가 일치하지 않습니다.");
+        user.updatePassword(passwordEncoder, newPassword);
+        userRepository.save(user);
+        userVerificationService.checkVerified(email);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -15,7 +15,7 @@ import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
-import in.koreatech.koin.domain.user.dto.GeneralUserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
@@ -46,7 +46,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void generalUserRegister(GeneralUserRegisterRequest request) {
+    public void userRegister(UserRegisterRequest request) {
         userValidationService.checkDuplicatedEmail(request.email());
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -15,7 +15,7 @@ import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.timetableV2.repository.TimetableFrameRepositoryV2;
 import in.koreatech.koin.domain.user.dto.AuthResponse;
-import in.koreatech.koin.domain.user.dto.UserRegisterRequest;
+import in.koreatech.koin.domain.user.dto.RegisterUserRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequest;
 import in.koreatech.koin.domain.user.dto.UserLoginRequestV2;
 import in.koreatech.koin.domain.user.dto.UserLoginResponse;
@@ -46,7 +46,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void userRegister(UserRegisterRequest request) {
+    public void userRegister(RegisterUserRequest request) {
         userValidationService.checkDuplicatedEmail(request.email());
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -37,6 +37,9 @@ public class UserValidationService {
     }
 
     public void checkDuplicatedEmail(String email) {
+        if (Objects.isNull(email)) {
+            return;
+        }
         if (userRepository.existsByEmail(email)) {
             throw DuplicationEmailException.withDetail("email: " + email);
         }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -18,6 +18,7 @@ import in.koreatech.koin.domain.user.exception.UserNotFoundException;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.integration.email.exception.DuplicationEmailException;
+import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -37,7 +38,7 @@ public class UserValidationService {
     }
 
     public void checkDuplicatedEmail(String email) {
-        if (Objects.isNull(email)) {
+        if (StringUtils.isBlank(email)) {
             return;
         }
         if (userRepository.existsByEmail(email)) {

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
@@ -51,14 +51,13 @@ public class UserVerificationService {
     }
 
     private UserDailyVerificationCount increaseUserDailyVerificationCount(String phoneNumberOrEmail) {
-        UserDailyVerificationCount verificationCount = userDailyVerificationCountRedisRepository.findById(
-                phoneNumberOrEmail)
-            .map(existing -> {
-                existing.incrementVerificationCount();
-                return existing;
+        UserDailyVerificationCount updatedCount = userDailyVerificationCountRedisRepository.findById(phoneNumberOrEmail)
+            .map(count -> {
+                count.incrementVerificationCount();
+                return count;
             })
             .orElseGet(() -> UserDailyVerificationCount.from(phoneNumberOrEmail));
-        return userDailyVerificationCountRedisRepository.save(verificationCount);
+        return userDailyVerificationCountRedisRepository.save(updatedCount);
     }
 
     public void verifyCode(String phoneNumberOrEmail, String verificationCode) {
@@ -70,10 +69,10 @@ public class UserVerificationService {
         userVerificationStatusRedisRepository.save(verificationStatus);
     }
 
-    public void consumeVerification(String phoneNumber) {
-        userVerificationStatusRedisRepository.findById(phoneNumber)
+    public void consumeVerification(String phoneNumberOrEmail) {
+        userVerificationStatusRedisRepository.findById(phoneNumberOrEmail)
             .filter(UserVerificationStatus::isVerified)
             .orElseThrow(() -> new AuthenticationException("본인 인증 후 다시 시도해주십시오."));
-        userVerificationStatusRedisRepository.deleteById(phoneNumber);
+        userVerificationStatusRedisRepository.deleteById(phoneNumberOrEmail);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
@@ -70,7 +70,7 @@ public class UserVerificationService {
         userVerificationStatusRedisRepository.save(verificationStatus);
     }
 
-    public void checkVerified(String phoneNumber) {
+    public void consumeVerification(String phoneNumber) {
         userVerificationStatusRedisRepository.findById(phoneNumber)
             .filter(UserVerificationStatus::isVerified)
             .orElseThrow(() -> new AuthenticationException("본인 인증 후 다시 시도해주십시오."));


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1487

# 🚀 작업 내용

1. 닉네임 중복 체크 API 유효성 검사를 추가했습니다. (정규식 추가)
2. 인증 상태를 확인하는 모든 메서드에서 실패 시 인증 캐시를 소모하는 오류를 해결했습니다.
    - 인증 상태를 가장 마지막에 검사하는 방식으로 해결했습니다.
3. 인증 확인 메서드 이름 변경했습니다. (checkVerified -> consumeVerification)
    - 기존 메서드 명(checkVerified)은 자칫 읽기 전용 메서드로 오해할 수 있어 수정했습니다.
    - 인증 상태를 소모하는 사이드 이펙트가 잘 드러나도록 이름 변경했습니다.
4. 기타 적절하지 못한 변수 이름 수정했습니다.
5. 이메일 중복 검증 시 null 처리 하도록 수정했습니다.

# 💬 리뷰 중점사항
