### PR TITLE
fix: 본인 인증 오류 횟수 초과 시 인증 번호를 전송하는 오류 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserVerificationService.java
@@ -34,21 +34,21 @@ public class UserVerificationService {
     private final MailService mailService;
 
     public SendVerificationResponse sendSmsVerification(String phoneNumber) {
+        UserDailyVerificationCount verificationCount = increaseUserDailyVerificationCount(phoneNumber);
         String verificationCode = CertificateNumberGenerator.generate();
         naverSmsService.sendVerificationCode(verificationCode, phoneNumber);
         userVerificationStatusRedisRepository.save(UserVerificationStatus.ofSms(phoneNumber, verificationCode));
         eventPublisher.publishEvent(new UserSmsVerificationSendEvent(phoneNumber));
-        UserDailyVerificationCount verificationCount = increaseUserDailyVerificationCount(phoneNumber);
         return SendVerificationResponse.from(verificationCount);
     }
 
     public SendVerificationResponse sendEmailVerification(String email) {
+        UserDailyVerificationCount verificationCount = increaseUserDailyVerificationCount(email);
         String verificationCode = CertificateNumberGenerator.generate();
         MailFormData mailFormData = new UserEmailVerificationData(verificationCode);
         mailService.sendMail(email, mailFormData);
         userVerificationStatusRedisRepository.save(UserVerificationStatus.ofEmail(email, verificationCode));
         eventPublisher.publishEvent(new UserEmailVerificationSendEvent(email));
-        UserDailyVerificationCount verificationCount = increaseUserDailyVerificationCount(email);
         return SendVerificationResponse.from(verificationCount);
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

![image](https://github.com/user-attachments/assets/c2877f3d-dcaf-4d0c-9194-736906c4e63f)
- close #1498 

# 🚀 작업 내용

1. 본인 인증 오류 횟수 초과 시 인증 번호를 전송하는 오류 해결했습니다.

# 💬 리뷰 중점사항
