### PR TITLE
fix: 탈퇴한 유저 예외처리 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/auth/AuthArgumentResolver.java
+++ b/src/main/java/in/koreatech/koin/_common/auth/AuthArgumentResolver.java
@@ -45,6 +45,10 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         Integer userId = authContext.getUserId();
         User user = userRepository.getById(userId);
 
+        if (user.isDeleted()) {
+            throw new AuthorizationException("이미 탈퇴한 계정입니다.");
+        }
+
         if (permitStatus.contains(user.getUserType())) {
             if (!user.isAuthed()) {
                 if (user.getUserType() == OWNER) {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1523 

# 🚀 작업 내용

1. 탈퇴한 유저의 인증 예외처리를 추가했습니다.

