### PR TITLE
refactor: 동아리 조회 시 비관적락을 원자적 연산으로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -3,15 +3,13 @@ package in.koreatech.koin.domain.club.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.club.exception.ClubNotFoundException;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubCategory;
-import jakarta.persistence.LockModeType;
 
 public interface ClubRepository extends Repository<Club, Integer> {
 
@@ -23,19 +21,9 @@ public interface ClubRepository extends Repository<Club, Integer> {
         return findById(id).orElseThrow(() -> ClubNotFoundException.withDetail("id : " + id));
     }
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT c FROM Club c WHERE c.id = :id")
-    Club findByIdWithPessimisticLock(@Param("id") Integer id);
-
-    default Club getByIdWithPessimisticLock(Integer id) {
-        Club club = findByIdWithPessimisticLock(id);
-
-        if (club == null) {
-            throw ClubNotFoundException.withDetail("id : " + id);
-        }
-
-        return club;
-    }
+    @Modifying
+    @Query("UPDATE Club c SET c.hits = c.hits + 1 WHERE c.id = :id")
+    void incrementHits(Integer id);
 
     Club save(Club club);
 

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -131,14 +131,14 @@ public class ClubService {
 
     @Transactional
     public ClubResponse getClub(Integer clubId, Integer userId) {
-        Club club = clubRepository.getByIdWithPessimisticLock(clubId);
+        Club club = clubRepository.getById(clubId);
         if (!club.getIsActive()) {
             throw new IllegalStateException("비활성화 동아리입니다.");
         }
-        club.increaseHits();
+        clubRepository.incrementHits(clubId);
+
         List<ClubSNS> clubSNSs = clubSNSRepository.findAllByClub(club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, userId);
-
         Boolean isLiked = clubLikeRepository.existsByClubIdAndUserId(clubId, userId);
 
         return ClubResponse.from(club, clubSNSs, manager, isLiked);
@@ -208,7 +208,6 @@ public class ClubService {
         return hotClubRedisRepository.findById(ClubHotRedis.REDIS_KEY)
             .map(ClubHotResponse::from)
             .orElseGet(this::getHotClubFromDBAndCache);
-
     }
 
     private ClubHotResponse getHotClubFromDBAndCache() {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1661 

# 🚀 작업 내용

- 동아리 조회 시 비관적락으로 동시성 문제를 방지하던 방식을 원자적 연산으로 변경하였습니다

# 💬 리뷰 중점사항
- 조회 → 조회한값 + 1과같은 상황때문에 동시성문제가 발생하는 것이므로 원자적 연산으로 조회와 별개로 조회하도록 했습니다.