### PR TITLE
refactor: 동아리 조회수 갱신 로직을 redis 스케줄링 방식으로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -43,7 +43,7 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + :value WHERE c.id = :id")
-    void incrementHitsByValue(Integer id, Long value);
+    void incrementHitsByValue(Integer id, Integer value);
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + 1 WHERE c.id = :id")

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -24,6 +24,9 @@ public interface ClubRepository extends Repository<Club, Integer> {
         return findById(id).orElseThrow(() -> ClubNotFoundException.withDetail("id : " + id));
     }
 
+    @Query("SELECT c.id FROM Club c WHERE c.id IN :ids")
+    List<Integer> findExistingIds(List<Integer> ids);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Club c WHERE c.id = :id")
     Club findByIdWithPessimisticLock(@Param("id") Integer id);
@@ -37,6 +40,10 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
         return club;
     }
+
+    @Modifying
+    @Query("UPDATE Club c SET c.hits = c.hits + :value WHERE c.id = :id")
+    void incrementHitsByValue(Integer id, Long value);
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + 1 WHERE c.id = :id")

--- a/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
@@ -21,9 +21,9 @@ public class ClubHitsRedisRepository {
         return redisTemplate.keys("club:hits:*");
     }
 
-    public Long getHits(String key) {
+    public Integer getHits(String key) {
         Object value = redisTemplate.opsForValue().get(key);
-        return value instanceof Integer ? (Integer) value : 0L;
+        return value instanceof Integer ? (Integer) value : 0;
     }
 
     public void deleteHitsByKeys(Set<String> keys) {

--- a/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.club.repository.redis;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ClubHitsRedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void incrementHits(Integer clubId) {
+        redisTemplate.opsForValue().increment("club:hits:" + clubId);
+    }
+
+    public Set<String> getAllHitsKeys() {
+        return redisTemplate.keys("club:hits:*");
+    }
+
+    public Long getHits(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return value instanceof Long ? (Long) value : 0L;
+    }
+
+    public void deleteHitsByKeys(Set<String> keys) {
+        redisTemplate.delete(keys);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/redis/ClubHitsRedisRepository.java
@@ -23,7 +23,7 @@ public class ClubHitsRedisRepository {
 
     public Long getHits(String key) {
         Object value = redisTemplate.opsForValue().get(key);
-        return value instanceof Long ? (Long) value : 0L;
+        return value instanceof Integer ? (Integer) value : 0L;
     }
 
     public void deleteHitsByKeys(Set<String> keys) {

--- a/src/main/java/in/koreatech/koin/domain/club/scheduler/ClubScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/club/scheduler/ClubScheduler.java
@@ -22,4 +22,13 @@ public class ClubScheduler {
             log.error("인기 동아리 업데이트 중에 오류가 발생했습니다.", e);
         }
     }
+
+    @Scheduled(fixedRate = 20000)
+    public void syncClubHits() {
+        try {
+            scheduleService.syncHitsFromRedisToDatabase();
+        } catch (Exception e) {
+            log.error("조회수 동기화 중에 오류가 발생했습니다.", e);
+        }
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/scheduler/ClubScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/club/scheduler/ClubScheduler.java
@@ -23,7 +23,7 @@ public class ClubScheduler {
         }
     }
 
-    @Scheduled(fixedRate = 20000)
+    @Scheduled(fixedRate = 600000)
     public void syncClubHits() {
         try {
             scheduleService.syncHitsFromRedisToDatabase();

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
@@ -93,7 +93,7 @@ public class ClubScheduleService {
         for (Integer clubId : existingIds) {
             try {
                 String key = clubIdToKeyMap.get(clubId);
-                Long hits = clubHitsRedisRepository.getHits(key);
+                Integer hits = clubHitsRedisRepository.getHits(key);
                 clubRepository.incrementHitsByValue(clubId, hits);
                 deletedKeys.add(key);
             } catch (Exception e) {

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubScheduleService.java
@@ -2,8 +2,13 @@ package in.koreatech.koin.domain.club.service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +18,7 @@ import in.koreatech.koin.domain.club.model.ClubHot;
 import in.koreatech.koin.domain.club.model.redis.ClubHotRedis;
 import in.koreatech.koin.domain.club.repository.ClubHotRepository;
 import in.koreatech.koin.domain.club.repository.ClubRepository;
+import in.koreatech.koin.domain.club.repository.redis.ClubHitsRedisRepository;
 import in.koreatech.koin.domain.club.repository.redis.ClubHotRedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class ClubScheduleService {
 
+    private static final int KEY_PREFIX_LENGTH = "club:hits:".length();
+
     private final ClubRepository clubRepository;
     private final ClubHotRedisRepository hotClubRedisRepository;
     private final ClubHotRepository clubHotRepository;
+    private final ClubHitsRedisRepository clubHitsRedisRepository;
 
     @Transactional
     public void updateHotClub() {
@@ -62,5 +71,36 @@ public class ClubScheduleService {
         return LocalDate.now()
             .minusWeeks(1)
             .with(DayOfWeek.SUNDAY);
+    }
+
+    @Transactional
+    public void syncHitsFromRedisToDatabase() {
+        Set<String> keys = clubHitsRedisRepository.getAllHitsKeys();
+        if (keys.isEmpty()) return;
+
+        Map<Integer, String> clubIdToKeyMap = new HashMap<>();
+        List<Integer> clubIds = new ArrayList<>();
+
+        for (String key : keys) {
+            Integer clubId = Integer.parseInt(key.substring(KEY_PREFIX_LENGTH));
+            clubIdToKeyMap.put(clubId, key);
+            clubIds.add(clubId);
+        }
+
+        List<Integer> existingIds = clubRepository.findExistingIds(clubIds);
+        Set<String> deletedKeys = new HashSet<>();
+
+        for (Integer clubId : existingIds) {
+            try {
+                String key = clubIdToKeyMap.get(clubId);
+                Long hits = clubHitsRedisRepository.getHits(key);
+                clubRepository.incrementHitsByValue(clubId, hits);
+                deletedKeys.add(key);
+            } catch (Exception e) {
+                log.warn("clubId {}의 조회수 DB 반영 실패", clubId, e);
+            }
+        }
+
+        clubHitsRedisRepository.deleteHitsByKeys(deletedKeys);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -42,6 +42,7 @@ import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
 import in.koreatech.koin.domain.club.repository.ClubRepository;
 import in.koreatech.koin.domain.club.repository.ClubSNSRepository;
 import in.koreatech.koin.domain.club.repository.redis.ClubCreateRedisRepository;
+import in.koreatech.koin.domain.club.repository.redis.ClubHitsRedisRepository;
 import in.koreatech.koin.domain.club.repository.redis.ClubHotRedisRepository;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
@@ -66,6 +67,7 @@ public class ClubService {
     private final UserRepository userRepository;
     private final ClubCreateRedisRepository clubCreateRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final ClubHitsRedisRepository clubHitsRedisRepository;
 
     @Transactional
     public void createClubRequest(ClubCreateRequest request, Integer studentId) {
@@ -135,7 +137,7 @@ public class ClubService {
         if (!club.getIsActive()) {
             throw new IllegalStateException("비활성화 동아리입니다.");
         }
-        clubRepository.incrementHits(clubId);
+        clubHitsRedisRepository.incrementHits(clubId);
 
         List<ClubSNS> clubSNSs = clubSNSRepository.findAllByClub(club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, userId);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1663 

# 🚀 작업 내용

### 도입 이유
- 동아리 기능 사용률이 높아짐
- 동아리 상세조회 시 조회수 카운팅으로 인해 매번 쓰기를 수행하는 것은 반복적인 DB 부하
- 또한 인기 동아리인 경우 여러명이 동시에 접근할때 동시성 문제도 발생할 수 있음
  - 이는 기존의 비관적 락 방식(SELECT → UPDATE)에서 앞서 단순 UPDATE 방식으로 변경해 락 점유를 개선한 바 있음
  - 하지만, 여전히 row-level lock으로 인한 병목 발생
- 조회수는 정합성, 실시간성이 매우 중요한 부분은 아님

### 도입 효과
- 반복적인 DB 쓰기로 인한 부하를 줄일 수 있음 
  - 10분마다 스케줄링을 통해 조회수 일괄 갱신 
- 조회 트래픽 급증시에도 안정적 처리
- 동시성 문제 해결
  - Redis의 INCR는 원자적으로 작동 
- 추후 인기 동아리 관리와 여러 캐싱통계 활용 가능

### 로직
- 조회가 발생하는 경우 redis에 INCR로 카운팅
- 10분마다 스케줄링 수행
  - 조회가 발생한 key를 통해 Id를 추출
  - Id가 여전히 유효한 지 쿼리하여 유효한 Id만 남김
  - 해당 Id들에 대해 조회수 갱신 수행

### 갱신 실패 시 해결방안
- 배치 시간 내에 redis에 저장된 id의 동아리가 삭제될 수 있음
  -  Id가 여전히 유효한 지 쿼리하여 유효한 Id만 남기고 로직 수행하도록 개선
- 갱신중간에 실패할 수 있음
  - try-catch를 통해 로깅 및 다음 스케줄링 시 재시도하도록 구성

# 💬 리뷰 중점사항
- 고려하지 못한 예외가 있다면 리뷰 부탁드립니다!
