### PR TITLE
fix: 미승인 동아리 상세조회 신청자 이름 NPE 발생 오류 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminPendingClubResponse.java
@@ -54,7 +54,7 @@ public record AdminPendingClubResponse(
         return new AdminPendingClubResponse(
             redis.getName(),
             requester.getPhoneNumber(),
-            Objects.requireNonNull(requester.getName(), "동아리 관리자"),
+            Objects.requireNonNullElse(requester.getName(), "동아리 관리자"),
             clubCategory,
             redis.getLocation(),
             redis.getImageUrl(),


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1599 

# 🚀 작업 내용

1. 미승인 동아리 조회 시, 신청자의 이름이 NULL인 경우 NPE가 터지던 오류를 수정했습니다.
   신청자의 이름이 없는 경우, 기본 값으로 "동아리 관리자"를 매핑합니다.

# 💬 리뷰 중점사항
이름도 Null이 될 수 있는데, 기존 사용하던 requireNonNull이 이를 "동아리 관리자" 메세지를 보내며 NPE를 발생시키는 것을 확인했습니다.
의도하던대로, 기존 매핑 값이 "동아리 관리자"로 반환될 수 있도록 requireNonNullElse를 사용했습니다.

와 한줄!