### PR TITLE
fix: Club 탈퇴한 회원의 Qna 조회 시 NPE 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/QnasResponse.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.club.model.ClubQna;
+import in.koreatech.koin.domain.student.model.Student;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -47,16 +48,23 @@ public record QnasResponse(
     ) {
 
         public static InnerQnaResponse from(ClubQna qna) {
-            String nickname = qna.getAuthor().getUser().getNickname();
-            if (nickname == null) {
-                nickname = qna.getAuthor().getAnonymousNickname();
+            String nickname;
+            Student author = qna.getAuthor();
+            if (author != null) {
+                nickname = qna.getAuthor().getUser().getNickname();
+                if (nickname == null) {
+                    nickname = qna.getAuthor().getAnonymousNickname();
+                }
+            } else {
+                nickname = "탈퇴한 회원";
             }
+
             List<InnerQnaResponse> children = qna.getChildren().stream()
                 .map(InnerQnaResponse::from)
                 .toList();
             return new InnerQnaResponse(
                 qna.getId(),
-                qna.getAuthor().getId(),
+                author == null ? null : author.getId(),
                 nickname,
                 qna.getContent(),
                 qna.getCreatedAt(),


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1605

# 🚀 작업 내용

- 탈퇴한 회원의 QNA 조회 시에 author_id를 null로 반환하고, nickname을 탈퇴한 회원으로 반환하도록 수정했습니다.

# 💬 리뷰 중점사항
