### PR TITLE
fix: 코인 어드민 동아리 Index 응답값 계산 수식 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/response/AdminClubManagersResponse.java
@@ -97,7 +97,7 @@ public record AdminClubManagersResponse(
             criteria.getPage() + 1,
             IntStream.range(0, pagedResult.getContent().size())
                 .mapToObj(i -> InnerClubManagersResponse.from(pagedResult.getContent().get(i),
-                    (pagedResult.getContent().size() * (criteria.getPage())) + (i + 1)))
+                    (criteria.getLimit() * criteria.getPage()) + (i + 1)))
                 .toList()
         );
     }

--- a/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
+++ b/src/main/java/in/koreatech/koin/admin/club/service/AdminClubService.java
@@ -219,7 +219,7 @@ public class AdminClubService {
                 .mapToObj(i -> AdminClubManagersResponse.InnerClubManagersResponse.fromRedis(
                     paged.get(i),
                     userMap.get(paged.get(i).getRequesterId()),
-                    (paged.size() * criteria.getPage()) + (i + 1)
+                    (criteria.getLimit() * criteria.getPage()) + (i + 1)
                 ))
                 .toList();
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1617 

# 🚀 작업 내용

- 코인 어드민 동아리 Index 응답값 계산 수식을 수정했습니다.
  - (최대 조회 개수 * 현재 페이지) + (현재 동아리 순번)

# 💬 리뷰 중점사항
능지 이슈