### PR TITLE
feat: 1526-normal 동아리

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
@@ -39,7 +39,19 @@ public record CreateAdminClubRequest(
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
     @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
-    String description
+    String description,
+
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    String instagram,
+
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    String googleForm,
+
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    String openChat,
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerClubAdminRequest(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.*;
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.ResponseEntity;
@@ -20,7 +20,7 @@ import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
-import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -107,7 +107,7 @@ public interface ClubApi {
     )
     @Operation(summary = "카테고리를 기준으로 동아리를 조회한다")
     @PostMapping("/categories/{categoryId}")
-    ResponseEntity<GetClubByCategoryResponse> getClubByCategory(
+    ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
         @Parameter(in = PATH) @PathVariable Integer categoryId,
         @RequestParam(required = false) String sort
     );
@@ -132,9 +132,9 @@ public interface ClubApi {
         }
     )
     @Operation(summary = "동아리 좋아요를 누른다")
-    @PutMapping("/like/{clubId}")
-    ResponseEntity<Void> likeDining(
-        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+    @PutMapping("/{clubId}/like")
+    ResponseEntity<Void> likeClub(
+        @Auth(permit = {STUDENT}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     );
 
@@ -147,9 +147,9 @@ public interface ClubApi {
         }
     )
     @Operation(summary = "동아리 좋아요를 취소한다")
-    @DeleteMapping("/like/cancel/{clubId}")
-    ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+    @DeleteMapping("/{clubId}/like-cancel")
+    ResponseEntity<Void> likeClubCancel(
+        @Auth(permit = {STUDENT}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
@@ -45,6 +46,22 @@ public interface ClubApi {
     @PostMapping
     ResponseEntity<Void> createClubRequest(
         @RequestBody @Valid CreateClubRequest createClubRequest,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 정보를 수정한다")
+    @PutMapping("/{clubId}")
+    ResponseEntity<ClubResponse> updateClub(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @RequestBody UpdateClubRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
@@ -62,6 +63,23 @@ public interface ClubApi {
     ResponseEntity<ClubResponse> updateClub(
         @Parameter(in = PATH) @PathVariable Integer clubId,
         @RequestBody UpdateClubRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 상세정보를 수정한다")
+    @PutMapping("/{clubId}/introduction")
+    ResponseEntity<ClubResponse> updateClubIntroduction(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @RequestBody UpdateClubIntroductionRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -41,9 +41,9 @@ public interface ClubApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "동아리를 생성한다")
+    @Operation(summary = "동아리 생성을 요청한다")
     @PostMapping
-    ResponseEntity<Void> createClub(
+    ResponseEntity<Void> createClubRequest(
         @RequestBody @Valid CreateClubRequest createClubRequest,
         @Auth(permit = {STUDENT}) Integer studentId
     );

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -106,10 +106,10 @@ public interface ClubApi {
         }
     )
     @Operation(summary = "카테고리를 기준으로 동아리를 조회한다")
-    @PostMapping("/categories/{categoryId}")
+    @PostMapping
     ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
-        @Parameter(in = PATH) @PathVariable Integer categoryId,
-        @RequestParam(required = false) String sort
+        @RequestParam Integer categoryId,
+        @RequestParam(required = false) Boolean hitSort
     );
 
     @ApiResponses(
@@ -147,7 +147,7 @@ public interface ClubApi {
         }
     )
     @Operation(summary = "동아리 좋아요를 취소한다")
-    @DeleteMapping("/{clubId}/like-cancel")
+    @DeleteMapping("/{clubId}/like/cancel")
     ResponseEntity<Void> likeClubCancel(
         @Auth(permit = {STUDENT}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.ResponseEntity;
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -87,6 +88,35 @@ public interface ClubApi {
     @GetMapping("/hot")
     ResponseEntity<ClubHotResponse> getHotClub();
 
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 좋아요를 누른다")
+    @PutMapping("/like/{clubId}")
+    ResponseEntity<Void> likeDining(
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 좋아요를 취소한다")
+    @DeleteMapping("/like/cancel/{clubId}")
+    ResponseEntity<Void> likeDiningCancel(
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    );
 
     @Operation(
         summary = "특정 동아리의 모든 QNA를 조회한다",
@@ -96,7 +126,7 @@ public interface ClubApi {
             - is_deleted 값이 false인 경우 "삭제된 댓글입니다"로 표현.
             - is_admin 필드를 통해 관리자 댓글 여부를 알 수 있음.
             - 트리 구조는 대댓글 형태로 재귀적으로 구성됩니다.
-            
+                        
             ```java
             예시
             댓글 1
@@ -106,7 +136,7 @@ public interface ClubApi {
             │   └── 댓글 1-1-2
             ├── 댓글 1-2
             └── 댓글 1-3
-            
+                        
             댓글 2
             └── 댓글 2-1
                 └── 댓글 2-1-1

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -10,10 +10,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubResponse;
+import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,6 +31,50 @@ import jakarta.validation.Valid;
 @Tag(name = "(Normal) Club: 동아리", description = "동아리 정보를 관리한다")
 @RequestMapping("/clubs")
 public interface ClubApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리를 생성한다")
+    @PostMapping
+    ResponseEntity<Void> createClub(
+        @RequestBody @Valid CreateClubRequest createClubRequest,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리를 상세조회한다")
+    @PostMapping("/{clubId}")
+    ResponseEntity<ClubResponse> getClub(
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "카테고리를 기준으로 동아리를 조회한다")
+    @PostMapping("/categories/{categoryId}")
+    ResponseEntity<GetClubByCategoryResponse> getClubByCategory(
+        @Parameter(in = PATH) @PathVariable Integer categoryId,
+        @RequestParam(required = false) String sort
+    );
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
@@ -1,12 +1,9 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,7 +27,5 @@ public interface ClubCategoryApi {
     )
     @Operation(summary = "동아리 카테고리 정보를 모두 조회한다.")
     @GetMapping
-    ResponseEntity<ClubCategoriesResponse> getClubCategories(
-        @Auth(permit = {STUDENT}) Integer studentId
-    );
+    ResponseEntity<ClubCategoriesResponse> getClubCategories();
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.domain.club.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Club Category: 동아리 카테고리", description = "동아리 카테고리 정보를 관리한다")
+@RequestMapping("club-categories")
+public interface ClubCategoryApi {
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 카테고리 정보를 모두 조회한다.")
+    @GetMapping
+    ResponseEntity<ClubCategoriesResponse> getClubCategories(
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryApi.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Club Category: 동아리 카테고리", description = "동아리 카테고리 정보를 관리한다")
-@RequestMapping("club-categories")
+@RequestMapping("/clubs/categories")
 public interface ClubCategoryApi {
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
@@ -1,13 +1,10 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
 import in.koreatech.koin.domain.club.service.ClubCategoryService;
 import lombok.RequiredArgsConstructor;
@@ -15,14 +12,12 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("club-categories")
-public class ClubCategoryController {
+public class ClubCategoryController implements ClubCategoryApi {
 
     private final ClubCategoryService clubCategoryService;
 
     @GetMapping
-    public ResponseEntity<ClubCategoriesResponse> getClubCategories(
-        @Auth(permit = {STUDENT}) Integer studentId
-    ) {
+    public ResponseEntity<ClubCategoriesResponse> getClubCategories() {
         ClubCategoriesResponse response = clubCategoryService.getClubCategories();
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.domain.club.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
+import in.koreatech.koin.domain.club.service.ClubCategoryService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("club-categories")
+public class ClubCategoryController {
+
+    private final ClubCategoryService clubCategoryService;
+
+    @GetMapping
+    public ResponseEntity<ClubCategoriesResponse> getClubCategories(
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ClubCategoriesResponse response = clubCategoryService.getClubCategories();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubCategoryController.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("club-categories")
+@RequestMapping("/clubs/categories")
 public class ClubCategoryController implements ClubCategoryApi {
 
     private final ClubCategoryService clubCategoryService;

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
@@ -51,6 +52,16 @@ public class ClubController implements ClubApi {
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
         ClubResponse response = clubService.updateClub(clubId, request, studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{clubId}/introduction")
+    public ResponseEntity<ClubResponse> updateClubIntroduction(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @RequestBody UpdateClubIntroductionRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ClubResponse response = clubService.updateClubIntroduction(clubId, request, studentId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -22,7 +22,7 @@ import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
-import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import in.koreatech.koin.domain.club.service.ClubService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -65,12 +65,12 @@ public class ClubController implements ClubApi {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/categories/{categoryId}")
-    public ResponseEntity<GetClubByCategoryResponse> getClubByCategory(
-        @Parameter(in = PATH) @PathVariable Integer categoryId,
+    @GetMapping
+    public ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
+        @RequestParam Integer categoryId,
         @RequestParam(required = false) String sort
     ) {
-        GetClubByCategoryResponse response = clubService.getClubByCategory(categoryId, sort);
+        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, sort);
         return ResponseEntity.ok(response);
     }
 
@@ -83,8 +83,8 @@ public class ClubController implements ClubApi {
     }
 
     @PutMapping("/like/{clubId}")
-    public ResponseEntity<Void> likeDining(
-        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+    public ResponseEntity<Void> likeClub(
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     ) {
         clubService.likeClub(clubId, userId);
@@ -92,8 +92,8 @@ public class ClubController implements ClubApi {
     }
 
     @DeleteMapping("/like/cancel/{clubId}")
-    public ResponseEntity<Void> likeDiningCancel(
-        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+    public ResponseEntity<Void> likeClubCancel(
+        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     ) {
         clubService.likeClubCancel(clubId, userId);

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.*;
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.HttpStatus;
@@ -68,9 +68,9 @@ public class ClubController implements ClubApi {
     @GetMapping
     public ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
         @RequestParam Integer categoryId,
-        @RequestParam(required = false) String sort
+        @RequestParam(required = false) Boolean hitSort
     ) {
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, sort);
+        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, hitSort);
         return ResponseEntity.ok(response);
     }
 
@@ -82,18 +82,18 @@ public class ClubController implements ClubApi {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/like/{clubId}")
+    @PutMapping("/{clubId}/like")
     public ResponseEntity<Void> likeClub(
-        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId,
+        @Auth(permit = {STUDENT}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     ) {
         clubService.likeClub(clubId, userId);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/like/cancel/{clubId}")
+    @DeleteMapping("/{clubId}/like/cancel")
     public ResponseEntity<Void> likeClubCancel(
-        @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId,
+        @Auth(permit = {STUDENT}) Integer userId,
         @Parameter(in = PATH) @PathVariable Integer clubId
     ) {
         clubService.likeClubCancel(clubId, userId);

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.controller;
 
-import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
 import org.springframework.http.HttpStatus;
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,7 +38,7 @@ public class ClubController implements ClubApi {
     public ResponseEntity<Void> createClub(
         @RequestBody @Valid CreateClubRequest createClubRequest,
         @Auth(permit = {STUDENT}) Integer studentId
-    ){
+    ) {
         clubService.createClub(createClubRequest);
         return ResponseEntity.ok().build();
     }
@@ -46,7 +47,7 @@ public class ClubController implements ClubApi {
     public ResponseEntity<GetClubByCategoryResponse> getClubByCategory(
         @Parameter(in = PATH) @PathVariable Integer categoryId,
         @RequestParam(required = false) String sort
-    ){
+    ) {
         GetClubByCategoryResponse response = clubService.getClubByCategory(categoryId, sort);
         return ResponseEntity.ok(response);
     }
@@ -54,9 +55,27 @@ public class ClubController implements ClubApi {
     @GetMapping("/{clubId}")
     public ResponseEntity<ClubResponse> getClub(
         @Parameter(in = PATH) @PathVariable Integer clubId
-    ){
+    ) {
         ClubResponse response = clubService.getClub(clubId);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/like/{clubId}")
+    public ResponseEntity<Void> likeDining(
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    ) {
+        clubService.likeClub(clubId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/like/cancel/{clubId}")
+    public ResponseEntity<Void> likeDiningCancel(
+        @Auth(permit = {GENERAL, STUDENT, COOP, COUNCIL}) Integer userId,
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    ) {
+        clubService.likeClubCancel(clubId, userId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/hot")
@@ -78,7 +97,7 @@ public class ClubController implements ClubApi {
         @RequestBody @Valid CreateQnaRequest request,
         @Parameter(in = PATH) @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
-    ){
+    ) {
         clubService.createQna(request, clubId, studentId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
@@ -41,6 +42,16 @@ public class ClubController implements ClubApi {
     ) {
         clubService.createClubRequest(createClubRequest, studentId);
         return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{clubId}")
+    public ResponseEntity<ClubResponse> updateClub(
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @RequestBody UpdateClubRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ClubResponse response = clubService.updateClub(clubId, request, studentId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/categories/{categoryId}")

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -35,11 +35,11 @@ public class ClubController implements ClubApi {
     private final ClubService clubService;
 
     @PostMapping
-    public ResponseEntity<Void> createClub(
+    public ResponseEntity<Void> createClubRequest(
         @RequestBody @Valid CreateClubRequest createClubRequest,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
-        clubService.createClub(createClubRequest);
+        clubService.createClubRequest(createClubRequest, studentId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -11,11 +11,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubResponse;
+import in.koreatech.koin.domain.club.dto.response.GetClubByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
 import in.koreatech.koin.domain.club.service.ClubService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,6 +32,32 @@ import lombok.RequiredArgsConstructor;
 public class ClubController implements ClubApi {
 
     private final ClubService clubService;
+
+    @PostMapping
+    public ResponseEntity<Void> createClub(
+        @RequestBody @Valid CreateClubRequest createClubRequest,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ){
+        clubService.createClub(createClubRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/categories/{categoryId}")
+    public ResponseEntity<GetClubByCategoryResponse> getClubByCategory(
+        @Parameter(in = PATH) @PathVariable Integer categoryId,
+        @RequestParam(required = false) String sort
+    ){
+        GetClubByCategoryResponse response = clubService.getClubByCategory(categoryId, sort);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{clubId}")
+    public ResponseEntity<ClubResponse> getClub(
+        @Parameter(in = PATH) @PathVariable Integer clubId
+    ){
+        ClubResponse response = clubService.getClub(clubId);
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/hot")
     public ResponseEntity<ClubHotResponse> getHotClub() {

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import in.koreatech.koin.admin.club.dto.request.CreateAdminClubRequest;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubAdmin;
 import in.koreatech.koin.domain.club.model.ClubCategory;
@@ -28,7 +27,7 @@ public record CreateClubRequest(
 
     @Schema(description = "동아리 관리자 ID 리스트", requiredMode = REQUIRED)
     @NotEmpty(message = "동아리 관리자는 필수 입력 사항입니다.")
-    List<CreateAdminClubRequest.InnerClubAdminRequest> clubAdmins,
+    List<InnerClubAdminRequest> clubAdmins,
 
     @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
     @NotNull(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
@@ -1,0 +1,84 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.admin.club.dto.request.CreateAdminClubRequest;
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubAdmin;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CreateClubRequest(
+    @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")
+    String name,
+
+    @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 사진은 필수 입력 사항입니다.")
+    String imageUrl,
+
+    @Schema(description = "동아리 관리자 ID 리스트", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아리 관리자는 필수 입력 사항입니다.")
+    List<CreateAdminClubRequest.InnerClubAdminRequest> clubAdmins,
+
+    @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
+    Integer clubCategoryId,
+
+    @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 위치는 필수 입력 사항입니다.")
+    String location,
+
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
+    String description,
+
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    String instagram,
+
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    String googleForm,
+
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    String openChat,
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    String phoneNumber
+) {
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record InnerClubAdminRequest(
+        @Schema(description = "동아리 관리자 id", example = "bcsdlab", requiredMode = REQUIRED)
+        String userid
+    ) {
+        public ClubAdmin toEntity(Club club, User user) {
+            return ClubAdmin.builder()
+                .club(club)
+                .user(user)
+                .build();
+        }
+    }
+
+    public Club toEntity(ClubCategory clubCategory) {
+        return Club.builder()
+            .name(name)
+            .lastWeekHits(0)
+            .active(false)
+            .likes(0)
+            .hits(0)
+            .introduction("")
+            .imageUrl(imageUrl)
+            .clubCategory(clubCategory)
+            .description(description)
+            .location(location)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
@@ -13,7 +13,6 @@ import in.koreatech.koin.domain.club.model.ClubCategory;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record CreateClubRequest(
@@ -22,7 +21,7 @@ public record CreateClubRequest(
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 사진은 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 사진은 필수 입력 사항입니다.")
     String imageUrl,
 
     @Schema(description = "동아리 관리자 ID 리스트", requiredMode = REQUIRED)
@@ -30,15 +29,15 @@ public record CreateClubRequest(
     List<InnerClubAdminRequest> clubAdmins,
 
     @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
     Integer clubCategoryId,
 
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 위치는 필수 입력 사항입니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubIntroductionRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubIntroductionRequest.java
@@ -1,0 +1,17 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UpdateClubIntroductionRequest(
+    @Schema(description = "동아리 상세 소개", example = "BCSD는 스타트업형 IT 동아리로 KOIN을 운영하고 있습니다", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아리 상세 소개를 입력해주세요.")
+    String introduction
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubIntroductionRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubIntroductionRequest.java
@@ -2,13 +2,13 @@ package in.koreatech.koin.domain.club.dto.request;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UpdateClubIntroductionRequest(
     @Schema(description = "동아리 상세 소개", example = "BCSD는 스타트업형 IT 동아리로 KOIN을 운영하고 있습니다", requiredMode = REQUIRED)
     @NotEmpty(message = "동아리 상세 소개를 입력해주세요.")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
@@ -2,7 +2,7 @@ package in.koreatech.koin.domain.club.dto.request;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.Club;
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public record UpdateClubRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
@@ -9,7 +9,6 @@ import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record UpdateClubRequest(
@@ -18,19 +17,19 @@ public record UpdateClubRequest(
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 사진은 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 사진은 필수 입력 사항입니다.")
     String imageUrl,
 
     @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
     Integer clubCategoryId,
 
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 위치는 필수 입력 사항입니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
+    @NotEmpty(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/UpdateClubRequest.java
@@ -1,0 +1,63 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UpdateClubRequest(
+    @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")
+    String name,
+
+    @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 사진은 필수 입력 사항입니다.")
+    String imageUrl,
+
+    @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 분과 카테고리는 필수 입력 사항입니다.")
+    Integer clubCategoryId,
+
+    @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 위치는 필수 입력 사항입니다.")
+    String location,
+
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
+    String description,
+
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    String instagram,
+
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    String googleForm,
+
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    String openChat,
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    String phoneNumber
+) {
+
+    public Club toEntity(ClubCategory clubCategory) {
+        return Club.builder()
+            .name(name)
+            .lastWeekHits(0)
+            .active(false)
+            .likes(0)
+            .hits(0)
+            .introduction("")
+            .imageUrl(imageUrl)
+            .clubCategory(clubCategory)
+            .description(description)
+            .location(location)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubCategoriesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubCategoriesResponse.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.domain.club.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubCategoriesResponse(
+    @Schema(description = "동아리 카테고리 리스트", requiredMode = REQUIRED)
+    List<ClubCategoriesResponse.InnerClubCategoryResponse> clubCategories
+) {
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record InnerClubCategoryResponse(
+        @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "동아리 카테고리 이름", example = "학술", requiredMode = REQUIRED)
+        String name
+    ) {
+        private static ClubCategoriesResponse.InnerClubCategoryResponse from(ClubCategory category) {
+            return new ClubCategoriesResponse.InnerClubCategoryResponse(category.getId(), category.getName());
+        }
+    }
+
+    public static ClubCategoriesResponse from(List<ClubCategory> clubCategories) {
+        return new ClubCategoriesResponse(clubCategories.stream()
+            .map(ClubCategoriesResponse.InnerClubCategoryResponse::from)
+            .toList()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubCategoriesResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubCategoriesResponse.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ClubCategoriesResponse(
     @Schema(description = "동아리 카테고리 리스트", requiredMode = REQUIRED)
-    List<ClubCategoriesResponse.InnerClubCategoryResponse> clubCategories
+    List<InnerClubCategoryResponse> clubCategories
 ) {
     @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record InnerClubCategoryResponse(
@@ -22,14 +22,14 @@ public record ClubCategoriesResponse(
         @Schema(description = "동아리 카테고리 이름", example = "학술", requiredMode = REQUIRED)
         String name
     ) {
-        private static ClubCategoriesResponse.InnerClubCategoryResponse from(ClubCategory category) {
-            return new ClubCategoriesResponse.InnerClubCategoryResponse(category.getId(), category.getName());
+        private static InnerClubCategoryResponse from(ClubCategory category) {
+            return new InnerClubCategoryResponse(category.getId(), category.getName());
         }
     }
 
     public static ClubCategoriesResponse from(List<ClubCategory> clubCategories) {
         return new ClubCategoriesResponse(clubCategories.stream()
-            .map(ClubCategoriesResponse.InnerClubCategoryResponse::from)
+            .map(InnerClubCategoryResponse::from)
             .toList()
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubHotResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubHotResponse.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.dto.response;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
@@ -28,6 +28,9 @@ public record ClubResponse(
     @Schema(description = "좋아요 수", example = "100", requiredMode = REQUIRED)
     Integer likes,
 
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
+    String description,
+
     @Schema(description = "동아리 상세 소개", example = "안녕하세요 BCSDLab입니다", requiredMode = REQUIRED)
     String introduction,
 
@@ -65,6 +68,7 @@ public record ClubResponse(
             club.getLocation(),
             club.getImageUrl(),
             club.getLikes(),
+            club.getDescription(),
             club.getIntroduction(),
             instagram,
             googleForm,

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
@@ -1,0 +1,75 @@
+package in.koreatech.koin.domain.club.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+import java.util.Optional;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubSNS;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubResponse(
+    @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "동아리 이름", example = "학술", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "카테고리", example = "학술", requiredMode = REQUIRED)
+    String category,
+
+    @Schema(description = "동아리 위치", example = "학생식당 건물 406호", requiredMode = REQUIRED)
+    String location,
+
+    @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
+    String imageUrl,
+
+    @Schema(description = "좋아요 수", example = "100", requiredMode = REQUIRED)
+    Integer likes,
+
+    @Schema(description = "동아리 상세 소개", example = "안녕하세요 BCSDLab입니다", requiredMode = REQUIRED)
+    String introduction,
+
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    Optional<String> instagram,
+
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    Optional<String> googleForm,
+
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    Optional<String> openChat,
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    Optional<String> phoneNumber
+) {
+    public static ClubResponse from(Club club, List<ClubSNS> clubSNSs) {
+        Optional<String> instagram = Optional.empty();
+        Optional<String> googleForm = Optional.empty();
+        Optional<String> openChat = Optional.empty();
+        Optional<String> phoneNumber = Optional.empty();
+
+        for (ClubSNS sns : clubSNSs) {
+            switch (sns.getSnsType()) {
+                case INSTAGRAM -> instagram = Optional.of(sns.getContact());
+                case GOOGLE_FORM -> googleForm = Optional.of(sns.getContact());
+                case OPEN_CHAT -> openChat = Optional.of(sns.getContact());
+                case PHONE_NUMBER -> phoneNumber = Optional.of(sns.getContact());
+            }
+        }
+
+        return new ClubResponse(
+            club.getId(),
+            club.getName(),
+            club.getClubCategory().getName(),
+            club.getLocation(),
+            club.getImageUrl(),
+            club.getLikes(),
+            club.getIntroduction(),
+            instagram,
+            googleForm,
+            openChat,
+            phoneNumber
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
@@ -7,9 +7,9 @@ import java.util.List;
 import in.koreatech.koin.domain.club.model.Club;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record GetClubByCategoryResponse(
+public record ClubsByCategoryResponse(
     @Schema(description = "동아리 리스트", requiredMode = REQUIRED)
-    List<GetClubByCategoryResponse.InnerClubResponse> clubCategories
+    List<ClubsByCategoryResponse.InnerClubResponse> clubCategories
 ) {
     public record InnerClubResponse(
         @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)
@@ -24,16 +24,16 @@ public record GetClubByCategoryResponse(
         @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
         String imageUrl
     ) {
-        private static GetClubByCategoryResponse.InnerClubResponse from(Club club) {
-            return new GetClubByCategoryResponse.InnerClubResponse(
+        private static ClubsByCategoryResponse.InnerClubResponse from(Club club) {
+            return new ClubsByCategoryResponse.InnerClubResponse(
                 club.getId(), club.getName(), club.getClubCategory().getName(), club.getImageUrl()
             );
         }
     }
 
-    public static GetClubByCategoryResponse from(List<Club> clubs) {
-        return new GetClubByCategoryResponse(clubs.stream()
-            .map(GetClubByCategoryResponse.InnerClubResponse::from)
+    public static ClubsByCategoryResponse from(List<Club> clubs) {
+        return new ClubsByCategoryResponse(clubs.stream()
+            .map(ClubsByCategoryResponse.InnerClubResponse::from)
             .toList()
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/GetClubByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/GetClubByCategoryResponse.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.club.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.club.model.Club;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetClubByCategoryResponse(
+    @Schema(description = "동아리 리스트", requiredMode = REQUIRED)
+    List<GetClubByCategoryResponse.InnerClubResponse> clubCategories
+) {
+    public record InnerClubResponse(
+        @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "동아리 이름", example = "학술", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "카테고리", example = "학술", requiredMode = REQUIRED)
+        String category,
+
+        @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
+        String imageUrl
+    ) {
+        private static GetClubByCategoryResponse.InnerClubResponse from(Club club) {
+            return new GetClubByCategoryResponse.InnerClubResponse(
+                club.getId(), club.getName(), club.getClubCategory().getName(), club.getImageUrl()
+            );
+        }
+    }
+
+    public static GetClubByCategoryResponse from(List<Club> clubs) {
+        return new GetClubByCategoryResponse(clubs.stream()
+            .map(GetClubByCategoryResponse.InnerClubResponse::from)
+            .toList()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.club.dto.response;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;

--- a/src/main/java/in/koreatech/koin/domain/club/exception/ClubLikeNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/ClubLikeNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.DataNotFoundException;
+
+public class ClubLikeNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "좋아요를 누른적이 없는 동아리입니다!";
+
+    public ClubLikeNotFoundException(String message) {
+        super(message);
+    }
+
+    public ClubLikeNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ClubLikeNotFoundException withDetail(Integer clubId) {
+        return new ClubLikeNotFoundException(DEFAULT_MESSAGE, "clubId: " + clubId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/exception/DuplicateClubLikiException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/DuplicateClubLikiException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.DuplicationException;
+
+public class DuplicateClubLikiException extends DuplicationException {
+
+    private static final String DEFAULT_MESSAGE = "이미 좋아요를 누른 동아리입니다!";
+
+    public DuplicateClubLikiException(String message) {
+        super(message);
+    }
+
+    public DuplicateClubLikiException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static DuplicateClubLikiException withDetail(Integer clubId) {
+        return new DuplicateClubLikiException(DEFAULT_MESSAGE, "clubId: '" + clubId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -119,6 +119,10 @@ public class Club extends BaseEntity {
         return hits - lastWeekHits;
     }
 
+    public void increaseHits() {
+        this.hits++;
+    }
+
     public void modifyClub(
         String name,
         String imageUrl,

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -138,4 +138,12 @@ public class Club extends BaseEntity {
         this.description = description;
         this.active = active;
     }
+
+    public void increaseLikes() {
+        this.likes++;
+    }
+
+    public void cancelLikes() {
+        this.likes--;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -161,7 +161,7 @@ public class Club extends BaseEntity {
         this.description = description;
     }
 
-    public void updateIntroduction(String introduction){
+    public void updateIntroduction(String introduction) {
         this.introduction = introduction;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -160,4 +160,8 @@ public class Club extends BaseEntity {
         this.location = location;
         this.description = description;
     }
+
+    public void updateIntroduction(String introduction){
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -146,4 +146,18 @@ public class Club extends BaseEntity {
     public void cancelLikes() {
         this.likes--;
     }
+
+    public void update(
+        String name,
+        String imageUrl,
+        ClubCategory category,
+        String location,
+        String description
+    ) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.clubCategory = category;
+        this.location = location;
+        this.description = description;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubHot.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubHot.java
@@ -4,7 +4,6 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 
 import in.koreatech.koin._common.model.BaseEntity;

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.student.model.Student;
-import in.koreatech.koin.domain.user.model.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubSNS.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubSNS.java
@@ -55,4 +55,10 @@ public class ClubSNS {
         this.snsType = snsType;
         this.contact = contact;
     }
+
+    public ClubSNS(Club club, SNSType snsType, String contact) {
+        this.club = club;
+        this.snsType = snsType;
+        this.contact = contact;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -1,0 +1,88 @@
+package in.koreatech.koin.domain.club.model.redis;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("createClub")
+public class ClubCreateRedis {
+
+    public static final String REDIS_KEY = "create_club";
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String imageUrl;
+
+    private List<CreateClubRequest.InnerClubAdminRequest> clubAdmins;
+
+    private Integer clubCategoryId;
+
+    private String location;
+
+    private String description;
+
+    private String instagram;
+
+    private String googleForm;
+
+    private String openChat;
+
+    private String phoneNumber;
+
+    private Integer requesterId;
+
+    @Builder
+    private ClubCreateRedis(
+        String id,
+        String name,
+        String imageUrl,
+        List<CreateClubRequest.InnerClubAdminRequest> clubAdmins,
+        Integer clubCategoryId,
+        String location,
+        String description,
+        String instagram,
+        String googleForm,
+        String openChat,
+        String phoneNumber,
+        Integer requesterId
+    ) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.clubAdmins = clubAdmins;
+        this.clubCategoryId = clubCategoryId;
+        this.location = location;
+        this.description = description;
+        this.instagram = instagram;
+        this.googleForm = googleForm;
+        this.openChat = openChat;
+        this.phoneNumber = phoneNumber;
+        this.requesterId = requesterId;
+    }
+
+    public static ClubCreateRedis of(CreateClubRequest request, Integer requesterId) {
+        return ClubCreateRedis.builder()
+            .id(REDIS_KEY + ":" + request.name())
+            .name(request.name())
+            .imageUrl(request.imageUrl())
+            .clubAdmins(request.clubAdmins())
+            .clubCategoryId(request.clubCategoryId())
+            .location(request.location())
+            .description(request.description())
+            .instagram(request.instagram())
+            .googleForm(request.googleForm())
+            .openChat(request.openChat())
+            .phoneNumber(request.phoneNumber())
+            .requesterId(requesterId)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -10,10 +10,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@RedisHash("createClub")
+@RedisHash("ClubCreateRequest")
 public class ClubCreateRedis {
-
-    public static final String REDIS_KEY = "create_club";
 
     @Id
     private String id;
@@ -71,7 +69,7 @@ public class ClubCreateRedis {
 
     public static ClubCreateRedis of(CreateClubRequest request, Integer requesterId) {
         return ClubCreateRedis.builder()
-            .id(REDIS_KEY + ":" + request.name())
+            .id(request.name())
             .name(request.name())
             .imageUrl(request.imageUrl())
             .clubAdmins(request.clubAdmins())

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubCategoryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubCategoryRepository.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.admin.club.exception.ClubCategoryNotFound;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+
+public interface ClubCategoryRepository extends Repository<ClubCategory, Integer> {
+
+    List<ClubCategory> findAll();
+
+    Optional<ClubCategory> findByName(String name);
+
+    default ClubCategory getByName(String name) {
+        return findByName(name)
+            .orElseThrow(() -> ClubCategoryNotFound.withDetail("name : " + name));
+    }
+
+    ClubCategory save(ClubCategory category);
+
+    Optional<ClubCategory> findById(Integer id);
+
+    default ClubCategory getById(Integer id) {
+        return findById(id)
+            .orElseThrow(() -> ClubCategoryNotFound.withDetail("id : " + id));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubLikeRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubLikeRepository.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.exception.ClubNotFoundException;
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubLike;
+import in.koreatech.koin.domain.user.model.User;
+
+public interface ClubLikeRepository extends Repository<ClubLike, Integer> {
+
+    boolean existsByClubAndUser(Club club, User user);
+
+    Optional<ClubLike> findByClubAndUser(Club club, User user);
+
+    default ClubLike getByClubAndUser(Club club, User user) {
+        return findByClubAndUser(club, user)
+            .orElseThrow(() -> ClubNotFoundException.withDetail("id : "));
+    }
+
+    void save(ClubLike clubLike);
+
+    void deleteByClubAndUser(Club club, User user);
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -3,10 +3,15 @@ package in.koreatech.koin.domain.club.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.club.exception.ClubNotFoundException;
 import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import jakarta.persistence.LockModeType;
 
 public interface ClubRepository extends Repository<Club, Integer> {
 
@@ -17,4 +22,26 @@ public interface ClubRepository extends Repository<Club, Integer> {
         return findById(id)
             .orElseThrow(() -> ClubNotFoundException.withDetail("id : " + id));
     }
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Club c WHERE c.id = :id")
+    Club findByIdWithPessimisticLock(@Param("id") Integer id);
+
+    default Club getByIdWithPessimisticLock(Integer id) {
+        Club club = findByIdWithPessimisticLock(id);
+
+        if (club == null) {
+            throw ClubNotFoundException.withDetail("id : " + id);
+        }
+
+        return club;
+    }
+
+    Club save(Club club);
+
+    List<Club> findByClubCategory(ClubCategory category);
+
+    List<Club> findByClubCategoryOrderByIdAsc(ClubCategory category);
+
+    List<Club> findByClubCategoryOrderByHitsDesc(ClubCategory category);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubSNSRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubSNSRepository.java
@@ -12,4 +12,6 @@ public interface ClubSNSRepository extends Repository<ClubSNS, Integer> {
     void save(ClubSNS clubSNS);
 
     List<ClubSNS> findAllByClub(Club club);
+
+    void deleteAllByClub(Club club);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubSNSRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubSNSRepository.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubSNS;
+
+public interface ClubSNSRepository extends Repository<ClubSNS, Integer> {
+
+    void save(ClubSNS clubSNS);
+
+    List<ClubSNS> findAllByClub(Club club);
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubCreateRedisRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubCreateRedisRepository.java
@@ -1,0 +1,8 @@
+package in.koreatech.koin.domain.club.repository.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+import in.koreatech.koin.domain.club.model.redis.ClubCreateRedis;
+
+public interface ClubCreateRedisRepository extends CrudRepository<ClubCreateRedis, String> {
+}

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubCategoryService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubCategoryService.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.club.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import in.koreatech.koin.domain.club.repository.ClubCategoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubCategoryService {
+
+    private final ClubCategoryRepository clubCategoryRepository;
+
+    public ClubCategoriesResponse getClubCategories() {
+        List<ClubCategory> clubCategories = clubCategoryRepository.findAll();
+        return ClubCategoriesResponse.from(clubCategories);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
@@ -4,7 +4,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -7,10 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin._common.auth.exception.AuthorizationException;
-import in.koreatech.koin.admin.club.repository.AdminClubAdminRepository;
-import in.koreatech.koin.admin.user.repository.AdminUserRepository;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
@@ -54,8 +53,6 @@ public class ClubService {
     private final StudentRepository studentRepository;
     private final ClubAdminRepository clubAdminRepository;
     private final ClubCategoryRepository clubCategoryRepository;
-    private final AdminClubAdminRepository adminClubAdminRepository;
-    private final AdminUserRepository adminUserRepository;
     private final ClubSNSRepository clubSNSRepository;
     private final ClubLikeRepository clubLikeRepository;
     private final UserRepository userRepository;
@@ -97,6 +94,21 @@ public class ClubService {
             clubSNSRepository.save(sns);
         }
         return newSNS;
+    }
+
+    @Transactional
+    public ClubResponse updateClubIntroduction(
+        Integer clubId, UpdateClubIntroductionRequest request, Integer studentId
+    ) {
+        Club club = clubRepository.getById(clubId);
+        if (!clubAdminRepository.existsByClubIdAndUserId(clubId, studentId)) {
+            throw AuthorizationException.withDetail("studentId: " + studentId);
+        }
+
+        club.updateIntroduction(request.introduction());
+        List<ClubSNS> clubSNSs = club.getClubSNSs();
+
+        return ClubResponse.from(club, clubSNSs);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -122,10 +122,10 @@ public class ClubService {
         return ClubResponse.from(club, clubSNSs);
     }
 
-    public ClubsByCategoryResponse getClubByCategory(Integer categoryId, String sort) {
+    public ClubsByCategoryResponse getClubByCategory(Integer categoryId, Boolean hitSort) {
         ClubCategory category = clubCategoryRepository.getById(categoryId);
 
-        if ("hits".equalsIgnoreCase(sort)) {
+        if (hitSort) {
             List<Club> clubs = clubRepository.findByClubCategoryOrderByHitsDesc(category);
             return ClubsByCategoryResponse.from(clubs);
         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1526 

# 🚀 작업 내용

- [x]  동아리 좋아요
- [x]  동아리 좋아요 취소
- [x]  카테고리별 동아리 전체 조회 (페이징 x, 정렬만)
- [x]  동아리 상세 조회 → 여기서 조회 카운팅
- [x]  동아리 생성 (요청까지 같이 받아서)
- [x]  동아리 카테고리 전체 조회
- [x]  동아리 수정 (동아리 방, 동아리 소개 등 일반 정보 수정)
- [x]  동아리 상세 소개 수정

# 💬 리뷰 중점사항
오랜만에 코딩 하니까 힘드네요
동아리 생성 요청 부분은 
![image](https://github.com/user-attachments/assets/68ba23ae-a14f-4470-9c45-443d6b24431f)
이런식으로 redis에 올라갑니다

PatchMapping으로 수정기능 구현하려다가 1시간이 날아갔습니다
포기하고 PutMapping으로 하니까 바로 되네요
여러분은 PutMapping 쓰세요..