### PR TITLE
feat: S3 이미지 삭제, 수정 시 반복되는 로직 imageDeleteService로 분리 후 모듈화 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopMenuService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopMenuService.java
@@ -120,6 +120,7 @@ public class AdminShopMenuService {
     public void modifyMenu(Integer shopId, Integer menuId, AdminModifyMenuRequest request) {
         Menu menu = adminMenuRepository.getById(menuId);
         adminShopRepository.getById(shopId);
+        imageDeleteService.publishImagesModifyEvent(menu.getMenuImages(), request.imageUrls(), MenuImage::getImageUrl);
         menu.modifyMenu(request.name(), request.description());
         menu.modifyMenuImages(request.imageUrls(), entityManager);
         menu.modifyMenuCategories(adminMenuCategoryRepository.findAllByIdIn(request.categoryIds()), entityManager);

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
@@ -21,26 +21,6 @@ public class ImageDeleteService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public <T> void publishImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
-        List<String> imageUrls = extractUrls(images, extractor);
-        eventPublisher.publishEvent(new ImagesDeletedEvent(imageUrls));
-    }
-
-    public <T> void publishImageDeletedEvent(T image, Function<T, String> extractor) {
-        String imageUrl = extractor.apply(image);
-        eventPublisher.publishEvent(new ImageDeletedEvent(imageUrl));
-    }
-
-    public <T> void publishSensitiveImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
-        List<String> imageUrls = extractUrls(images, extractor);
-        eventPublisher.publishEvent(new ImagesSensitiveDeletedEvent(imageUrls));
-    }
-
-    public <T> void publishSensitiveImageDeletedEvent(T image, Function<T, String> extractor) {
-        String imageUrl = extractor.apply(image);
-        eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(imageUrl));
-    }
-
     public <T> void publishImagesModifyEvent(
         Collection<T> oldImages,
         List<String> newImages,
@@ -59,6 +39,30 @@ public class ImageDeleteService {
         List<String> oldImageUrls = extractUrls(oldImages, extractor);
         List<String> toDeleteUrls = extractDeleteUrls(newImages, oldImageUrls);
         eventPublisher.publishEvent(new ImagesSensitiveDeletedEvent(toDeleteUrls));
+    }
+
+    public <T> void publishImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
+        List<String> imageUrls = extractUrls(images, extractor);
+        eventPublisher.publishEvent(new ImagesDeletedEvent(imageUrls));
+    }
+
+    public <T> void publishSensitiveImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
+        List<String> imageUrls = extractUrls(images, extractor);
+        eventPublisher.publishEvent(new ImagesSensitiveDeletedEvent(imageUrls));
+    }
+
+    /*
+        추후 인자 T image, Function<T, String> extractor로 변경 필요
+    */
+    public <T> void publishImageDeletedEvent(String image) {
+        eventPublisher.publishEvent(new ImageDeletedEvent(image));
+    }
+
+    /*
+        추후 인자 T image, Function<T, String> extractor로 변경 필요
+     */
+    public <T> void publishSensitiveImageDeletedEvent(String image) {
+        eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(image));
     }
 
     private <T> List<String> extractUrls(Collection<T> images, Function<T, String> extractor) {

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.infrastructure.s3.service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin._common.event.ImageDeletedEvent;
+import in.koreatech.koin._common.event.ImageSensitiveDeletedEvent;
+import in.koreatech.koin._common.event.ImagesDeletedEvent;
+import in.koreatech.koin._common.event.ImagesSensitiveDeletedEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ImageDeleteService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public <T> void publishImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
+        List<String> imageUrls = extractUrls(images, extractor);
+        eventPublisher.publishEvent(new ImagesDeletedEvent(imageUrls));
+    }
+
+    public <T> void publishImageDeletedEvent(T image, Function<T, String> extractor) {
+        String imageUrl = extractor.apply(image);
+        eventPublisher.publishEvent(new ImageDeletedEvent(imageUrl));
+    }
+
+    public <T> void publishSensitiveImagesDeletedEvent(Collection<T> images, Function<T, String> extractor) {
+        List<String> imageUrls = extractUrls(images, extractor);
+        eventPublisher.publishEvent(new ImagesSensitiveDeletedEvent(imageUrls));
+    }
+
+    public <T> void publishSensitiveImageDeletedEvent(T image, Function<T, String> extractor) {
+        String imageUrl = extractor.apply(image);
+        eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(imageUrl));
+    }
+
+    private <T> List<String> extractUrls(Collection<T> images, Function<T, String> extractor) {
+        return images.stream()
+            .map(extractor)
+            .toList();
+    }
+}

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
@@ -68,7 +68,7 @@ public class ImageDeleteService {
         eventPublisher.publishEvent(new ImageDeletedEvent(image));
     }
 
-    public <T> void publishSensitiveImageDeletedEvent(String image) {
+    public void publishSensitiveImageDeletedEvent(String image) {
         eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(image));
     }
 

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/service/ImageDeleteService.java
@@ -52,15 +52,22 @@ public class ImageDeleteService {
     }
 
     /*
-        추후 인자 T image, Function<T, String> extractor로 변경 필요
+        아래 4개의 메소드는 추후 인자 T image, Function<T, String> extractor로 변경 필요
     */
-    public <T> void publishImageDeletedEvent(String image) {
+    public void publishImageModifyEvent(String oldImage, String newImage) {
+        if (oldImage.equals(newImage)) return;
+        eventPublisher.publishEvent(new ImageDeletedEvent(oldImage));
+    }
+
+    public void publishSensitiveImageModifyEvent(String oldImage, String newImage) {
+        if (oldImage.equals(newImage)) return;
+        eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(oldImage));
+    }
+
+    public void publishImageDeletedEvent(String image) {
         eventPublisher.publishEvent(new ImageDeletedEvent(image));
     }
 
-    /*
-        추후 인자 T image, Function<T, String> extractor로 변경 필요
-     */
     public <T> void publishSensitiveImageDeletedEvent(String image) {
         eventPublisher.publishEvent(new ImageSensitiveDeletedEvent(image));
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1563

# 🚀 작업 내용

- 도메인 서비스에서 이미지 수정, 삭제시에 imageDeleteService의 메소드를 호출하면 되도록 구성
### 민감한 이미지 차이 : CloudFront의 캐시를 즉시 만료시켜서 접근할 수 없도록 함
→ 일반 삭제, 수정은 s3에서 삭제되어도 최대 24시간까지 url로 접근 가능


### 여러 이미지 수정
- 여러 이미지 수정 : publishImagesModifyEvent(엔티티에 저장된 이미지리스트, 새이미지url 리스트, 엔티티 이미지url getter)
- 여러 민감한 이미지 수정 : publishSensitiveImagesModifyEvent(위와동일)
#### 사용예시
```java
imageDeleteService.publishImagesModifyEvent(menu.getMenuImages(), request.imageUrls(), MenuImage::getImageUrl);
```

### 여러 이미지 삭제
- 여러 이미지 삭제 : publishImagesDeletedEvent(엔티티에 저장된 이미지 리스트, 엔티티 이미지url getter)
- 여러 민감한 이미지 삭제 : publishSensitiveImagesDeletedEvent(위와동일)
#### 사용예시
```java
imageDeleteService.publishImagesDeletedEvent(menu.getMenuImages(), MenuImage::getImageUrl);
```

### 단일 이미지 수정
- 단일 이미지 수정 : publishImageDeletedEvent(이전이미지, 새이미지)
- 단일 민감한 이미지 수정 : publishSensitiveImageDeletedEvent(위와동일)
#### 사용예시
```java
imageDeleteService.publishImageDeletedEvent(oldImage, newImage)
```

### 단일 이미지 삭제
- 단일 이미지 삭제 : publishImageDeletedEvent(삭제할이미지)
- 단일 민감한 이미지 삭제 : publishSensitiveImageDeletedEvent(위와동일)
#### 사용예시
```java
imageDeleteService.publishImageDeletedEvent(image)
```


# 💬 리뷰 중점사항
- 서비스에서 변환 로직이 반복되면 코드가 불명확해지고 여러 책임을 가지게되는 것 같아서 추출하고 처리하는 로직을 별도의 서비스로 분리했습니다.
- 더 좋은 방안 있으면 의견 주세요!
- 이미지 테이블, 컬럼이 매우 많아서 테스트만 하고 적용은 나중에 진행해야 할 것 같습니다.
- Image 테이블이 분리되어 있어서 쉽지않네요
