### PR TITLE
fix: 사용자 정보 수정 미반영 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
+++ b/src/main/java/in/koreatech/koin/domain/student/service/StudentService.java
@@ -128,9 +128,9 @@ public class StudentService {
             user
         );
 
-        updateStudentInfo(student, request.studentNumber(), request.major());
         user.update(request.email(), request.nickname(), request.name(), request.phoneNumber(), request.gender());
         user.updatePassword(passwordEncoder, request.password());
+        updateStudentInfo(student, request.studentNumber(), request.major());
 
         return UpdateStudentResponse.from(student);
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1699

# 🚀 작업 내용

1. `post /v2/users/students/me`: 학부 수정 시 다른 유저 정보(ex: 성별, 이름 등) 미수정 오류 수정
2. [관련 쓰레드](https://bcsdlab.slack.com/archives/C08GSHWASLC/p1751096882710819)

# 💬 리뷰 중점사항
#### 문제 원인
1. `updateStudentInfo(student, request.studentNumber(), request.major());` 메소드 내부에 `entityManager.clear()` 동작이 포함
2. User JPA 엔티티 detached
3. 더티체크를 하지 못해 User 변경사항이 업데이트 안됨

#### 문제 해결
기존의 `Student 정보 수정(clear) -> User 정보 수정` 
`User 정보 수정 -> Student 정보 수정(clear)` << 이렇게 순서 변경