### PR TITLE
fix: shop 엔티티 db와 column name 불일치 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -142,7 +142,7 @@ public class Shop extends BaseEntity {
     private String bank;
 
     @Size(max = 20)
-    @Column(name = "accountNumber", length = 20)
+    @Column(name = "account_number", length = 20)
     private String accountNumber;
 
     @Builder


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1591

# 🚀 작업 내용

- account_number 컬럼이 accountNumber로 되어있던 문제 해결

# 💬 리뷰 중점사항
- 1줄