### PR TITLE
fix: 1차 QA 이슈 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
@@ -22,8 +22,8 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(SnakeCaseStrategy.class)
 public record RegisterStudentRequestV2(
     @NotBlank(message = "이름은 필수입니다.")
-    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
     @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)
@@ -40,6 +40,7 @@ public record RegisterStudentRequestV2(
 
     @NotBlank(message = "학번은 필수입니다.")
     @Schema(description = "학번", example = "2025000123", requiredMode = NOT_REQUIRED)
+    @Pattern(regexp = "^[0-9]{8,10}$", message = "학번엔 8-10자리 숫자만 입력 가능합니다.")
     String studentNumber,
 
     @NotBlank(message = "학부는 필수입니다.")
@@ -50,12 +51,16 @@ public record RegisterStudentRequestV2(
     UserGender gender,
 
     @NotBlank(message = "아이디는 필수입니다.")
-    @Size(max = 50, message = "아이디는 50자 이내여야 합니다.")
     @Schema(description = "사용자 아이디", example = "example123", requiredMode = REQUIRED)
+    @Pattern(regexp = "^[A-Za-z0-9._-]{5,13}$", message = "5-13자의 영문자, 숫자, 특수문자만 사용할 수 있습니다.")
     String loginId,
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
+        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자만 사용할 수 있습니다."
+    )
     String password,
 
     @Schema(description = "마케팅 수신 동의 여부", example = "true", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
@@ -79,6 +79,7 @@ public record RegisterStudentRequestV2(
             .userType(STUDENT)
             .isAuthed(false)
             .isDeleted(false)
+            .deviceToken("TEMPORARY_TOKEN")
             .build();
         Student student = Student.builder()
             .user(user)

--- a/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
@@ -58,8 +58,8 @@ public record RegisterStudentRequestV2(
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
     @Pattern(
-        regexp = "^(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
-        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자만 사용할 수 있습니다."
+        regexp = "^[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
+        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자(-, _, + 등)만 사용할 수 있습니다."
     )
     String password,
 

--- a/src/main/java/in/koreatech/koin/domain/student/dto/UpdateStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/UpdateStudentRequestV2.java
@@ -39,8 +39,7 @@ public record UpdateStudentRequestV2(
     String major,
 
     @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
-    @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
+    @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
     @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin._common.concurrent.ConcurrencyGuard;
 import in.koreatech.koin._common.event.StudentFindPasswordEvent;
 import in.koreatech.koin._common.event.StudentRegisterEvent;
 import in.koreatech.koin._common.event.StudentRegisterRequestEvent;
+import in.koreatech.koin._common.event.UserRegisterEvent;
 import in.koreatech.koin.domain.graduation.repository.StandardGraduationRequirementsRepository;
 import in.koreatech.koin.domain.graduation.service.GraduationService;
 import in.koreatech.koin.domain.student.dto.RegisterStudentRequest;
@@ -303,9 +304,9 @@ public class StudentService {
         Student student = request.toStudent(passwordEncoder, department);
         studentRepository.save(student);
         userRepository.save(student.getUser());
-        // eventPublisher.publishEvent(
-        //     new UserRegisterEvent(student.getUser().getId(), request.marketingNotificationAgreement())
-        // );
+        eventPublisher.publishEvent(
+            new UserRegisterEvent(student.getUser().getId(), request.marketingNotificationAgreement())
+        );
         userVerificationService.consumeVerification(request.phoneNumber());
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
@@ -20,8 +20,8 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(SnakeCaseStrategy.class)
 public record RegisterUserRequest(
     @NotBlank(message = "이름은 필수입니다.")
-    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
     @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)
@@ -42,12 +42,16 @@ public record RegisterUserRequest(
     UserGender gender,
 
     @NotBlank(message = "아이디는 필수입니다.")
-    @Size(max = 50, message = "아이디는 50자 이내여야 합니다.")
     @Schema(description = "로그인 아이디", example = "example123", requiredMode = REQUIRED)
+    @Pattern(regexp = "^[A-Za-z0-9._-]{5,13}$", message = "5-13자의 영문자, 숫자, 특수문자만 사용할 수 있습니다.")
     String loginId,
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
+        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자만 사용할 수 있습니다."
+    )
     String password,
 
     @Schema(description = "마케팅 수신 동의 여부", example = "true", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
@@ -49,8 +49,8 @@ public record RegisterUserRequest(
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "password", requiredMode = REQUIRED)
     @Pattern(
-        regexp = "^(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
-        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자만 사용할 수 있습니다."
+        regexp = "^[A-Za-z0-9!@#\\$%\\^&\\*\\-_+=]{6,18}$",
+        message = "6자 이상 18자 이내의 영문자, 숫자, 특수문자(-, _, + 등)만 사용할 수 있습니다."
     )
     String password,
 

--- a/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/RegisterUserRequest.java
@@ -70,6 +70,7 @@ public record RegisterUserRequest(
             .userType(GENERAL)
             .isAuthed(false)
             .isDeleted(false)
+            .deviceToken("TEMPORARY_TOKEN")
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UpdateUserRequest.java
@@ -20,8 +20,7 @@ public record UpdateUserRequest(
     String email,
 
     @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
-    @Size(max = 50, message = "이름의 길이는 최대 50자 입니다.")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z]+$", message = "이름은 한글, 영문만 사용할 수 있습니다.")
+    @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
     @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin._common.auth.JwtProvider;
 import in.koreatech.koin._common.event.UserDeleteEvent;
+import in.koreatech.koin._common.event.UserRegisterEvent;
 import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
@@ -76,7 +77,7 @@ public class UserService {
         );
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);
-        // eventPublisher.publishEvent(new UserRegisterEvent(user.getId(), request.marketingNotificationAgreement()));
+        eventPublisher.publishEvent(new UserRegisterEvent(user.getId(), request.marketingNotificationAgreement()));
         userVerificationService.consumeVerification(request.phoneNumber());
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1534 

# 🚀 작업 내용

1. 아이디, 학번, 비밀번호, 이름의 정규식을 추가하였습니다.
2. 마케팅 수신 동의 주석 해제 및 임시 디바이스 토큰 값을 추가하였습니다.

# 💬 리뷰 중점사항
