### PR TITLE
fix: 유저와 학생 회원가입 및 업데이트 유효성 검사 통일

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/RegisterStudentRequestV2.java
@@ -16,47 +16,69 @@ import in.koreatech.koin.domain.user.model.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record RegisterStudentRequestV2(
-    @NotBlank(message = "이름은 필수입니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @NotBlank(message = "이름은 필수입니다.")
     @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
-    @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)
+    @Schema(description = "닉네임", example = "캔따개", requiredMode = NOT_REQUIRED)
+    @Size(max = 10, message = "닉네임은 최대 10자입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname,
 
-    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
-    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
+    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = NOT_REQUIRED)
+    @Size(max = 30, message = "이메일의 길이는 최대 30자 입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
 
-    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     @Schema(description = "휴대폰 번호", example = "01012341234", requiredMode = REQUIRED)
+    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
+    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = REQUIRED)
+    @NotNull(message = "성별은 필수입니다.")
+    UserGender gender,
+
+    @Schema(
+        description = """
+            전공
+            - 기계공학부
+            - 컴퓨터공학부
+            - 메카트로닉스공학부
+            - 전기전자통신공학부
+            - 디자인공학부
+            - 건축공학부
+            - 화학생명공학부
+            - 에너지신소재공학부
+            - 산업경영학부
+            - 고용서비스정책학과
+            """,
+        example = "컴퓨터공학부",
+        requiredMode = REQUIRED
+    )
+    @NotBlank(message = "전공은 필수입니다.")
+    String department,
+
+    @Schema(description = "학번", example = "2025000123", requiredMode = REQUIRED)
     @NotBlank(message = "학번은 필수입니다.")
-    @Schema(description = "학번", example = "2025000123", requiredMode = NOT_REQUIRED)
     @Pattern(regexp = "^[0-9]{8,10}$", message = "학번엔 8-10자리 숫자만 입력 가능합니다.")
     String studentNumber,
 
-    @NotBlank(message = "학부는 필수입니다.")
-    @Schema(description = "학부", example = "컴퓨터공학부", requiredMode = REQUIRED)
-    String department,
-
-    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
-    UserGender gender,
-
-    @NotBlank(message = "아이디는 필수입니다.")
     @Schema(description = "사용자 아이디", example = "example123", requiredMode = REQUIRED)
+    @NotBlank(message = "아이디는 필수입니다.")
     @Pattern(regexp = "^[A-Za-z0-9._-]{5,13}$", message = "5-13자의 영문자, 숫자, 특수문자만 사용할 수 있습니다.")
     String loginId,
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 64, max = 64, message = "비밀번호 해시값은 16진수 64자여야 합니다.")
     String password,
 
     @Schema(description = "마케팅 수신 동의 여부", example = "true", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/student/dto/UpdateStudentRequestV2.java
+++ b/src/main/java/in/koreatech/koin/domain/student/dto/UpdateStudentRequestV2.java
@@ -1,18 +1,23 @@
 package in.koreatech.koin.domain.student.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.user.model.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record UpdateStudentRequestV2(
-    @Schema(description = "이름", example = "최준호", requiredMode = NOT_REQUIRED)
+    @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @NotBlank(message = "이름은 필수입니다.")
     @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
@@ -21,16 +26,19 @@ public record UpdateStudentRequestV2(
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname,
 
-    @Schema(description = "휴대폰 번호", example = "01012345678", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.")
-    String phoneNumber,
-
     @Schema(description = "이메일 주소", example = "koin123@koreatech.ac.kr", requiredMode = NOT_REQUIRED)
     @Size(max = 30, message = "이메일의 길이는 최대 30자 입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
 
-    @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = NOT_REQUIRED)
-    String password,
+    @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = REQUIRED)
+    @NotBlank(message = "휴대폰 번호는 필수 입력입니다.")
+    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.") //TODO: 강업 후 11자리 숫자만 허용
+    String phoneNumber,
+
+    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = REQUIRED)
+    @NotNull(message = "성별은 필수입니다.")
+    UserGender gender,
 
     @Schema(
         description = """
@@ -47,16 +55,20 @@ public record UpdateStudentRequestV2(
             - 고용서비스정책학과
             """,
         example = "컴퓨터공학부",
-        requiredMode = NOT_REQUIRED
+        requiredMode = REQUIRED
     )
+    @NotBlank(message = "전공은 필수입니다.")
     String major,
 
-    @Schema(description = "학번", example = "2021136012", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^[0-9]{10}$", message = "학번엔 10자리 숫자만 입력 가능합니다.")
+    @Schema(description = "학번", example = "2025000123", requiredMode = REQUIRED)
+    @NotBlank(message = "학번은 필수입니다.")
+    @Pattern(regexp = "^[0-9]{8,10}$", message = "학번엔 8-10자리 숫자만 입력 가능합니다.")
     String studentNumber,
 
-    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
-    UserGender gender
+    @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 64, max = 64, message = "비밀번호 해시값은 16진수 64자여야 합니다.")
+    String password
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserRegisterRequest.java
@@ -14,39 +14,44 @@ import in.koreatech.koin.domain.user.model.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record UserRegisterRequest(
-    @NotBlank(message = "이름은 필수입니다.")
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @NotBlank(message = "이름은 필수입니다.")
     @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
-    @Schema(description = "닉네임", example = "캔따개", requiredMode = REQUIRED)
-    @Pattern(regexp = "\\S+", message = "빈 문자열일 수 없습니다.")
+    @Schema(description = "닉네임", example = "캔따개", requiredMode = NOT_REQUIRED)
+    @Size(max = 10, message = "닉네임은 최대 10자입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname,
 
-    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = REQUIRED)
-    @Email(message = "이메일 형식을 지켜주세요. ${validatedValue}")
-    @Pattern(regexp = "\\S+", message = "빈 문자열일 수 없습니다.")
+    @Schema(description = "이메일", example = "koin123@koreatech.ac.kr", requiredMode = NOT_REQUIRED)
+    @Size(max = 30, message = "이메일의 길이는 최대 30자 입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
 
-    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     @Schema(description = "휴대폰 번호", example = "01012341234", requiredMode = REQUIRED)
+    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
+    @NotNull(message = "성별은 필수입니다.")
     UserGender gender,
 
-    @NotBlank(message = "아이디는 필수입니다.")
     @Schema(description = "로그인 아이디", example = "example123", requiredMode = REQUIRED)
+    @NotBlank(message = "아이디는 필수입니다.")
     @Pattern(regexp = "^[A-Za-z0-9._-]{5,13}$", message = "5-13자의 영문자, 숫자, 특수문자만 사용할 수 있습니다.")
     String loginId,
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 64, max = 64, message = "비밀번호 해시값은 16진수 64자여야 합니다.")
     String password,
 
     @Schema(description = "마케팅 수신 동의 여부", example = "true", requiredMode = NOT_REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/user/dto/UserUpdateRequest.java
@@ -8,32 +8,41 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.user.model.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record UserUpdateRequest(
-    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = NOT_REQUIRED)
-    UserGender gender,
-
-    @Schema(description = "이메일 주소", example = "general123@naver.com", requiredMode = NOT_REQUIRED)
-    @Size(max = 30, message = "이메일의 길이는 최대 30자 입니다.")
-    String email,
-
     @Schema(description = "이름", example = "최준호", requiredMode = REQUIRED)
+    @NotBlank(message = "이름은 필수입니다.")
     @Pattern(regexp = "^(?:[가-힣]{2,5}|[A-Za-z]{2,30})$", message = "한글은 2-5자, 영문은 2-30자 이어야 합니다.")
     String name,
 
-    @Schema(description = "닉네임", example = "juno", requiredMode = NOT_REQUIRED)
+    @Schema(description = "닉네임", example = "캔따개", requiredMode = NOT_REQUIRED)
     @Size(max = 10, message = "닉네임은 최대 10자입니다.")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$", message = "한글, 영문 및 숫자만 사용할 수 있습니다.")
     String nickname,
 
-    @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = NOT_REQUIRED)
-    @Pattern(regexp = "^(\\d{3}-\\d{3,4}-\\d{4}|\\d{10,11})$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "이메일 주소", example = "general123@naver.com", requiredMode = NOT_REQUIRED)
+    @Size(max = 30, message = "이메일의 길이는 최대 30자 입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    String email,
+
+    @Schema(description = "휴대폰 번호", example = "010-1234-5678 또는 01012345678", requiredMode = REQUIRED)
+    @NotBlank(message = "휴대폰 번호는 필수 입력입니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
-    @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = NOT_REQUIRED)
+    @Schema(description = "성별(남:0, 여:1)", example = "0", requiredMode = REQUIRED)
+    @NotNull(message = "성별은 필수입니다.")
+    UserGender gender,
+
+    @Schema(description = "비밀번호 (SHA 256 해싱된 값)", example = "cd06f8c2b0dd065faf6...", requiredMode = REQUIRED)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 64, max = 64, message = "비밀번호 해시값은 16진수 64자여야 합니다.")
     String password
 ) {
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1611 

# 🚀 작업 내용

- [x] PUT v2/users/me에 수정된 정보를 보낼 때, 이메일 형식 검증 오류
- [x] PUT user/student/me 이메일 검증
- [x] PUT v2/users/students/me 학번 검증로직 불일치
- [x] 정보 수정 시 이메일 빈 값 요청 409 상태코드 발생 -> 이전 리팩토링에서 처리 완료

