### PR TITLE
feat: 마케팅 알림 구독 타입 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/integration/fcm/notification/model/NotificationSubscribeType.java
+++ b/src/main/java/in/koreatech/koin/integration/fcm/notification/model/NotificationSubscribeType.java
@@ -17,7 +17,8 @@ public enum NotificationSubscribeType {
     DINING_SOLD_OUT(List.of(BREAKFAST, LUNCH, DINNER)),
     DINING_IMAGE_UPLOAD(List.of()),
     ARTICLE_KEYWORD(List.of()),
-    LOST_ITEM_CHAT(List.of())
+    LOST_ITEM_CHAT(List.of()),
+    MARKETING(List.of()),
     ;
 
     private final List<NotificationDetailSubscribeType> detailTypes;

--- a/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/NotificationApiTest.java
@@ -130,6 +130,13 @@ class NotificationApiTest extends AcceptanceTest {
                              "detail_subscribes": [
                                 \s
                              ]
+                         },
+                         {
+                             "type": "MARKETING",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
                          }
                     ]
                 }
@@ -248,6 +255,13 @@ class NotificationApiTest extends AcceptanceTest {
                              "detail_subscribes": [
                                 \s
                              ]
+                         },
+                         {
+                             "type": "MARKETING",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
                          }
                      ]
                  }
@@ -362,6 +376,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "LOST_ITEM_CHAT",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "MARKETING",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s
@@ -492,6 +513,13 @@ class NotificationApiTest extends AcceptanceTest {
                              "detail_subscribes": [
                                 \s
                              ]
+                         },
+                         {
+                             "type": "MARKETING",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
                          }
                      ]
                  }
@@ -611,6 +639,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "LOST_ITEM_CHAT",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "MARKETING",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1492 

# 🚀 작업 내용

1. 마케팅 알림 구독 타입 추가

이미 기존에 기능이 있어서 간단하게 만들었는데, 리팩터링이 필요해보이네요

