### PR TITLE
fix: 어드민 코인 동아리 CRU API 수정사항 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubCategoryApi.java
+++ b/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubCategoryApi.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "(Admin) Club Category: 동아리 카테고리", description = "어드민 동아리 카테고리 정보를 관리한다")
-@RequestMapping("/admin/club-categories")
+@RequestMapping("/admin/clubs/categories")
 public interface AdminClubCategoryApi {
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubCategoryController.java
+++ b/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubCategoryController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/club-categories")
+@RequestMapping("/admin/clubs/categories")
 public class AdminClubCategoryController implements AdminClubCategoryApi {
 
     private final AdminClubCategoryService adminClubCategoryService;

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.admin.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
@@ -42,16 +41,20 @@ public record CreateAdminClubRequest(
     @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
-    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = REQUIRED)
+    @NotNull(message = "인스타그램 링크는 필수 입력 사항입니다.")
     String instagram,
 
-    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = REQUIRED)
+    @NotNull(message = "구글 폼 링크는 필수 입력 사항입니다.")
     String googleForm,
 
-    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = REQUIRED)
+    @NotNull(message = "오픈 채팅 링크는 필수 입력 사항입니다.")
     String openChat,
 
-    @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
+    @Schema(description = "전화번호", example = "01012345678", requiredMode = REQUIRED)
+    @NotNull(message = "전화 번호 링크는 필수 입력 사항입니다.")
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/CreateAdminClubRequest.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.admin.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
@@ -41,16 +42,16 @@ public record CreateAdminClubRequest(
     @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
-    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     String instagram,
 
-    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     String googleForm,
 
-    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     String openChat,
 
-    @Schema(description = "전화번호", example = "010-1234-5678")
+    @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/ModifyAdminClubRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/ModifyAdminClubRequest.java
@@ -42,7 +42,23 @@ public record ModifyAdminClubRequest(
 
     @Schema(description = "동아리 활성화 여부", example = "false", requiredMode = REQUIRED)
     @NotNull(message = "동아리 활성화 여부는 필수 입력 사항입니다.")
-    Boolean active
+    Boolean active,
+
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = REQUIRED)
+    @NotNull(message = "인스타그램 링크는 필수 입력 사항입니다.")
+    String instagram,
+
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = REQUIRED)
+    @NotNull(message = "구글 폼 링크는 필수 입력 사항입니다.")
+    String googleForm,
+
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = REQUIRED)
+    @NotNull(message = "오픈 채팅 링크는 필수 입력 사항입니다.")
+    String openChat,
+
+    @Schema(description = "전화번호", example = "01012345678", requiredMode = REQUIRED)
+    @NotNull(message = "전화 번호 링크는 필수 입력 사항입니다.")
+    String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerClubAdminUpdateRequest(

--- a/src/main/java/in/koreatech/koin/admin/club/repository/AdminClubSnsRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/club/repository/AdminClubSnsRepository.java
@@ -2,8 +2,12 @@ package in.koreatech.koin.admin.club.repository;
 
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubSNS;
 
 public interface AdminClubSnsRepository extends Repository<ClubSNS, Integer> {
+
     void saveAll(Iterable<ClubSNS> clubSNSs);
+
+    void deleteAllByClub(Club club);
 }

--- a/src/main/java/in/koreatech/koin/admin/club/repository/AdminClubSnsRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/club/repository/AdminClubSnsRepository.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.admin.club.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.model.ClubSNS;
+
+public interface AdminClubSnsRepository extends Repository<ClubSNS, Integer> {
+    void saveAll(Iterable<ClubSNS> clubSNSs);
+}

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -101,6 +101,13 @@ public class AdminClubService {
             )
             .toList();
 
+        List<ClubSNS> clubSNSs = List.of(
+            new ClubSNS(club, SNSType.INSTAGRAM, request.instagram()),
+            new ClubSNS(club, SNSType.GOOGLE_FORM, request.googleForm()),
+            new ClubSNS(club, SNSType.PHONE_NUMBER, request.phoneNumber()),
+            new ClubSNS(club, SNSType.OPEN_CHAT, request.openChat())
+        );
+
         club.modifyClub(request.name(),
             request.imageUrl(),
             clubCategory,
@@ -108,6 +115,9 @@ public class AdminClubService {
             request.description(),
             request.active()
         );
+
+        adminClubSnsRepository.deleteAllByClub(club);
+        adminClubSnsRepository.saveAll(clubSNSs);
 
         adminClubAdminRepository.deleteAllByClub(club);
         adminClubAdminRepository.saveAll(clubAdmins);

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -16,10 +16,13 @@ import in.koreatech.koin.admin.club.dto.response.AdminClubsResponse;
 import in.koreatech.koin.admin.club.repository.AdminClubAdminRepository;
 import in.koreatech.koin.admin.club.repository.AdminClubCategoryRepository;
 import in.koreatech.koin.admin.club.repository.AdminClubRepository;
+import in.koreatech.koin.admin.club.repository.AdminClubSnsRepository;
 import in.koreatech.koin.admin.user.repository.AdminUserRepository;
+import in.koreatech.koin.domain.club.enums.SNSType;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubAdmin;
 import in.koreatech.koin.domain.club.model.ClubCategory;
+import in.koreatech.koin.domain.club.model.ClubSNS;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -31,6 +34,7 @@ public class AdminClubService {
     private final AdminClubAdminRepository adminClubAdminRepository;
     private final AdminClubRepository adminClubRepository;
     private final AdminUserRepository adminUserRepository;
+    private final AdminClubSnsRepository adminClubSnsRepository;
 
     public AdminClubsResponse getClubs(Integer page, Integer limit, Boolean sortByLike, Integer clubCategoryId) {
         boolean hasCategory = clubCategoryId != null;
@@ -74,6 +78,14 @@ public class AdminClubService {
             )
             .toList();
 
+        List<ClubSNS> clubSNSs = List.of(
+            new ClubSNS(club, SNSType.INSTAGRAM, request.instagram()),
+            new ClubSNS(club, SNSType.GOOGLE_FORM, request.googleForm()),
+            new ClubSNS(club, SNSType.PHONE_NUMBER, request.phoneNumber()),
+            new ClubSNS(club, SNSType.OPEN_CHAT, request.openChat())
+        );
+
+        adminClubSnsRepository.saveAll(clubSNSs);
         adminClubAdminRepository.saveAll(clubAdmins);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubSNS.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubSNS.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -21,7 +22,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "club_sns")
+@Table(
+    name = "club_sns",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"club_id", "sns_type"})
+    }
+)
 @NoArgsConstructor(access = PROTECTED)
 public class ClubSNS {
 

--- a/src/main/resources/db/migration/V158__alter_club_sns_unique.sql
+++ b/src/main/resources/db/migration/V158__alter_club_sns_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `koin`.`club_sns`
+    ADD CONSTRAINT unique_club_id_sns_type UNIQUE (club_id, sns_type);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1542 

# 🚀 작업 내용

- 어드민 코인 동아리 CRU API 수정사항을 반영했습니다.
  - 생성, 수정 시 동아리 연락처를 생성, 수정하는 로직을 추가했습니다.
  - 어드민 코인 동아리 카테고리 API Path를 변경했습니다.
  - 생성, 수정 요청 DTO 스웨거 설정을 변경했습니다. (값이 없는 경우 null이 아닌 공백으로 입력 받습니다)
- 코인 동아리 테이블에 유니크 제약 조건을 설정했습니다.

# 💬 리뷰 중점사항
