### PR TITLE
feat: 동아리 QNA 기획 수정사항 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -214,8 +214,8 @@ public interface ClubApi {
     @Operation(summary = "특정 동아리의 QNA를 삭제한다",
         description = """
             - 관리자는 모든 QNA 삭제 가능, 그 외에는 본인의 QNA만 삭제 가능
-            - 부모 QNA(질문 QNA)인 경우, 자식 QNA까지 모두 삭제
-            - 자식 QNA(답변 QNA)인 경우, 그거만 삭제 
+            - 부모 QNA(질문 QNA)인 경우, 답변 QNA까지 모두 삭제
+            - 자식 QNA(답변 QNA)인 경우, 답변 QNA만 삭제 
             """)
     @DeleteMapping("/{clubId}/qna/{qnaId}")
     ResponseEntity<Void> deleteQna(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -158,8 +158,6 @@ public interface ClubApi {
         description = """
             - authorId 확인하여 작성자 본인인 경우 삭제 버튼(x) 표시.
             - 닉네임은 존재 시 그대로 반환되며, 없는 경우 student의 익명 닉네임으로 반환.
-            - is_deleted 값이 false인 경우 "삭제된 댓글입니다"로 표현.
-            - is_admin 필드를 통해 관리자 댓글 여부를 알 수 있음.
             - 트리 구조는 대댓글 형태로 재귀적으로 구성됩니다.
                         
             ```java
@@ -192,7 +190,11 @@ public interface ClubApi {
         }
     )
     @Operation(summary = "특정 동아리의 QNA를 생성한다",
-        description = "parentId를 null 요청 시 첫 QNA, 부모 QNA의 id를 넣어서 요청하면 대댓글 형식으로 생성")
+        description = """
+            사용자의 경우 질문만 가능, 관리자의 경우 답변만 가능
+            parentId를 null 요청 시 질문, 질문 QNA의 id를 넣어서 요청하면 답변 형식으로 생성
+            """
+    )
     @PostMapping("/{clubId}/qna")
     ResponseEntity<Void> createQna(
         @RequestBody @Valid CreateQnaRequest request,
@@ -212,8 +214,8 @@ public interface ClubApi {
     @Operation(summary = "특정 동아리의 QNA를 삭제한다",
         description = """
             - 관리자는 모든 QNA 삭제 가능, 그 외에는 본인의 QNA만 삭제 가능
-            - 부모 QNA(맨처음 QNA)인 경우, 그 아래 QNA들까지 모두 삭제
-            - 자식 QNA인 경우, 삭제 시 삭제된 댓글입니다로만 표시하고 구조를 깨지 않음
+            - 부모 QNA(질문 QNA)인 경우, 자식 QNA까지 모두 삭제
+            - 자식 QNA(답변 QNA)인 경우, 그거만 삭제 
             """)
     @DeleteMapping("/{clubId}/qna/{qnaId}")
     ResponseEntity<Void> deleteQna(

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
@@ -38,12 +38,6 @@ public record QnasResponse(
         @Schema(description = "내용", example = "언제 모집하나요?", requiredMode = REQUIRED)
         String content,
 
-        @Schema(description = "삭제여부", example = "false", requiredMode = REQUIRED)
-        Boolean isDeleted,
-
-        @Schema(description = "관리자여부", example = "true", requiredMode = REQUIRED)
-        Boolean isAdmin,
-
         @Schema(description = "작성 일시", example = "2025.05.12 14:00", requiredMode = REQUIRED)
         @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
         LocalDateTime createdAt,
@@ -65,8 +59,6 @@ public record QnasResponse(
                 qna.getAuthor().getId(),
                 nickname,
                 qna.getContent(),
-                qna.getIsDeleted(),
-                qna.getIsAdmin(),
                 qna.getCreatedAt(),
                 children
             );

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubQna.java
@@ -81,11 +81,26 @@ public class ClubQna extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    public void removeChild(ClubQna child) {
+        children.remove(child);
+        child.parent = null;
+    }
+
     public void delete() {
         isDeleted = true;
     }
 
     public boolean isRoot() {
         return parent == null;
+    }
+
+    public boolean isChild() {
+        return parent != null;
+    }
+
+    public void detachFromParentIfChild() {
+        if (isChild()) {
+            parent.removeChild(this);
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -211,11 +211,8 @@ public class ClubService {
     public void deleteQna(Integer clubId, Integer qnaId, Integer studentId) {
         ClubQna qna = clubQnaRepository.getById(qnaId);
         validateQnaDeleteAuthorization(clubId, qna, studentId);
-        if (qna.isRoot()) {
-            clubQnaRepository.delete(qna);
-        } else {
-            qna.delete();
-        }
+        qna.detachFromParentIfChild();
+        clubQnaRepository.delete(qna);
     }
 
     private void validateQnaDeleteAuthorization(Integer clubId, ClubQna qna, Integer studentId) {

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -67,7 +67,7 @@ public class ClubService {
     @Transactional
     public ClubResponse updateClub(Integer clubId, UpdateClubRequest request, Integer studentId) {
         Club club = clubRepository.getById(clubId);
-        isClubAdmin(clubId, studentId);
+        isClubManager(clubId, studentId);
 
         ClubCategory clubCategory = clubCategoryRepository.getById(request.clubCategoryId());
         club.update(request.name(), request.imageUrl(), clubCategory, request.location(), request.description());
@@ -99,7 +99,7 @@ public class ClubService {
         Integer clubId, UpdateClubIntroductionRequest request, Integer studentId
     ) {
         Club club = clubRepository.getById(clubId);
-        isClubAdmin(clubId, studentId);
+        isClubManager(clubId, studentId);
 
         club.updateIntroduction(request.introduction());
         List<ClubSNS> clubSNSs = club.getClubSNSs();
@@ -107,7 +107,7 @@ public class ClubService {
         return ClubResponse.from(club, clubSNSs);
     }
 
-    private void isClubAdmin(Integer clubId, Integer studentId) {
+    private void isClubManager(Integer clubId, Integer studentId) {
         if (!clubAdminRepository.existsByClubIdAndUserId(clubId, studentId)) {
             throw AuthorizationException.withDetail("studentId: " + studentId);
         }
@@ -193,16 +193,16 @@ public class ClubService {
     public void createQna(CreateQnaRequest request, Integer clubId, Integer studentId) {
         Club club = clubRepository.getById(clubId);
         Student student = studentRepository.getById(studentId);
-        boolean isAdmin = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
+        boolean isManager = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
         boolean isQuestion = request.parentId() == null;
-        validateQnaCreateAuthorization(studentId, isQuestion, isAdmin);
+        validateQnaCreateAuthorization(studentId, isQuestion, isManager);
         ClubQna parentQna = request.parentId() == null ? null : clubQnaRepository.getById(request.parentId());
-        ClubQna qna = request.toClubQna(club, student, parentQna, isAdmin);
+        ClubQna qna = request.toClubQna(club, student, parentQna, isManager);
         clubQnaRepository.save(qna);
     }
 
-    private static void validateQnaCreateAuthorization(Integer studentId, boolean isQuestion, boolean isAdmin) {
-        if (isQuestion == isAdmin) {
+    private static void validateQnaCreateAuthorization(Integer studentId, boolean isQuestion, boolean isManager) {
+        if (isQuestion == isManager) {
             throw AuthorizationException.withDetail("studentId: " + studentId);
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -193,10 +193,18 @@ public class ClubService {
     public void createQna(CreateQnaRequest request, Integer clubId, Integer studentId) {
         Club club = clubRepository.getById(clubId);
         Student student = studentRepository.getById(studentId);
-        ClubQna parentQna = request.parentId() == null ? null : clubQnaRepository.getById(request.parentId());
         boolean isAdmin = clubAdminRepository.existsByClubIdAndUserId(clubId, studentId);
+        boolean isQuestion = request.parentId() == null;
+        validateQnaCreateAuthorization(studentId, isQuestion, isAdmin);
+        ClubQna parentQna = request.parentId() == null ? null : clubQnaRepository.getById(request.parentId());
         ClubQna qna = request.toClubQna(club, student, parentQna, isAdmin);
         clubQnaRepository.save(qna);
+    }
+
+    private static void validateQnaCreateAuthorization(Integer studentId, boolean isQuestion, boolean isAdmin) {
+        if (isQuestion == isAdmin) {
+            throw AuthorizationException.withDetail("studentId: " + studentId);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1545 

# 🚀 작업 내용

1. QNA 생성 시 질문은 사용자만, 답변은 관리자만 가능하도록 수정
2. QNA 삭제 시 자식인경우에도 hard deleted 되도록 수정 (기존엔 부모인경우만 hard delete 및 자식에 전파)
3. QNA 조회 시 isDeleted와 isAdmin을 반환하지 않음
4. 관련 swagger 명세 수정

# 💬 리뷰 중점사항
- 다 머지되면 admin 표현을 manager로 다 변경하고 develop으로 머지해야할 것 같네요.
- flyway도 다 머지 끝나면 정리한번 해야할 거 같습니다
- 대표 동아리 API는 변경 사항이 없어서 그대로 사용합니다.
- 우선 isAdmin이나 isDeleted는 확장성을 위해 남겨놨습니다.
