### PR TITLE
fix: 코인 동아리 QA 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubApi.java
+++ b/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubApi.java
@@ -189,7 +189,7 @@ public interface AdminClubApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @PostMapping("/decision")
     ResponseEntity<Void> decideClubAdmin(
-        @RequestBody AdminClubManagerDecideRequest request,
+        @RequestBody @Valid AdminClubManagerDecideRequest request,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubController.java
+++ b/src/main/java/in/koreatech/koin/admin/club/controller/AdminClubController.java
@@ -114,7 +114,7 @@ public class AdminClubController implements AdminClubApi {
 
     @PostMapping("/decision")
     public ResponseEntity<Void> decideClubAdmin(
-        @RequestBody AdminClubManagerDecideRequest request,
+        @RequestBody @Valid AdminClubManagerDecideRequest request,
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         adminClubService.decideClubManager(request.clubName(), request);

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -81,7 +81,7 @@ public record AdminClubCreateRequest(
         return Club.builder()
             .name(name)
             .lastWeekHits(0)
-            .active(false)
+            .isActive(false)
             .likes(0)
             .hits(0)
             .introduction("")

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminClubCreateRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
-    @Size(max = 50, message = "동아리 이름은 최대 50자 입니다.")
+    @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
     String name,
 
@@ -45,7 +45,7 @@ public record AdminClubCreateRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
-    @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
+    @Size(max = 40, message = "동아리 소개는 최대 40자 입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminClubManagerDecideRequest(
     @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
-    @Size(max = 50, message = "동아리 이름은 최대 50자 입니다.")
+    @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
     String clubName,
 

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -20,7 +20,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record AdminClubModifyRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
-    @Size(max = 50, message = "동아리 이름은 최대 50자 입니다.")
+    @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
     String name,
 
@@ -43,7 +43,7 @@ public record AdminClubModifyRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @NotBlank(message = "동아리 소개는 필수 입력 사항입니다.")
+    @Size(max = 40, message = "동아리 소개는 최대 40자 입니다.")
     String description,
 
     @Schema(description = "동아리 활성화 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -43,7 +43,6 @@ public record AdminClubModifyRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
     @NotBlank(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
@@ -96,7 +96,8 @@ public record AdminClubManagersResponse(
             pagedResult.getTotalPages(),
             criteria.getPage() + 1,
             IntStream.range(0, pagedResult.getContent().size())
-                .mapToObj(i -> InnerClubManagersResponse.from(pagedResult.getContent().get(i), i + 1))
+                .mapToObj(i -> InnerClubManagersResponse.from(pagedResult.getContent().get(i),
+                    (pagedResult.getContent().size() * (criteria.getPage())) + (i + 1)))
                 .toList()
         );
     }

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
@@ -1,10 +1,12 @@
 package in.koreatech.koin.admin.club.dto.response;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
 
@@ -37,8 +39,14 @@ public record AdminClubManagersResponse(
 ) {
     @JsonNaming(SnakeCaseStrategy.class)
     public record InnerClubManagersResponse(
-        @Schema(description = "동아리 아이디", example = "1", requiredMode = REQUIRED)
+        @Schema(description = "인덱스", example = "1", requiredMode = REQUIRED)
+        Integer index,
+
+        @Schema(description = "동아리 고유 id", example = "1", requiredMode = NOT_REQUIRED)
         Integer clubId,
+
+        @Schema(description = "동아리 관리자 고유 id", example = "1", requiredMode = REQUIRED)
+        Integer clubManagerId,
 
         @Schema(description = "동아리 관리자 이름", example = "배진호", requiredMode = REQUIRED)
         String clubManagerName,
@@ -53,12 +61,14 @@ public record AdminClubManagersResponse(
         @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
         String clubName
     ) {
-        public static InnerClubManagersResponse from(ClubManager clubManager) {
+        public static InnerClubManagersResponse from(ClubManager clubManager, Integer index) {
             Club club = clubManager.getClub();
             User user = clubManager.getUser();
 
             return new InnerClubManagersResponse(
+                index,
                 club.getId(),
+                user.getId(),
                 clubManager.getClubManagerName(),
                 user.getPhoneNumber(),
                 club.getCreatedAt(),
@@ -66,9 +76,11 @@ public record AdminClubManagersResponse(
             );
         }
 
-        public static InnerClubManagersResponse fromRedis(ClubCreateRedis redis, User requester) {
+        public static InnerClubManagersResponse fromRedis(ClubCreateRedis redis, User requester, Integer index) {
             return new InnerClubManagersResponse(
+                index,
                 null,
+                requester.getId(),
                 requester.getName(),
                 requester.getPhoneNumber(),
                 redis.getCreatedAt(),
@@ -83,8 +95,8 @@ public record AdminClubManagersResponse(
             pagedResult.getContent().size(),
             pagedResult.getTotalPages(),
             criteria.getPage() + 1,
-            pagedResult.getContent().stream()
-                .map(InnerClubManagersResponse::from)
+            IntStream.range(0, pagedResult.getContent().size())
+                .mapToObj(i -> InnerClubManagersResponse.from(pagedResult.getContent().get(i), i + 1))
                 .toList()
         );
     }

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubResponse.java
@@ -105,7 +105,7 @@ public record AdminClubResponse(
                 .map(InnerClubSNSResponse::from)
                 .toList(),
             club.getCreatedAt().toLocalDate(),
-            club.getActive()
+            club.getIsActive()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubsResponse.java
@@ -90,7 +90,7 @@ public record AdminClubsResponse(
                     .toList(),
                 club.getClubCategory().getName(),
                 club.getCreatedAt().toLocalDate(),
-                club.getActive()
+                club.getIsActive()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -263,5 +263,6 @@ public class AdminClubService {
             .toList();
 
         adminClubSnsRepository.saveAll(clubSNSs);
+        clubCreateRedisRepository.delete(clubCreateRedis);
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
@@ -213,9 +214,14 @@ public class AdminClubService {
             paged.stream().map(ClubCreateRedis::getRequesterId).toList()
         ).stream().collect(Collectors.toMap(User::getId, Function.identity()));
 
-        List<AdminClubManagersResponse.InnerClubManagersResponse> responseList = paged.stream()
-            .map(redis -> AdminClubManagersResponse.InnerClubManagersResponse.fromRedis(
-                redis, userMap.get(redis.getRequesterId()))).toList();
+        List<AdminClubManagersResponse.InnerClubManagersResponse> responseList =
+            IntStream.range(0, paged.size())
+                .mapToObj(i -> AdminClubManagersResponse.InnerClubManagersResponse.fromRedis(
+                    paged.get(i),
+                    userMap.get(paged.get(i).getRequesterId()),
+                    i + 1
+                ))
+                .toList();
 
         return new AdminClubManagersResponse(
             (long)totalCount,

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -219,7 +219,7 @@ public class AdminClubService {
                 .mapToObj(i -> AdminClubManagersResponse.InnerClubManagersResponse.fromRedis(
                     paged.get(i),
                     userMap.get(paged.get(i).getRequesterId()),
-                    i + 1
+                    (paged.size() * criteria.getPage()) + (i + 1)
                 ))
                 .toList();
 

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -65,7 +65,7 @@ public interface ClubApi {
     @PutMapping("/{clubId}")
     ResponseEntity<ClubResponse> updateClub(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @RequestBody ClubUpdateRequest request,
+        @RequestBody @Valid ClubUpdateRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 
@@ -82,7 +82,7 @@ public interface ClubApi {
     @PutMapping("/{clubId}/introduction")
     ResponseEntity<ClubResponse> updateClubIntroduction(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @RequestBody ClubIntroductionUpdateRequest request,
+        @RequestBody @Valid ClubIntroductionUpdateRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 
@@ -222,7 +222,7 @@ public interface ClubApi {
         description = """
             - 관리자는 모든 QNA 삭제 가능, 그 외에는 본인의 QNA만 삭제 가능
             - 부모 QNA(질문 QNA)인 경우, 답변 QNA까지 모두 삭제
-            - 자식 QNA(답변 QNA)인 경우, 답변 QNA만 삭제 
+            - 자식 QNA(답변 QNA)인 경우, 답변 QNA만 삭제
             """)
     @DeleteMapping("/{clubId}/qna/{qnaId}")
     ResponseEntity<Void> deleteQna(

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -51,7 +51,7 @@ public class ClubController implements ClubApi {
     @PutMapping("/{clubId}")
     public ResponseEntity<ClubResponse> updateClub(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @RequestBody ClubUpdateRequest request,
+        @RequestBody @Valid ClubUpdateRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
         ClubResponse response = clubService.updateClub(clubId, request, studentId);
@@ -61,7 +61,7 @@ public class ClubController implements ClubApi {
     @PutMapping("/{clubId}/introduction")
     public ResponseEntity<ClubResponse> updateClubIntroduction(
         @Parameter(in = PATH) @PathVariable Integer clubId,
-        @RequestBody ClubIntroductionUpdateRequest request,
+        @RequestBody @Valid ClubIntroductionUpdateRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
         ClubResponse response = clubService.updateClubIntroduction(clubId, request, studentId);

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubCreateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
-    @Size(max = 50, message = "동아리 이름은 최대 50자 입니다.")
+    @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
     String name,
 
@@ -45,7 +45,7 @@ public record ClubCreateRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
-    @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
+    @Size(max = 40, message = "동아리 소개는 최대 40자 입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -45,7 +45,6 @@ public record ClubCreateRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
-    @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
     @NotBlank(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -89,7 +89,7 @@ public record ClubCreateRequest(
         return Club.builder()
             .name(name)
             .lastWeekHits(0)
-            .active(false)
+            .isActive(false)
             .likes(0)
             .hits(0)
             .introduction("")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -45,7 +45,7 @@ public record ClubCreateRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
-    @NotBlank(message = "동아리 소개는 필수 입력 사항입니다.")
+    @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -3,6 +3,8 @@ package in.koreatech.koin.domain.club.dto.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -37,7 +39,6 @@ public record ClubUpdateRequest(
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
     @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
-    @NotBlank(message = "동아리 소개는 필수 입력 사항입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
@@ -71,7 +72,7 @@ public record ClubUpdateRequest(
             .introduction("")
             .imageUrl(imageUrl)
             .clubCategory(clubCategory)
-            .description(description)
+            .description(Objects.requireNonNullElse(description, ""))
             .location(location)
             .isLikeHidden(isLikeHidden)
             .build();

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -19,7 +19,7 @@ import jakarta.validation.constraints.Size;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubUpdateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
-    @Size(max = 50, message = "동아리 이름은 최대 50자 입니다.")
+    @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")
     String name,
 
@@ -38,7 +38,7 @@ public record ClubUpdateRequest(
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
-    @Size(max = 100, message = "동아리 소개는 최대 100자 입니다.")
+    @Size(max = 40, message = "동아리 소개는 최대 40자 입니다.")
     String description,
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -66,7 +66,7 @@ public record ClubUpdateRequest(
         return Club.builder()
             .name(name)
             .lastWeekHits(0)
-            .active(false)
+            .isActive(false)
             .likes(0)
             .hits(0)
             .introduction("")

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -162,13 +162,15 @@ public class Club extends BaseEntity {
         String imageUrl,
         ClubCategory category,
         String location,
-        String description
+        String description,
+        Boolean isLikeHidden
     ) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.clubCategory = category;
         this.location = location;
         this.description = description;
+        this.isLikeHidden = isLikeHidden;
     }
 
     public void updateIntroduction(String introduction) {

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -54,7 +54,7 @@ public class Club extends BaseEntity {
 
     @NotNull
     @Column(name = "is_active", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
-    private Boolean active = FALSE;
+    private Boolean isActive = FALSE;
 
     @NotNull
     @Size(max = 255)
@@ -95,7 +95,7 @@ public class Club extends BaseEntity {
         Integer hits,
         Integer lastWeekHits,
         String description,
-        Boolean active,
+        Boolean isActive,
         String imageUrl,
         Integer likes,
         String location,
@@ -108,7 +108,7 @@ public class Club extends BaseEntity {
         this.hits = hits;
         this.lastWeekHits = lastWeekHits;
         this.description = description;
-        this.active = active;
+        this.isActive = isActive;
         this.imageUrl = imageUrl;
         this.likes = likes;
         this.location = location;
@@ -135,18 +135,18 @@ public class Club extends BaseEntity {
         ClubCategory clubCategory,
         String location,
         String description,
-        Boolean active
+        Boolean isActive
     ) {
         this.name = name;
         this.imageUrl = imageUrl;
         this.clubCategory = clubCategory;
         this.location = location;
         this.description = description;
-        this.active = active;
+        this.isActive = isActive;
     }
 
     public void updateActive(Boolean active) {
-        this.active = active;
+        this.isActive = active;
     }
 
     public void increaseLikes() {

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -117,7 +117,7 @@ public class ClubCreateRedis {
             .likes(0)
             .hits(0)
             .lastWeekHits(0)
-            .active(false)
+            .isActive(false)
             .introduction("")
             .isLikeHidden(this.isLikeHidden)
             .build();

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -41,13 +41,13 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
     List<Club> findByClubCategory(ClubCategory category);
 
-    List<Club> findByClubCategoryOrderByIdAsc(ClubCategory category);
+    List<Club> findByIsActiveTrueAndClubCategoryOrderByIdAsc(ClubCategory category);
 
-    List<Club> findByClubCategoryOrderByHitsDesc(ClubCategory category);
+    List<Club> findByIsActiveTrueAndClubCategoryOrderByHitsDesc(ClubCategory category);
 
-    List<Club> findByOrderByHitsDesc();
+    List<Club> findByIsActiveTrueOrderByHitsDesc();
 
-    List<Club> findByOrderByIdAsc();
+    List<Club> findByIsActiveTrueOrderByIdAsc();
 
     void deleteById(Integer id);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -132,6 +132,9 @@ public class ClubService {
     @Transactional
     public ClubResponse getClub(Integer clubId, Integer userId) {
         Club club = clubRepository.getByIdWithPessimisticLock(clubId);
+        if (!club.getIsActive()) {
+            throw new IllegalStateException("비활성화 동아리입니다.");
+        }
         club.increaseHits();
         List<ClubSNS> clubSNSs = clubSNSRepository.findAllByClub(club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, userId);
@@ -152,14 +155,14 @@ public class ClubService {
     private List<Club> getClubs(Integer categoryId, ClubSortType sortType) {
         if (categoryId == null) {
             return sortType.equals(HITS_DESC)
-                ? clubRepository.findByOrderByHitsDesc()
-                : clubRepository.findByOrderByIdAsc();
+                ? clubRepository.findByIsActiveTrueOrderByHitsDesc()
+                : clubRepository.findByIsActiveTrueOrderByIdAsc();
         }
 
         ClubCategory category = clubCategoryRepository.getById(categoryId);
         return sortType.equals(HITS_DESC)
-            ? clubRepository.findByClubCategoryOrderByHitsDesc(category)
-            : clubRepository.findByClubCategoryOrderByIdAsc(category);
+            ? clubRepository.findByIsActiveTrueAndClubCategoryOrderByHitsDesc(category)
+            : clubRepository.findByIsActiveTrueAndClubCategoryOrderByIdAsc(category);
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -81,7 +81,7 @@ public class ClubService {
         isClubManager(clubId, studentId);
 
         ClubCategory clubCategory = clubCategoryRepository.getById(request.clubCategoryId());
-        club.update(request.name(), request.imageUrl(), clubCategory, request.location(), request.description());
+        club.update(request.name(), request.imageUrl(), clubCategory, request.location(), request.description(), request.isLikeHidden());
 
         List<ClubSNS> newSNS = updateClubSNS(request, club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, studentId);

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -232,7 +232,7 @@ public class ClubService {
         clubQnaRepository.save(qna);
     }
 
-    private static void validateQnaCreateAuthorization(Integer studentId, boolean isQuestion, boolean isManager) {
+    private void validateQnaCreateAuthorization(Integer studentId, boolean isQuestion, boolean isManager) {
         if (isQuestion == isManager) {
             throw AuthorizationException.withDetail("studentId: " + studentId);
         }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1614 

# 🚀 작업 내용

- @Valid 어노테이션 추가했습니다.
- 요청 DTO 필수/선택값 확인 후 수정했습니다. 
- 어드민 응답값에 user_id, index 추가했습니다.
- Normal 동아리 조회 시 활성화 동아리만 조회되도록 수정했습니다.
- DTO 요청값 길이 제한 수정했습니다.
  - 동아리 이름 : 20자
  - 동아리 소개 : 40자
  - 동아리 직책 : 10자
- 동아리 요청 승인/반려 시 레디스 데이터 삭제 로직 추가했습니다.
- 동아리 정보 수정 시 좋아요 숨김이 업데이트 안되는 로직 수정했습니다.

# 💬 리뷰 중점사항
얼추 다 쳐낸거 같은데.. 크로스 체크 부탁드립니다 !