### PR TITLE
feat: ClubHotRedis에 clubId추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubHotResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubHotResponse.java
@@ -11,6 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubHotResponse(
+    @Schema(description = "인기 동아리 ID", example = "1", requiredMode = REQUIRED)
+    Integer clubId,
+
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     String name,
 
@@ -20,6 +23,7 @@ public record ClubHotResponse(
 
     public static ClubHotResponse from(ClubHotRedis clubHotRedis) {
         return new ClubHotResponse(
+            clubHotRedis.getClubId(),
             clubHotRedis.getName(),
             clubHotRedis.getImageUrl()
         );
@@ -27,6 +31,7 @@ public record ClubHotResponse(
 
     public static ClubHotResponse from(Club club) {
         return new ClubHotResponse(
+            club.getId(),
             club.getName(),
             club.getImageUrl()
         );

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubHotRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubHotRedis.java
@@ -16,13 +16,16 @@ public class ClubHotRedis {
     @Id
     private String id;
 
+    private Integer clubId;
+
     private String name;
 
     private String imageUrl;
 
     @Builder
-    private ClubHotRedis(String id, String name, String imageUrl) {
+    private ClubHotRedis(String id, Integer clubId, String name, String imageUrl) {
         this.id = id;
+        this.clubId = clubId;
         this.name = name;
         this.imageUrl = imageUrl;
     }
@@ -30,6 +33,7 @@ public class ClubHotRedis {
     public static ClubHotRedis from(Club club) {
         return ClubHotRedis.builder()
             .id(REDIS_KEY)
+            .clubId(club.getId())
             .name(club.getName())
             .imageUrl(club.getImageUrl())
             .build();


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1558

# 🚀 작업 내용

- ClubHotRedis에서 clubId를 추가로 관리하도록 했습니다.
- 인기 동아리 조회 시 해당 동아리로 바로 이동할 수 있도록 clubId를 추가로 반환하도록 했습니다.

# 💬 리뷰 중점사항
