### PR TITLE
fix: 코인 동아리 활성화 여부 변수명 통일

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -42,7 +42,7 @@ public record AdminClubModifyRequest(
 
     @Schema(description = "동아리 활성화 여부", example = "false", requiredMode = REQUIRED)
     @NotNull(message = "동아리 활성화 여부는 필수 입력 사항입니다.")
-    Boolean active,
+    Boolean isActive,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = REQUIRED)
     String instagram,

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
@@ -35,7 +35,6 @@ public record AdminClubManagersResponse(
     @Schema(description = "동아리 리스트", requiredMode = REQUIRED)
     List<InnerClubManagersResponse> clubs
 ) {
-
     @JsonNaming(SnakeCaseStrategy.class)
     public record InnerClubManagersResponse(
         @Schema(description = "동아리 아이디", example = "1", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
@@ -55,7 +55,7 @@ public record AdminClubsResponse(
         LocalDate createdAt,
 
         @Schema(description = "활성화 여부", example = "true", requiredMode = REQUIRED)
-        Boolean active
+        Boolean isActive
     ) {
         @JsonNaming(value = SnakeCaseStrategy.class)
         public record InnerClubManagerResponse(

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -151,7 +151,7 @@ public class AdminClubService {
             clubCategory,
             request.location(),
             request.description(),
-            request.active()
+            request.isActive()
         );
 
         adminClubSnsRepository.deleteAllByClub(club);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1561 

# 🚀 작업 내용

- 코인 동아리 관련 dto에 있는 동아리 활성화 변수명을 `isActive`으로 통일했습니다.

# 💬 리뷰 중점사항
