### PR TITLE
hotfix: Timetable NPE 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
+++ b/src/main/java/in/koreatech/koin/domain/graduation/service/GraduationService.java
@@ -600,7 +600,7 @@ public class GraduationService {
         TimetableFrame graduationFrame, CourseType courseType, GeneralEducationArea generalEducationArea) {
         return TimetableLecture.builder()
             .classTitle(data.classTitle())
-            .classTime(lecture != null ? lecture.getClassTime() : null)
+            .classTime(lecture != null ? lecture.getClassTime() : "[]")
             .professor(data.professor())
             .grades(data.credit())
             .isDeleted(false)

--- a/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/LectureInfoResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV3/dto/response/LectureInfoResponse.java
@@ -77,6 +77,9 @@ public record LectureInfoResponse(
         }
 
         List<Integer> classTimes = parseToIntegerList(classTime);
+        if (classTimes.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<LectureInfoResponse> response = new ArrayList<>();
 
         List<String> classPlaces = getClassPlaces(classPlace, classTimes);


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

- timetable에서 발생하는 NPE를 수정했습니다.
  - 졸업학점 계산기 엑셀 업로드 과정에서 정규강의가 아닌 강의는 임의로 생성되서 timetable_lecture에 저장
  - 이 과정에서 온라인 강의 같은 수업의 classTime이 Null로 들어갔음
  - 온라인 강의의 classTime은 `[]`으로 들어가야 하므로, 생성 로직 수정
  - 응답값 반환과정에서도 빈 리스트 처리

# 해당 PR은 Main 브랜치를 향하고 있습니다.
