### PR TITLE
feat: 동아리 관리자 권한 위임 기능 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/event/ClubCreateEvent.java
+++ b/src/main/java/in/koreatech/koin/_common/event/ClubCreateEvent.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin._common.event;
+
+public record ClubCreateEvent(
+    String clubName
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -1,15 +1,14 @@
 package in.koreatech.koin.admin.club.service;
 
+import static in.koreatech.koin.domain.club.enums.SNSType.*;
+
+import java.util.AbstractMap;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.AbstractMap;
-import java.util.List;
 import java.util.stream.Stream;
-
-import static in.koreatech.koin.domain.club.enums.SNSType.*;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -36,7 +35,7 @@ import in.koreatech.koin.domain.club.exception.ClubNotFoundException;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubAdmin;
 import in.koreatech.koin.domain.club.model.ClubCategory;
-
+import in.koreatech.koin.domain.club.model.ClubSNS;
 import in.koreatech.koin.domain.club.model.redis.ClubCreateRedis;
 import in.koreatech.koin.domain.club.repository.ClubAdminRepository;
 import in.koreatech.koin.domain.club.repository.ClubCategoryRepository;
@@ -44,8 +43,6 @@ import in.koreatech.koin.domain.club.repository.ClubRepository;
 import in.koreatech.koin.domain.club.repository.redis.ClubCreateRedisRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
-import in.koreatech.koin.domain.club.model.ClubSNS;
-
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin._common.auth.UserId;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
 import in.koreatech.koin.domain.club.dto.request.EmpowermentClubManagerRequest;
@@ -96,7 +97,7 @@ public interface ClubApi {
     @PostMapping("/{clubId}")
     ResponseEntity<ClubResponse> getClub(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @UserId Integer userId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.EmpowermentClubManagerRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -220,6 +221,22 @@ public interface ClubApi {
     ResponseEntity<Void> deleteQna(
         @Parameter(in = PATH) @PathVariable Integer clubId,
         @Parameter(in = PATH) @PathVariable Integer qnaId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "동아리 관리자 권한을 위임한다")
+    @PutMapping("/empowerment")
+    ResponseEntity<Void> empowermentClubManager(
+        @RequestBody @Valid EmpowermentClubManagerRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -94,7 +94,8 @@ public interface ClubApi {
     @Operation(summary = "동아리를 상세조회한다")
     @PostMapping("/{clubId}")
     ResponseEntity<ClubResponse> getClub(
-        @Parameter(in = PATH) @PathVariable Integer clubId
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -141,7 +141,7 @@ public class ClubController implements ClubApi {
     public ResponseEntity<Void> empowermentClubManager(
         @RequestBody @Valid EmpowermentClubManagerRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
-    ){
+    ) {
         clubService.empowermentClubManager(request, studentId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -76,9 +76,10 @@ public class ClubController implements ClubApi {
 
     @GetMapping("/{clubId}")
     public ResponseEntity<ClubResponse> getClub(
-        @Parameter(in = PATH) @PathVariable Integer clubId
+        @Parameter(in = PATH) @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
     ) {
-        ClubResponse response = clubService.getClub(clubId);
+        ClubResponse response = clubService.getClub(clubId, studentId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin._common.auth.UserId;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
 import in.koreatech.koin.domain.club.dto.request.EmpowermentClubManagerRequest;
@@ -78,9 +79,9 @@ public class ClubController implements ClubApi {
     @GetMapping("/{clubId}")
     public ResponseEntity<ClubResponse> getClub(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @Auth(permit = {STUDENT}) Integer studentId
+        @UserId Integer userId
     ) {
-        ClubResponse response = clubService.getClub(clubId, studentId);
+        ClubResponse response = clubService.getClub(clubId, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
+import in.koreatech.koin.domain.club.dto.request.EmpowermentClubManagerRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -133,5 +134,14 @@ public class ClubController implements ClubApi {
     ) {
         clubService.deleteQna(clubId, qnaId, studentId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/empowerment")
+    public ResponseEntity<Void> empowermentClubManager(
+        @RequestBody @Valid EmpowermentClubManagerRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ){
+        clubService.empowermentClubManager(request, studentId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
@@ -27,7 +27,7 @@ public record CreateClubRequest(
 
     @Schema(description = "동아리 관리자 ID 리스트", requiredMode = REQUIRED)
     @NotEmpty(message = "동아리 관리자는 필수 입력 사항입니다.")
-    List<InnerCluManagerRequest> clubAdmins,
+    List<InnerClubManagerRequest> clubManagers,
 
     @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
     @NotNull(message = "동아리 분과 카테고리 ID는 필수 입력 사항입니다.")
@@ -54,7 +54,7 @@ public record CreateClubRequest(
     String phoneNumber
 ) {
     @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record InnerCluManagerRequest(
+    public record InnerClubManagerRequest(
         @Schema(description = "동아리 관리자 id", example = "bcsdlab", requiredMode = REQUIRED)
         String userid
     ) {

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/CreateClubRequest.java
@@ -27,7 +27,7 @@ public record CreateClubRequest(
 
     @Schema(description = "동아리 관리자 ID 리스트", requiredMode = REQUIRED)
     @NotEmpty(message = "동아리 관리자는 필수 입력 사항입니다.")
-    List<InnerClubAdminRequest> clubAdmins,
+    List<InnerCluManagerRequest> clubAdmins,
 
     @Schema(description = "동아리 분과 카테고리 ID", example = "1", requiredMode = REQUIRED)
     @NotNull(message = "동아리 분과 카테고리 ID는 필수 입력 사항입니다.")
@@ -54,7 +54,7 @@ public record CreateClubRequest(
     String phoneNumber
 ) {
     @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public record InnerClubAdminRequest(
+    public record InnerCluManagerRequest(
         @Schema(description = "동아리 관리자 id", example = "bcsdlab", requiredMode = REQUIRED)
         String userid
     ) {

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/EmpowermentClubManagerRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/EmpowermentClubManagerRequest.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record EmpowermentClubManagerRequest(
+    @Schema(description = "동아리 아이디", example = "1", requiredMode = REQUIRED)
+    Integer clubId,
+
+    @Schema(description = "위임받는 매니저의 이메일", example = "example@koreatech.ac.kr", requiredMode = REQUIRED)
+    @NotEmpty(message = "위임받는 사람의 이메일을 입력해주세요.")
+    String changedManagerEmail
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/EmpowermentClubManagerRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/EmpowermentClubManagerRequest.java
@@ -9,8 +9,8 @@ public record EmpowermentClubManagerRequest(
     @Schema(description = "동아리 아이디", example = "1", requiredMode = REQUIRED)
     Integer clubId,
 
-    @Schema(description = "위임받는 매니저의 이메일", example = "example@koreatech.ac.kr", requiredMode = REQUIRED)
-    @NotEmpty(message = "위임받는 사람의 이메일을 입력해주세요.")
-    String changedManagerEmail
+    @Schema(description = "위임받는 사용자의 아이디", example = "example", requiredMode = REQUIRED)
+    @NotEmpty(message = "위임받는 사용자의 아이디를 입력해주세요.")
+    String changedManagerId
 ) {
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
@@ -44,9 +44,12 @@ public record ClubResponse(
     Optional<String> openChat,
 
     @Schema(description = "전화번호", example = "010-1234-5678")
-    Optional<String> phoneNumber
+    Optional<String> phoneNumber,
+
+    @Schema(description = "동아리 관리자 여부", example = "true")
+    Boolean manager
 ) {
-    public static ClubResponse from(Club club, List<ClubSNS> clubSNSs) {
+    public static ClubResponse from(Club club, List<ClubSNS> clubSNSs, Boolean manager) {
         Optional<String> instagram = Optional.empty();
         Optional<String> googleForm = Optional.empty();
         Optional<String> openChat = Optional.empty();
@@ -73,7 +76,8 @@ public record ClubResponse(
             instagram,
             googleForm,
             openChat,
-            phoneNumber
+            phoneNumber,
+            manager
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/exception/AlreadyManagerException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/AlreadyManagerException.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.KoinException;
+
+public class AlreadyManagerException extends KoinException {
+    private static final String DEFAULT_MESSAGE = "이미 동아리의 관리자입니다.";
+
+    public AlreadyManagerException(String message) {
+        super(message);
+    }
+
+    public AlreadyManagerException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AlreadyManagerException withDetail(String detail) {
+        return new AlreadyManagerException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -25,7 +25,7 @@ public class ClubCreateRedis {
 
     private String imageUrl;
 
-    private List<CreateClubRequest.InnerClubAdminRequest> clubAdmins;
+    private List<CreateClubRequest.InnerCluManagerRequest> clubAdmins;
 
     private Integer clubCategoryId;
 
@@ -50,7 +50,7 @@ public class ClubCreateRedis {
         String id,
         String name,
         String imageUrl,
-        List<CreateClubRequest.InnerClubAdminRequest> clubAdmins,
+        List<CreateClubRequest.InnerCluManagerRequest> clubAdmins,
         Integer clubCategoryId,
         String location,
         String description,

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.club.model.redis;
 
+import static in.koreatech.koin.domain.club.dto.request.CreateClubRequest.InnerClubManagerRequest;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class ClubCreateRedis {
 
     private String imageUrl;
 
-    private List<CreateClubRequest.InnerCluManagerRequest> clubAdmins;
+    private List<InnerClubManagerRequest> clubAdmins;
 
     private Integer clubCategoryId;
 
@@ -50,7 +52,7 @@ public class ClubCreateRedis {
         String id,
         String name,
         String imageUrl,
-        List<CreateClubRequest.InnerCluManagerRequest> clubAdmins,
+        List<InnerClubManagerRequest> clubAdmins,
         Integer clubCategoryId,
         String location,
         String description,
@@ -81,7 +83,7 @@ public class ClubCreateRedis {
             .id(request.name())
             .name(request.name())
             .imageUrl(request.imageUrl())
-            .clubAdmins(request.clubAdmins())
+            .clubAdmins(request.clubManagers())
             .clubCategoryId(request.clubCategoryId())
             .location(request.location())
             .description(request.description())

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubAdminRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubAdminRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubAdmin;
+import in.koreatech.koin.domain.user.model.User;
 
 public interface ClubAdminRepository extends Repository<ClubAdmin, Integer> {
 
@@ -26,4 +28,8 @@ public interface ClubAdminRepository extends Repository<ClubAdmin, Integer> {
     int countAll();
 
     boolean existsByClubIdAndUserId(Integer clubId, Integer studentId);
+
+    boolean existsByClubAndUser(Club club, User user);
+
+    void deleteByClubAndUser(Club club, User user);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -73,8 +73,9 @@ public class ClubService {
         club.update(request.name(), request.imageUrl(), clubCategory, request.location(), request.description());
 
         List<ClubSNS> newSNS = updateClubSNS(request, club);
+        Boolean manager = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
 
-        return ClubResponse.from(club, newSNS);
+        return ClubResponse.from(club, newSNS, manager);
     }
 
     private List<ClubSNS> updateClubSNS(UpdateClubRequest request, Club club) {
@@ -103,8 +104,9 @@ public class ClubService {
 
         club.updateIntroduction(request.introduction());
         List<ClubSNS> clubSNSs = club.getClubSNSs();
+        Boolean manager = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
 
-        return ClubResponse.from(club, clubSNSs);
+        return ClubResponse.from(club, clubSNSs, manager);
     }
 
     private void isClubAdmin(Integer clubId, Integer studentId) {
@@ -114,12 +116,13 @@ public class ClubService {
     }
 
     @Transactional
-    public ClubResponse getClub(Integer clubId) {
+    public ClubResponse getClub(Integer clubId, Integer studentId) {
         Club club = clubRepository.getByIdWithPessimisticLock(clubId);
         club.increaseHits();
         List<ClubSNS> clubSNSs = clubSNSRepository.findAllByClub(club);
+        Boolean manager = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
 
-        return ClubResponse.from(club, clubSNSs);
+        return ClubResponse.from(club, clubSNSs, manager);
     }
 
     public ClubsByCategoryResponse getClubByCategory(Integer categoryId, Boolean hitSort) {

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -3,10 +3,12 @@ package in.koreatech.koin.domain.club.service;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin._common.auth.exception.AuthorizationException;
+import in.koreatech.koin._common.event.ClubCreateEvent;
 import in.koreatech.koin.domain.club.dto.request.CreateClubRequest;
 import in.koreatech.koin.domain.club.dto.request.CreateQnaRequest;
 import in.koreatech.koin.domain.club.dto.request.UpdateClubIntroductionRequest;
@@ -57,11 +59,19 @@ public class ClubService {
     private final ClubLikeRepository clubLikeRepository;
     private final UserRepository userRepository;
     private final ClubCreateRedisRepository clubCreateRedisRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void createClubRequest(CreateClubRequest request, Integer studentId) {
         ClubCreateRedis createRedis = ClubCreateRedis.of(request, studentId);
         clubCreateRedisRepository.save(createRedis);
+
+        sendSlackNotification(request.name());
+    }
+
+    public void sendSlackNotification(String clubName) {
+        ClubCreateEvent clubCreateEvent = new ClubCreateEvent(clubName);
+        eventPublisher.publishEvent(clubCreateEvent);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.infrastructure.slack.eventlistener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin._common.event.ClubCreateEvent;
+import in.koreatech.koin.infrastructure.slack.client.SlackClient;
+import in.koreatech.koin.infrastructure.slack.model.SlackNotificationFactory;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class ClubEventListener {
+
+    private final SlackClient slackClient;
+    private final SlackNotificationFactory slackNotificationFactory;
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void onClubCreateEvent(ClubCreateEvent event){
+        var notification = slackNotificationFactory.generateClubCreateSendNotification(event.clubName());
+        slackClient.sendMessage(notification);
+    }
+}

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/model/SlackNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/model/SlackNotificationFactory.java
@@ -219,4 +219,19 @@ public class SlackNotificationFactory {
             )
             .build();
     }
+
+    /**
+     * 동아리 생성 요청 알림
+     */
+    public SlackNotification generateClubCreateSendNotification(
+        String clubName
+    ) {
+        return SlackNotification.builder()
+            .slackUrl(eventNotificationUrl)
+            .text(String.format("""
+                        `%s` 동아리 생성 요청이 들어왔습니다. 
+                        """, clubName)
+            )
+            .build();
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1527 

# 🚀 작업 내용

1. 동아리 관리자 권한 위임 API 추가
2. 동아리 생성 요청 시 슬랙에 알림 오도록 추가

# 💬 리뷰 중점사항
