### PR TITLE
hotfix: TransactionalEventListener BEFORE_COMMIT readonly 오류 핫픽스 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.ArticleKeywordEvent;
@@ -35,7 +34,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
     private final KeywordService keywordService;
     private final ArticleRepository articleRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onKeywordRequest(ArticleKeywordEvent event) {
         Article article = articleRepository.getById(event.articleId());
         Board board = article.getBoard();
@@ -50,7 +49,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             .map(subscribe -> createAndRecordNotification(article, board, event.keyword(), subscribe))
             .toList();
 
-        notificationService.push(notifications);
+        notificationService.pushNotifications(notifications);
     }
 
     private boolean hasDeviceToken(NotificationSubscribe subscribe) {

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -6,6 +6,7 @@ import static in.koreatech.koin.domain.notification.model.NotificationSubscribeT
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈니스로직 제거 및 알림 책임만 갖도록)
 
     private final NotificationService notificationService;

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -4,6 +4,7 @@ import static in.koreatech.koin._common.model.MobileAppPath.DINING;
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.DINING_IMAGE_UPLOAD;
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.DINING_SOLD_OUT;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로직 제거 및 알림 책임만 갖도록)
 
     private final NotificationService notificationService;

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.notification.model.NotificationSubscribeT
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.DINING_SOLD_OUT;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.DiningImageUploadEvent;
@@ -27,7 +26,7 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
     private final NotificationFactory notificationFactory;
     private final DiningSoldOutCacheRepository diningSoldOutCacheRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
         diningSoldOutCacheRepository.save(DiningSoldOutCache.from(event.place()));
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
@@ -45,10 +44,10 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
                 event.place(),
                 subscribe.getUser()
             )).toList();
-        notificationService.push(notifications);
+        notificationService.pushNotifications(notifications);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onDiningImageUploadRequest(DiningImageUploadEvent event) {
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailTypeIsNull(DINING_IMAGE_UPLOAD).stream()
@@ -60,6 +59,6 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
                 subscribe.getUser()
             )).toList();
 
-        notificationService.push(notifications);
+        notificationService.pushNotifications(notifications);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/NotificationEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.notification.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class NotificationEventListener { // TODO : 리팩터링 필요 (비즈니스로직 제거 및 알림 책임만 갖도록)
 
     private final NotificationService notificationService;

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/NotificationEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/NotificationEventListener.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.notification.eventlistener;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.UserRegisterEvent;
@@ -15,7 +14,7 @@ public class NotificationEventListener { // TODO : 리팩터링 필요 (비즈�
 
     private final NotificationService notificationService;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onUserRegisterEvent(UserRegisterEvent event) {
         if (event.marketingNotificationAgreement()) {
             notificationService.permitNotificationSubscribe(event.userId(), NotificationSubscribeType.MARKETING);

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ShopEventListener.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.domain.notification.model.NotificationSubscribeT
 
 import java.util.List;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class ShopEventListener { // TODO : 리팩터링 필요 (비즈니스로직 제거 및 알림 책임만 갖도록)
 
     private final NotificationService notificationService;

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ShopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ShopEventListener.java
@@ -6,7 +6,6 @@ import static in.koreatech.koin.domain.notification.model.NotificationSubscribeT
 import java.util.List;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.EventArticleCreateShopEvent;
@@ -24,7 +23,7 @@ public class ShopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
     private final NotificationFactory notificationFactory;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onShopEventCreate(EventArticleCreateShopEvent event) {
         List<Notification> notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailTypeIsNull(SHOP_EVENT)
@@ -38,6 +37,6 @@ public class ShopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
                 event.title(),
                 subscribe.getUser()
             )).toList();
-        notificationService.push(notifications);
+        notificationService.pushNotifications(notifications);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NotificationService {
 
     private final UserRepository userRepository;
@@ -28,13 +29,14 @@ public class NotificationService {
     private final FcmClient fcmClient;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
 
-    public void push(List<Notification> notifications) {
+    public void pushNotifications(List<Notification> notifications) {
         for (Notification notification : notifications) {
-            push(notification);
+            pushNotification(notification);
         }
     }
 
-    public void push(Notification notification) {
+    @Transactional
+    public void pushNotification(Notification notification) {
         notificationRepository.save(notification);
         String deviceToken = notification.getUser().getDeviceToken();
         fcmClient.sendMessage(

--- a/src/main/java/in/koreatech/koin/domain/shop/cache/ShopsCacheRefreshListener.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/cache/ShopsCacheRefreshListener.java
@@ -23,7 +23,7 @@ public class ShopsCacheRefreshListener {
         shopsCacheService.refreshShopsCache();
     }
 
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onShopsCacheRefresh(ShopsCacheRefreshEvent event) {
         shopsCacheService.refreshShopsCache();
     }

--- a/src/main/java/in/koreatech/koin/domain/shop/service/NotificationScheduleService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/NotificationScheduleService.java
@@ -53,7 +53,7 @@ public class NotificationScheduleService {
             })
             .toList();
 
-        notificationService.push(notifications);
+        notificationService.pushNotifications(notifications);
         shopReviewNotificationRedisRepository.deleteSentNotifications(dueNotifications);
     }
 

--- a/src/main/java/in/koreatech/koin/infrastructure/email/eventlistener/EmailEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/email/eventlistener/EmailEventListener.java
@@ -21,19 +21,19 @@ public class EmailEventListener {
 
     private final EmailService emailService;
 
-    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onUserEmailVerificationSendEvent(UserEmailVerificationSendEvent event) {
         EmailForm emailForm = new UserVerificationEmailForm(event.verificationCode());
         emailService.sendVerificationEmail(event.email(), emailForm);
     }
 
-    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onStudentEmailRequestEvent(StudentRegisterRequestEvent event) {
         EmailForm emailForm = new StudentRegisterRequestEmailForm(event.serverUrl(), event.authToken());
         emailService.sendVerificationEmail(event.email(), emailForm);
     }
 
-    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onStudentFindPasswordEvent(StudentFindPasswordEvent event) {
         EmailForm emailForm = new StudentFindPasswordEmailForm(event.serverUrl(), event.resetToken());
         emailService.sendVerificationEmail(event.email(), emailForm);

--- a/src/main/java/in/koreatech/koin/infrastructure/email/eventlistener/EmailEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/email/eventlistener/EmailEventListener.java
@@ -1,22 +1,22 @@
 package in.koreatech.koin.infrastructure.email.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.BEFORE_COMMIT;
-
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import in.koreatech.koin._common.event.StudentRegisterRequestEvent;
 import in.koreatech.koin._common.event.StudentFindPasswordEvent;
+import in.koreatech.koin._common.event.StudentRegisterRequestEvent;
 import in.koreatech.koin._common.event.UserEmailVerificationSendEvent;
+import in.koreatech.koin.infrastructure.email.form.EmailForm;
 import in.koreatech.koin.infrastructure.email.form.StudentFindPasswordEmailForm;
 import in.koreatech.koin.infrastructure.email.form.StudentRegisterRequestEmailForm;
-import in.koreatech.koin.infrastructure.email.service.EmailService;
-import in.koreatech.koin.infrastructure.email.form.EmailForm;
 import in.koreatech.koin.infrastructure.email.form.UserVerificationEmailForm;
+import in.koreatech.koin.infrastructure.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class EmailEventListener {
 
     private final EmailService emailService;

--- a/src/main/java/in/koreatech/koin/infrastructure/naver/eventlistener/NaverSmsEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/naver/eventlistener/NaverSmsEventListener.java
@@ -16,12 +16,12 @@ public class NaverSmsEventListener {
 
     private final NaverSmsService naverSmsService;
 
-    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onUserSmsVerificationSendEvent(UserSmsVerificationSendEvent event) {
         naverSmsService.sendVerificationCode(event.verificationCode(), event.phoneNumber());
     }
 
-    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    @TransactionalEventListener
     public void onOwnerSmsVerificationSendEvent(OwnerSmsVerificationSendEvent event) {
         naverSmsService.sendVerificationCode(event.verificationCode(), event.phoneNumber());
     }

--- a/src/main/java/in/koreatech/koin/infrastructure/naver/eventlistener/NaverSmsEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/naver/eventlistener/NaverSmsEventListener.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.infrastructure.naver.eventlistener;
 
 import static org.springframework.transaction.event.TransactionPhase.*;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class NaverSmsEventListener {
 
     private final NaverSmsService naverSmsService;

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/eventlistener/S3EventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/eventlistener/S3EventListener.java
@@ -1,7 +1,5 @@
 package in.koreatech.koin.infrastructure.s3.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.*;
-
 import java.util.List;
 
 import org.springframework.context.annotation.Profile;
@@ -26,21 +24,21 @@ public class S3EventListener {
     private final CloudFrontClientWrapper cloudFrontClientWrapper;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onImageDeleted(ImageDeletedEvent event) {
         String s3Key = s3Client.extractKeyFromUrl(event.imageUrl());
         s3Client.deleteFile(s3Key);
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onImagesDeleted(ImagesDeletedEvent event) {
         List<String> s3Keys = s3Client.extractKeysFromUrls(event.imageUrls());
         s3Client.deleteFiles(s3Keys);
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onSensitiveImageDeleted(ImageSensitiveDeletedEvent event) {
         String s3Key = s3Client.extractKeyFromUrl(event.imageUrl());
         s3Client.deleteFile(s3Key);
@@ -48,7 +46,7 @@ public class S3EventListener {
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onSensitiveImagesDeleted(ImagesSensitiveDeletedEvent event) {
         List<String> s3Keys = s3Client.extractKeysFromUrls(event.imageUrls());
         s3Client.deleteFiles(s3Keys);

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class ClubEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ClubEventListener.java
@@ -1,11 +1,7 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.ClubCreateEvent;
@@ -15,15 +11,14 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class ClubEventListener {
 
     private final SlackClient slackClient;
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void onClubCreateEvent(ClubCreateEvent event){
+    @TransactionalEventListener
+    public void onClubCreateEvent(ClubCreateEvent event) {
         var notification = slackNotificationFactory.generateClubCreateSendNotification(event.clubName());
         slackClient.sendMessage(notification);
     }

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/LostItemReportEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/LostItemReportEventListener.java
@@ -1,11 +1,7 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.LostItemReportEvent;
@@ -16,14 +12,13 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = REQUIRES_NEW)
 public class LostItemReportEventListener {
 
     private final SlackClient slackClient;
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onLostItemReportRegister(LostItemReportEvent event) {
         SlackNotification notification = slackNotificationFactory.generateLostItemReportNotification(
             event.lostItemArticleId());

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/LostItemReportEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/LostItemReportEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class LostItemReportEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/OwnerEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class OwnerEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/OwnerEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/OwnerEventListener.java
@@ -1,11 +1,7 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.OwnerRegisterEvent;
@@ -16,14 +12,13 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class OwnerEventListener {
 
     private final SlackClient slackClient;
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onOwnerPhoneRequest(OwnerSmsVerificationSendEvent ownerPhoneRequestEvent) {
         var notification = slackNotificationFactory.generateOwnerPhoneVerificationRequestNotification(
             ownerPhoneRequestEvent.phoneNumber());
@@ -31,7 +26,7 @@ public class OwnerEventListener {
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onOwnerRegisterBySms(OwnerRegisterEvent event) {
         var notification = slackNotificationFactory.generateOwnerRegisterRequestNotification(
             event.ownerName(),

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ReviewEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ReviewEventListener.java
@@ -1,11 +1,7 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.ReviewRegisterEvent;
@@ -16,14 +12,13 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class ReviewEventListener {
 
     private final SlackClient slackClient;
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onReviewRegister(ReviewRegisterEvent event) {
         var notification = slackNotificationFactory.generateReviewRegisterNotification(
             event.shop(),
@@ -34,7 +29,7 @@ public class ReviewEventListener {
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onReviewReportRegister(ReviewReportEvent event) {
         var notification = slackNotificationFactory.generateReviewReportNotification(event.shop());
         slackClient.sendMessage(notification);

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ReviewEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/ReviewEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class ReviewEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/StudentEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/StudentEventListener.java
@@ -1,9 +1,8 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.StudentRegisterEvent;
@@ -14,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = Propagation.REQUIRES_NEW)
+@Profile("!test")
 public class StudentEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/StudentEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/StudentEventListener.java
@@ -1,15 +1,13 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import in.koreatech.koin._common.event.StudentRegisterRequestEvent;
 import in.koreatech.koin._common.event.StudentRegisterEvent;
+import in.koreatech.koin._common.event.StudentRegisterRequestEvent;
 import in.koreatech.koin.infrastructure.slack.client.SlackClient;
 import in.koreatech.koin.infrastructure.slack.model.SlackNotificationFactory;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +21,14 @@ public class StudentEventListener {
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onStudentRegisterRequestEvent(StudentRegisterRequestEvent event) {
         var notification = slackNotificationFactory.generateStudentEmailVerificationRequestNotification(event.email());
         slackClient.sendMessage(notification);
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onStudentRegisterEvent(StudentRegisterEvent event) {
         var notification = slackNotificationFactory.generateStudentRegisterCompleteNotification(event.email());
         slackClient.sendMessage(notification);

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/UserEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/UserEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class UserEventListener {
 
     private final SlackClient slackClient;

--- a/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/UserEventListener.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/slack/eventlistener/UserEventListener.java
@@ -1,11 +1,7 @@
 package in.koreatech.koin.infrastructure.slack.eventlistener;
 
-import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin._common.event.UserDeleteEvent;
@@ -17,21 +13,20 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class UserEventListener {
 
     private final SlackClient slackClient;
     private final SlackNotificationFactory slackNotificationFactory;
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onUserDeleteEvent(UserDeleteEvent event) {
         var notification = slackNotificationFactory.generateUserDeleteNotification(event.email(), event.userType());
         slackClient.sendMessage(notification);
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onUserSmsVerificationSendEvent(UserSmsVerificationSendEvent userSmsVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserPhoneVerificationSendNotification(
             userSmsVerificationSendEvent.phoneNumber());
@@ -39,7 +34,7 @@ public class UserEventListener {
     }
 
     @Async
-    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @TransactionalEventListener
     public void onUserEmailVerificationSendEvent(UserEmailVerificationSendEvent userEmailVerificationSendEvent) {
         var notification = slackNotificationFactory.generateUserEmailVerificationSendNotification(
             userEmailVerificationSendEvent.email());

--- a/src/main/java/in/koreatech/koin/socket/domain/notification/service/MessageReceivedEventListener.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/notification/service/MessageReceivedEventListener.java
@@ -57,7 +57,7 @@ public class MessageReceivedEventListener {
             partner
         );
 
-        notificationService.push(notification);
+        notificationService.pushNotification(notification);
     }
 
     /**

--- a/src/main/java/in/koreatech/koin/socket/domain/notification/service/MessageReceivedEventListener.java
+++ b/src/main/java/in/koreatech/koin/socket/domain/notification/service/MessageReceivedEventListener.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.socket.domain.notification.service;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class MessageReceivedEventListener {
 
     private final NotificationService notificationService;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1631 

# 🚀 작업 내용

1. TransactionalEventListener가 BEFORE_COMMIT 상태여서 transactional readonly 이 전파되는 오류해결
2. 테스트시 빈 생성 방지

