### PR TITLE
feat: 장바구니 조회 API 이미지 응답값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -36,9 +36,7 @@ public interface CartApi {
                 @ExampleObject(name = "장바구니에 상품 존재", value = """
                     {
                       "shop_name": "굿모닝살로만치킨",
-                      "shop_image_urls": [
-                        "https://static.koreatech.in/test.png"
-                      ],
+                      "shop_thumbnail_image_url": "https://static.koreatech.in/test.png",
                       "orderable_shop_id": 2,
                       "is_delivery_available": true,
                       "is_takeout_available": true,
@@ -90,7 +88,7 @@ public interface CartApi {
                 @ExampleObject(name = "장바구니에 상품 없음", value = """
                     {
                       "shop_name": null,
-                      "image_url": null,
+                      "shop_thumbnail_image_url": null,
                       "orderable_shop_id": null,
                       "is_delivery_available": false,
                       "is_takeout_available": false,

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -120,7 +120,7 @@ public interface CartApi {
         
         ### nullable
         - **shop_thumbnail_image_url** : 주문 가능 상점의 썸네일 이미지가 존재하지 않는 경우
-        - **menu_thumbnail_image_url** : 주문 가능 상점의 메뉴 썸네일 이미지가 존재하지 않는 경우
+        - **items[i].menu_thumbnail_image_url** : 주문 가능 상점의 메뉴 썸네일 이미지가 존재하지 않는 경우
         - **items[i].price.name** : 주문 가능 상점 메뉴의 가격 옵션 이름이 없는 경우 (단일 가격)
         """)
     @GetMapping("/cart")

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -45,9 +45,7 @@ public interface CartApi {
                         {
                           "cart_menu_item_id": 12,
                           "name": "허니콤보",
-                          "menu_image_urls": [
-                            "https://static.koreatech.in/test.png"
-                          ],
+                          "menu_thumbnail_image_url": "https://static.koreatech.in/test.png",
                           "quantity": 1,
                           "total_amount": 23000,
                           "price": {
@@ -60,9 +58,7 @@ public interface CartApi {
                         {
                           "cart_menu_item_id": 13,
                           "name": "레드콤보",
-                          "menu_image_urls": [
-                            "https://static.koreatech.in/test.png"
-                          ],
+                          "menu_thumbnail_image_url": "https://static.koreatech.in/test.png",
                           "quantity": 2,
                           "total_amount": 47000,
                           "price": {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -83,7 +83,8 @@ public interface CartApi {
                       ],
                       "items_amount": 70000,
                       "delivery_fee": 0,
-                      "total_amount": 70000
+                      "total_amount": 70000,
+                      "final_payment_amount": 70000
                     }
                     """),
                 @ExampleObject(name = "장바구니에 상품 없음", value = """
@@ -97,7 +98,8 @@ public interface CartApi {
                       "items": [],
                       "items_amount": 0,
                       "delivery_fee": 0,
-                      "total_amount": 0
+                      "total_amount": 0,
+                      "final_payment_amount": 0
                     }
                     """)
             })

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -36,6 +36,9 @@ public interface CartApi {
                 @ExampleObject(name = "장바구니에 상품 존재", value = """
                     {
                       "shop_name": "굿모닝살로만치킨",
+                      "shop_image_urls": [
+                        "https://static.koreatech.in/test.png"
+                      ],
                       "orderable_shop_id": 2,
                       "is_delivery_available": true,
                       "is_takeout_available": true,
@@ -44,6 +47,9 @@ public interface CartApi {
                         {
                           "cart_menu_item_id": 12,
                           "name": "허니콤보",
+                          "menu_image_urls": [
+                            "https://static.koreatech.in/test.png"
+                          ],
                           "quantity": 1,
                           "total_amount": 23000,
                           "price": {
@@ -56,6 +62,9 @@ public interface CartApi {
                         {
                           "cart_menu_item_id": 13,
                           "name": "레드콤보",
+                          "menu_image_urls": [
+                            "https://static.koreatech.in/test.png"
+                          ],
                           "quantity": 2,
                           "total_amount": 47000,
                           "price": {
@@ -80,6 +89,7 @@ public interface CartApi {
                 @ExampleObject(name = "장바구니에 상품 없음", value = """
                     {
                       "shop_name": null,
+                      "image_url": null,
                       "orderable_shop_id": null,
                       "is_delivery_available": false,
                       "is_takeout_available": false,

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -117,6 +117,11 @@ public interface CartApi {
         ### 응답 케이스
         - **장바구니에 상품이 있는 경우**: 장바구니 상세 정보 응답 반환합니다.
         - **장바구니가 비어있는 경우**: 필드가 null로 비어있는 응답 반환합니다.
+        
+        ### nullable
+        - **shop_thumbnail_image_url** : 주문 가능 상점의 썸네일 이미지가 존재하지 않는 경우
+        - **menu_thumbnail_image_url** : 주문 가능 상점의 메뉴 썸네일 이미지가 존재하지 않는 경우
+        - **items[i].price.name** : 주문 가능 상점 메뉴의 가격 옵션 이름이 없는 경우 (단일 가격)
         """)
     @GetMapping("/cart")
     ResponseEntity<CartResponse> getCartItems(

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -21,7 +21,7 @@ public record CartResponse(
     @Schema(description = "상점 이름", example = "굿모닝 살로만 치킨")
     String shopName,
     @Schema(description = "상점 이미지", example = "https://static.koreatech.in/test.png")
-    List<String> shopImageUrls,
+    String shopThumbnailImageUrl,
     @Schema(description = "주문 가능 상점 ID", example = "1")
     Integer orderableShopId,
     @Schema(description = "배달 가능 여부", example = "true")
@@ -131,9 +131,7 @@ public record CartResponse(
 
         return new CartResponse(
             shop.getName(),
-            shop.getShopImages().stream()
-                .map(ShopImage::getImageUrl)
-                .toList(),
+            orderableShop.getThumbnailImage().orElse(null),
             orderableShop.getId(),
             orderableShop.isDelivery(),
             orderableShop.isTakeout(),

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -21,7 +21,7 @@ public record CartResponse(
     @Schema(description = "상점 이름", example = "굿모닝 살로만 치킨")
     String shopName,
     @Schema(description = "상점 이미지", example = "https://static.koreatech.in/test.png")
-    List<String> imageUrl,
+    List<String> shopImageUrls,
     @Schema(description = "주문 가능 상점 ID", example = "1")
     Integer orderableShopId,
     @Schema(description = "배달 가능 여부", example = "true")
@@ -47,7 +47,7 @@ public record CartResponse(
         @Schema(description = "메뉴 이름", example = "허니콤보")
         String name,
         @Schema(description = "메뉴 이미지", example = "https://static.koreatech.in/test.png")
-        List<String> imageUrl,
+        List<String> imageUrls,
         @Schema(description = "수량", example = "1")
         Integer quantity,
         @Schema(description = "해당 상품의 총 금액 (가격 * 수량)", example = "23000")

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -36,8 +36,10 @@ public record CartResponse(
     Integer itemsAmount,
     @Schema(description = "배달비", example = "3500")
     Integer deliveryFee,
-    @Schema(description = "최종 결제 금액 (상품 총 금액 + 배달비)", example = "20500")
-    Integer totalAmount
+    @Schema(description = "최종 계산 금액 (상품 총 금액 + 배달비)", example = "20500")
+    Integer totalAmount,
+    @Schema(description = "결제 예정 금액 (할인 등을 반영한 최종 금액)", example = "28000")
+    Integer finalPaymentAmount
 ) {
 
     @JsonNaming(value = SnakeCaseStrategy.class)
@@ -125,6 +127,7 @@ public record CartResponse(
         int itemsAmount = cart.calculateItemsAmount();
         int deliveryFee = orderableShop.calculateDeliveryFee(itemsAmount);
         int totalAmount = itemsAmount + deliveryFee;
+        int finalPaymentAmount = totalAmount; // 추후 쿠폰&적립금 등 할인 정책에 관한 요구 사항 추가 시 수정
 
         return new CartResponse(
             shop.getName(),
@@ -138,7 +141,8 @@ public record CartResponse(
             itemResponses,
             itemsAmount,
             deliveryFee,
-            totalAmount
+            totalAmount,
+            finalPaymentAmount
         );
     }
 
@@ -151,6 +155,7 @@ public record CartResponse(
             false,
             0,
             List.of(),
+            0,
             0,
             0,
             0

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -48,8 +48,8 @@ public record CartResponse(
         Integer cartMenuItemId,
         @Schema(description = "메뉴 이름", example = "허니콤보")
         String name,
-        @Schema(description = "메뉴 이미지", example = "https://static.koreatech.in/test.png")
-        List<String> menuImageUrls,
+        @Schema(description = "메뉴 썸네일 이미지", example = "https://static.koreatech.in/test.png")
+        String menuThumbnailImageUrl,
         @Schema(description = "수량", example = "1")
         Integer quantity,
         @Schema(description = "해당 상품의 총 금액 (가격 * 수량)", example = "23000")
@@ -70,9 +70,7 @@ public record CartResponse(
             return new InnerCartItemResponse(
                 cartMenuItem.getId(),
                 cartMenuItem.getOrderableShopMenu().getName(),
-                cartMenuItem.getOrderableShopMenu().getMenuImages().stream()
-                    .map(OrderableShopMenuImage::getImageUrl)
-                    .toList(),
+                cartMenuItem.getOrderableShopMenu().getThumbnailImage(),
                 cartMenuItem.getQuantity(),
                 cartMenuItem.calculateTotalAmount(),
                 InnerPriceResponse.from(cartMenuItem.getOrderableShopMenuPrice()),

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -47,7 +47,7 @@ public record CartResponse(
         @Schema(description = "메뉴 이름", example = "허니콤보")
         String name,
         @Schema(description = "메뉴 이미지", example = "https://static.koreatech.in/test.png")
-        List<String> imageUrls,
+        List<String> menuImageUrls,
         @Schema(description = "수량", example = "1")
         Integer quantity,
         @Schema(description = "해당 상품의 총 금액 (가격 * 수량)", example = "23000")

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -9,15 +9,19 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import in.koreatech.koin.domain.order.cart.model.Cart;
 import in.koreatech.koin.domain.order.cart.model.CartMenuItem;
 import in.koreatech.koin.domain.order.cart.model.CartMenuItemOption;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuImage;
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record CartResponse(
     @Schema(description = "상점 이름", example = "굿모닝 살로만 치킨")
     String shopName,
+    @Schema(description = "상점 이미지", example = "https://static.koreatech.in/test.png")
+    List<String> imageUrl,
     @Schema(description = "주문 가능 상점 ID", example = "1")
     Integer orderableShopId,
     @Schema(description = "배달 가능 여부", example = "true")
@@ -37,11 +41,13 @@ public record CartResponse(
 ) {
 
     @JsonNaming(value = SnakeCaseStrategy.class)
-    public record InnerCartItemResponse (
+    public record InnerCartItemResponse(
         @Schema(description = "장바구니 상품 고유 ID", example = "101")
         Integer cartMenuItemId,
         @Schema(description = "메뉴 이름", example = "허니콤보")
         String name,
+        @Schema(description = "메뉴 이미지", example = "https://static.koreatech.in/test.png")
+        List<String> imageUrl,
         @Schema(description = "수량", example = "1")
         Integer quantity,
         @Schema(description = "해당 상품의 총 금액 (가격 * 수량)", example = "23000")
@@ -62,6 +68,9 @@ public record CartResponse(
             return new InnerCartItemResponse(
                 cartMenuItem.getId(),
                 cartMenuItem.getOrderableShopMenu().getName(),
+                cartMenuItem.getOrderableShopMenu().getMenuImages().stream()
+                    .map(OrderableShopMenuImage::getImageUrl)
+                    .toList(),
                 cartMenuItem.getQuantity(),
                 cartMenuItem.calculateTotalAmount(),
                 InnerPriceResponse.from(cartMenuItem.getOrderableShopMenuPrice()),
@@ -72,7 +81,7 @@ public record CartResponse(
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)
-    public record InnerMenuOptionResponse (
+    public record InnerMenuOptionResponse(
         @Schema(description = "옵션 그룹 이름", example = "소스 추가")
         String optionGroupName,
         @Schema(description = "옵션 이름", example = "레드디핑 소스")
@@ -94,7 +103,7 @@ public record CartResponse(
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)
-    public record InnerPriceResponse (
+    public record InnerPriceResponse(
         @Schema(description = "가격 옵션 이름", example = "순살", nullable = true)
         String name,
         @Schema(description = "가격", example = "23000")
@@ -119,6 +128,9 @@ public record CartResponse(
 
         return new CartResponse(
             shop.getName(),
+            shop.getShopImages().stream()
+                .map(ShopImage::getImageUrl)
+                .toList(),
             orderableShop.getId(),
             orderableShop.isDelivery(),
             orderableShop.isTakeout(),
@@ -132,6 +144,7 @@ public record CartResponse(
 
     public static CartResponse empty() {
         return new CartResponse(
+            null,
             null,
             null,
             false,

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartResponse.java
@@ -129,7 +129,7 @@ public record CartResponse(
 
         return new CartResponse(
             shop.getName(),
-            orderableShop.getThumbnailImage().orElse(null),
+            orderableShop.getThumbnailImage(),
             orderableShop.getId(),
             orderableShop.isDelivery(),
             orderableShop.isTakeout(),

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -106,9 +106,9 @@ public class OrderableShop extends BaseEntity {
     }
 
     public Optional<String> getThumbnailImage() {
-        return shopImages.stream()
+        return this.shopImages.stream()
             .filter(OrderableShopImage::getIsThumbnail)
-            .findFirst()
-            .map(OrderableShopImage::getImageUrl);
+            .map(OrderableShopImage::getImageUrl)
+            .findFirst();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Where;
@@ -66,6 +67,9 @@ public class OrderableShop extends BaseEntity {
     @OneToMany(mappedBy = "orderableShop", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderableShopMenuGroup> menuGroups = new ArrayList<>();
 
+    @OneToMany(mappedBy = "orderableShop", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderableShopImage> shopImages = new ArrayList<>();
+
     @OneToOne(mappedBy = "orderableShop", fetch = FetchType.LAZY)
     private OrderableShopDeliveryOption deliveryOption;
 
@@ -99,5 +103,12 @@ public class OrderableShop extends BaseEntity {
         if (totalOrderAmount < minimumOrderAmount) {
             throw new CartException(CartErrorCode.ORDER_AMOUNT_BELOW_MINIMUM);
         }
+    }
+
+    public Optional<String> getThumbnailImage() {
+        return shopImages.stream()
+            .filter(OrderableShopImage::getIsThumbnail)
+            .findFirst()
+            .map(OrderableShopImage::getImageUrl);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -105,10 +105,11 @@ public class OrderableShop extends BaseEntity {
         }
     }
 
-    public Optional<String> getThumbnailImage() {
+    public String getThumbnailImage() {
         return this.shopImages.stream()
             .filter(OrderableShopImage::getIsThumbnail)
             .map(OrderableShopImage::getImageUrl)
-            .findFirst();
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShopImage.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShopImage.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.order.shop.model.entity.shop;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import org.hibernate.annotations.Where;
+
+import in.koreatech.koin._common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "orderable_shop_image")
+@Where(clause = "is_deleted=0")
+public class OrderableShopImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "is_thumbnail", nullable = false)
+    private Boolean isThumbnail = false;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+}

--- a/src/main/resources/db/migration/V193__add_orderable_shop_image_table.sql
+++ b/src/main/resources/db/migration/V193__add_orderable_shop_image_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `koin`.`orderable_shop_image`
+(
+    `id`                     INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '고유 ID',
+    `orderable_shop_id`      INT UNSIGNED NOT NULL                COMMENT '주문 가능 상점 ID',
+    `image_url`              VARCHAR(255) NOT NULL                COMMENT '이미지 URL',
+    `is_thumbnail`           TINYINT(1)   NOT NULL DEFAULT 0      COMMENT '대표 이미지 여부',
+    `is_deleted`             TINYINT(1)   NOT NULL DEFAULT 0      COMMENT '삭제 여부',
+    `created_at`             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`)
+);
+
+CREATE INDEX idx_images_on_orderable_shop_id ON `koin`.`orderable_shop_image` (orderable_shop_id);

--- a/src/main/resources/db/migration/V193__add_orderable_shop_image_table.sql
+++ b/src/main/resources/db/migration/V193__add_orderable_shop_image_table.sql
@@ -11,3 +11,4 @@ CREATE TABLE IF NOT EXISTS `koin`.`orderable_shop_image`
 );
 
 CREATE INDEX idx_images_on_orderable_shop_id ON `koin`.`orderable_shop_image` (orderable_shop_id);
+CREATE INDEX idx_thumbnail_images ON `koin`.`orderable_shop_image` (orderable_shop_id, is_thumbnail);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1704 

# 🚀 작업 내용

- 장바구니 조회 API에 이미지(상점, 메뉴) 응답값을 추가했습니다.

# 💬 리뷰 중점사항
레거시인지 모르겠는데, 상점 이미지의 경우 리스트로 관리가 되고 있더라구요
썸네일을 위해 링크 하나만 던져줘야 할까요..? (메뉴도 동일 / 아침에 여쭤보겠읍니다 )