### PR TITLE
feat: 카테고리 별 동아리 조회 응답값 좋아요 수 필드 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
@@ -25,12 +25,15 @@ public record ClubsByCategoryResponse(
         @Schema(description = "동아리 카테고리", example = "학술", requiredMode = REQUIRED)
         String category,
 
+        @Schema(description = "동아리 좋아요 수", example = "9999999", requiredMode = REQUIRED)
+        Integer likes,
+
         @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
         String imageUrl
     ) {
         private static ClubsByCategoryResponse.InnerClubResponse from(Club club) {
             return new ClubsByCategoryResponse.InnerClubResponse(
-                club.getId(), club.getName(), club.getClubCategory().getName(), club.getImageUrl()
+                club.getId(), club.getName(), club.getClubCategory().getName(), club.getLikes(), club.getImageUrl()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
@@ -19,10 +19,10 @@ public record ClubsByCategoryResponse(
         @Schema(description = "동아리 고유 id", example = "1", requiredMode = REQUIRED)
         Integer id,
 
-        @Schema(description = "동아리 이름", example = "학술", requiredMode = REQUIRED)
+        @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
         String name,
 
-        @Schema(description = "카테고리", example = "학술", requiredMode = REQUIRED)
+        @Schema(description = "동아리 카테고리", example = "학술", requiredMode = REQUIRED)
         String category,
 
         @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubsByCategoryResponse(
     @Schema(description = "동아리 리스트", requiredMode = REQUIRED)
-    List<ClubsByCategoryResponse.InnerClubResponse> clubCategories
+    List<ClubsByCategoryResponse.InnerClubResponse> clubs
 ) {
     public record InnerClubResponse(
         @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubsByCategoryResponse.java
@@ -16,7 +16,7 @@ public record ClubsByCategoryResponse(
     List<ClubsByCategoryResponse.InnerClubResponse> clubs
 ) {
     public record InnerClubResponse(
-        @Schema(description = "동아리 카테고리 고유 id", example = "1", requiredMode = REQUIRED)
+        @Schema(description = "동아리 고유 id", example = "1", requiredMode = REQUIRED)
         Integer id,
 
         @Schema(description = "동아리 이름", example = "학술", requiredMode = REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1568 

# 🚀 작업 내용

- 카테고리 별 동아리 조회 응답값에 좋아요 수를 추가했습니다.
- 응답값 필드명을 수정했습니다.
- 스웨거 설정을 변경했습니다. 

# 💬 리뷰 중점사항
