### PR TITLE
feat: 도로명 주소 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/GlobalExceptionHandler.java
@@ -26,6 +26,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.WebUtils;
 
+import com.amazonaws.services.ec2.model.Address;
+
 import in.koreatech.koin._common.auth.exception.AuthenticationException;
 import in.koreatech.koin._common.auth.exception.AuthorizationException;
 import in.koreatech.koin._common.exception.custom.DataNotFoundException;
@@ -36,6 +38,7 @@ import in.koreatech.koin._common.exception.custom.KoinIllegalArgumentException;
 import in.koreatech.koin._common.exception.custom.KoinIllegalStateException;
 import in.koreatech.koin._common.exception.custom.RequestTooFastException;
 import in.koreatech.koin._common.exception.custom.TooManyRequestsException;
+import in.koreatech.koin.domain.order.address.exception.AddressApiException;
 import in.koreatech.koin.domain.order.cart.exception.CartException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -276,6 +279,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleCartException(
         HttpServletRequest request,
         CartException e
+    ) {
+        log.warn(e.getFullMessage());
+        requestLogging(request);
+        return buildErrorResponseWithErrorCode(
+            HttpStatus.valueOf(e.getErrorCode().getHttpIntegerCode()),
+            e.getFullMessage(),
+            e.getErrorCode().name()
+        );
+    }
+
+    @ExceptionHandler(AddressApiException.class)
+    public ResponseEntity<Object> handleAddressApiException(
+        HttpServletRequest request,
+        AddressApiException e
     ) {
         log.warn(e.getFullMessage());
         requestLogging(request);

--- a/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
@@ -1,0 +1,90 @@
+package in.koreatech.koin.domain.order.address.controller;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import in.koreatech.koin.domain.order.address.dto.AddressSearchRequest;
+import in.koreatech.koin.domain.order.address.dto.AddressSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Common) Address: 주소", description = "주소 API")
+public interface AddressApi {
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "주소 검색 성공",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "검색 결과 존재", value = """
+                    {
+                      "total_count": "203",
+                      "current_page": 1,
+                      "count_per_page": 2,
+                      "addresses": [
+                        {
+                          "road_addr": "충청남도 천안시 동남구 병천면 충절로 1506-4",
+                          "jibun_addr": "충청남도 천안시 동남구 병천면 가전리 278-1",
+                          "eng_addr": "1506-4 Chungjeol-ro, Byeongcheon-myeon, Dongnam-gu, Cheonan-si, Chungcheongnam-do",
+                          "zip_no": "31253"
+                        },
+                        {
+                          "road_addr": "충청남도 천안시 동남구 병천면 충절로 1506-6",
+                          "jibun_addr": "충청남도 천안시 동남구 병천면 가전리 278-1",
+                          "eng_addr": "1506-6 Chungjeol-ro, Byeongcheon-myeon, Dongnam-gu, Cheonan-si, Chungcheongnam-do",
+                          "zip_no": "31253"
+                        }
+                      ]
+                    }
+                    """),
+                @ExampleObject(name = "검색 결과 없음", value = """
+                    {
+                      "total_count": "0",
+                      "current_page": 1,
+                      "count_per_page": 10,
+                      "addresses": []
+                    }
+                    """)
+            })
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "검색어 글자 수 부족", value = """
+                    {
+                      "code": "KEYWORD_TOO_SHORT",
+                      "message": "검색어는 두글자 이상 입력되어야 합니다.",
+                      "errorTraceId": "a3e73b85-8c84-41f1-9f24-e6a4ae38aea3"
+                    }
+                    """)
+            })
+        ),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "외부 API 연동 실패", summary = "외부 API 시스템 오류", value = """
+                    {
+                      "code": "EXTERNAL_API_ERROR",
+                      "message": "주소 정보를 가져오는 중 오류가 발생했습니다.",
+                      "errorTraceId": "a3e73b85-8c84-41f1-9f24-e6a4ae38aea3"
+                    }
+                    """)
+            })
+        )
+    })
+    @Operation(summary = "주소 검색", description = """
+        ### 키워드를 사용하여 주소를 검색합니다.
+        - 행정안전부 주소기반산업지원서비스 API를 호출하여 결과를 반환합니다.
+                
+        ### 요청 파라미터
+        - **keyword**: 검색할 주소 (**필수**, 2자 이상, 한글 40자 이하, 숫자만 검색 불가, 시도명으로는 검색 불가, 특수문자(%,=,>,<,[,]) 불가)
+        - **current_page**: 현재 페이지 (1 이상)
+        - **count_per_page**: 페이지당 항목 수 (1 이상)
+        """)
+    @GetMapping("/api/addresses/search")
+    ResponseEntity<AddressSearchResponse> searchAddress(
+        @ParameterObject @Valid AddressSearchRequest request
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
-@Tag(name = "(Common) Address: 주소", description = "주소 API")
+@Tag(name = "(Normal) Address: 주소", description = "주소 API")
 public interface AddressApi {
 
     @ApiResponses(value = {
@@ -70,6 +70,13 @@ public interface AddressApi {
                       "message": "주소 정보를 가져오는 중 오류가 발생했습니다.",
                       "errorTraceId": "a3e73b85-8c84-41f1-9f24-e6a4ae38aea3"
                     }
+                    """),
+                @ExampleObject(name = "외부 API 연동 실패", summary = "요청 키 만료", value = """
+                    {
+                      "code": "INVALID_API_KEY",
+                      "message": "승인되지 않은 KEY 입니다.",
+                      "errorTraceId": "eed20ecf-0dd1-49f7-bfe7-1f7686fb6729"
+                    }
                     """)
             })
         )
@@ -83,7 +90,7 @@ public interface AddressApi {
         - **current_page**: 현재 페이지 (1 이상)
         - **count_per_page**: 페이지당 항목 수 (1 이상)
         """)
-    @GetMapping("/api/addresses/search")
+    @GetMapping("/order/address/search")
     ResponseEntity<AddressSearchResponse> searchAddress(
         @ParameterObject @Valid AddressSearchRequest request
     );

--- a/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressController.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.domain.order.address.controller;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.order.address.dto.AddressSearchRequest;
+import in.koreatech.koin.domain.order.address.dto.AddressSearchResponse;
+import in.koreatech.koin.domain.order.address.service.AddressService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AddressController implements AddressApi {
+
+    private final AddressService addressService;
+
+    @GetMapping("/order/address/search")
+    public ResponseEntity<AddressSearchResponse> searchAddress(
+        @ParameterObject @Valid AddressSearchRequest request
+    ) {
+        AddressSearchResponse response = addressService.searchAddress(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchRequest.java
@@ -1,0 +1,31 @@
+package in.koreatech.koin.domain.order.address.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AddressSearchRequest(
+
+    @Schema(description = "검색할 주소 키워드", example = "병천면 충절로", requiredMode = REQUIRED)
+    @NotBlank
+    String keyword,
+
+    @Schema(description = "현재 페이지 번호", example = "1")
+    @NotNull
+    @Min(value = 1)
+    Integer currentPage,
+
+    @Schema(description = "페이지당 결과 수", example = "10")
+    @NotNull
+    @Min(value = 1)
+    Integer countPerPage
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchResponse.java
@@ -27,16 +27,26 @@ public record AddressSearchResponse(
     @JsonNaming(value = SnakeCaseStrategy.class)
     public record AddressInfo(
         @Schema(description = "전체 도로명 주소")
-        String roadAddr,
-
+        String roadAddress,
         @Schema(description = "지번 주소")
-        String jibunAddr,
-
+        String jibunAddress,
         @Schema(description = "영문 주소")
-        String engAddr,
-
+        String engAddress,
         @Schema(description = "우편번호")
-        String zipNo
+        String zipNo,
+        @Schema(description = "건물명")
+        String bdNm,
+        @Schema(description = "시도명")
+        String siNm,
+        @Schema(description = "시군구명")
+        String sggNm,
+        @Schema(description = "읍면동명")
+        String emdNm,
+        @Schema(description = "법정리명")
+        String liNm,
+        @Schema(description = "도로명")
+        String rn
+
     ) {
 
         public static AddressInfo from(RoadNameAddressApiResponse.Juso juso) {
@@ -44,7 +54,13 @@ public record AddressSearchResponse(
                 juso.roadAddr(),
                 juso.jibunAddr(),
                 juso.engAddr(),
-                juso.zipNo()
+                juso.zipNo(),
+                juso.bdNm(),
+                juso.siNm(),
+                juso.sggNm(),
+                juso.emdNm(),
+                juso.liNm(),
+                juso.rn()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/dto/AddressSearchResponse.java
@@ -1,0 +1,72 @@
+package in.koreatech.koin.domain.order.address.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record AddressSearchResponse(
+
+    @Schema(description = "전체 검색 데이터 수")
+    String totalCount,
+
+    @Schema(description = "현재 페이지 번호")
+    Integer currentPage,
+
+    @Schema(description = "페이지당 결과 수")
+    Integer countPerPage,
+
+    @Schema(description = "주소 목록")
+    List<AddressInfo> addresses
+) {
+
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record AddressInfo(
+        @Schema(description = "전체 도로명 주소")
+        String roadAddr,
+
+        @Schema(description = "지번 주소")
+        String jibunAddr,
+
+        @Schema(description = "영문 주소")
+        String engAddr,
+
+        @Schema(description = "우편번호")
+        String zipNo
+    ) {
+
+        public static AddressInfo from(RoadNameAddressApiResponse.Juso juso) {
+            return new AddressInfo(
+                juso.roadAddr(),
+                juso.jibunAddr(),
+                juso.engAddr(),
+                juso.zipNo()
+            );
+        }
+    }
+
+    public static AddressSearchResponse from(RoadNameAddressApiResponse apiResponse) {
+        RoadNameAddressApiResponse.Results results = apiResponse.results();
+        RoadNameAddressApiResponse.Common common = results.common();
+        List<AddressInfo> addressInfos;
+
+        if (results.jusoList() != null && !results.jusoList().isEmpty()) {
+            addressInfos = results.jusoList().stream()
+                .map(AddressInfo::from)
+                .collect(Collectors.toList());
+        } else {
+            addressInfos = Collections.emptyList();
+        }
+
+        return new AddressSearchResponse(
+            common.totalCount(),
+            common.currentPage(),
+            common.countPerPage(),
+            addressInfos
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/dto/RoadNameAddressApiResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/dto/RoadNameAddressApiResponse.java
@@ -1,0 +1,60 @@
+package in.koreatech.koin.domain.order.address.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RoadNameAddressApiResponse(
+    Results results
+) {
+
+    public record Results(
+        Common common,
+        @JsonProperty("juso")
+        List<Juso> jusoList
+    ) {
+
+    }
+
+    public record Common(
+        String totalCount,
+        Integer currentPage,
+        Integer countPerPage,
+        String errorCode,
+        String errorMessage
+    ) {
+
+    }
+
+    public record Juso(
+        String roadAddr,
+        String roadAddrPart1,
+        String roadAddrPart2,
+        String jibunAddr,
+        String engAddr,
+        String zipNo,
+        String admCd,
+        String rnMgtSn,
+        String bdMgtSn,
+        String detBdNmList,
+        String bdNm,
+        String bdKdcd,
+        String siNm,
+        String sggNm,
+        String emdNm,
+        String liNm,
+        String rn,
+        String udrtYn,
+        String buldMnnm,
+        String buldSlnm,
+        String mtYn,
+        String lnbrMnnm,
+        String lnbrSlnm,
+        String emdNo,
+        String hstryYn,
+        String relJibun,
+        String hemdNm
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/exception/AddressApiException.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/exception/AddressApiException.java
@@ -1,0 +1,26 @@
+package in.koreatech.koin.domain.order.address.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AddressApiException extends RuntimeException {
+
+    private final AddressErrorCode errorCode;
+    private final String detail;
+
+    public AddressApiException(AddressErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = null;
+    }
+
+    public AddressApiException(AddressErrorCode errorCode, String detail) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+    public String getFullMessage() {
+        return detail != null ? String.format("%s", detail) : getMessage();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/exception/AddressErrorCode.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/exception/AddressErrorCode.java
@@ -1,0 +1,51 @@
+package in.koreatech.koin.domain.order.address.exception;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.springframework.http.HttpStatus;
+
+import in.koreatech.koin._common.exception.errorcode.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AddressErrorCode implements BaseErrorCode {
+
+    // 400 (사용자 입력 오류)
+    KEYWORD_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "E0005", "검색어를 입력해주세요."),
+    KEYWORD_TOO_EXTENSIVE(HttpStatus.BAD_REQUEST, "E0006", "주소를 상세히 입력해 주세요"),
+    KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "E0008", "검색어는 두 글자 이상 입력해야 합니다."),
+    KEYWORD_ONLY_NUMBER(HttpStatus.BAD_REQUEST, "E0009", "검색어는 문자와 숫자 같이 입력되어야 합니다."),
+    KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "E0010", "검색어가 너무 깁니다. (한글 40자 이하)"),
+    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "E0013", "검색어에 사용할 수 없는 특수문자(%,=,<,[,])가 포함되어 있습니다."),
+    SEARCH_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E0015", "검색 결과가 너무 많습니다."),
+
+    // 500 (서버 오류 또는 외부 API 호출 문제)
+    SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "-999", "도로명주소 API 시스템에 에러가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    INVALID_API_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "E0001", "서비스 설정에 오류가 발생했습니다."),
+    API_KEY_EXPIRED(HttpStatus.INTERNAL_SERVER_ERROR, "E0014", "서비스 설정에 오류가 발생했습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL_API_ERROR", "주소 정보를 가져오는 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatusCode;
+    private final String externalApiCode;
+    @Getter
+    private final String message;
+
+    @Override
+    public String getHttpCode() {
+        return httpStatusCode.toString();
+    }
+
+    @Override
+    public Integer getHttpIntegerCode() {
+        return httpStatusCode.value();
+    }
+
+    public static AddressErrorCode from(String externalApiCode) {
+        return Arrays.stream(AddressErrorCode.values())
+            .filter(code -> Objects.equals(code.externalApiCode, externalApiCode))
+            .findFirst()
+            .orElse(EXTERNAL_API_ERROR);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/service/AddressService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/service/AddressService.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AddressService {
 
     private final RoadNameAddressClient roadNameAddressClient;

--- a/src/main/java/in/koreatech/koin/domain/order/address/service/AddressService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/service/AddressService.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.order.address.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.order.address.dto.AddressSearchRequest;
+import in.koreatech.koin.domain.order.address.dto.AddressSearchResponse;
+import in.koreatech.koin.domain.order.address.dto.RoadNameAddressApiResponse;
+import in.koreatech.koin.domain.order.address.service.client.RoadNameAddressClient;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressService {
+
+    private final RoadNameAddressClient roadNameAddressClient;
+
+    public AddressSearchResponse searchAddress(AddressSearchRequest request) {
+        RoadNameAddressApiResponse apiResponse = roadNameAddressClient.searchAddress(
+            request.keyword(),
+            request.currentPage(),
+            request.countPerPage()
+        );
+
+        return AddressSearchResponse.from(apiResponse);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/address/service/client/RoadNameAddressClient.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/service/client/RoadNameAddressClient.java
@@ -1,0 +1,67 @@
+package in.koreatech.koin.domain.order.address.service.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import in.koreatech.koin.domain.order.address.dto.RoadNameAddressApiResponse;
+import in.koreatech.koin.domain.order.address.exception.AddressApiException;
+import in.koreatech.koin.domain.order.address.exception.AddressErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RoadNameAddressClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${ROAD_NAME_ADDRESS_OPEN_API_KEY}")
+    private String apiKey;
+    private static final String OPEN_API_URL = "https://business.juso.go.kr/addrlink/addrLinkApi.do";
+
+    public RoadNameAddressApiResponse searchAddress(String keyword, int currentPage, int countPerPage) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        var requestEntity = getHttpRequestEntity(headers, keyword, currentPage, countPerPage);
+
+        try {
+            RoadNameAddressApiResponse apiResponse = restTemplate.postForObject(OPEN_API_URL, requestEntity,
+                RoadNameAddressApiResponse.class);
+
+            if (apiResponse == null || apiResponse.results() == null || apiResponse.results().common() == null) {
+                throw new AddressApiException(AddressErrorCode.EXTERNAL_API_ERROR);
+            }
+
+            String errorCode = apiResponse.results().common().errorCode();
+            if (!errorCode.equals("0")) {
+                AddressErrorCode addressErrorCode = AddressErrorCode.from(errorCode);
+                String originalErrorMessage = apiResponse.results().common().errorMessage();
+                throw new AddressApiException(addressErrorCode, originalErrorMessage);
+            }
+            return apiResponse;
+
+        } catch (RestClientException e) {
+            throw new AddressApiException(AddressErrorCode.EXTERNAL_API_ERROR, e.getMessage());
+        }
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> getHttpRequestEntity(HttpHeaders headers, String keyword,
+        int currentPage, int countPerPage) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("confmKey", apiKey);
+        body.add("currentPage", String.valueOf(currentPage));
+        body.add("countPerPage", String.valueOf(countPerPage));
+        body.add("keyword", keyword);
+        body.add("resultType", "json");
+        return new HttpEntity<>(body, headers);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -102,3 +102,8 @@ naver:
 OPEN_API_KEY_PUBLIC: testck
 
 OPEN_API_KEY_TMONEY: testck
+
+address:
+  api:
+    url: https://business.juso.go.kr/addrlink/addrLinkApi.do
+    key: testck


### PR DESCRIPTION
# 🔥 연관 이슈

- #1496 

# 🚀 작업 내용

1. 행정안전부 주소기반산업지원서비스 도로명주소 검색 API 호출 (https://business.juso.go.kr/addrlink/openApi/searchApi.do)

# 💬 리뷰 중점사항
- 외부 API 호출 재미있어요