### PR TITLE
feat: S3 삭제 후 CDN(CloudFront) 캐시 무효화 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ dependencies {
 
     // Zip Compress
     implementation 'net.lingala.zip4j:zip4j:2.6.1'
+
+    // Cloudfront
+    implementation 'software.amazon.awssdk:cloudfront'
 }
 
 clean {

--- a/src/main/java/in/koreatech/koin/_common/config/CloudFrontConfig.java
+++ b/src/main/java/in/koreatech/koin/_common/config/CloudFrontConfig.java
@@ -1,0 +1,31 @@
+package in.koreatech.koin._common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import in.koreatech.koin.infrastructure.cloudfront.client.CloudFrontClientWrapper;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+
+@Configuration
+public class CloudFrontConfig {
+
+    @Value("${cloudfront.distribution-id}")
+    private String distributionId;
+
+    @Value("${cloudfront.region}")
+    private String region;
+
+    @Bean
+    public CloudFrontClient cloudFrontClient() {
+        return CloudFrontClient.builder()
+            .region(Region.of(region))
+            .build();
+    }
+
+    @Bean
+    public CloudFrontClientWrapper cloudFrontClientWrapper(CloudFrontClient cloudFrontClient) {
+        return new CloudFrontClientWrapper(cloudFrontClient, distributionId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/_common/config/CloudFrontConfig.java
+++ b/src/main/java/in/koreatech/koin/_common/config/CloudFrontConfig.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import in.koreatech.koin.infrastructure.cloudfront.client.CloudFrontClientWrapper;
+import in.koreatech.koin.infrastructure.s3.client.CloudFrontClientWrapper;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
 

--- a/src/main/java/in/koreatech/koin/_common/event/ImageSensitiveDeletedEvent.java
+++ b/src/main/java/in/koreatech/koin/_common/event/ImageSensitiveDeletedEvent.java
@@ -1,0 +1,7 @@
+package in.koreatech.koin._common.event;
+
+public record ImageSensitiveDeletedEvent(
+    String imageUrl
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/_common/event/ImagesSensitiveDeletedEvent.java
+++ b/src/main/java/in/koreatech/koin/_common/event/ImagesSensitiveDeletedEvent.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin._common.event;
+
+import java.util.List;
+
+public record ImagesSensitiveDeletedEvent(
+    List<String> imageUrls
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopMenuService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopMenuService.java
@@ -8,7 +8,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin._common.event.ImagesDeletedEvent;
+import in.koreatech.koin._common.event.ImagesSensitiveDeletedEvent;
 import in.koreatech.koin.admin.shop.dto.menu.*;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuRepository;
@@ -146,6 +146,6 @@ public class AdminShopMenuService {
             .map(MenuImage::getImageUrl)
             .toList();
         adminMenuRepository.deleteById(menuId);
-        eventPublisher.publishEvent(new ImagesDeletedEvent(imageUrls));
+        eventPublisher.publishEvent(new ImagesSensitiveDeletedEvent(imageUrls));
     }
 }

--- a/src/main/java/in/koreatech/koin/infrastructure/cloudfront/client/CloudFrontClientWrapper.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/cloudfront/client/CloudFrontClientWrapper.java
@@ -1,0 +1,53 @@
+package in.koreatech.koin.infrastructure.cloudfront.client;
+
+import java.util.List;
+
+import in.koreatech.koin._common.exception.custom.KoinIllegalStateException;
+import software.amazon.awssdk.services.cloudfront.CloudFrontClient;
+import software.amazon.awssdk.services.cloudfront.model.CreateInvalidationRequest;
+import software.amazon.awssdk.services.cloudfront.model.InvalidationBatch;
+import software.amazon.awssdk.services.cloudfront.model.Paths;
+
+public class CloudFrontClientWrapper {
+
+    private final CloudFrontClient cloudFrontClient;
+    private final String distributionId;
+
+    public CloudFrontClientWrapper(CloudFrontClient cloudFrontClient, String distributionId) {
+        this.cloudFrontClient = cloudFrontClient;
+        this.distributionId = distributionId;
+    }
+
+    public void invalidate(String path) {
+        invalidateAll(List.of(path));
+    }
+
+    public void invalidateAll(List<String> paths) {
+        try {
+            List<String> normalizedPaths = paths.stream()
+                .map(path -> path.startsWith("/") ? path : "/" + path)
+                .distinct()
+                .toList();
+            if (normalizedPaths.isEmpty()) return;
+
+            Paths cloudFrontPaths = Paths.builder()
+                .items(normalizedPaths)
+                .quantity(normalizedPaths.size())
+                .build();
+
+            InvalidationBatch batch = InvalidationBatch.builder()
+                .paths(cloudFrontPaths)
+                .callerReference(String.valueOf(System.currentTimeMillis()))
+                .build();
+
+            CreateInvalidationRequest request = CreateInvalidationRequest.builder()
+                .distributionId(distributionId)
+                .invalidationBatch(batch)
+                .build();
+
+            cloudFrontClient.createInvalidation(request);
+        } catch (Exception e) {
+            throw new KoinIllegalStateException("CloudFront 캐시 무효화 중 문제가 발생했습니다. " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/client/CloudFrontClientWrapper.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/client/CloudFrontClientWrapper.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.infrastructure.cloudfront.client;
+package in.koreatech.koin.infrastructure.s3.client;
 
 import java.util.List;
 

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/eventlistener/S3EventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/eventlistener/S3EventListener.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.ImageDeletedEvent;
+import in.koreatech.koin._common.event.ImageSensitiveDeletedEvent;
 import in.koreatech.koin._common.event.ImagesDeletedEvent;
+import in.koreatech.koin._common.event.ImagesSensitiveDeletedEvent;
 import in.koreatech.koin.infrastructure.s3.client.CloudFrontClientWrapper;
 import in.koreatech.koin.infrastructure.s3.client.S3Client;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +41,7 @@ public class S3EventListener {
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void onSensitiveImageDeleted(ImageDeletedEvent event) {
+    public void onSensitiveImageDeleted(ImageSensitiveDeletedEvent event) {
         String s3Key = s3Client.extractKeyFromUrl(event.imageUrl());
         s3Client.deleteFile(s3Key);
         cloudFrontClientWrapper.invalidate(s3Key);
@@ -47,7 +49,7 @@ public class S3EventListener {
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void onSensitiveImagesDeleted(ImagesDeletedEvent event) {
+    public void onSensitiveImagesDeleted(ImagesSensitiveDeletedEvent event) {
         List<String> s3Keys = s3Client.extractKeysFromUrls(event.imageUrls());
         s3Client.deleteFiles(s3Keys);
         cloudFrontClientWrapper.invalidateAll(s3Keys);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1541 

# 🚀 작업 내용

### 목적
- 이미지 삭제 시 이벤트 리스너에서 S3파일 삭제 처리는 진행했지만 CDN(CloudFront)를 사용하는 상황
- 캐시 TTL 만료까지 해당 링크를 사용하면 S3 파일 삭제가 되었음에도 접근 가능
- CloudFront 캐시정책을 확인해보니 기본 값으로 세팅되어 있음
- 따라서 최대 24시간(기본 TTL)뒤까지 해당 링크를 사용하여 접근할 수 있음

### 해결방안
- 민감한 이미지 정보가 아닌 경우엔 TTL 만료까지 접근되어도 큰 문제가 없음
- 민감한 이미지 정보인경우엔 캐시를 즉시 만료시켜 삭제해주는 절차가 필요하다고 판단
- 따라서 민감한 이미지를 삭제할 때 사용하는 이벤트를 추가하였음
  - 이벤트 리스너에서 민감한 이미지 관련 이벤트는 cloudfront 무효화 로직을 추가로 호출 
- awssdk2를 이용하여 cloudfront 무효화 기능을 구현함

### build.gradle 및 yml파일 변경사항
```java
// Cloudfront
implementation 'software.amazon.awssdk:cloudfront'
```
- build.gradle의존성 추가 필요

```java
cloudfront:
  distribution-id: 빌드서버에서확인
  region: 빌드서버에서확인
```
- yml파일 정보 추가

### 추후 진행해야 할 사항
- stage 서버에서 테스트해서 cloudfront 캐시 무효화 확인하기
- 이미지 관련 API들 찾아서 적용하기

# 💬 리뷰 중점사항
