### PR TITLE
fix: 코인 동아리 QA 2차 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -81,7 +81,7 @@ public record AdminClubCreateRequest(
         return Club.builder()
             .name(name)
             .lastWeekHits(0)
-            .isActive(false)
+            .isActive(true)
             .likes(0)
             .hits(0)
             .introduction("")

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.validation.NotEmoji;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
 import in.koreatech.koin.domain.club.model.ClubManager;
@@ -24,6 +25,7 @@ public record AdminClubCreateRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
+    @NotEmoji
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -42,6 +44,7 @@ public record AdminClubCreateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmoji
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
@@ -50,18 +53,22 @@ public record AdminClubCreateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
+    @NotEmoji
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
+    @NotEmoji
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
+    @NotEmoji
     String openChat,
 
     @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
+    @NotEmoji
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.validation.NotEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ public record AdminClubManagerDecideRequest(
     @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
+    @NotEmoji
     String clubName,
 
     @Schema(description = "동아리 관리자 승인 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.validation.NotEmoji;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.user.model.User;
@@ -22,6 +23,7 @@ public record AdminClubModifyRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
+    @NotEmoji
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -40,6 +42,7 @@ public record AdminClubModifyRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmoji
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
@@ -52,18 +55,22 @@ public record AdminClubModifyRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
+    @NotEmoji
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
+    @NotEmoji
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
+    @NotEmoji
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
+    @NotEmoji
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.validation.NotEmoji;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
 import in.koreatech.koin.domain.club.model.ClubManager;
@@ -24,6 +25,7 @@ public record ClubCreateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
+    @NotEmoji
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -42,6 +44,7 @@ public record ClubCreateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmoji
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
@@ -50,22 +53,27 @@ public record ClubCreateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
+    @NotEmoji
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
+    @NotEmoji
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
+    @NotEmoji
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
+    @NotEmoji
     String phoneNumber,
 
     @Schema(description = "동아리 내 역할", example = "회장", requiredMode = REQUIRED)
     @NotBlank(message = "동아리 내 역할은 필수 입력 사항입니다.")
+    @NotEmoji
     String role,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.validation.NotEmoji;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,6 +22,7 @@ public record ClubUpdateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")
+    @NotEmoji
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -35,6 +37,7 @@ public record ClubUpdateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
+    @NotEmoji
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
@@ -43,18 +46,22 @@ public record ClubUpdateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
+    @NotEmoji
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
+    @NotEmoji
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
+    @NotEmoji
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
+    @NotEmoji
     String phoneNumber,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1619 

# 🚀 작업 내용

- 어드민 API를 통해 만든 동아리 활성화 기본값을 `true` 으로 변경했습니다.
- 동아리 이름, 위치, 직책, SNS에 이모지를 작성하지 못하도록 검증 어노테이션을 추가했습니다. 

# 💬 리뷰 중점사항
