### PR TITLE
fix: 코인 어드민 동아리 & 일반 동아리 API 변경사항 적용

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -45,7 +45,7 @@ public record AdminClubResponse(
     LocalDate createdAt,
 
     @Schema(description = "활성화 여부", example = "true", requiredMode = REQUIRED)
-    Boolean active
+    Boolean isActive
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerClubManagerResponse(

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
@@ -12,42 +12,45 @@ import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record AdminPendingClubResponse
-    (
-        @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
-        String name,
+public record AdminPendingClubResponse(
+    @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
+    String name,
 
-        @Schema(description = "동아리 신청자 전화번호", example = "01012345678", requiredMode = REQUIRED)
-        String requesterPhoneNumber,
+    @Schema(description = "동아리 신청자 전화번호", example = "01012345678", requiredMode = REQUIRED)
+    String requesterPhoneNumber,
 
-        @Schema(description = "동아리 분과 카테고리", example = "학술", requiredMode = REQUIRED)
-        String clubCategory,
+    @Schema(description = "동아리 신청자 이름", example = "정해성", requiredMode = REQUIRED)
+    String requesterNumber,
 
-        @Schema(description = "동아리 위치", example = "학생식당 건물 406호", requiredMode = REQUIRED)
-        String location,
+    @Schema(description = "동아리 분과 카테고리", example = "학술", requiredMode = REQUIRED)
+    String clubCategory,
 
-        @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
-        String imageUrl,
+    @Schema(description = "동아리 위치", example = "학생식당 건물 406호", requiredMode = REQUIRED)
+    String location,
 
-        @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-        String description,
+    @Schema(description = "동아리 이미지 url", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
+    String imageUrl,
 
-        @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
-        Optional<String> instagram,
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
+    String description,
 
-        @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
-        Optional<String> googleForm,
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    Optional<String> instagram,
 
-        @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
-        Optional<String> openChat,
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    Optional<String> googleForm,
 
-        @Schema(description = "동아리 관리자 전화번호", example = "01098765432")
-        Optional<String> phoneNumber
-    ) {
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    Optional<String> openChat,
+
+    @Schema(description = "동아리 관리자 전화번호", example = "01098765432")
+    Optional<String> phoneNumber
+) {
     public static AdminPendingClubResponse from(ClubCreateRedis redis, User requester, String clubCategory) {
         return new AdminPendingClubResponse(
             redis.getName(),
             requester.getPhoneNumber(),
+            requester.getName(),
             clubCategory,
             redis.getLocation(),
             redis.getImageUrl(),

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -16,14 +16,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin._common.auth.UserId;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
-import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
-import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
+import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
+import in.koreatech.koin.domain.club.enums.ClubSortType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -114,7 +115,7 @@ public interface ClubApi {
     @GetMapping
     ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
         @RequestParam(required = false) Integer categoryId,
-        @RequestParam(required = false, defaultValue = "false") Boolean hitSort
+        @RequestParam(required = false, defaultValue = "NONE") ClubSortType sortType
     );
 
     @ApiResponses(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -26,6 +26,7 @@ import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
+import in.koreatech.koin.domain.club.enums.ClubSortType;
 import in.koreatech.koin.domain.club.service.ClubService;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -70,9 +71,9 @@ public class ClubController implements ClubApi {
     @GetMapping
     public ResponseEntity<ClubsByCategoryResponse> getClubByCategory(
         @RequestParam(required = false) Integer categoryId,
-        @RequestParam(required = false, defaultValue = "false") Boolean hitSort
+        @RequestParam(required = false, defaultValue = "NONE") ClubSortType sortType
     ) {
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, hitSort);
+        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, sortType);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
+++ b/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.domain.club.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ClubSortType {
+    NONE,
+    HITS_DESC,
+    ;
+}

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.club.service;
 
+import static in.koreatech.koin.domain.club.enums.ClubSortType.HITS_DESC;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -18,6 +20,7 @@ import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
 import in.koreatech.koin.domain.club.dto.response.QnasResponse;
+import in.koreatech.koin.domain.club.enums.ClubSortType;
 import in.koreatech.koin.domain.club.enums.SNSType;
 import in.koreatech.koin.domain.club.exception.ClubHotNotFoundException;
 import in.koreatech.koin.domain.club.exception.ClubLikeDuplicateException;
@@ -133,20 +136,20 @@ public class ClubService {
         return ClubResponse.from(club, clubSNSs, manager);
     }
 
-    public ClubsByCategoryResponse getClubByCategory(Integer categoryId, Boolean hitSort) {
-        List<Club> clubs = getClubs(categoryId, hitSort);
+    public ClubsByCategoryResponse getClubByCategory(Integer categoryId, ClubSortType sortType) {
+        List<Club> clubs = getClubs(categoryId, sortType);
         return ClubsByCategoryResponse.from(clubs);
     }
 
-    private List<Club> getClubs(Integer categoryId, Boolean hitSort) {
+    private List<Club> getClubs(Integer categoryId, ClubSortType sortType) {
         if (categoryId == null) {
-            return hitSort
+            return sortType.equals(HITS_DESC)
                 ? clubRepository.findByOrderByHitsDesc()
                 : clubRepository.findByOrderByIdAsc();
         }
 
         ClubCategory category = clubCategoryRepository.getById(categoryId);
-        return hitSort
+        return sortType.equals(HITS_DESC)
             ? clubRepository.findByClubCategoryOrderByHitsDesc(category)
             : clubRepository.findByClubCategoryOrderByIdAsc(category);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1572 

# 🚀 작업 내용

- 코인 어드민 동아리 API 변경사항을 적용했습니다.
  - 변수명을 isActive로 통일시켰습니다.
  - 동아리 신청자 이름을 응답값에 추가했습니다.
- 일반 동아리 API 변경사항을 적용했습니다.
  - 검색 조건 요청값을 ENUM으로 관리하도록 수정했습니다.

# 💬 리뷰 중점사항
일반 동아리 API 코드가 뭔가 쉽지 않은 느낌이 듭니다.. 
QuaryDSL을 써야할지 다른 방법이 있는지 여쭙고 싶습니다.