### PR TITLE
fix: 코인 어드민 동아리 수정사항 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubApi.java
+++ b/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubApi.java
@@ -68,7 +68,9 @@ public interface AdminClubApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "특정 동아리 정보를 조회한다.")
+    @Operation(summary = "특정 동아리 정보를 조회한다.", description = """
+        sns_contacts의 snsType값은 총 4개(인스타그램, 전화 번호, 구글 폼, 오픈 채팅)값이 내려갑니다.
+        """)
     @GetMapping("/{clubId}")
     ResponseEntity<AdminClubResponse> getClub(
         @PathVariable(value = "clubId") Integer clubId,

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
@@ -59,7 +59,7 @@ public record AdminClubManagersResponse(
 
             return new InnerClubManagersResponse(
                 club.getId(),
-                user.getName(),
+                clubManager.getClubManagerName(),
                 user.getPhoneNumber(),
                 club.getCreatedAt(),
                 club.getName()

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -76,7 +76,7 @@ public record AdminClubResponse(
         String snsType,
 
         @Schema(description = "동아리 SNS 연락처", example = "https://www.instagram.com/bcsdlab/", requiredMode = REQUIRED)
-        String contract
+        String contact
     ) {
         private static InnerClubSNSResponse from(ClubSNS clubSNS) {
             return new InnerClubSNSResponse(

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.club.model.ClubSNS;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -61,9 +62,11 @@ public record AdminClubResponse(
         @Schema(description = "동아리 관리자 전화번호", example = "01012345678", requiredMode = REQUIRED)
         String phoneNumber
     ) {
-        private static InnerClubManagerResponse from(User user) {
+        private static InnerClubManagerResponse from(ClubManager clubManager) {
+            User user = clubManager.getUser();
+
             return new InnerClubManagerResponse(
-                user.getName(),
+                clubManager.getClubManagerName(),
                 user.getUserId(),
                 user.getPhoneNumber()
             );
@@ -92,7 +95,7 @@ public record AdminClubResponse(
             club.getName(),
             club.getImageUrl(),
             club.getClubManagers().stream()
-                .map(clubAdmin -> InnerClubManagerResponse.from(clubAdmin.getUser()))
+                .map(InnerClubManagerResponse::from)
                 .toList(),
             club.getClubCategory().getName(),
             club.getLikes(),

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -37,6 +37,9 @@ public record AdminClubResponse(
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
     String description,
 
+    @Schema(description = "동아리 위치", example = "학생회괸", requiredMode = REQUIRED)
+    String location,
+
     @Schema(description = "동아리 연락처 리스트", requiredMode = REQUIRED)
     List<InnerClubSNSResponse> snsContacts,
 
@@ -94,6 +97,7 @@ public record AdminClubResponse(
             club.getClubCategory().getName(),
             club.getLikes(),
             club.getDescription(),
+            club.getLocation(),
             club.getClubSNSs().stream()
                 .map(InnerClubSNSResponse::from)
                 .toList(),

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -38,7 +38,7 @@ public record AdminClubResponse(
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
     String description,
 
-    @Schema(description = "동아리 위치", example = "학생회괸", requiredMode = REQUIRED)
+    @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     String location,
 
     @Schema(description = "동아리 연락처 리스트", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -68,9 +69,11 @@ public record AdminClubsResponse(
             @Schema(description = "동아리 관리자 전화번호", example = "01012345678", requiredMode = REQUIRED)
             String phoneNumber
         ) {
-            private static InnerClubManagerResponse from(User user) {
+            private static InnerClubManagerResponse from(ClubManager clubManager) {
+                User user = clubManager.getUser();
+
                 return new InnerClubManagerResponse(
-                    user.getName(),
+                    clubManager.getClubManagerName(),
                     user.getUserId(),
                     user.getPhoneNumber()
                 );
@@ -83,7 +86,7 @@ public record AdminClubsResponse(
                 club.getName(),
                 club.getImageUrl(),
                 club.getClubManagers().stream()
-                    .map(clubAdmin -> InnerClubManagerResponse.from(clubAdmin.getUser()))
+                    .map(InnerClubManagerResponse::from)
                     .toList(),
                 club.getClubCategory().getName(),
                 club.getCreatedAt().toLocalDate(),

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubManager.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubManager.java
@@ -10,7 +10,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +23,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "club_manager")
 @NoArgsConstructor(access = PROTECTED)
 public class ClubManager {
+
+    private static final String NOT_REGISTER_USER_NAME = "미등록";
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -33,6 +38,9 @@ public class ClubManager {
     @ManyToOne(fetch = LAZY)
     private User user;
 
+    @Transient
+    private String clubManagerName;
+
     @Builder
     private ClubManager(
         Integer id,
@@ -42,5 +50,15 @@ public class ClubManager {
         this.id = id;
         this.club = club;
         this.user = user;
+    }
+
+    @PostPersist
+    @PostLoad
+    public void updateClubManagerName() {
+        if (user.getName() != null) {
+            clubManagerName = user.getName();
+            return;
+        }
+        clubManagerName = NOT_REGISTER_USER_NAME;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubManager.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubManager.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class ClubManager {
 
-    private static final String NOT_REGISTER_USER_NAME = "미등록";
+    private static final String DEFAULT_MANAGER_NAME = "동아리 관리자";
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -59,6 +59,6 @@ public class ClubManager {
             clubManagerName = user.getName();
             return;
         }
-        clubManagerName = NOT_REGISTER_USER_NAME;
+        clubManagerName = DEFAULT_MANAGER_NAME;
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1576 

# 🚀 작업 내용

- 코인 어드민 동아리 API 수정사항을 반영했습니다.
  - `GET /admin/clubs/{clubId}`의 contract 변수명을 contact으로 변경했습니다.
  - `GET /admin/clubs/{clubId}`의 반환값에 동아리 위치를 추가했습니다.
  - 응답값 중 동아리 관리자의 이름이 없는 경우, `미등록`으로 응답하도록 수정했습니다.

# 💬 리뷰 중점사항
