### PR TITLE
fix: 코인 동아리 API 수정사항 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubActiveChangeRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubActiveChangeRequest.java
@@ -10,8 +10,8 @@ import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminClubActiveChangeRequest(
-    @NotNull
     @Schema(description = "동아리 활성화 여부", example = "false", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 활성화 여부는 필수 입력사항입니다.")
     Boolean isActive
 ) {
     

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -79,6 +79,7 @@ public record AdminClubCreateRequest(
             .clubCategory(clubCategory)
             .description(Objects.requireNonNullElse(description, ""))
             .location(location)
+            .isLikeHidden(false)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -1,15 +1,17 @@
 package in.koreatech.koin.admin.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.Club;
-import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.club.model.ClubCategory;
+import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
@@ -37,8 +39,7 @@ public record AdminClubCreateRequest(
     @NotNull(message = "동아리 위치는 필수 입력 사항입니다.")
     String location,
 
-    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @NotNull(message = "동아리 소개는 필수 입력 사항입니다.")
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = REQUIRED)
@@ -76,7 +77,7 @@ public record AdminClubCreateRequest(
             .introduction("")
             .imageUrl(imageUrl)
             .clubCategory(clubCategory)
-            .description(description)
+            .description(Objects.requireNonNullElse(description, ""))
             .location(location)
             .build();
     }

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
@@ -6,16 +6,17 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminClubManagerDecideRequest(
-    @NotNull
     @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아리 이름은 필수 입력사항입니다.")
     String clubName,
 
-    @NotNull
     @Schema(description = "동아리 관리자 승인 여부", example = "false", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 관리자 승인 여부는 필수 입력사항입니다.")
     Boolean isAccept
 ) {
 

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.admin.club.dto.response;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -53,7 +54,7 @@ public record AdminPendingClubResponse(
         return new AdminPendingClubResponse(
             redis.getName(),
             requester.getPhoneNumber(),
-            requester.getName(),
+            Objects.requireNonNull(requester.getName(), "동아리 관리자"),
             clubCategory,
             redis.getLocation(),
             redis.getImageUrl(),

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -1,9 +1,11 @@
 package in.koreatech.koin.domain.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -37,8 +39,7 @@ public record ClubCreateRequest(
     @NotEmpty(message = "동아리 위치는 필수 입력 사항입니다.")
     String location,
 
-    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @NotEmpty(message = "동아리 소개는 필수 입력 사항입니다.")
+    @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
@@ -79,7 +80,7 @@ public record ClubCreateRequest(
             .introduction("")
             .imageUrl(imageUrl)
             .clubCategory(clubCategory)
-            .description(description)
+            .description(Objects.requireNonNullElse(description, ""))
             .location(location)
             .build();
     }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -86,6 +86,7 @@ public record ClubCreateRequest(
             .clubCategory(clubCategory)
             .description(Objects.requireNonNullElse(description, ""))
             .location(location)
+            .isLikeHidden(isLikeHidden)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -55,7 +55,11 @@ public record ClubCreateRequest(
     String phoneNumber,
 
     @Schema(description = "동아리 내 역할", example = "회장")
-    String role
+    String role,
+
+    @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)
+    @NotNull(message = "좋아요 숨김 여부는 필수 입력 사항입니다.")
+    Boolean isLikeHidden
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerClubManagerRequest(

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -42,19 +42,20 @@ public record ClubCreateRequest(
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
     String description,
 
-    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     String instagram,
 
-    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     String googleForm,
 
-    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     String openChat,
 
-    @Schema(description = "전화번호", example = "010-1234-5678")
+    @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = NOT_REQUIRED)
     String phoneNumber,
 
-    @Schema(description = "동아리 내 역할", example = "회장")
+    @Schema(description = "동아리 내 역할", example = "회장", requiredMode = REQUIRED)
+    @NotEmpty(message = "동아 내 역할은 필수 입력 사항입니다.")
     String role,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubManagerEmpowermentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubManagerEmpowermentRequest.java
@@ -1,17 +1,18 @@
 package in.koreatech.koin.domain.club.dto.request;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubManagerEmpowermentRequest(
     @Schema(description = "동아리 아이디", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "동아리 아이디는 필수 입력사항입니다.")
     Integer clubId,
 
     @Schema(description = "위임받는 사용자의 아이디", example = "example", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -10,6 +10,7 @@ import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubUpdateRequest(
@@ -43,7 +44,11 @@ public record ClubUpdateRequest(
     String openChat,
 
     @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = NOT_REQUIRED)
-    String phoneNumber
+    String phoneNumber,
+
+    @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)
+    @NotNull(message = "좋아요 숨김 여부는 필수 입력 사항입니다.")
+    Boolean isLikeHidden
 ) {
 
     public Club toEntity(ClubCategory clubCategory) {
@@ -58,6 +63,7 @@ public record ClubUpdateRequest(
             .clubCategory(clubCategory)
             .description(description)
             .location(location)
+            .isLikeHidden(isLikeHidden)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.club.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
@@ -32,16 +33,16 @@ public record ClubUpdateRequest(
     @NotEmpty(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
-    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/")
+    @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     String instagram,
 
-    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example")
+    @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     String googleForm,
 
-    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example")
+    @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     String openChat,
 
-    @Schema(description = "전화번호", example = "010-1234-5678")
+    @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = NOT_REQUIRED)
     String phoneNumber
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -76,7 +76,7 @@ public class Club extends BaseEntity {
 
     @NotNull
     @Column(name = "is_like_hidden", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
-    private Boolean likeHidden = FALSE;
+    private Boolean isLikeHidden = FALSE;
 
     @JoinColumn(name = "club_category_id")
     @ManyToOne(fetch = LAZY)
@@ -100,7 +100,7 @@ public class Club extends BaseEntity {
         Integer likes,
         String location,
         String introduction,
-        Boolean likeHidden,
+        Boolean isLikeHidden,
         ClubCategory clubCategory
     ) {
         this.id = id;
@@ -113,7 +113,7 @@ public class Club extends BaseEntity {
         this.likes = likes;
         this.location = location;
         this.introduction = introduction;
-        this.likeHidden = likeHidden;
+        this.isLikeHidden = isLikeHidden;
         this.clubCategory = clubCategory;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -74,6 +74,10 @@ public class Club extends BaseEntity {
     @Column(name = "introduction", nullable = false, columnDefinition = "TEXT")
     private String introduction;
 
+    @NotNull
+    @Column(name = "is_like_hidden", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private Boolean likeHidden = FALSE;
+
     @JoinColumn(name = "club_category_id")
     @ManyToOne(fetch = LAZY)
     private ClubCategory clubCategory;
@@ -96,6 +100,7 @@ public class Club extends BaseEntity {
         Integer likes,
         String location,
         String introduction,
+        Boolean likeHidden,
         ClubCategory clubCategory
     ) {
         this.id = id;
@@ -108,6 +113,7 @@ public class Club extends BaseEntity {
         this.likes = likes;
         this.location = location;
         this.introduction = introduction;
+        this.likeHidden = likeHidden;
         this.clubCategory = clubCategory;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -49,6 +49,8 @@ public class ClubCreateRedis {
 
     private String role;
 
+    private Boolean isLikeHidden;
+
     @Builder
     private ClubCreateRedis(
         String id,
@@ -64,7 +66,8 @@ public class ClubCreateRedis {
         String phoneNumber,
         Integer requesterId,
         LocalDateTime createdAt,
-        String role
+        String role,
+        Boolean isLikeHidden
     ) {
         this.id = id;
         this.name = name;
@@ -80,6 +83,7 @@ public class ClubCreateRedis {
         this.requesterId = requesterId;
         this.createdAt = createdAt;
         this.role = role;
+        this.isLikeHidden = isLikeHidden;
     }
 
     public static ClubCreateRedis of(ClubCreateRequest request, Integer requesterId) {
@@ -98,6 +102,7 @@ public class ClubCreateRedis {
             .requesterId(requesterId)
             .createdAt(LocalDateTime.now())
             .role(request.role())
+            .isLikeHidden(request.isLikeHidden())
             .build();
     }
 
@@ -113,6 +118,7 @@ public class ClubCreateRedis {
             .lastWeekHits(0)
             .active(false)
             .introduction("")
+            .isLikeHidden(this.isLikeHidden)
             .build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -4,6 +4,7 @@ import static in.koreatech.koin.domain.club.dto.request.ClubCreateRequest.InnerC
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.redis.core.RedisHash;
 
@@ -112,7 +113,7 @@ public class ClubCreateRedis {
             .imageUrl(this.imageUrl)
             .clubCategory(category)
             .location(this.location)
-            .description(this.description)
+            .description(Objects.requireNonNull(this.description, ""))
             .likes(0)
             .hits(0)
             .lastWeekHits(0)

--- a/src/main/resources/db/migration/V157__add_column_is_like_hidden.sql
+++ b/src/main/resources/db/migration/V157__add_column_is_like_hidden.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `koin`.`club`
+    ADD COLUMN `is_like_hidden` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '좋아요 숨김 여부';


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1595 

# 🚀 작업 내용

- 코인 동아리 생성 과정에서 동아리 소개를 선택값으로 수정했습니다.
- 코인 동아리 생성 시 좋아요 숨김 컬럼을 추가했습니다.
- 어드민 코인 동아리에서 생성 요청자의 이름에서 발생하는 NPE를 해결했습니다.
- 스웨거 설정을 변경했습니다.

# 💬 리뷰 중점사항
