### PR TITLE
feat: 동아리 QNA API

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -34,7 +34,31 @@ public interface ClubApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "특정 동아리의 모든 QNA를 조회한다")
+    @Operation(
+        summary = "특정 동아리의 모든 QNA를 조회한다",
+        description = """
+            - authorId 확인하여 작성자 본인인 경우 삭제 버튼(x) 표시.
+            - 닉네임은 존재 시 그대로 반환되며, 없는 경우 student의 익명 닉네임으로 반환.
+            - is_deleted 값이 false인 경우 "삭제된 댓글입니다"로 표현.
+            - is_admin 필드를 통해 관리자 댓글 여부를 알 수 있음.
+            - 트리 구조는 대댓글 형태로 재귀적으로 구성됩니다.
+            
+            ```java
+            예시
+            댓글 1
+            ├── 댓글 1-1
+            │   ├── 댓글 1-1-1
+            │   │   └── 댓글 1-1-1-1
+            │   └── 댓글 1-1-2
+            ├── 댓글 1-2
+            └── 댓글 1-3
+            
+            댓글 2
+            └── 댓글 2-1
+                └── 댓글 2-1-1
+            ```
+            """
+    )
     @GetMapping("/{clubId}/qna")
     ResponseEntity<QnasResponse> getQnas(
         @Parameter(in = PATH) @PathVariable Integer clubId

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -72,7 +72,8 @@ public interface ClubApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "특정 동아리의 QNA를 생성한다")
+    @Operation(summary = "특정 동아리의 QNA를 생성한다",
+        description = "parentId를 null 요청 시 첫 QNA, 부모 QNA의 id를 넣어서 요청하면 대댓글 형식으로 생성")
     @PostMapping("/{clubId}/qna")
     ResponseEntity<Void> createQna(
         @RequestBody @Valid CreateQnaRequest request,
@@ -89,7 +90,12 @@ public interface ClubApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "특정 동아리의 QNA를 삭제한다")
+    @Operation(summary = "특정 동아리의 QNA를 삭제한다",
+        description = """
+            - 관리자는 모든 QNA 삭제 가능, 그 외에는 본인의 QNA만 삭제 가능
+            - 부모 QNA(맨처음 QNA)인 경우, 그 아래 QNA들까지 모두 삭제
+            - 자식 QNA인 경우, 삭제 시 삭제된 댓글입니다로만 표시하고 구조를 깨지 않음
+            """)
     @DeleteMapping("/{clubId}/qna/{qnaId}")
     ResponseEntity<Void> deleteQna(
         @Parameter(in = PATH) @PathVariable Integer clubId,

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.domain.club.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Normal) Club: 동아리", description = "동아리 정보를 관리한다")
+@RequestMapping("/clubs")
+public interface ClubApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 동아리의 QNA를 생성한다")
+    @PostMapping("/{clubId}/qna")
+    ResponseEntity<Void> createQna(
+        @RequestBody @Valid CreateQnaRequest request,
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -1,9 +1,11 @@
 package in.koreatech.koin.domain.club.controller;
 
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,6 +39,23 @@ public interface ClubApi {
     ResponseEntity<Void> createQna(
         @RequestBody @Valid CreateQnaRequest request,
         @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 동아리의 QNA를 삭제한다")
+    @DeleteMapping("/{clubId}/qna/{qnaId}")
+    ResponseEntity<Void> deleteQna(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Parameter(in = PATH) @PathVariable Integer qnaId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -1,11 +1,11 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,6 +26,19 @@ import jakarta.validation.Valid;
 @Tag(name = "(Normal) Club: 동아리", description = "동아리 정보를 관리한다")
 @RequestMapping("/clubs")
 public interface ClubApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 동아리의 모든 QNA를 조회한다")
+    @GetMapping("/{clubId}/qna")
+    ResponseEntity<QnasResponse> getQnas(
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    );
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.domain.club.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.service.ClubService;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/clubs")
+public class ClubController implements ClubApi {
+
+    private final ClubService clubService;
+
+    @PostMapping("/{clubId}/qna")
+    public ResponseEntity<Void> createQna(
+        @RequestBody @Valid CreateQnaRequest request,
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ){
+        clubService.createQna(request, clubId, studentId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import in.koreatech.koin.domain.club.service.ClubService;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -25,6 +27,14 @@ import lombok.RequiredArgsConstructor;
 public class ClubController implements ClubApi {
 
     private final ClubService clubService;
+
+    @GetMapping("/{clubId}/qna")
+    public ResponseEntity<QnasResponse> getQnas(
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    ) {
+        QnasResponse response = clubService.getQnas(clubId);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/{clubId}/qna")
     public ResponseEntity<Void> createQna(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,5 +34,15 @@ public class ClubController implements ClubApi {
     ){
         clubService.createQna(request, clubId, studentId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{clubId}/qna/{qnaId}")
+    public ResponseEntity<Void> deleteQna(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Parameter(in = PATH) @PathVariable Integer qnaId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.deleteQna(clubId, qnaId, studentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateQnaRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateQnaRequest.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubQna;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CreateQnaRequest(
+    @Schema(description = "부모 qna id", example = "1", requiredMode = NOT_REQUIRED)
+    Integer parentId,
+
+    @Schema(description = "내용", example = "언제 모집하나요?", requiredMode = REQUIRED)
+    @NotBlank(message = "내용은 공백일 수 없습니다")
+    @Size(max = 255, message = "내용은 최대 255자 입니다.")
+    String content
+) {
+
+    public ClubQna toClubQna(Club club, User user, ClubQna parentQna) {
+        return ClubQna.builder()
+            .club(club)
+            .user(user)
+            .parent(parentQna)
+            .content(content)
+            .isDeleted(false)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateQnaRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateQnaRequest.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubQna;
-import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.student.model.Student;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -24,13 +24,14 @@ public record CreateQnaRequest(
     String content
 ) {
 
-    public ClubQna toClubQna(Club club, User user, ClubQna parentQna) {
+    public ClubQna toClubQna(Club club, Student student, ClubQna parentQna, boolean isAdmin) {
         return ClubQna.builder()
             .club(club)
-            .user(user)
+            .author(student)
             .parent(parentQna)
             .content(content)
             .isDeleted(false)
+            .isAdmin(isAdmin)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
@@ -1,0 +1,85 @@
+package in.koreatech.koin.domain.club.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.club.model.ClubQna;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record QnasResponse(
+    @Schema(example = "10", description = "해당 동아리의 루트 질문 총 개수", requiredMode = REQUIRED)
+    Integer rootCount,
+
+    @Schema(example = "30", description = "해당 동아리의 qna 총 개수", requiredMode = REQUIRED)
+    Integer totalCount,
+
+    @Schema(description = "해당 동아리의 qna 정보 리스트")
+    List<InnerQnaResponse> qnas
+) {
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerQnaResponse(
+        @Schema(description = "qna ID", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "작성자 ID", example = "5400", requiredMode = REQUIRED)
+        Integer authorId,
+
+        @Schema(description = "작성자 닉네임", example = "김성현", requiredMode = REQUIRED)
+        String nickname,
+
+        @Schema(description = "내용", example = "언제 모집하나요?", requiredMode = REQUIRED)
+        String content,
+
+        @Schema(description = "삭제여부", example = "false", requiredMode = REQUIRED)
+        Boolean isDeleted,
+
+        @Schema(description = "관리자여부", example = "true", requiredMode = REQUIRED)
+        Boolean isAdmin,
+
+        @Schema(description = "작성 일시", example = "2025.05.12 14:00", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
+        LocalDateTime createdAt,
+
+        @Schema(description = "해당 qna의 대댓글 정보 리스트")
+        List<InnerQnaResponse> children
+    ) {
+
+        public static InnerQnaResponse from(ClubQna qna) {
+            String nickname = qna.getAuthor().getUser().getNickname();
+            if (nickname == null) {
+                nickname = qna.getAuthor().getAnonymousNickname();
+            }
+            List<InnerQnaResponse> children = qna.getChildren().stream()
+                .map(InnerQnaResponse::from)
+                .toList();
+            return new InnerQnaResponse(
+                qna.getId(),
+                qna.getAuthor().getId(),
+                nickname,
+                qna.getContent(),
+                qna.getIsDeleted(),
+                qna.getIsAdmin(),
+                qna.getCreatedAt(),
+                children
+            );
+        }
+    }
+
+    public static QnasResponse from(List<ClubQna> qnas) {
+        List<InnerQnaResponse> roots = qnas.stream()
+            .filter(ClubQna::isRoot)
+            .sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()))
+            .map(InnerQnaResponse::from)
+            .toList();
+
+        return new QnasResponse(roots.size(), qnas.size(), roots);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/exception/ClubNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/ClubNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.DataNotFoundException;
+
+public class ClubNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "동아리가 존재하지 않습니다.";
+
+    public ClubNotFoundException(String message) {
+        super(message);
+    }
+
+    public ClubNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ClubNotFoundException withDetail(String detail) {
+        return new ClubNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/exception/ClubQnaNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/ClubQnaNotFoundException.java
@@ -4,7 +4,7 @@ import in.koreatech.koin._common.exception.custom.DataNotFoundException;
 
 public class ClubQnaNotFoundException extends DataNotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "동아리QNA가 존재하지 않습니다.";
+    private static final String DEFAULT_MESSAGE = "동아리 QNA가 존재하지 않습니다.";
 
     public ClubQnaNotFoundException(String message) {
         super(message);

--- a/src/main/java/in/koreatech/koin/domain/club/exception/ClubQnaNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/ClubQnaNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.DataNotFoundException;
+
+public class ClubQnaNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "동아리QNA가 존재하지 않습니다.";
+
+    public ClubQnaNotFoundException(String message) {
+        super(message);
+    }
+
+    public ClubQnaNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ClubQnaNotFoundException withDetail(String detail) {
+        return new ClubQnaNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
@@ -5,14 +5,19 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static java.lang.Boolean.FALSE;
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -42,6 +47,9 @@ public class ClubQna extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private ClubQna parent;
 
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ClubQna> children = new ArrayList<>();
+
     @NotNull
     @Column(nullable = false)
     private String content;
@@ -65,5 +73,13 @@ public class ClubQna extends BaseEntity {
         this.parent = parent;
         this.content = content;
         this.isDeleted = isDeleted;
+    }
+
+    public void delete() {
+        isDeleted = true;
+    }
+
+    public boolean isRoot() {
+        return parent == null;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import in.koreatech.koin._common.model.BaseEntity;
+import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -39,9 +40,9 @@ public class ClubQna extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     private Club club;
 
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "author_id")
     @ManyToOne(fetch = LAZY)
-    private User user;
+    private Student author;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "parent_id")
@@ -55,6 +56,10 @@ public class ClubQna extends BaseEntity {
     private String content;
 
     @NotNull
+    @Column(name = "is_admin", nullable = false)
+    private Boolean isAdmin;
+
+    @NotNull
     @Column(name = "is_deleted", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
     private Boolean isDeleted = FALSE;
 
@@ -62,16 +67,18 @@ public class ClubQna extends BaseEntity {
     private ClubQna(
         Integer id,
         Club club,
-        User user,
+        Student author,
         ClubQna parent,
         String content,
+        Boolean isAdmin,
         Boolean isDeleted
     ) {
         this.id = id;
         this.club = club;
-        this.user = user;
+        this.author = author;
         this.parent = parent;
         this.content = content;
+        this.isAdmin = isAdmin;
         this.isDeleted = isDeleted;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
@@ -1,0 +1,69 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.lang.Boolean.FALSE;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import in.koreatech.koin.domain.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "club_qna")
+@NoArgsConstructor(access = PROTECTED)
+public class ClubQna extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @JoinColumn(name = "club_id", nullable = false)
+    @ManyToOne(fetch = LAZY)
+    private Club club;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "parent_id")
+    private ClubQna parent;
+
+    @NotNull
+    @Column(nullable = false)
+    private String content;
+
+    @NotNull
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private Boolean isDeleted = FALSE;
+
+    @Builder
+    private ClubQna(
+        Integer id,
+        Club club,
+        User user,
+        ClubQna parent,
+        String content,
+        Boolean isDeleted
+    ) {
+        this.id = id;
+        this.club = club;
+        this.user = user;
+        this.parent = parent;
+        this.content = content;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubAdminRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubAdminRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.domain.club.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.model.ClubAdmin;
+
+public interface ClubAdminRepository extends Repository<ClubAdmin, Integer> {
+
+    boolean existsByClubIdAndUserId(Integer clubId, Integer studentId);
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.exception.ClubQnaNotFoundException;
+import in.koreatech.koin.domain.club.model.ClubQna;
+
+public interface ClubQnaRepository extends Repository<ClubQna, Integer> {
+
+    ClubQna save(ClubQna qna);
+
+    Optional<ClubQna> findById(Integer id);
+
+    default ClubQna getById(Integer id) {
+        return findById(id)
+            .orElseThrow(() -> ClubQnaNotFoundException.withDetail("id : " + id));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.club.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.Repository;
@@ -9,7 +10,7 @@ import in.koreatech.koin.domain.club.model.ClubQna;
 
 public interface ClubQnaRepository extends Repository<ClubQna, Integer> {
 
-    ClubQna save(ClubQna qna);
+    List<ClubQna> findAllByClubId(Integer clubId);
 
     Optional<ClubQna> findById(Integer id);
 
@@ -17,6 +18,8 @@ public interface ClubQnaRepository extends Repository<ClubQna, Integer> {
         return findById(id)
             .orElseThrow(() -> ClubQnaNotFoundException.withDetail("id : " + id));
     }
+
+    ClubQna save(ClubQna qna);
 
     void delete(ClubQna qna);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubQnaRepository.java
@@ -17,4 +17,6 @@ public interface ClubQnaRepository extends Repository<ClubQna, Integer> {
         return findById(id)
             .orElseThrow(() -> ClubQnaNotFoundException.withDetail("id : " + id));
     }
+
+    void delete(ClubQna qna);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.exception.ClubNotFoundException;
+import in.koreatech.koin.domain.club.model.Club;
+
+public interface ClubRepository extends Repository<Club, Integer> {
+
+    Optional<Club> findById(Integer id);
+
+    default Club getById(Integer id) {
+        return findById(id)
+            .orElseThrow(() -> ClubNotFoundException.withDetail("id : " + id));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.club.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubQna;
+import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
+import in.koreatech.koin.domain.club.repository.ClubRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubService {
+
+    private final ClubQnaRepository clubQnaRepository;
+    private final ClubRepository clubRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createQna(CreateQnaRequest request, Integer clubId, Integer studentId) {
+        Club club = clubRepository.getById(clubId);
+        User user = userRepository.getById(studentId);
+        ClubQna parentQna = request.parentId() == null ? null : clubQnaRepository.getById(request.parentId());
+        ClubQna qna = request.toClubQna(club, user, parentQna) ;
+        clubQnaRepository.save(qna);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -1,11 +1,15 @@
 package in.koreatech.koin.domain.club.service;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin._common.auth.exception.AuthorizationException;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubQna;
+import in.koreatech.koin.domain.club.repository.ClubAdminRepository;
 import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
 import in.koreatech.koin.domain.club.repository.ClubRepository;
 import in.koreatech.koin.domain.user.model.User;
@@ -20,6 +24,7 @@ public class ClubService {
     private final ClubQnaRepository clubQnaRepository;
     private final ClubRepository clubRepository;
     private final UserRepository userRepository;
+    private final ClubAdminRepository clubAdminRepository;
 
     @Transactional
     public void createQna(CreateQnaRequest request, Integer clubId, Integer studentId) {
@@ -28,5 +33,22 @@ public class ClubService {
         ClubQna parentQna = request.parentId() == null ? null : clubQnaRepository.getById(request.parentId());
         ClubQna qna = request.toClubQna(club, user, parentQna) ;
         clubQnaRepository.save(qna);
+    }
+
+    @Transactional
+    public void deleteQna(Integer clubId, Integer qnaId, Integer studentId) {
+        ClubQna qna = clubQnaRepository.getById(qnaId);
+        validateQnaDeleteAuthorization(clubId, qna, studentId);
+        if (qna.isRoot()) {
+            clubQnaRepository.delete(qna);
+        } else {
+            qna.delete();
+        }
+    }
+
+    private void validateQnaDeleteAuthorization(Integer clubId, ClubQna qna, Integer studentId) {
+        if (Objects.equals(qna.getUser().getId(), studentId)) return;
+        if (clubAdminRepository.existsByClubIdAndUserId(clubId, studentId)) return;
+        throw AuthorizationException.withDetail("studentId: " + studentId);
     }
 }

--- a/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
@@ -50,6 +50,7 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.coopshop",
             "in.koreatech.koin.domain.dining",
             "in.koreatech.koin.domain.banner",
+            "in.koreatech.koin.domain.club",
         };
 
         return createGroupedOpenApi("3. Campus API", packagesPath);
@@ -64,7 +65,7 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.timetableV2",
             "in.koreatech.koin.domain.timetableV3",
             "in.koreatech.koin.domain.dept",
-            "in.koreatech.koin.domain.graduation"
+            "in.koreatech.koin.domain.graduation",
         };
 
         return createGroupedOpenApi("4. User API", packagesPath);

--- a/src/main/resources/db/migration/V154__add_club_qna_table.sql
+++ b/src/main/resources/db/migration/V154__add_club_qna_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS `koin`.`club_qna`
     `user_id`            INT UNSIGNED NULL COMMENT '유저 ID',
     `parent_id`          INT UNSIGNED NULL COMMENT '부모 qna ID',
     `content`            VARCHAR(255) NOT NULL COMMENT '내용',
+    `is_deleted`         TINYINT(1) NOT NULL DEFAULT 0 COMMENT '삭제 여부',
     `created_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
     `updated_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
     PRIMARY KEY (`id`),

--- a/src/main/resources/db/migration/V154__add_club_qna_table.sql
+++ b/src/main/resources/db/migration/V154__add_club_qna_table.sql
@@ -2,14 +2,15 @@ CREATE TABLE IF NOT EXISTS `koin`.`club_qna`
 (
     `id`                 INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
     `club_id`            INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
-    `user_id`            INT UNSIGNED NULL COMMENT '유저 ID',
+    `author_id`          INT UNSIGNED NULL COMMENT '작성자 ID',
     `parent_id`          INT UNSIGNED NULL COMMENT '부모 qna ID',
     `content`            VARCHAR(255) NOT NULL COMMENT '내용',
     `is_deleted`         TINYINT(1) NOT NULL DEFAULT 0 COMMENT '삭제 여부',
+    `is_admin`           TINYINT(1) NOT NULL COMMENT '관리자 여부',
     `created_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
     `updated_at`         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
     PRIMARY KEY (`id`),
     FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`),
-    FOREIGN KEY (`user_id`) REFERENCES `koin`.`users` (`id`) ON DELETE SET NULL,
+    FOREIGN KEY (`author_id`) REFERENCES `koin`.`users` (`id`) ON DELETE SET NULL,
     FOREIGN KEY (`parent_id`) REFERENCES `koin`.`club_qna` (`id`)
 );

--- a/src/test/java/in/koreatech/koin/unit/ClubTest.java
+++ b/src/test/java/in/koreatech/koin/unit/ClubTest.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.unit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
+import in.koreatech.koin.domain.club.service.ClubService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubTest {
+
+    @InjectMocks
+    private ClubService clubService;
+
+    @Mock
+    private ClubQnaRepository clubQnaRepository;
+
+    @Test
+    void QNA를_성공적으로_작성한다() {
+        //given
+
+        //when
+
+        //then
+    }
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1510

# 🚀 작업 내용

### 특정 동아리의 QNA 생성
- parentId를 null로 요청하면 첫 QNA
- parentId에 부모 qna의 id를 넣어서 요청하면 대댓글 형식으로 생성됨
- 생성 시 관리자 인경우 qna에 is_admin을 true로해서 생성
  - 추후 관리자가 변경되어도 유지할 수 있도록 하기 위함 

### 특정 동아리의 모든 QNA 조회
- 작성자 본인일 경우에만 x(삭제표시)를 보이게할 수 있도록 authorId를 함께 반환
- 닉네임은 있는경우 반환, 없는경우 student의 익명 닉네임을 반환
- 중간 댓글의 경우 삭제되어도 트리의 구조를 해치지 않도록 is_deleted를 통해 클라이언트가 '삭제된 댓글입니다' 표시할 수 있도록 함
- 관리자 댓글인 경우 구분할 수 있도록 isAdmin 필드 추가 
- 대댓글 형태로 재귀하여 반환하도록 하였음
```java
댓글 1
├── 댓글 1-1
│   ├── 댓글 1-1-1
│   │   └── 댓글 1-1-1-1
│   └── 댓글 1-1-2
├── 댓글 1-2
└── 댓글 1-3

댓글 2
└── 댓글 2-1
    └── 댓글 2-1-1

```

### 특정 동아리의 QNA 삭제
- 관리자는 모든 QNA 삭제 가능, 그 외에는 본인의 QNA만 삭제 가능
- 부모 QNA (맨 처음 QNA)인 경우 삭제 시 hard delete, 자식까지 cascade
- 자식 QNA인 경우 is_deleted 처리하여 부모, 자식 트리 형태가 깨지지 않고 유지될 수 있도록 함
- 조회 반환 값에서 is_deleted = true로 반환하여 클라이언트 화면에서는 '삭제된 댓글입니다'로 표시

# 💬 리뷰 중점사항
- 아직 테스트코드 작성 못했습니다 ㅠㅠ
