### PR TITLE
feat: club_qna 테이블 추가

### DIFF
--- a/src/main/resources/db/migration/V154__add_club_qna_table.sql
+++ b/src/main/resources/db/migration/V154__add_club_qna_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club_qna`
+(
+    `id`                 INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `club_id`            INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
+    `user_id`            INT UNSIGNED NULL COMMENT '유저 ID',
+    `parent_id`          INT UNSIGNED NULL COMMENT '부모 qna ID',
+    `content`            VARCHAR(255) NOT NULL COMMENT '내용',
+    `created_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`),
+    FOREIGN KEY (`user_id`) REFERENCES `koin`.`users` (`id`) ON DELETE SET NULL,
+    FOREIGN KEY (`parent_id`) REFERENCES `koin`.`club_qna` (`id`)
+);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1515

# 🚀 작업 내용

- club_qna 테이블을 추가하였습니다
- 작성자가 탈퇴하면 SET NULL로 설정하여 user_id가 null이 되도록 했습니다.
- 방식은 parent_id 필드를 두어 최상위 댓글은 null로두고 그 외의 댓글들은 자식의 형태로 두고자합니다.
- 따라서 user_id와 parent_id는 nullable하게 설정하였습니다.
- parent_id는 자기참조 관계로 club_qna 테이블을 참조합니다.

# 💬 리뷰 중점사항
