### PR TITLE
feat: 코인 공지 테스트 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/test/TestApi.java
+++ b/src/main/java/in/koreatech/koin/domain/test/TestApi.java
@@ -35,4 +35,9 @@ public interface TestApi {
         @RequestParam(defaultValue = "HOME") MobileAppPath mobileAppPath,
         @Parameter(description = "스킴 uri(ex: shop?id=1)") @RequestParam String url
     );
+
+    @ApiResponse(responseCode = "503", content = @Content(schema = @Schema(hidden = true)))
+    @Operation(summary = "Service Unavailable 테스트")
+    @GetMapping("/service-unavailable")
+    ResponseEntity<Object> testServiceUnavailable();
 }

--- a/src/main/java/in/koreatech/koin/domain/test/TestApi.java
+++ b/src/main/java/in/koreatech/koin/domain/test/TestApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.test;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Profile("dev")
 @Tag(name = "(Normal) Test: 테스트", description = "테스트용 API")
 @RequestMapping("/test")
 public interface TestApi {

--- a/src/main/java/in/koreatech/koin/domain/test/TestController.java
+++ b/src/main/java/in/koreatech/koin/domain/test/TestController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import in.koreatech.koin.domain.notification.model.NotificationType;
 import in.koreatech.koin.infrastructure.fcm.FcmClient;
 import lombok.RequiredArgsConstructor;
 
+@Profile("dev")
 @RestController
 @RequestMapping("/test")
 @RequiredArgsConstructor

--- a/src/main/java/in/koreatech/koin/domain/test/TestController.java
+++ b/src/main/java/in/koreatech/koin/domain/test/TestController.java
@@ -1,14 +1,19 @@
 package in.koreatech.koin.domain.test;
 
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin._common.model.MobileAppPath;
 import in.koreatech.koin.domain.notification.model.NotificationType;
 import in.koreatech.koin.infrastructure.fcm.FcmClient;
-import in.koreatech.koin._common.model.MobileAppPath;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,5 +42,15 @@ public class TestController implements TestApi {
             NotificationType.MESSAGE.name().toLowerCase()
         );
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/service-unavailable")
+    public ResponseEntity<Object> testServiceUnavailable() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "서비스 점검 중입니다.");
+        response.put("start_time", "2025-04-10T00:00");
+        response.put("end_time", "2026-12-31T23:59");
+
+        return ResponseEntity.status(SERVICE_UNAVAILABLE).body(response);
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1521 

# 🚀 작업 내용

- 클라이언트 요청으로 코인 공지 테스트를 위한 API를 추가했습니다.
- 테스트 패키지에 dev Profile 추가했습니다.

# 💬 리뷰 중점사항
