### PR TITLE
fix: 채팅방 조회 시 404 응답 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/chatroom/service/LostItemChatRoomInfoService.java
@@ -67,7 +67,7 @@ public class LostItemChatRoomInfoService {
 
         return chatRoomInfoList.stream()
             .flatMap(entity -> {
-                if (userReader.readUser(entity.getOwnerId()) == null) {
+                if (userReader.isNotExistUser(entity.getOwnerId())) {
                     return Stream.empty();
                 }
 

--- a/src/main/java/in/koreatech/koin/socket/domain/session/service/implement/UserReader.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/session/service/implement/UserReader.java
@@ -13,6 +13,6 @@ public class UserReader {
     private final UserRepository userRepository;
 
     public User readUser(Integer id) {
-        return userRepository.getById(id);
+        return userRepository.findById(id).orElse(null);
     }
 }

--- a/src/main/java/in/koreatech/koin/socket/domain/session/service/implement/UserReader.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/session/service/implement/UserReader.java
@@ -13,6 +13,10 @@ public class UserReader {
     private final UserRepository userRepository;
 
     public User readUser(Integer id) {
-        return userRepository.findById(id).orElse(null);
+        return userRepository.getById(id);
+    }
+
+    public boolean isNotExistUser(Integer id) {
+        return userRepository.findById(id).isEmpty();
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1584

# 🚀 작업 내용

1. 채팅방 조회 시 사용자가 존재하지 않을 경우 404 응답하는 오류를 수정했습니다.

# 💬 리뷰 중점사항
@DHkimgit  혹시 추가로 고려해야할 사항이 있다면 알려주세요.