### PR TITLE
fix: 코인 동아리 NotEmoji 에러 메시지 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/GlobalExceptionHandler.java
@@ -267,7 +267,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         requestLogging(request);
         String errorMessages = e.getBindingResult().getAllErrors().stream()
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
-            .collect(Collectors.joining(", "));
+            .collect(Collectors.joining("\n"));
         return buildErrorResponse(HttpStatus.BAD_REQUEST, errorMessages);
     }
 

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -25,7 +25,7 @@ public record AdminClubCreateRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 이름에는 이모지가 들어갈 수 없습니다.")
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -44,7 +44,7 @@ public record AdminClubCreateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 위치에는 이모지가 들어갈 수 없습니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
@@ -53,22 +53,22 @@ public record AdminClubCreateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "인스타그램 링크에는 이모지가 들어갈 수 없습니다.")
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "구글폼 링크에는 이모지가 들어갈 수 없습니다.")
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "오픈 채팅 링크에는 이모지가 들어갈 수 없습니다.")
     String openChat,
 
-    @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = NOT_REQUIRED)
+    @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "전화번호에는 이모지가 들어갈 수 없습니다.")
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubManagerDecideRequest.java
@@ -16,7 +16,7 @@ public record AdminClubManagerDecideRequest(
     @Schema(description = "동아리 이름", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 이름에는 이모지가 들어갈 수 없습니다.")
     String clubName,
 
     @Schema(description = "동아리 관리자 승인 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -23,7 +23,7 @@ public record AdminClubModifyRequest(
     @Schema(description = "동아리 이름", example = "BCSD Lab", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 이름에는 이모지가 들어갈 수 없습니다.")
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -42,7 +42,7 @@ public record AdminClubModifyRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 위치에는 이모지가 들어갈 수 없습니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
@@ -55,22 +55,22 @@ public record AdminClubModifyRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "인스타그램 링크에는 이모지가 들어갈 수 없습니다.")
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "구글폼 링크에는 이모지가 들어갈 수 없습니다.")
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "오픈 채팅 링크에는 이모지가 들어갈 수 없습니다.")
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "전화번호에는 이모지가 들어갈 수 없습니다.")
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -25,7 +25,7 @@ public record ClubCreateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotBlank(message = "동아리 이름은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 이름에는 이모지가 들어갈 수 없습니다.")
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -44,7 +44,7 @@ public record ClubCreateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 위치에는 이모지가 들어갈 수 없습니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = NOT_REQUIRED)
@@ -53,27 +53,27 @@ public record ClubCreateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "인스타그램 링크에는 이모지가 들어갈 수 없습니다.")
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "구글폼 링크에는 이모지가 들어갈 수 없습니다.")
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "오픈 채팅 링크에는 이모지가 들어갈 수 없습니다.")
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "전화번호에는 이모지가 들어갈 수 없습니다.")
     String phoneNumber,
 
     @Schema(description = "동아리 내 역할", example = "회장", requiredMode = REQUIRED)
     @NotBlank(message = "동아리 내 역할은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 내 역할에는 이모지가 들어갈 수 없습니다.")
     String role,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -22,7 +22,7 @@ public record ClubUpdateRequest(
     @Schema(description = "동아리명", example = "BCSD", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 이름은 최대 20자 입니다.")
     @NotEmpty(message = "동아리 이름은 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 이름에는 이모지가 들어갈 수 없습니다.")
     String name,
 
     @Schema(description = "동아리 사진 링크", example = "https://bcsdlab.com/static/img/logo.d89d9cc.png", requiredMode = REQUIRED)
@@ -37,7 +37,7 @@ public record ClubUpdateRequest(
     @Schema(description = "동아리 위치", example = "학생회관", requiredMode = REQUIRED)
     @Size(max = 20, message = "동아리 위치는 최대 20자 입니다.")
     @NotBlank(message = "동아리 위치는 필수 입력 사항입니다.")
-    @NotEmoji
+    @NotEmoji(message = "동아리 위치에는 이모지가 들어갈 수 없습니다.")
     String location,
 
     @Schema(description = "동아리 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리", requiredMode = REQUIRED)
@@ -46,22 +46,22 @@ public record ClubUpdateRequest(
 
     @Schema(description = "인스타그램 링크", example = "https://www.instagram.com/bcsdlab/", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "인스타그램 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "인스타그램 링크에는 이모지가 들어갈 수 없습니다.")
     String instagram,
 
     @Schema(description = "구글 폼 링크", example = "https://forms.gle/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "구글폼 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "구글폼 링크에는 이모지가 들어갈 수 없습니다.")
     String googleForm,
 
     @Schema(description = "오픈 채팅 링크", example = "https://open.kakao.com/example", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "오픈 채팅 링크는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "오픈 채팅 링크에는 이모지가 들어갈 수 없습니다.")
     String openChat,
 
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
-    @NotEmoji
+    @NotEmoji(message = "전화번호에는 이모지가 들어갈 수 없습니다.")
     String phoneNumber,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1621 

# 🚀 작업 내용

- NotEmoji 어노테이션에서 뱉은 에러 메시지를 상황에 맞게 수정했습니다.
- handleMethodArgumentNotValid 에러 메시지를 개행으로 묶었습니다.

# 💬 리뷰 중점사항
