### PR TITLE
feat: 코인 동아리 테이블 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -1,0 +1,96 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.lang.Boolean.FALSE;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "club")
+@NoArgsConstructor(access = PROTECTED)
+public class Club extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @Size(max = 50)
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @NotNull
+    @Column(name = "hits", nullable = false, columnDefinition = "INT UNSIGNED DEFAULT 0")
+    private Integer hits = 0;
+
+    @NotNull
+    @Size(max = 100)
+    @Column(name = "description", length = 100, nullable = false)
+    private String description;
+
+    @NotNull
+    @Column(name = "is_active", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private Boolean active = FALSE;
+
+    @NotNull
+    @Size(max = 255)
+    @Column(name = "image_url", length = 255, nullable = false)
+    private String imageUrl;
+
+    @NotNull
+    @Column(name = "likes", nullable = false, columnDefinition = "INT UNSIGNED DEFAULT 0")
+    private Integer likes;
+
+    @NotNull
+    @Size(max = 20)
+    @Column(name = "location", length = 20, nullable = false)
+    private String location;
+
+    @NotNull
+    @Column(name = "introduction", nullable = false, columnDefinition = "TEXT")
+    private String introduction;
+
+    @JoinColumn(name = "club_category_id")
+    @ManyToOne(fetch = LAZY)
+    private ClubCategory clubCategory;
+
+    @Builder
+    private Club(
+        Integer id,
+        String name,
+        Integer hits,
+        String description,
+        Boolean active,
+        String imageUrl,
+        Integer likes,
+        String location,
+        String introduction,
+        ClubCategory clubCategory
+    ) {
+        this.id = id;
+        this.name = name;
+        this.hits = hits;
+        this.description = description;
+        this.active = active;
+        this.imageUrl = imageUrl;
+        this.likes = likes;
+        this.location = location;
+        this.introduction = introduction;
+        this.clubCategory = clubCategory;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubAdmin.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubAdmin.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "club_admin")
+@NoArgsConstructor(access = PROTECTED)
+public class ClubAdmin {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @JoinColumn(name = "club_id")
+    @ManyToOne(fetch = LAZY)
+    private Club club;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @Builder
+    private ClubAdmin(
+        Integer id,
+        Club club,
+        User user
+    ) {
+        this.id = id;
+        this.club = club;
+        this.user = user;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubCategory.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "club_category")
+@NoArgsConstructor(access = PROTECTED)
+public class ClubCategory {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Builder
+    private ClubCategory(
+        Integer id,
+        String name
+    ) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubLike.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubLike.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "club_like")
+@NoArgsConstructor(access = PROTECTED)
+public class ClubLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @JoinColumn(name = "club_id")
+    @ManyToOne(fetch = LAZY)
+    private Club club;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @Builder
+    private ClubLike(
+        Integer id,
+        Club club,
+        User user
+    ) {
+        this.id = id;
+        this.club = club;
+        this.user = user;
+    }
+}

--- a/src/main/resources/db/migration/V150__add_club_category_table.sql
+++ b/src/main/resources/db/migration/V150__add_club_category_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club_category`
+(
+    `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `name`          VARCHAR(255) NOT NULL COMMENT '동아리 카테고리 이름',
+    PRIMARY KEY (`id`)
+);
+
+INSERT INTO `koin`.`club_category` (`name`)
+VALUES
+    ('학술'),
+    ('운동'),
+    ('취미'),
+    ('종교'),
+    ('공연');

--- a/src/main/resources/db/migration/V151__add_club_table.sql
+++ b/src/main/resources/db/migration/V151__add_club_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club`
+(
+    `id`                 INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `club_category_id`   INT UNSIGNED NOT NULL COMMENT '동아리 카테고리 ID',
+    `name`               VARCHAR(50) NOT NULL COMMENT '동아리 이름',
+    `hits`               INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '조회수',
+    `description`        VARCHAR(100) NOT NULL COMMENT '동아리 소개',
+    `is_active`          TINYINT(1) NOT NULL DEFAULT 0 COMMENT '활성화 여부',
+    `image_url`          VARCHAR(255) NOT NULL COMMENT '동아리 사진',
+    `likes`              INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '동아리 좋아요 개수',
+    `location`           VARCHAR(20) NOT NULL COMMENT '동아리 장소',
+    `introduction`       TEXT NOT NULL COMMENT '동아리 상세 소개',
+    `created_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`club_category_id`) REFERENCES `koin`.`club_category` (`id`)
+);

--- a/src/main/resources/db/migration/V152__add_club_admin.sql
+++ b/src/main/resources/db/migration/V152__add_club_admin.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club_admin`
+(
+    `id`        INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `club_id`   INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
+    `user_id`   INT UNSIGNED NOT NULL COMMENT '동아리 관리자 유저 ID',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`),
+    FOREIGN KEY (`user_id`) REFERENCES `koin`.`users` (`id`) ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V153__add_club_like.sql
+++ b/src/main/resources/db/migration/V153__add_club_like.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club_like`
+(
+    `id`                 INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `club_id`            INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
+    `user_id`            INT UNSIGNED NOT NULL COMMENT '유저 ID',
+    `created_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`),
+    FOREIGN KEY (`user_id`) REFERENCES `koin`.`users` (`id`) ON DELETE CASCADE
+);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1513 

# 🚀 작업 내용

- 코인 동아리 테이블을 추가했습니다.
  - club, club_admin, club_like, club_category
  - 이번 스프린트에서 사용하는 qna는 구현 중 변경이 생길 수도 있을 것 같아, 작업 담당자 분께서 구현해주시면 감사하겠습니다.

# 💬 리뷰 중점사항
### 테이블
피그마와 백엔드 테이블 설계 문서를 보고 작성했습니다. 혹시나 빠트린 부분, 이상한 부분 코멘트 남겨주시면 감사하겠습니다.

### 동아리 연락처
<img width="99" alt="image" src="https://github.com/user-attachments/assets/ac7c5c6d-1ee0-4e7c-9d5d-b2c4457b1a32" />

동아리 연락처가 추가 됐는데, 이를 club 테이블에 역정규화로 넣어야 할지 별도의 테이블로 빼야할지 고민입니다.. 의견 주시면 감사하겠습니다..! 