### PR TITLE
feat: 주문 가능 상점 정보 단건 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -106,27 +106,27 @@ public interface OrderableShopApi {
         }
     )
     @Operation(summary = "주문 가능한 모든 상점 조회", description = """
-            ### 주문 가능한 상점 정보 조회
-            - **정렬 기준**
-                - **null**: 가나다순 (기본)
-                - **NONE**: 가나다순 (기본)
-                - **COUNT**: 리뷰 개수 내림차순
-                - **COUNT_ASC**: 리뷰 개수 오름차순
-                - **COUNT_DESC**: 리뷰 개수 내림차순
-                - **RATING**: 평점 수 내림차순
-                - **RATING_ASC**: 평점 수 오름차순
-                - **RATING_DESC**: 평점 수 내림차순
-            - **적용 필터**
-                - **IS_OPEN**: 현재 영업 중인 상점
-                - **DELIVERY_AVAILABLE**: 배달 가능한 상점
-                - **TAKEOUT_AVAILABLE**: 포장 가능한 상점
-                - **FREE_DELIVERY_TIP**: 배달비 무료 상점
-            - **최소 주문 금액 필터**: minimum_order_amount. 해당 최소 주문 금액 이하의 상점을 반환
-            - **open_status**: 현재 요일과 시간을 고려 하여 상점의 영업 상태를 결정.
-                - **OPERATING**: 영업중
-                - **PREPARING**: 영업 준비중
-                - **CLOSED**: 영업 종료
-            """)
+        ### 주문 가능한 상점 정보 조회
+        - **정렬 기준**
+            - **null**: 가나다순 (기본)
+            - **NONE**: 가나다순 (기본)
+            - **COUNT**: 리뷰 개수 내림차순
+            - **COUNT_ASC**: 리뷰 개수 오름차순
+            - **COUNT_DESC**: 리뷰 개수 내림차순
+            - **RATING**: 평점 수 내림차순
+            - **RATING_ASC**: 평점 수 오름차순
+            - **RATING_DESC**: 평점 수 내림차순
+        - **적용 필터**
+            - **IS_OPEN**: 현재 영업 중인 상점
+            - **DELIVERY_AVAILABLE**: 배달 가능한 상점
+            - **TAKEOUT_AVAILABLE**: 포장 가능한 상점
+            - **FREE_DELIVERY_TIP**: 배달비 무료 상점
+        - **최소 주문 금액 필터**: minimum_order_amount. 해당 최소 주문 금액 이하의 상점을 반환
+        - **open_status**: 현재 요일과 시간을 고려 하여 상점의 영업 상태를 결정.
+            - **OPERATING**: 영업중
+            - **PREPARING**: 영업 준비중
+            - **CLOSED**: 영업 종료
+        """)
     @GetMapping("/order/shops")
     ResponseEntity<List<OrderableShopsResponse>> getOrderableShops(
         @Parameter(description = "정렬 기준. 중복 지정 불가")
@@ -148,6 +148,7 @@ public interface OrderableShopApi {
                           "shop_id": 2,
                           "orderable_shop_id": 1,
                           "name": "가장 맛있는 족발",
+                          "introduction": "안녕하세요 맛있는 족발입니다. 고객님에게 신선한 음식을 제공하고자 즐거운 하루를 보내시고 감사합니다.",
                           "is_delivery_available": true,
                           "is_takeout_available": false,
                           "minimum_order_amount": 10000,
@@ -163,32 +164,32 @@ public interface OrderableShopApi {
             @ApiResponse(responseCode = "404", description = "주문 가능 상점을 찾을 수 없음",
                 content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "상점 미존재", value = """
-                    {
-                      "status": 404,
-                      "error": "Not Found",
-                      "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
-                    }
-                    """
+                        {
+                          "status": 404,
+                          "error": "Not Found",
+                          "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
+                        }
+                        """
                     )
                 })
             )
         }
     )
     @Operation(summary = "특정 주문 가능 상점 요약 정보 조회", description = """
-            ### 주문 가능 상점 요약 정보 조회
-            - 특정 주문 가능 상점의 요약 정보를 반환합니다.
-            - 반환 정보:
-                - shop_id: 상점 고유 식별자
-                - orderable_shop_id: 주문 가능 상점 고유 식별자
-                - name: 상점 이름
-                - is_delivery_available: 배달 가능 여부
-                - is_takeout_available: 포장 가능 여부
-                - minimum_order_amount: 최소 주문 금액
-                - rating_average: 평균 평점
-                - review_count: 리뷰 수
-                - minimum_delivery_tip: 최소 배달비
-                - maximum_delivery_tip: 최대 배달비
-            """)
+        ### 주문 가능 상점 요약 정보 조회
+        - 특정 주문 가능 상점의 요약 정보를 반환합니다.
+        - 반환 정보:
+            - shop_id: 상점 고유 식별자
+            - orderable_shop_id: 주문 가능 상점 고유 식별자
+            - name: 상점 이름
+            - is_delivery_available: 배달 가능 여부
+            - is_takeout_available: 포장 가능 여부
+            - minimum_order_amount: 최소 주문 금액
+            - rating_average: 평균 평점
+            - review_count: 리뷰 수
+            - minimum_delivery_tip: 최소 배달비
+            - maximum_delivery_tip: 최대 배달비
+        """)
     @GetMapping("/order/shop/{orderableShopId}/summary")
     ResponseEntity<OrderableShopInfoSummaryResponse> getOrderableShopInfoSummary(
         @Parameter(description = "주문 가능 상점 고유 식별자(orderable_shop_id)", example = "1")
@@ -247,35 +248,35 @@ public interface OrderableShopApi {
             @ApiResponse(responseCode = "404", description = "주문 가능 상점을 찾을 수 없음",
                 content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "상점 미존재", value = """
-                    {
-                      "status": 404,
-                      "error": "Not Found",
-                      "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
-                    }
-                    """
+                        {
+                          "status": 404,
+                          "error": "Not Found",
+                          "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
+                        }
+                        """
                     )
                 })
             )
         }
     )
     @Operation(summary = "특정 주문 가능 상점 가게 정보·원산지 조회", description = """
-            ### 주문 가능 상점 가게 정보·원산지 조회
-            - 특정 주문 가능 상점의 가게 정보·원산지 조회 결과를 반환합니다.
-            - 반환 정보:
-                - shop_id: 상점 고유 식별자
-                - orderable_shop_id: 주문 가능 상점 고유 식별자
-                - name: 상점 이름
-                - address: 상점 주소
-                - open_time: 영업 시작 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
-                - close_time: 영업 종료 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
-                - closed_days: 휴무 요일 목록
-                - phone: 상점 전화번호
-                - introduction: 가게 소개
-                - notice: 가게 알림
-                - delivery_tips: 주문 금액별 총 배달팁
-                - owner_info: 사업자 정보
-                - origins: 원산지 표기
-            """)
+        ### 주문 가능 상점 가게 정보·원산지 조회
+        - 특정 주문 가능 상점의 가게 정보·원산지 조회 결과를 반환합니다.
+        - 반환 정보:
+            - shop_id: 상점 고유 식별자
+            - orderable_shop_id: 주문 가능 상점 고유 식별자
+            - name: 상점 이름
+            - address: 상점 주소
+            - open_time: 영업 시작 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
+            - close_time: 영업 종료 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
+            - closed_days: 휴무 요일 목록
+            - phone: 상점 전화번호
+            - introduction: 가게 소개
+            - notice: 가게 알림
+            - delivery_tips: 주문 금액별 총 배달팁
+            - owner_info: 사업자 정보
+            - origins: 원산지 표기
+        """)
     @GetMapping("/order/shop/{orderableShopId}/detail")
     ResponseEntity<OrderableShopInfoDetailResponse> getOrderableShopInfoDetail(
         @Parameter(description = "주문 가능 상점 고유 식별자(orderable_shop_id)", example = "1")

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -149,6 +149,8 @@ public interface OrderableShopApi {
                           "orderable_shop_id": 1,
                           "name": "가장 맛있는 족발",
                           "introduction": "안녕하세요 맛있는 족발입니다. 고객님에게 신선한 음식을 제공하고자 즐거운 하루를 보내시고 감사합니다.",
+                          "pay_card": true,
+                          "pay_bank": false,
                           "is_delivery_available": true,
                           "is_takeout_available": false,
                           "minimum_order_amount": 10000,
@@ -184,6 +186,8 @@ public interface OrderableShopApi {
             - name: 상점 이름
             - is_delivery_available: 배달 가능 여부
             - is_takeout_available: 포장 가능 여부
+            - pay_card: 카드 결제 가능 여부
+            - pay_bank: 계좌 이체 가능 여부
             - minimum_order_amount: 최소 주문 금액
             - rating_average: 평균 평점
             - review_count: 리뷰 수

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -29,6 +29,7 @@ public interface OrderableShopApi {
                             [
                               {
                                 "shop_id": 2,
+                                "orderable_shop_id": 1,
                                 "name": "가장 맛있는 족발",
                                 "is_delivery_available": true,
                                 "is_takeout_available": false,

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -249,16 +249,16 @@ public interface OrderableShopApi {
             )
         }
     )
-    @Operation(summary = "특정 주문 가능 상점 가게 정보/원산지 조회", description = """
-            ### 주문 가능 상점 가게 정보/원산지 조회
-            - 특정 주문 가능 상점의 가게 정보/원산지 조회 결과를 반환합니다.
+    @Operation(summary = "특정 주문 가능 상점 가게 정보·원산지 조회", description = """
+            ### 주문 가능 상점 가게 정보·원산지 조회
+            - 특정 주문 가능 상점의 가게 정보·원산지 조회 결과를 반환합니다.
             - 반환 정보:
                 - shop_id: 상점 고유 식별자
                 - orderable_shop_id: 주문 가능 상점 고유 식별자
                 - name: 상점 이름
                 - address: 상점 주소
-                - open_time: 영업 시작 시간 (오늘 기준, 영업하지 않는 날은 null)
-                - close_time: 영업 종료 시간 (오늘 기준, 영업하지 않는 날은 null)
+                - open_time: 영업 시작 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
+                - close_time: 영업 종료 시간 (오늘 요일 기준, 영업 하지 않는 날은 null)
                 - closed_days: 휴무 요일 목록
                 - phone: 상점 전화번호
                 - introduction: 가게 소개

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -215,7 +215,7 @@ public interface OrderableShopApi {
                           "closed_days": [],
                           "phone": "041-523-5849",
                           "introduction": "안녕하세요 맛있는 족발입니다. 고객님에게 신선한 음식을 제공하고자 즐거운 하루를 보내시고 감사합니다.",
-                          "notice": "*행사 이벤트 진행중입니다*\\n단체 주문 시 20% 할인 합니다.\\n50,000원 이상 주문 시 막국수 서비스 드립니다",
+                          "notice": "*행사 이벤트 진행중입니다* 단체 주문 시 20% 할인 합니다. 50,000원 이상 주문 시 막국수 서비스 드립니다",
                           "delivery_tips": [
                             {
                               "from_amount": 10000,
@@ -242,8 +242,8 @@ public interface OrderableShopApi {
                             {
                               "ingredient": "쌀",
                               "origin": "국내산"
-                             },
-                          ],
+                             }
+                          ]
                         }
                         """
                     )

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoDetailResponse;
 import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
@@ -100,7 +101,6 @@ public interface OrderableShopApi {
                     )
                 })
             ),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
         }
@@ -174,16 +174,15 @@ public interface OrderableShopApi {
             )
         }
     )
-    @Operation(summary = "주문 가능 상점 요약 정보 조회", description = """
+    @Operation(summary = "특정 주문 가능 상점 요약 정보 조회", description = """
             ### 주문 가능 상점 요약 정보 조회
             - 특정 주문 가능 상점의 요약 정보를 반환합니다.
-            - **orderableShopId**: 조회하려는 주문 가능 상점의 고유 식별자.
             - 반환 정보:
-                - shop_id: 상점의 고유 식별자
-                - orderable_shop_id: 주문 가능 상점의 고유 식별자
+                - shop_id: 상점 고유 식별자
+                - orderable_shop_id: 주문 가능 상점 고유 식별자
                 - name: 상점 이름
                 - is_delivery_available: 배달 가능 여부
-                - is_takeout_available: 테이크아웃 가능 여부
+                - is_takeout_available: 포장 가능 여부
                 - minimum_order_amount: 최소 주문 금액
                 - rating_average: 평균 평점
                 - review_count: 리뷰 수
@@ -192,7 +191,85 @@ public interface OrderableShopApi {
             """)
     @GetMapping("/order/shop/{orderableShopId}/summary")
     ResponseEntity<OrderableShopInfoSummaryResponse> getOrderableShopInfoSummary(
-        @Parameter(description = "주문 가능 상점의 고유 식별자", example = "1")
+        @Parameter(description = "주문 가능 상점 고유 식별자(orderable_shop_id)", example = "1")
+        @PathVariable Integer orderableShopId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "주문 가능 상점 상세 정보 조회 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                        {
+                          "shop_id": 2,
+                          "orderable_shop_id": 1,
+                          "name": "가장 맛있는 족발",
+                          "address": "천안시 동남구 충절로 880 가동 1층",
+                          "open_time": "16:00:00",
+                          "close_time": "00:00:00",
+                          "closed_days": [],
+                          "phone": "041-523-5849",
+                          "introduction": "안녕하세요 맛있는 족발입니다. 고객님에게 신선한 음식을 제공하고자 즐거운 하루를 보내시고 감사합니다.",
+                          "notice": "*행사 이벤트 진행중입니다*\\n단체 주문 시 20% 할인 합니다.\\n50,000원 이상 주문 시 막국수 서비스 드립니다",
+                          "delivery_tips": [
+                            {
+                              "from_amount": 10000,
+                              "to_amount": 18000,
+                              "fee": 4500
+                            },
+                            {
+                              "from_amount": 18000,
+                              "to_amount": null,
+                              "fee": 2500
+                            }
+                          ],
+                          "owner_info": {
+                            "name": "홍길동",
+                            "shop_name": "가장 맛있는 족발",
+                            "address": "천안시 동남구 충절로 880 가동 1층",
+                            "company_registration_number": "123-21-31313"
+                          },
+                          "origin": "뒷발(국내산), 앞발(국내산), 쌀(국내산), 배추(국내산)"
+                        }
+                        """
+                    )
+                })
+            ),
+            @ApiResponse(responseCode = "404", description = "주문 가능 상점을 찾을 수 없음",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "상점 미존재", value = """
+                    {
+                      "status": 404,
+                      "error": "Not Found",
+                      "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
+                    }
+                    """
+                    )
+                })
+            )
+        }
+    )
+    @Operation(summary = "특정 주문 가능 상점 가게 정보/원산지 조회", description = """
+            ### 주문 가능 상점 가게 정보/원산지 조회
+            - 특정 주문 가능 상점의 가게 정보/원산지 조회 결과를 반환합니다.
+            - 반환 정보:
+                - shop_id: 상점 고유 식별자
+                - orderable_shop_id: 주문 가능 상점 고유 식별자
+                - name: 상점 이름
+                - address: 상점 주소
+                - open_time: 영업 시작 시간 (오늘 기준, 영업하지 않는 날은 null)
+                - close_time: 영업 종료 시간 (오늘 기준, 영업하지 않는 날은 null)
+                - closed_days: 휴무 요일 목록
+                - phone: 상점 전화번호
+                - introduction: 가게 소개
+                - notice: 가게 알림
+                - delivery_tips: 주문 금액별 총 배달팁
+                - owner_info: 사업자 정보
+                - origin: 원산지 표기
+            """)
+    @GetMapping("/order/shop/{orderableShopId}/detail")
+    ResponseEntity<OrderableShopInfoDetailResponse> getOrderableShopInfoDetail(
+        @Parameter(description = "주문 가능 상점 고유 식별자(orderable_shop_id)", example = "1")
         @PathVariable Integer orderableShopId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.controller;
+package in.koreatech.koin.domain.order.shop.controller;
 
 import java.util.List;
 
@@ -6,9 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsFilterCriteria;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsSortCriteria;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,7 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "(Normal) OrderShop: 주문 가능 상점", description = "주문 가능 상점 정보를 관리한다")
-public interface OrderShopApi {
+public interface OrderableShopApi {
 
     @ApiResponses(
         value = {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
@@ -135,5 +137,62 @@ public interface OrderableShopApi {
 
         @Parameter(description = "최소 주문 금액 필터 (단위: 원). null 가능")
         @RequestParam(name = "minimum_order_amount", required = false) Integer minimumOrderAmount
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "주문 가능 상점 요약 정보 조회 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                        {
+                          "shop_id": 2,
+                          "orderable_shop_id": 1,
+                          "name": "가장 맛있는 족발",
+                          "is_delivery_available": true,
+                          "is_takeout_available": false,
+                          "minimum_order_amount": 10000,
+                          "rating_average": 4.5,
+                          "review_count": 120,
+                          "minimum_delivery_tip": 2000,
+                          "maximum_delivery_tip": 5000
+                        }
+                        """
+                    )
+                })
+            ),
+            @ApiResponse(responseCode = "404", description = "주문 가능 상점을 찾을 수 없음",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "상점 미존재", value = """
+                    {
+                      "status": 404,
+                      "error": "Not Found",
+                      "message": "존재하지 않는 상점입니다.: 해당 상점이 존재하지 않습니다.: 1"
+                    }
+                    """
+                    )
+                })
+            )
+        }
+    )
+    @Operation(summary = "주문 가능 상점 요약 정보 조회", description = """
+            ### 주문 가능 상점 요약 정보 조회
+            - 특정 주문 가능 상점의 요약 정보를 반환합니다.
+            - **orderableShopId**: 조회하려는 주문 가능 상점의 고유 식별자.
+            - 반환 정보:
+                - shop_id: 상점의 고유 식별자
+                - orderable_shop_id: 주문 가능 상점의 고유 식별자
+                - name: 상점 이름
+                - is_delivery_available: 배달 가능 여부
+                - is_takeout_available: 테이크아웃 가능 여부
+                - minimum_order_amount: 최소 주문 금액
+                - rating_average: 평균 평점
+                - review_count: 리뷰 수
+                - minimum_delivery_tip: 최소 배달비
+                - maximum_delivery_tip: 최대 배달비
+            """)
+    @GetMapping("/order/shop/{orderableShopId}/summary")
+    ResponseEntity<OrderableShopInfoSummaryResponse> getOrderableShopInfoSummary(
+        @Parameter(description = "주문 가능 상점의 고유 식별자", example = "1")
+        @PathVariable Integer orderableShopId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -229,7 +229,16 @@ public interface OrderableShopApi {
                             "address": "천안시 동남구 충절로 880 가동 1층",
                             "company_registration_number": "123-21-31313"
                           },
-                          "origin": "뒷발(국내산), 앞발(국내산), 쌀(국내산), 배추(국내산)"
+                          "origins": [
+                            {
+                              "ingredient": "소고기",
+                              "origin": "국내산 한우"
+                            },
+                            {
+                              "ingredient": "쌀",
+                              "origin": "국내산"
+                             },
+                          ],
                         }
                         """
                     )
@@ -265,7 +274,7 @@ public interface OrderableShopApi {
                 - notice: 가게 알림
                 - delivery_tips: 주문 금액별 총 배달팁
                 - owner_info: 사업자 정보
-                - origin: 원산지 표기
+                - origins: 원산지 표기
             """)
     @GetMapping("/order/shop/{orderableShopId}/detail")
     ResponseEntity<OrderableShopInfoDetailResponse> getOrderableShopInfoDetail(

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.controller;
+package in.koreatech.koin.domain.order.shop.controller;
 
 import java.util.List;
 
@@ -7,17 +7,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsFilterCriteria;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsSortCriteria;
-import in.koreatech.koin.domain.shop.service.OrderableShopService;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
+import in.koreatech.koin.domain.order.shop.service.OrderableShopListService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class OrderShopController implements OrderShopApi{
+public class OrderableShopController implements OrderableShopApi {
 
-    private final OrderableShopService orderableShopService;
+    private final OrderableShopListService orderableShopListService;
 
     @GetMapping("/order/shops")
     public ResponseEntity<List<OrderableShopsResponse>> getOrderableShops(
@@ -25,7 +25,7 @@ public class OrderShopController implements OrderShopApi{
         @RequestParam(name = "filter", required = false) List<OrderableShopsFilterCriteria> orderableShopsSortCriteria,
         @RequestParam(name = "minimum_order_amount", required = false) Integer minimumOrderAmount
     ) {
-        List<OrderableShopsResponse> orderableShops = orderableShopService.getOrderableShops(sortBy, orderableShopsSortCriteria, minimumOrderAmount);
+        List<OrderableShopsResponse> orderableShops = orderableShopListService.getOrderableShops(sortBy, orderableShopsSortCriteria, minimumOrderAmount);
         return ResponseEntity.ok(orderableShops);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
+import in.koreatech.koin.domain.order.shop.service.OrderableShopInformationService;
 import in.koreatech.koin.domain.order.shop.service.OrderableShopListService;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderableShopController implements OrderableShopApi {
 
     private final OrderableShopListService orderableShopListService;
+    private final OrderableShopInformationService orderableShopInformationService;
 
     @GetMapping("/order/shops")
     public ResponseEntity<List<OrderableShopsResponse>> getOrderableShops(
@@ -25,7 +29,17 @@ public class OrderableShopController implements OrderableShopApi {
         @RequestParam(name = "filter", required = false) List<OrderableShopsFilterCriteria> orderableShopsSortCriteria,
         @RequestParam(name = "minimum_order_amount", required = false) Integer minimumOrderAmount
     ) {
-        List<OrderableShopsResponse> orderableShops = orderableShopListService.getOrderableShops(sortBy, orderableShopsSortCriteria, minimumOrderAmount);
+        List<OrderableShopsResponse> orderableShops = orderableShopListService.getOrderableShops(sortBy,
+            orderableShopsSortCriteria, minimumOrderAmount);
         return ResponseEntity.ok(orderableShops);
+    }
+
+    @GetMapping("/order/shop/{orderableShopId}/summary")
+    public ResponseEntity<OrderableShopInfoSummaryResponse> getOrderableShopInfoSummary(
+        @PathVariable Integer orderableShopId
+    ) {
+        OrderableShopInfoSummaryResponse orderableShopInfoSummary = orderableShopInformationService.getOrderableShopInfoByIdJpaDtoProjection(
+            orderableShopId);
+        return ResponseEntity.ok(orderableShopInfoSummary);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoDetailResponse;
 import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
@@ -38,8 +39,18 @@ public class OrderableShopController implements OrderableShopApi {
     public ResponseEntity<OrderableShopInfoSummaryResponse> getOrderableShopInfoSummary(
         @PathVariable Integer orderableShopId
     ) {
-        OrderableShopInfoSummaryResponse orderableShopInfoSummary = orderableShopInformationService.getOrderableShopInfoByIdJpaDtoProjection(
+        OrderableShopInfoSummaryResponse orderableShopInfoSummary = orderableShopInformationService.getOrderableShopInfoSummaryById(
             orderableShopId);
         return ResponseEntity.ok(orderableShopInfoSummary);
     }
+
+    @GetMapping("/order/shop/{orderableShopId}/detail")
+    public ResponseEntity<OrderableShopInfoDetailResponse> getOrderableShopInfoDetail(
+        @PathVariable Integer orderableShopId
+    ) {
+        OrderableShopInfoDetailResponse orderableShopInfoSummary = orderableShopInformationService.getOrderableShopInfoDetailById(
+            orderableShopId);
+        return ResponseEntity.ok(orderableShopInfoSummary);
+    }
+
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoDetailResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoDetailResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.order.shop.model.domain.ShopBaseDeliveryTipRange;
 import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
 import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.shop.model.menu.MenuOrigin;
 import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
 import in.koreatech.koin.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,9 +43,9 @@ public record OrderableShopInfoDetailResponse(
     String introduction,
     @Schema(description = "가게 알림", example = "*행사 이벤트 진행중입니다*\\n단체 주문 시 20% 할인 합니다.")
     String notice,
-    List<DeliveryTips> deliveryTips,
+    List<DeliveryTipsResponse> deliveryTips,
     OwnerInfo ownerInfo,
-    String origin
+    List<MenuOriginResponse> origins
 ) {
 
     public static OrderableShopInfoDetailResponse from(OrderableShop orderableShop) {
@@ -74,15 +75,15 @@ public record OrderableShopInfoDetailResponse(
             orderableShop.getShop().getPhone(),
             orderableShop.getShop().getIntroduction(),
             orderableShop.getShop().getNotice(),
-            DeliveryTips.from(orderableShop.getShop().getBaseDeliveryTips().getDeliveryTipRanges()),
+            DeliveryTipsResponse.from(orderableShop.getShop().getBaseDeliveryTips().getDeliveryTipRanges()),
             OwnerInfo.from(orderableShop.getShop().getOwner(), orderableShop.getShop().getName(),
                 orderableShop.getShop().getAddress()),
-            orderableShop.getShop().getOrigin().getOrigin()
+            MenuOriginResponse.from(orderableShop.getShop().getMenuOrigins().getOrigin())
         );
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)
-    public record DeliveryTips(
+    public record DeliveryTipsResponse(
         @Schema(description = "주문 금액 하한", example = "10000")
         Integer fromAmount,
         @Schema(description = "주문 금액 상한", example = "10000")
@@ -91,17 +92,39 @@ public record OrderableShopInfoDetailResponse(
         Integer fee
     ) {
 
-        public static DeliveryTips from(ShopBaseDeliveryTipRange range) {
-            return new DeliveryTips(
+        public static DeliveryTipsResponse from(ShopBaseDeliveryTipRange range) {
+            return new DeliveryTipsResponse(
                 range.fromAmount(),
                 range.toAmount(),
                 range.fee()
             );
         }
 
-        public static List<DeliveryTips> from(List<ShopBaseDeliveryTipRange> ranges) {
+        public static List<DeliveryTipsResponse> from(List<ShopBaseDeliveryTipRange> ranges) {
             return ranges.stream()
-                .map(DeliveryTips::from)
+                .map(DeliveryTipsResponse::from)
+                .collect(Collectors.toList());
+        }
+    }
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record MenuOriginResponse(
+        @Schema(description = "메뉴 재료", example = "김치")
+        String ingredient,
+        @Schema(description = "원산지", example = "국내산")
+        String origin
+    ) {
+
+        public static MenuOriginResponse from(MenuOrigin menuOrigin) {
+            return new MenuOriginResponse(
+                menuOrigin.getIngredient(),
+                menuOrigin.getOrigin()
+            );
+        }
+
+        public static List<MenuOriginResponse> from(List<MenuOrigin> origins) {
+            return origins.stream()
+                .map(MenuOriginResponse::from)
                 .collect(Collectors.toList());
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoDetailResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoDetailResponse.java
@@ -1,0 +1,138 @@
+package in.koreatech.koin.domain.order.shop.dto.shopinfo;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.order.shop.model.domain.ShopBaseDeliveryTipRange;
+import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
+import in.koreatech.koin.domain.owner.model.Owner;
+import in.koreatech.koin.domain.shop.model.shop.ShopOpen;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record OrderableShopInfoDetailResponse(
+    @Schema(description = "상점 ID", example = "14")
+    Integer shopId,
+    @Schema(description = "주문 가능 상점 ID", example = "1")
+    Integer orderableShopId,
+    @Schema(description = "상점 이름", example = "멕시카나 치킨 - 병천점")
+    String name,
+    @Schema(description = "상점 주소", example = "충청남도 천안시 동남구 병천면 병천리 163-12")
+    String address,
+    @Schema(description = "상점 영업 시작 시간", example = "11:30")
+    @DateTimeFormat(pattern = "HH:mm")
+    LocalTime openTime,
+    @Schema(description = "상점 영업 종료 시간", example = "20:30")
+    @DateTimeFormat(pattern = "HH:mm")
+    LocalTime closeTime,
+    @Schema(description = "상점 휴무일", example = "[\"TUESDAY\", \"SUNDAY\"]")
+    List<String> closedDays,
+    @Schema(description = "상점 전화 번호", example = "010-1234-5678")
+    String phone,
+    @Schema(description = "가게 소개", example = "안녕하세요 맛있는 족발입니다. 고객님에게 신선한 음식을 제공합니다")
+    String introduction,
+    @Schema(description = "가게 알림", example = "*행사 이벤트 진행중입니다*\\n단체 주문 시 20% 할인 합니다.")
+    String notice,
+    List<DeliveryTips> deliveryTips,
+    OwnerInfo ownerInfo,
+    String origin
+) {
+
+    public static OrderableShopInfoDetailResponse from(OrderableShop orderableShop) {
+        List<ShopOpen> shopOpens = orderableShop.getShop().getShopOpens();
+        String today = LocalDate.now().getDayOfWeek().toString();
+
+        Optional<ShopOpen> todayShopOpen = shopOpens.stream()
+            .filter(shopOpen -> shopOpen.getDayOfWeek().equals(today))
+            .findFirst();
+
+        LocalTime openTime = todayShopOpen.map(ShopOpen::getOpenTime).orElse(null);
+        LocalTime closeTime = todayShopOpen.map(ShopOpen::getCloseTime).orElse(null);
+
+        List<String> closedDays = shopOpens.stream()
+            .filter(ShopOpen::isClosed)
+            .map(ShopOpen::getDayOfWeek)
+            .collect(Collectors.toList());
+
+        return new OrderableShopInfoDetailResponse(
+            orderableShop.getShop().getId(),
+            orderableShop.getId(),
+            orderableShop.getShop().getName(),
+            orderableShop.getShop().getAddress(),
+            openTime,
+            closeTime,
+            closedDays,
+            orderableShop.getShop().getPhone(),
+            orderableShop.getShop().getIntroduction(),
+            orderableShop.getShop().getNotice(),
+            DeliveryTips.from(orderableShop.getShop().getBaseDeliveryTips().getDeliveryTipRanges()),
+            OwnerInfo.from(orderableShop.getShop().getOwner(), orderableShop.getShop().getName(),
+                orderableShop.getShop().getAddress()),
+            orderableShop.getShop().getOrigin().getOrigin()
+        );
+    }
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record DeliveryTips(
+        @Schema(description = "주문 금액 하한", example = "10000")
+        Integer fromAmount,
+        @Schema(description = "주문 금액 상한", example = "10000")
+        Integer toAmount,
+        @Schema(description = "주문 금액 구간별 배달팁", example = "2500")
+        Integer fee
+    ) {
+
+        public static DeliveryTips from(ShopBaseDeliveryTipRange range) {
+            return new DeliveryTips(
+                range.fromAmount(),
+                range.toAmount(),
+                range.fee()
+            );
+        }
+
+        public static List<DeliveryTips> from(List<ShopBaseDeliveryTipRange> ranges) {
+            return ranges.stream()
+                .map(DeliveryTips::from)
+                .collect(Collectors.toList());
+        }
+    }
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record OwnerInfo(
+        @Schema(description = "사장님 이름", example = "홍길동")
+        String name,
+        @Schema(description = "상호명", example = "맛있는 족발 - 병천점")
+        String shopName,
+        @Schema(description = "사업자 주소", example = "충청남도 천안시 동남구 190 -12")
+        String address,
+        @Schema(description = "사업자 등록번호", example = "홍길동")
+        String companyRegistrationNumber
+    ) {
+
+        public static OwnerInfo from(Owner owner, String shopName, String address) {
+            if (owner == null) {
+                return new OwnerInfo(null, null, null, null);
+            }
+
+            String ownerName = Optional.ofNullable(owner.getUser())
+                .map(User::getName)
+                .orElse(null);
+
+            return new OwnerInfo(
+                ownerName,
+                shopName,
+                address,
+                owner.getCompanyRegistrationNumber()
+            );
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -26,6 +26,12 @@ public record OrderableShopInfoSummaryResponse(
     @Schema(description = "포장 가능 여부", example = "false")
     Boolean isTakeoutAvailable,
 
+    @Schema(description = "카드 결제 가능 여부", example = "false")
+    Boolean payCard,
+
+    @Schema(description = "계좌 이체 가능 여부", example = "false")
+    Boolean payBank,
+
     @Schema(description = "최소 주문 금액", example = "15000")
     Integer minimumOrderAmount,
 
@@ -49,6 +55,8 @@ public record OrderableShopInfoSummaryResponse(
             entity.introduction(),
             entity.isDeliveryAvailable(),
             entity.isTakeoutAvailable(),
+            entity.payCard(),
+            entity.payBank(),
             entity.minimumOrderAmount(),
             entity.ratingAverage(),
             entity.reviewCount(),

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -1,14 +1,9 @@
 package in.koreatech.koin.domain.order.shop.dto.shopinfo;
 
-import java.util.List;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary;
-import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
-import in.koreatech.koin.domain.order.shop.model.entity.ShopBaseDeliveryTip;
-import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -35,7 +30,7 @@ public record OrderableShopInfoSummaryResponse(
     Double ratingAverage,
 
     @Schema(description = "리뷰 수", example = "120")
-    Long reviewCount,
+    Integer reviewCount,
 
     @Schema(description = "최소 배달비", example = "0")
     Integer minimumDeliveryTip,
@@ -55,31 +50,6 @@ public record OrderableShopInfoSummaryResponse(
             entity.reviewCount(),
             entity.minimumDeliveryTip(),
             entity.maximumDeliveryTip()
-        );
-    }
-
-    public static OrderableShopInfoSummaryResponse fromEntity(
-        OrderableShop entity
-        ) {
-        List<ShopReview> reviews = entity.getShop().getReviews();
-        List<ShopBaseDeliveryTip> baseDeliveryTips = entity.getShop().getBaseDeliveryTips();
-
-        long reviewCount = reviews.size();
-        Double ratingAverage = reviews.stream().mapToDouble(ShopReview::getRating).average().orElse(0.0);
-        Integer minimumDeliveryTip = baseDeliveryTips.stream().mapToInt(ShopBaseDeliveryTip::getFee).min().orElse(0);
-        Integer maximumDeliveryTip = baseDeliveryTips.stream().mapToInt(ShopBaseDeliveryTip::getFee).max().orElse(0);
-
-        return new OrderableShopInfoSummaryResponse(
-            entity.getShop().getId(),
-            entity.getId(),
-            entity.getShop().getName(),
-            entity.isDelivery(),
-            entity.isTakeout(),
-            entity.getMinimumOrderAmount(),
-            ratingAverage,
-            reviewCount,
-            minimumDeliveryTip,
-            maximumDeliveryTip
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -17,6 +17,9 @@ public record OrderableShopInfoSummaryResponse(
     @Schema(description = "상점 이름", example = "멕시카나 치킨 - 병천점")
     String name,
 
+    @Schema(description = "상점 소개", example = "안녕하세요 멕시카나 치킨입니다.")
+    String introduction,
+
     @Schema(description = "배달 가능 여부", example = "true")
     Boolean isDeliveryAvailable,
 
@@ -43,6 +46,7 @@ public record OrderableShopInfoSummaryResponse(
             entity.shopId(),
             entity.orderableShopId(),
             entity.name(),
+            entity.introduction(),
             entity.isDeliveryAvailable(),
             entity.isTakeoutAvailable(),
             entity.minimumOrderAmount(),

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -1,0 +1,85 @@
+package in.koreatech.koin.domain.order.shop.dto.shopinfo;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary;
+import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
+import in.koreatech.koin.domain.order.shop.model.entity.ShopBaseDeliveryTip;
+import in.koreatech.koin.domain.shop.model.review.ShopReview;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record OrderableShopInfoSummaryResponse(
+    @Schema(description = "상점 ID", example = "14")
+    Integer shopId,
+
+    @Schema(description = "주문 가능 상점 ID", example = "1")
+    Integer orderableShopId,
+
+    @Schema(description = "상점 이름", example = "멕시카나 치킨 - 병천점")
+    String name,
+
+    @Schema(description = "배달 가능 여부", example = "true")
+    Boolean isDeliveryAvailable,
+
+    @Schema(description = "포장 가능 여부", example = "false")
+    Boolean isTakeoutAvailable,
+
+    @Schema(description = "최소 주문 금액", example = "15000")
+    Integer minimumOrderAmount,
+
+    @Schema(description = "리뷰 평균 평점", example = "4.5")
+    Double ratingAverage,
+
+    @Schema(description = "리뷰 수", example = "120")
+    Long reviewCount,
+
+    @Schema(description = "최소 배달비", example = "0")
+    Integer minimumDeliveryTip,
+
+    @Schema(description = "최대 배달비", example = "3000")
+    Integer maximumDeliveryTip
+) {
+    public static OrderableShopInfoSummaryResponse from(OrderableShopInfoSummary entity) {
+        return new OrderableShopInfoSummaryResponse(
+            entity.shopId(),
+            entity.orderableShopId(),
+            entity.name(),
+            entity.isDeliveryAvailable(),
+            entity.isTakeoutAvailable(),
+            entity.minimumOrderAmount(),
+            entity.ratingAverage(),
+            entity.reviewCount(),
+            entity.minimumDeliveryTip(),
+            entity.maximumDeliveryTip()
+        );
+    }
+
+    public static OrderableShopInfoSummaryResponse fromEntity(
+        OrderableShop entity
+        ) {
+        List<ShopReview> reviews = entity.getShop().getReviews();
+        List<ShopBaseDeliveryTip> baseDeliveryTips = entity.getShop().getBaseDeliveryTips();
+
+        long reviewCount = reviews.size();
+        Double ratingAverage = reviews.stream().mapToDouble(ShopReview::getRating).average().orElse(0.0);
+        Integer minimumDeliveryTip = baseDeliveryTips.stream().mapToInt(ShopBaseDeliveryTip::getFee).min().orElse(0);
+        Integer maximumDeliveryTip = baseDeliveryTips.stream().mapToInt(ShopBaseDeliveryTip::getFee).max().orElse(0);
+
+        return new OrderableShopInfoSummaryResponse(
+            entity.getShop().getId(),
+            entity.getId(),
+            entity.getShop().getName(),
+            entity.isDelivery(),
+            entity.isTakeout(),
+            entity.getMinimumOrderAmount(),
+            ratingAverage,
+            reviewCount,
+            minimumDeliveryTip,
+            maximumDeliveryTip
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopBaseInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopBaseInfo.java
@@ -1,9 +1,9 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse.ShopOpenInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse.ShopOpenInfo;
 
 public record OrderableShopBaseInfo(
     Integer shopId,

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopDetailInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopDetailInfo.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopOpenStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopOpenStatus.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
 public enum OrderableShopOpenStatus {
 

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsFilterCriteria.java
@@ -1,8 +1,8 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
-import static in.koreatech.koin.domain.shop.model.order.QOrderableShop.orderableShop;
-import static in.koreatech.koin.domain.shop.model.order.QShopBaseDeliveryTip.shopBaseDeliveryTip;
-import static in.koreatech.koin.domain.shop.model.order.QShopOperation.shopOperation;
+import static in.koreatech.koin.domain.order.shop.model.entity.QOrderableShop.orderableShop;
+import static in.koreatech.koin.domain.order.shop.model.entity.QShopBaseDeliveryTip.shopBaseDeliveryTip;
+import static in.koreatech.koin.domain.order.shop.model.entity.QShopOperation.shopOperation;
 import static in.koreatech.koin.domain.shop.model.shop.QShop.shop;
 
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsResponse.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsSortCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopsSortCriteria.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.dto.order;
+package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
 import java.util.Comparator;
 

--- a/src/main/java/in/koreatech/koin/domain/order/shop/exception/OrderableShopNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/exception/OrderableShopNotFoundException.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.order.shop.exception;
+
+import in.koreatech.koin._common.exception.custom.DataNotFoundException;
+import in.koreatech.koin.domain.shop.exception.ShopNotFoundException;
+
+public class OrderableShopNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 상점입니다.";
+
+    public OrderableShopNotFoundException(String message) {
+        super(message);
+    }
+
+    public OrderableShopNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static OrderableShopNotFoundException withDetail(String detail) {
+        return new OrderableShopNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -4,6 +4,7 @@ public record OrderableShopInfoSummary(
     Integer shopId,
     Integer orderableShopId,
     String name,
+    String introduction,
     Boolean isDeliveryAvailable,
     Boolean isTakeoutAvailable,
     Integer minimumOrderAmount,

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -8,7 +8,7 @@ public record OrderableShopInfoSummary(
     Boolean isTakeoutAvailable,
     Integer minimumOrderAmount,
     Double ratingAverage,
-    Long reviewCount,
+    Integer reviewCount,
     Integer minimumDeliveryTip,
     Integer maximumDeliveryTip
 ) {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.order.shop.model.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record OrderableShopInfoSummary(
     Integer shopId,
     Integer orderableShopId,
@@ -7,6 +9,8 @@ public record OrderableShopInfoSummary(
     String introduction,
     Boolean isDeliveryAvailable,
     Boolean isTakeoutAvailable,
+    Boolean payCard,
+    Boolean payBank,
     Integer minimumOrderAmount,
     Double ratingAverage,
     Integer reviewCount,

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+public record OrderableShopInfoSummary(
+    Integer shopId,
+    Integer orderableShopId,
+    String name,
+    Boolean isDeliveryAvailable,
+    Boolean isTakeoutAvailable,
+    Integer minimumOrderAmount,
+    Double ratingAverage,
+    Long reviewCount,
+    Integer minimumDeliveryTip,
+    Integer maximumDeliveryTip
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTipRange.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTipRange.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+public record ShopBaseDeliveryTipRange(
+    Integer fromAmount,
+    Integer toAmount,
+    Integer fee
+) {
+
+    public boolean isInRange(Integer orderAmount) {
+        if (orderAmount < fromAmount) {
+            return false;
+        }
+        return toAmount == null || orderAmount < toAmount;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTips.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopBaseDeliveryTips.java
@@ -1,0 +1,69 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+import static jakarta.persistence.CascadeType.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import in.koreatech.koin.domain.order.shop.model.entity.ShopBaseDeliveryTip;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class ShopBaseDeliveryTips {
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopBaseDeliveryTip> baseDeliveryTips = new ArrayList<>();
+
+    public Integer getMinimumDeliveryTip() {
+        return baseDeliveryTips.stream()
+            .mapToInt(ShopBaseDeliveryTip::getFee)
+            .min()
+            .orElse(0);
+    }
+
+    public Integer getMaximumDeliveryTip() {
+        return baseDeliveryTips.stream()
+            .mapToInt(ShopBaseDeliveryTip::getFee)
+            .max()
+            .orElse(0);
+    }
+
+    public List<ShopBaseDeliveryTipRange> getDeliveryTipRanges() {
+        if (baseDeliveryTips.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<ShopBaseDeliveryTip> sortedTips = getSortedByOrderAmount();
+        List<ShopBaseDeliveryTipRange> ranges = new ArrayList<>();
+
+        for (int i = 0; i < sortedTips.size(); i++) {
+            ShopBaseDeliveryTip currentTip = sortedTips.get(i);
+            Integer toAmount = null;
+
+            if (i < sortedTips.size() - 1) {
+                toAmount = sortedTips.get(i + 1).getOrderAmount();
+            }
+
+            ranges.add(new ShopBaseDeliveryTipRange(
+                currentTip.getOrderAmount(),
+                toAmount,
+                currentTip.getFee()
+            ));
+        }
+        return ranges;
+    }
+
+    private List<ShopBaseDeliveryTip> getSortedByOrderAmount() {
+        return baseDeliveryTips.stream()
+            .sorted(Comparator.comparing(ShopBaseDeliveryTip::getOrderAmount))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.order.shop.model.domain;
+
+import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.CascadeType.REMOVE;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.shop.model.menu.MenuOrigin;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Embeddable
+@RequiredArgsConstructor
+public class ShopMenuOrigins {
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<MenuOrigin> origin;
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/ShopMenuOrigins.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.order.shop.model.domain;
 import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.CascadeType.REMOVE;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import in.koreatech.koin.domain.shop.model.menu.MenuOrigin;
@@ -17,6 +18,6 @@ import lombok.RequiredArgsConstructor;
 public class ShopMenuOrigins {
 
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
-    private List<MenuOrigin> origin;
+    private List<MenuOrigin> origin = new ArrayList<>();
 
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/OrderableShop.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.model.order;
+package in.koreatech.koin.domain.order.shop.model.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/ShopBaseDeliveryTip.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/ShopBaseDeliveryTip.java
@@ -1,10 +1,11 @@
-package in.koreatech.koin.domain.shop.model.order;
+package in.koreatech.koin.domain.order.shop.model.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import org.hibernate.annotations.Where;
 
+import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,7 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,22 +21,25 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@Table(name = "shop_operation")
+@Table(name = "shop_base_delivery_tip")
 @Where(clause = "is_deleted=0")
-public class ShopOperation {
+public class ShopBaseDeliveryTip extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "shop_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 
-    @Column(name = "is_open", nullable = false)
-    private boolean isOpen = false;
+    @Column(name = "order_amount", nullable = false)
+    private Integer orderAmount;
+
+    @Column(name = "fee", nullable = false)
+    private Integer fee;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+    private Boolean isDeleted;
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/ShopOperation.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/ShopOperation.java
@@ -1,11 +1,10 @@
-package in.koreatech.koin.domain.shop.model.order;
+package in.koreatech.koin.domain.order.shop.model.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import org.hibernate.annotations.Where;
 
-import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,25 +21,22 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-@Table(name = "shop_base_delivery_tip")
+@Table(name = "shop_operation")
 @Where(clause = "is_deleted=0")
-public class ShopBaseDeliveryTip extends BaseEntity {
+public class ShopOperation {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "shop_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false, unique = true)
     private Shop shop;
 
-    @Column(name = "order_amount", nullable = false)
-    private Integer orderAmount;
-
-    @Column(name = "fee", nullable = false)
-    private Integer fee;
+    @Column(name = "is_open", nullable = false)
+    private boolean isOpen = false;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted;
+    private boolean isDeleted = false;
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopListCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopListCustomRepository.java
@@ -1,8 +1,8 @@
-package in.koreatech.koin.domain.shop.repository.order;
+package in.koreatech.koin.domain.order.shop.repository;
 
-import static in.koreatech.koin.domain.shop.model.order.QOrderableShop.orderableShop;
-import static in.koreatech.koin.domain.shop.model.order.QShopBaseDeliveryTip.shopBaseDeliveryTip;
-import static in.koreatech.koin.domain.shop.model.order.QShopOperation.shopOperation;
+import static in.koreatech.koin.domain.order.shop.model.entity.QOrderableShop.orderableShop;
+import static in.koreatech.koin.domain.order.shop.model.entity.QShopBaseDeliveryTip.shopBaseDeliveryTip;
+import static in.koreatech.koin.domain.order.shop.model.entity.QShopOperation.shopOperation;
 import static in.koreatech.koin.domain.shop.model.review.QShopReview.shopReview;
 import static in.koreatech.koin.domain.shop.model.shop.QShop.shop;
 import static in.koreatech.koin.domain.shop.model.shop.QShopCategoryMap.shopCategoryMap;
@@ -24,14 +24,14 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopBaseInfo;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsFilterCriteria;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse.ShopOpenInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopBaseInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse.ShopOpenInfo;
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class OrderableShopCustomRepository {
+public class OrderableShopListCustomRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -152,7 +152,8 @@ public class OrderableShopCustomRepository {
             .where(shopOpen.shop.id.in(shopIds))
             .fetch()
             .stream()
-            .map(opens -> new ShopOpenInfo(opens.getShop().getId(), opens.getDayOfWeek(), opens.isClosed(), opens.getOpenTime(), opens.getCloseTime()))
+            .map(opens -> new ShopOpenInfo(opens.getShop().getId(), opens.getDayOfWeek(), opens.isClosed(),
+                opens.getOpenTime(), opens.getCloseTime()))
             .collect(Collectors.groupingBy(ShopOpenInfo::shopId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopListQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopListQueryRepository.java
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class OrderableShopListCustomRepository {
+public class OrderableShopListQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.order.shop.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
+
+public interface OrderableShopRepository extends JpaRepository<OrderableShop, Integer> {
+
+    @Query("""
+         SELECT os
+         FROM OrderableShop os
+         JOIN FETCH os.shop
+         JOIN FETCH os.shop.reviews
+         WHERE os.id =:shopId
+    """)
+    Optional<OrderableShop> findById(@Param("shopId") Integer shopId);
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -17,6 +17,7 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
             s.id,
             os.id,
             s.name,
+            s.introduction,
             os.delivery,
             os.takeout,
             os.minimumOrderAmount,

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -13,30 +13,48 @@ import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
 public interface OrderableShopRepository extends JpaRepository<OrderableShop, Integer> {
 
     @Query("""
-    SELECT new in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary(
-        s.id,
-        os.id,
-        s.name,
-        os.delivery,
-        os.takeout,
-        os.minimumOrderAmount,
-        CAST(COALESCE(AVG(r.rating), 0.0) AS double),
-        CAST(COUNT(DISTINCT r.id) AS long),
-        CAST(COALESCE(MIN(bdt.fee), 0) AS int),
-        CAST(COALESCE(MAX(bdt.fee), 0) AS int)
-    )
-    FROM OrderableShop os
-    JOIN os.shop s
-    LEFT JOIN s.reviews r
-    LEFT JOIN s.baseDeliveryTips bdt
-    WHERE os.id = :orderableShopId
-    GROUP BY os.id, s.id
+        SELECT new in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary(
+            s.id,
+            os.id,
+            s.name,
+            os.delivery,
+            os.takeout,
+            os.minimumOrderAmount,
+            CAST(COALESCE(AVG(r.rating), 0.0) AS double),
+            CAST(COUNT(DISTINCT r.id) AS int),
+            CAST(COALESCE(MIN(bdt.fee), 0) AS int),
+            CAST(COALESCE(MAX(bdt.fee), 0) AS int)
+        )
+        FROM OrderableShop os
+        JOIN os.shop s
+        LEFT JOIN s.reviews r
+        LEFT JOIN ShopBaseDeliveryTip bdt ON bdt.shop.id = s.id
+        WHERE os.id = :orderableShopId
+        GROUP BY os.id, s.id
     """)
     Optional<OrderableShopInfoSummary> findOrderableShopInfoSummaryById(@Param("orderableShopId") Integer orderableShopId);
 
     default OrderableShopInfoSummary getOrderableShopInfoSummaryById(Integer shopId) {
         return findOrderableShopInfoSummaryById(shopId).orElseThrow(
             () -> new OrderableShopNotFoundException("해당 상점이 존재하지 않습니다 : " + shopId)
+        );
+    }
+
+    @Query("""
+        SELECT os
+        FROM OrderableShop os
+        JOIN FETCH os.shop
+        LEFT JOIN FETCH os.shop.origin
+        LEFT JOIN FETCH os.shop.owner
+        LEFT JOIN FETCH os.shop.owner.user
+        LEFT JOIN FETCH os.shop.shopOpens
+        WHERE os.id = :orderableShopId
+    """)
+    Optional<OrderableShop> findByIdJoinFetchShop(@Param("orderableShopId") Integer orderableShopId);
+
+    default OrderableShop getOrderableShopInfoDetailById(Integer orderableShopId) {
+        return findByIdJoinFetchShop(orderableShopId).orElseThrow(
+            () -> new OrderableShopNotFoundException("해당 상점이 존재하지 않습니다 : " + orderableShopId)
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -13,48 +13,53 @@ import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
 public interface OrderableShopRepository extends JpaRepository<OrderableShop, Integer> {
 
     @Query("""
-        SELECT new in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary(
-            s.id,
-            os.id,
-            s.name,
-            s.introduction,
-            os.delivery,
-            os.takeout,
-            os.minimumOrderAmount,
-            CAST(COALESCE(AVG(r.rating), 0.0) AS double),
-            CAST(COUNT(DISTINCT r.id) AS int),
-            CAST(COALESCE(MIN(bdt.fee), 0) AS int),
-            CAST(COALESCE(MAX(bdt.fee), 0) AS int)
-        )
-        FROM OrderableShop os
-        JOIN os.shop s
-        LEFT JOIN s.reviews r
-        LEFT JOIN ShopBaseDeliveryTip bdt ON bdt.shop.id = s.id
-        WHERE os.id = :orderableShopId
-        GROUP BY os.id, s.id
-    """)
-    Optional<OrderableShopInfoSummary> findOrderableShopInfoSummaryById(@Param("orderableShopId") Integer orderableShopId);
+            SELECT new in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary(
+                s.id,
+                os.id,
+                s.name,
+                s.introduction,
+                os.delivery,
+                os.takeout,
+                os.minimumOrderAmount,
+                CAST(COALESCE(AVG(r.rating), 0.0) AS double),
+                CAST(COUNT(DISTINCT r.id) AS int),
+                CAST(COALESCE(MIN(bdt.fee), 0) AS int),
+                CAST(COALESCE(MAX(bdt.fee), 0) AS int)
+            )
+            FROM OrderableShop os
+            JOIN os.shop s
+            LEFT JOIN s.reviews r
+            LEFT JOIN ShopBaseDeliveryTip bdt ON bdt.shop.id = s.id
+            WHERE os.id = :orderableShopId
+            GROUP BY os.id, s.id
+        """)
+    Optional<OrderableShopInfoSummary> findOrderableShopInfoSummaryById(
+        @Param("orderableShopId") Integer orderableShopId);
 
     default OrderableShopInfoSummary getOrderableShopInfoSummaryById(Integer shopId) {
         return findOrderableShopInfoSummaryById(shopId).orElseThrow(
-            () -> new OrderableShopNotFoundException("해당 상점이 존재하지 않습니다 : " + shopId)
+            () -> new OrderableShopNotFoundException(
+                "해당 상점이 존재하지 않습니다 : " + shopId
+            )
         );
     }
 
     @Query("""
-        SELECT os
-        FROM OrderableShop os
-        JOIN FETCH os.shop
-        LEFT JOIN FETCH os.shop.owner
-        LEFT JOIN FETCH os.shop.owner.user
-        LEFT JOIN FETCH os.shop.shopOpens
-        WHERE os.id = :orderableShopId
-    """)
+            SELECT os
+            FROM OrderableShop os
+            JOIN FETCH os.shop
+            LEFT JOIN FETCH os.shop.owner
+            LEFT JOIN FETCH os.shop.owner.user
+            LEFT JOIN FETCH os.shop.shopOpens
+            WHERE os.id = :orderableShopId
+        """)
     Optional<OrderableShop> findByIdJoinFetchShop(@Param("orderableShopId") Integer orderableShopId);
 
     default OrderableShop getOrderableShopInfoDetailById(Integer orderableShopId) {
         return findByIdJoinFetchShop(orderableShopId).orElseThrow(
-            () -> new OrderableShopNotFoundException("해당 상점이 존재하지 않습니다 : " + orderableShopId)
+            () -> new OrderableShopNotFoundException(
+                "해당 상점이 존재하지 않습니다 : " + orderableShopId
+            )
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -20,6 +20,8 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
                 s.introduction,
                 os.delivery,
                 os.takeout,
+                os.shop.payCard,
+                os.shop.payBank,
                 os.minimumOrderAmount,
                 CAST(COALESCE(AVG(r.rating), 0.0) AS double),
                 CAST(COUNT(DISTINCT r.id) AS int),

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -44,7 +44,6 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
         SELECT os
         FROM OrderableShop os
         JOIN FETCH os.shop
-        LEFT JOIN FETCH os.shop.origin
         LEFT JOIN FETCH os.shop.owner
         LEFT JOIN FETCH os.shop.owner.user
         LEFT JOIN FETCH os.shop.shopOpens

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -6,16 +6,37 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.domain.order.shop.exception.OrderableShopNotFoundException;
+import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary;
 import in.koreatech.koin.domain.order.shop.model.entity.OrderableShop;
 
 public interface OrderableShopRepository extends JpaRepository<OrderableShop, Integer> {
 
     @Query("""
-         SELECT os
-         FROM OrderableShop os
-         JOIN FETCH os.shop
-         JOIN FETCH os.shop.reviews
-         WHERE os.id =:shopId
+    SELECT new in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary(
+        s.id,
+        os.id,
+        s.name,
+        os.delivery,
+        os.takeout,
+        os.minimumOrderAmount,
+        CAST(COALESCE(AVG(r.rating), 0.0) AS double),
+        CAST(COUNT(DISTINCT r.id) AS long),
+        CAST(COALESCE(MIN(bdt.fee), 0) AS int),
+        CAST(COALESCE(MAX(bdt.fee), 0) AS int)
+    )
+    FROM OrderableShop os
+    JOIN os.shop s
+    LEFT JOIN s.reviews r
+    LEFT JOIN s.baseDeliveryTips bdt
+    WHERE os.id = :orderableShopId
+    GROUP BY os.id, s.id
     """)
-    Optional<OrderableShop> findById(@Param("shopId") Integer shopId);
+    Optional<OrderableShopInfoSummary> findOrderableShopInfoSummaryById(@Param("orderableShopId") Integer orderableShopId);
+
+    default OrderableShopInfoSummary getOrderableShopInfoSummaryById(Integer shopId) {
+        return findOrderableShopInfoSummaryById(shopId).orElseThrow(
+            () -> new OrderableShopNotFoundException("해당 상점이 존재하지 않습니다 : " + shopId)
+        );
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
@@ -1,9 +1,20 @@
 package in.koreatech.koin.domain.order.shop.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
+import in.koreatech.koin.domain.order.shop.repository.OrderableShopRepository;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderableShopInformationService {
 
+    private final OrderableShopRepository orderableShopRepository;
 
+    public OrderableShopInfoSummaryResponse getOrderableShopInfoByIdJpaDtoProjection(Integer orderableShopId) {
+        return OrderableShopInfoSummaryResponse.from(orderableShopRepository.getOrderableShopInfoSummaryById(orderableShopId));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.order.shop.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoDetailResponse;
 import in.koreatech.koin.domain.order.shop.dto.shopinfo.OrderableShopInfoSummaryResponse;
 import in.koreatech.koin.domain.order.shop.repository.OrderableShopRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,13 @@ public class OrderableShopInformationService {
 
     private final OrderableShopRepository orderableShopRepository;
 
-    public OrderableShopInfoSummaryResponse getOrderableShopInfoByIdJpaDtoProjection(Integer orderableShopId) {
-        return OrderableShopInfoSummaryResponse.from(orderableShopRepository.getOrderableShopInfoSummaryById(orderableShopId));
+    public OrderableShopInfoSummaryResponse getOrderableShopInfoSummaryById(Integer orderableShopId) {
+        return OrderableShopInfoSummaryResponse.from(
+            orderableShopRepository.getOrderableShopInfoSummaryById(orderableShopId));
+    }
+
+    public OrderableShopInfoDetailResponse getOrderableShopInfoDetailById(Integer orderableShopId) {
+        return OrderableShopInfoDetailResponse.from(
+            orderableShopRepository.getOrderableShopInfoDetailById(orderableShopId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.domain.order.shop.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderableShopInformationService {
+
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopListService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopListService.java
@@ -1,4 +1,4 @@
-package in.koreatech.koin.domain.shop.service;
+package in.koreatech.koin.domain.order.shop.service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -12,22 +12,22 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopBaseInfo;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopDetailInfo;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopOpenStatus;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsFilterCriteria;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsResponse.ShopOpenInfo;
-import in.koreatech.koin.domain.shop.dto.order.OrderableShopsSortCriteria;
-import in.koreatech.koin.domain.shop.repository.order.OrderableShopCustomRepository;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopBaseInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopDetailInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopOpenStatus;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCriteria;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse.ShopOpenInfo;
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
+import in.koreatech.koin.domain.order.shop.repository.OrderableShopListCustomRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class OrderableShopService {
+public class OrderableShopListService {
 
-    private final OrderableShopCustomRepository orderableShopCustomRepository;
+    private final OrderableShopListCustomRepository orderableShopListCustomRepository;
 
     public List<OrderableShopsResponse> getOrderableShops(
         OrderableShopsSortCriteria sortCriteria,
@@ -51,7 +51,7 @@ public class OrderableShopService {
 
     private List<OrderableShopBaseInfo> findAllOrderableShopBaseInfo(List<OrderableShopsFilterCriteria> filterCriteria,
         Integer minimumAmount) {
-        return orderableShopCustomRepository.findAllOrderableShopInfo(filterCriteria, minimumAmount);
+        return orderableShopListCustomRepository.findAllOrderableShopInfo(filterCriteria, minimumAmount);
     }
 
     private OrderableShopDetailInfo findAllOrderableShopDetailInfo(List<OrderableShopBaseInfo> shopBaseInfo,
@@ -67,15 +67,15 @@ public class OrderableShopService {
     }
 
     private Map<Integer, List<Integer>> findAllShopCategoriesByShopIds(List<Integer> shopIds) {
-        return orderableShopCustomRepository.findAllCategoriesByShopIds(shopIds);
+        return orderableShopListCustomRepository.findAllCategoriesByShopIds(shopIds);
     }
 
     private Map<Integer, List<String>> findAllShopImagesByShopIds(List<Integer> shopIds) {
-        return orderableShopCustomRepository.findAllShopImagesByShopIds(shopIds);
+        return orderableShopListCustomRepository.findAllShopImagesByShopIds(shopIds);
     }
 
     private Map<Integer, List<ShopOpenInfo>> findAllShopOpensByShopIds(List<Integer> shopIds) {
-        return orderableShopCustomRepository.findAllShopOpensByShopIds(shopIds);
+        return orderableShopListCustomRepository.findAllShopOpensByShopIds(shopIds);
     }
 
     private Map<Integer, ShopOpenInfo> extractTodayOpenSchedule(Map<Integer, List<ShopOpenInfo>> allShopOpens) {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopListService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopListService.java
@@ -19,7 +19,7 @@ import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsFilterCrit
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsResponse.ShopOpenInfo;
 import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopsSortCriteria;
-import in.koreatech.koin.domain.order.shop.repository.OrderableShopListCustomRepository;
+import in.koreatech.koin.domain.order.shop.repository.OrderableShopListQueryRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderableShopListService {
 
-    private final OrderableShopListCustomRepository orderableShopListCustomRepository;
+    private final OrderableShopListQueryRepository orderableShopListQueryRepository;
 
     public List<OrderableShopsResponse> getOrderableShops(
         OrderableShopsSortCriteria sortCriteria,
@@ -51,7 +51,7 @@ public class OrderableShopListService {
 
     private List<OrderableShopBaseInfo> findAllOrderableShopBaseInfo(List<OrderableShopsFilterCriteria> filterCriteria,
         Integer minimumAmount) {
-        return orderableShopListCustomRepository.findAllOrderableShopInfo(filterCriteria, minimumAmount);
+        return orderableShopListQueryRepository.findAllOrderableShopInfo(filterCriteria, minimumAmount);
     }
 
     private OrderableShopDetailInfo findAllOrderableShopDetailInfo(List<OrderableShopBaseInfo> shopBaseInfo,
@@ -67,15 +67,15 @@ public class OrderableShopListService {
     }
 
     private Map<Integer, List<Integer>> findAllShopCategoriesByShopIds(List<Integer> shopIds) {
-        return orderableShopListCustomRepository.findAllCategoriesByShopIds(shopIds);
+        return orderableShopListQueryRepository.findAllCategoriesByShopIds(shopIds);
     }
 
     private Map<Integer, List<String>> findAllShopImagesByShopIds(List<Integer> shopIds) {
-        return orderableShopListCustomRepository.findAllShopImagesByShopIds(shopIds);
+        return orderableShopListQueryRepository.findAllShopImagesByShopIds(shopIds);
     }
 
     private Map<Integer, List<ShopOpenInfo>> findAllShopOpensByShopIds(List<Integer> shopIds) {
-        return orderableShopListCustomRepository.findAllShopOpensByShopIds(shopIds);
+        return orderableShopListQueryRepository.findAllShopOpensByShopIds(shopIds);
     }
 
     private Map<Integer, ShopOpenInfo> extractTodayOpenSchedule(Map<Integer, List<ShopOpenInfo>> allShopOpens) {

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.shop.model.menu;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "shop_menu_origin")
+@NoArgsConstructor(access = PROTECTED)
+public class MenuOrigin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private Shop shop;
+
+    @Lob
+    @Column(name = "origin")
+    private String origin;
+
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/menu/MenuOrigin.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -29,9 +30,13 @@ public class MenuOrigin extends BaseEntity {
     private Integer id;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
+
+    @Lob
+    @Column(name = "ingredient")
+    private String ingredient;
 
     @Lob
     @Column(name = "origin")

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -17,6 +17,7 @@ import org.hibernate.annotations.Where;
 
 import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.order.shop.model.domain.ShopBaseDeliveryTips;
+import in.koreatech.koin.domain.order.shop.model.domain.ShopMenuOrigins;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.event.EventArticle;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
@@ -142,6 +143,9 @@ public class Shop extends BaseEntity {
     @Embedded
     private ShopBaseDeliveryTips baseDeliveryTips = new ShopBaseDeliveryTips();
 
+    @Embedded
+    private ShopMenuOrigins menuOrigins = new ShopMenuOrigins();
+
     @Size(max = 10)
     @Column(name = "bank", length = 10)
     private String bank;
@@ -157,9 +161,6 @@ public class Shop extends BaseEntity {
     @Lob
     @Column(name = "notice")
     private String notice;
-
-    @OneToOne(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
-    private MenuOrigin origin;
 
     @Builder
     private Shop(

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -22,6 +22,7 @@ import org.hibernate.annotations.Where;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.event.EventArticle;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
+import in.koreatech.koin.domain.order.shop.model.entity.ShopBaseDeliveryTip;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
 import in.koreatech.koin._common.model.BaseEntity;
 import jakarta.persistence.Column;
@@ -136,6 +137,9 @@ public class Shop extends BaseEntity {
 
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
     private List<ShopReview> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private List<ShopBaseDeliveryTip> baseDeliveryTips = new ArrayList<>();
 
     @Size(max = 10)
     @Column(name = "bank", length = 10)

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -1,13 +1,9 @@
 package in.koreatech.koin.domain.shop.model.shop;
 
-import static jakarta.persistence.CascadeType.MERGE;
-import static jakarta.persistence.CascadeType.PERSIST;
-import static jakarta.persistence.CascadeType.REFRESH;
-import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import in.koreatech.koin.domain.shop.model.menu.Menu;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.TextStyle;
@@ -19,21 +15,26 @@ import java.util.Set;
 
 import org.hibernate.annotations.Where;
 
+import in.koreatech.koin._common.model.BaseEntity;
+import in.koreatech.koin.domain.order.shop.model.domain.ShopBaseDeliveryTips;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.event.EventArticle;
+import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
-import in.koreatech.koin.domain.order.shop.model.entity.ShopBaseDeliveryTip;
+import in.koreatech.koin.domain.shop.model.menu.MenuOrigin;
 import in.koreatech.koin.domain.shop.model.review.ShopReview;
-import in.koreatech.koin._common.model.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -138,8 +139,8 @@ public class Shop extends BaseEntity {
     @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
     private List<ShopReview> reviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
-    private List<ShopBaseDeliveryTip> baseDeliveryTips = new ArrayList<>();
+    @Embedded
+    private ShopBaseDeliveryTips baseDeliveryTips = new ShopBaseDeliveryTips();
 
     @Size(max = 10)
     @Column(name = "bank", length = 10)
@@ -148,6 +149,17 @@ public class Shop extends BaseEntity {
     @Size(max = 20)
     @Column(name = "account_number", length = 20)
     private String accountNumber;
+
+    @Lob
+    @Column(name = "introduction")
+    private String introduction;
+
+    @Lob
+    @Column(name = "notice")
+    private String notice;
+
+    @OneToOne(mappedBy = "shop", orphanRemoval = true, cascade = {PERSIST, REFRESH, MERGE, REMOVE})
+    private MenuOrigin origin;
 
     @Builder
     private Shop(

--- a/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/web/config/SwaggerGroupConfig.java
@@ -35,7 +35,8 @@ public class SwaggerGroupConfig {
             "in.koreatech.koin.domain.benefit",
             "in.koreatech.koin.domain.ownershop",
             "in.koreatech.koin.domain.shop",
-            "in.koreatech.koin.domain.land"
+            "in.koreatech.koin.domain.land",
+            "in.koreatech.koin.domain.order"
         };
 
         return createGroupedOpenApi("2. Business API", packagesPath);

--- a/src/main/resources/db/migration/V163__alter_shops_add_column_introduction_notice.sql
+++ b/src/main/resources/db/migration/V163__alter_shops_add_column_introduction_notice.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `shops`
+    ADD COLUMN `introduction` TEXT NULL COMMENT '가게 소개' AFTER `description`,
+    ADD COLUMN `notice`       TEXT NULL COMMENT '가게 알림'  AFTER `introduction`;

--- a/src/main/resources/db/migration/V164__add_shop_menu_origin.sql
+++ b/src/main/resources/db/migration/V164__add_shop_menu_origin.sql
@@ -1,7 +1,8 @@
 CREATE TABLE IF NOT EXISTS `koin`.`shop_menu_origin`
 (
     `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
-    `shop_id`       INT UNSIGNED NOT NULL UNIQUE    COMMENT '상점 ID',
+    `shop_id`       INT UNSIGNED NOT NULL           COMMENT '상점 ID',
+    `ingredient`    TEXT         NULL               COMMENT '재료 정보',
     `origin`        TEXT         NULL               COMMENT '원산지 정보',
     `is_deleted`    tinyint(1)   NOT NULL DEFAULT 0 COMMENT '삭제 여부',
     `created_at`    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',

--- a/src/main/resources/db/migration/V164__add_shop_menu_origin.sql
+++ b/src/main/resources/db/migration/V164__add_shop_menu_origin.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `koin`.`shop_menu_origin`
+(
+    `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `shop_id`       INT UNSIGNED NOT NULL UNIQUE    COMMENT '상점 ID',
+    `origin`        TEXT         NULL               COMMENT '원산지 정보',
+    `is_deleted`    tinyint(1)   NOT NULL DEFAULT 0 COMMENT '삭제 여부',
+    `created_at`    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`)
+);
+
+CREATE INDEX idx_shop_menu_origin_shop_id ON shop_menu_origin (shop_id);


### PR DESCRIPTION
# 🔥 연관 이슈

- #1644 

# 🚀 작업 내용

## 1. shop_menu_origin (원산지) 테이블 추가 (6.12 수정)
```mermaid
classDiagram
    class shop_menu_origin {
        +INT UNSIGNED id PK
        +INT UNSIGNED shop_id 
        +TEXT ingredient
        +TEXT origin
        +TINYINT(1) is_deleted
        +TIMESTAMP created_at
        +TIMESTAMP updated_at
    }

    %% Index
    note for shop_menu_origin "Index: idx_shop_menu_origin_shop_id ON shop_id"
``` 
- 6.12 수정사항 : 1:N 관계로 변경, 재료:원산지 형태로 저장. shop_id 유니크 제약조건 제거

## 2. shops 테이블에 introduction, notice 필드 추가
![image](https://github.com/user-attachments/assets/468c9be0-a9bc-48a7-8dab-ac061384b181)

## 3. 단일 상점 요약 정보 조회 api 추가
![image](https://github.com/user-attachments/assets/825e894a-4e4e-4862-8ce8-b6fd841d991e)
```json
{
  "shop_id": 2,
  "orderable_shop_id": 1,
  "name": "가장 맛있는 족발",
  "is_delivery_available": true,
  "is_takeout_available": false,
  "minimum_order_amount": 19000,
  "rating_average": 4.3,
  "review_count": 33,
  "minimum_delivery_tip": 2500,
  "maximum_delivery_tip": 4500
}
```
- 단순 조회 쿼리(영속성 유지 필요 없음) + 복수의 @OneToOne 관계로 인한 비효율 문제로 jpql dto 프로젝션으로 구현했습니다.

## 3. 단일 상점 가게 정보·원산지 조회 api 추가
![image](https://github.com/user-attachments/assets/2ceb1a34-0e6c-4f16-a3ae-0ea262d42591)

```json
{
  "shop_id": 11,
  "orderable_shop_id": 2,
  "name": "굿모닝살로만치킨",
  "address": "충청남도 천안시 동남구 병천면 충절로 1638 신한아파트 상가dsa",
  "open_time": "16:00:00",
  "close_time": "23:00:00",
  "closed_days": [],
  "phone": "041-557-7942",
  "introduction": "안녕하세요, 굿모닝 살로만 치킨입니다!\n최상급 국내산 닭고기를 사용해 바삭하고 촉촉한 치킨을 제공합니다.\n매일 신선한 재료로 정성껏 요리하며, 고객님의 행복한 식사를 위해 최선을 다하겠습니다.\n가족, 친구와 함께 즐기는 맛있는 치킨으로 특별한 순간을 만들어 보세요!\n언제나 굿모닝처럼 상쾌한 기분을 드리겠습니다.",
  "notice": "*굿모닝 치킨 이벤트*\n치킨 2마리 주문 시 콜라 1.25L 무료 증정!\n50,000원 이상 주문 시 감자튀김 서비스 제공!\n매주 월요일은 치킨 10% 할인 데이!\n포장 주문 시 추가 5% 할인!\n배달 주문은 빠르고 따뜻하게 도착합니다.",
  "delivery_tips": [
    {
      "from_amount": 15000,
      "to_amount": 20000,
      "fee": 3500
    },
    {
      "from_amount": 20000,
      "to_amount": null,
      "fee": 1500
    }
  ],
  "owner_info": {
    "name": null,
    "shop_name": null,
    "address": null,
    "company_registration_number": null
  },
  "origin": [
    {
      "ingredient": "소고기",
      "origin": "국내산 한우"
    },
    {
      "ingredient": "쌀",
      "origin": "국내산"
    }
  ]
}
```
- dto 프로젝션 사용하려고 했는데 너무 복잡해져서 JPA 사용했습니다. FETCH JOIN 사용해서 쿼리는 2번 나갑니다.

## 4. 패키지 구조 변경
- 기존 shop 패키지에 있던 주문 가능 상점 전체 조회 api 관련 코드를 별도의 도메인 패키지 `order` 에 분리했습니다.
- 일단 이렇게 해놓긴 했는데 기존의 shop 도메인과 겹치는 부분도 있어서 더 나은 방법을 고민해봐야 할 것 같습니다.

# 💬 리뷰 중점사항
