### PR TITLE
feat: 동아리 모집 테이블 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
@@ -1,0 +1,68 @@
+package in.koreatech.koin.domain.club.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDate;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+    schema = "koin",
+    name = "club_recruitment",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_club_recruitment_club_id", columnNames = "club_id")
+    }
+)
+@NoArgsConstructor(access = PROTECTED)
+public class ClubRecruitment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @NotNull
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @NotNull
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @NotNull
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "club_id", nullable = false, updatable = false)
+    private Club club;
+
+    @Builder
+    private ClubRecruitment(
+        LocalDate startDate,
+        LocalDate endDate,
+        String content,
+        Club club
+    ) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.content = content;
+        this.club = club;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
@@ -46,6 +46,10 @@ public class ClubRecruitment extends BaseEntity {
     private LocalDate endDate;
 
     @NotNull
+    @Column(name = "is_always_recruiting", nullable = false, columnDefinition = "TINYINT(1)")
+    private Boolean isAlwaysRecruiting;
+
+    @NotNull
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
@@ -57,11 +61,13 @@ public class ClubRecruitment extends BaseEntity {
     private ClubRecruitment(
         LocalDate startDate,
         LocalDate endDate,
+        Boolean isAlwaysRecruiting,
         String content,
         Club club
     ) {
         this.startDate = startDate;
         this.endDate = endDate;
+        this.isAlwaysRecruiting = isAlwaysRecruiting;
         this.content = content;
         this.club = club;
     }

--- a/src/main/resources/db/migration/V193__add_club_recruitment.sql
+++ b/src/main/resources/db/migration/V193__add_club_recruitment.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS `koin`.`club_recruitment`
     `created_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
     `updated_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
     PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_club_recruitment_id_club` (`id`, `club_id`),
     CONSTRAINT `fk_club` FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`)
 );

--- a/src/main/resources/db/migration/V193__add_club_recruitment.sql
+++ b/src/main/resources/db/migration/V193__add_club_recruitment.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `koin`.`club_recruitment`
+(
+    `id`                    INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '동아리 모집 고유 ID',
+    `club_id`               INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
+    `start_date`            DATE NOT NULL COMMENT '동아리 모집 시작 날짜',
+    `end_date`              DATE NOT NULL COMMENT '동아리 모집 마감 날짜',
+    `content`               TEXT NOT NULL COMMENT '동아리 모집 내용',
+    `created_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
+    `updated_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
+    PRIMARY KEY (`id`),
+    CONSTRAINT `fk_club` FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`)
+);

--- a/src/main/resources/db/migration/V193__add_club_recruitment.sql
+++ b/src/main/resources/db/migration/V193__add_club_recruitment.sql
@@ -1,12 +1,13 @@
 CREATE TABLE IF NOT EXISTS `koin`.`club_recruitment`
 (
-    `id`                    INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '동아리 모집 고유 ID',
-    `club_id`               INT UNSIGNED NOT NULL COMMENT '동아리 고유 ID',
-    `start_date`            DATE NOT NULL COMMENT '동아리 모집 시작 날짜',
-    `end_date`              DATE NOT NULL COMMENT '동아리 모집 마감 날짜',
-    `content`               TEXT NOT NULL COMMENT '동아리 모집 내용',
-    `created_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
-    `updated_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
+    `id`                    INT UNSIGNED        NOT NULL AUTO_INCREMENT COMMENT '동아리 모집 고유 ID',
+    `club_id`               INT UNSIGNED        NOT NULL COMMENT '동아리 고유 ID',
+    `start_date`            DATE                NOT NULL COMMENT '동아리 모집 시작 날짜',
+    `end_date`              DATE                NOT NULL COMMENT '동아리 모집 마감 날짜',
+    `is_always_recruiting`  TINYINT(1)          NOT NULL COMMENT '동아리 상시 모집 여부',
+    `content`               TEXT                NOT NULL COMMENT '동아리 모집 내용',
+    `created_at`            TIMESTAMP           NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
+    `updated_at`            TIMESTAMP           NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_club_recruitment_club_id` (`club_id`),
     CONSTRAINT `fk_club` FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`)

--- a/src/main/resources/db/migration/V193__add_club_recruitment.sql
+++ b/src/main/resources/db/migration/V193__add_club_recruitment.sql
@@ -8,6 +8,6 @@ CREATE TABLE IF NOT EXISTS `koin`.`club_recruitment`
     `created_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
     `updated_at`            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_club_recruitment_id_club` (`id`, `club_id`),
+    UNIQUE KEY `uk_club_recruitment_club_id` (`club_id`),
     CONSTRAINT `fk_club` FOREIGN KEY (`club_id`) REFERENCES `koin`.`club` (`id`)
 );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1701 

# 🚀 작업 내용

- 동아리 모집 테이블을 추가했습니다.
  - 동아리 모집 글은 동아리당 한개만 존재하기 때문에 유니크를 걸었습니다.
  - 동아리 모집 이미지의 경우 동아리 상세 소개처럼 글 내부에 들어가는지 의문이 들어서, 피그마에 [질문](https://www.figma.com/design/0qTK2s3lUj1JhwOpMWENZu?node-id=13511-13910#1318228888) 남겼습니다. (답변 받는대로 반영하겠습니다)
  - 상시 모집인 경우, 시작 날짜와 마감 날짜에 null을 넣기 위해 nullable으로 설정했습니다.

# 💬 리뷰 중점사항
