### PR TITLE
chore: 미승인 동아리 신청자 DTO 변수 수정(Number -> Name)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
@@ -20,7 +20,7 @@ public record AdminPendingClubResponse(
     String requesterPhoneNumber,
 
     @Schema(description = "동아리 신청자 이름", example = "정해성", requiredMode = REQUIRED)
-    String requesterNumber,
+    String requesterName,
 
     @Schema(description = "동아리 분과 카테고리", example = "학술", requiredMode = REQUIRED)
     String clubCategory,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1580

# 🚀 작업 내용

1. 미승인 동아리 조회 API GET `/admin/clubs/pending/{clubName}` Response 내의 동아리 신청자 변수 이름을 requesterNumber -> requesterName으로 변경했습니다.

# 💬 리뷰 중점사항
1줄 잔디 주워가세요