### PR TITLE
feat: is_deleted 단일 인덱스 삭제 및 is_deleted, is_notice 복합 인덱스 추가

### DIFF
--- a/src/main/resources/db/migration/V186__add_articles_deleted_notice_index.sql
+++ b/src/main/resources/db/migration/V186__add_articles_deleted_notice_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_articles_is_deleted ON new_articles;
+CREATE INDEX idx_articles_deleted_notice ON new_articles (is_deleted, is_notice);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1680 

# 🚀 작업 내용

### 문제상황
- 이전에 is_deleted 단일 인덱스를 추가하여 /articles를 개선함
- 하지만 여전히 간헐적으로 응답시간이 튀는 현상을 발견
![image](https://github.com/user-attachments/assets/eae65ac7-4bc8-45ea-a2d5-ed721514416c)

### 원인 
![image](https://github.com/user-attachments/assets/4d9f9434-e413-4e6b-9b5d-f13ec496f9d4)
![image](https://github.com/user-attachments/assets/9c946337-dee9-4aab-a48c-9144aa2287b6)
- 일반 공지만 불러오는 /articles 요청에서만 지연되는 것을 확인
- 원인은 현재 인덱스가 단일 인덱스(is_deleted)이므로 추가 조건인 is_notice때문에 Covering index가 되지 않을 것으로 추측

### 확인
```java
SELECT COUNT(a1_0.id)
FROM new_articles a1_0
WHERE a1_0.is_deleted = false
  AND a1_0.is_notice = false;
```
#### 단일 인덱스(is_deleted)만 있는 경우의 실행계획 분석
```java
-> Aggregate: count(a1_0.id)
   (cost=1915.63 rows=1)
   (actual time=102.273..102.273 rows=1 loops=1)

    -> Filter: (a1_0.is_notice = false)
       (cost=1828.34 rows=873)
       (actual time=1.757..102.245 rows=492 loops=1)

        -> Index lookup on a1_0 using idx_articles_is_deleted (is_deleted=false)
           (cost=1828.34 rows=8729)
           (actual time=1.710..101.615 rows=15466 loops=1)
```
- is_deleted는 인덱스를 탐
- 하지만 is_deleted는 대부분 false이므로 is_notice 조건을 처리하기위해 추가 필터링을 수행할 때 많은 비용이 필요
- 결국 full table scan을 통해 count하는 것과 큰 차이가 없는 상황

### 해결
- 단일 인덱스(is_deleted)를 삭제
- 복합 인덱스(is_deleted, is_notice) 추가
  - 순서가 is_deleted, is_notice 순으로 생성하면 is_deleted 인덱스의 효과도 얻을 수 있음
```java
-> Aggregate: count(a1_0.id)
   (cost=99.67 rows=1)
   (actual time=0.345..0.345 rows=1 loops=1)

    -> Covering index lookup on a1_0 using idx_articles_deleted_notice (is_deleted=false, is_notice=false)
       (cost=50.47 rows=492)
       (actual time=0.168..0.302 rows=492 loops=1)
```
- 커버링 인덱스로 처리됨을 확인

```java
-> Aggregate: count(a1_0.id)  
   (cost=1752.69 rows=1)  
   (actual time=6.269..6.269 rows=1 loops=1)

    -> Covering index lookup on a1_0 using idx_articles_deleted_notice (is_deleted=false)  
       (cost=879.79 rows=8729)  
       (actual time=0.120..5.083 rows=15466 loops=1)
```
- count의 where조건에 is_deleted만 사용하는 쿼리의 경우에도 커버링 인덱스 잘 작동함을 확인
- 로컬 기준 약 100ms에서 0.3ms로 약 300배의 성능 개선을 확인

# 💬 리뷰 중점사항
- 
