### PR TITLE
fix: 주문 엔티티 테이블 어노테이션 설정 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/model/Order.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/Order.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(schema = "koin", name = "order")
+@Table(schema = "koin", name = "`order`")
 @Where(clause = "is_deleted=0")
 @NoArgsConstructor(access = PROTECTED)
 public class Order extends BaseEntity {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1689 

# 🚀 작업 내용

- order 엔티티에 달린 테이블 어노테이션 설정을 수정했습니다.
  - MySQL에서 order는 예약어이므로, SQL 구문 오류 발생
  - 백틱(`)을 추가해 예약어 아님을 명시

# 💬 리뷰 중점사항
