### PR TITLE
feat: 부장 전용 동아리 모집 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/exception/errorcode/ErrorCode.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/errorcode/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     NOT_MATCHED_REFRESH_TOKEN(BAD_REQUEST, "refresh token이 일치하지 않습니다."),
     NOT_VALID_RESET_TOKEN(BAD_REQUEST, "Reset token이 존재하지 않습니다."),
     NOT_MATCHED_VERIFICATION_CODE(BAD_REQUEST, "인증 번호가 일치하지 않습니다."),
+    INVALID_RECRUITMENT_PERIOD(BAD_REQUEST, "모집 마감일은 모집 시작일 이후여야 합니다."),
+    MUST_BE_NULL_RECRUITMENT_PERIOD(BAD_REQUEST, "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다."),
+    REQUIRED_RECRUITMENT_PERIOD(BAD_GATEWAY, "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다."),
 
     // 403 Forbidden
     WITHDRAWN_USER(FORBIDDEN, "탈퇴한 계정입니다."),
@@ -32,6 +35,7 @@ public enum ErrorCode {
 
     // 404 Not Found
     NOT_FOUND_USER(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    NOT_FOUND_CLUB(NOT_FOUND, "동아리가 존재하지 않습니다."),
 
     // 409 Conflict
     CONFLICT_LOGIN_ID(CONFLICT, "이미 존재하는 로그인 아이디입니다."),

--- a/src/main/java/in/koreatech/koin/_common/exception/errorcode/ErrorCode.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/errorcode/ErrorCode.java
@@ -19,9 +19,6 @@ public enum ErrorCode {
     NOT_MATCHED_REFRESH_TOKEN(BAD_REQUEST, "refresh token이 일치하지 않습니다."),
     NOT_VALID_RESET_TOKEN(BAD_REQUEST, "Reset token이 존재하지 않습니다."),
     NOT_MATCHED_VERIFICATION_CODE(BAD_REQUEST, "인증 번호가 일치하지 않습니다."),
-    INVALID_RECRUITMENT_PERIOD(BAD_REQUEST, "모집 마감일은 모집 시작일 이후여야 합니다."),
-    MUST_BE_NULL_RECRUITMENT_PERIOD(BAD_REQUEST, "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다."),
-    REQUIRED_RECRUITMENT_PERIOD(BAD_GATEWAY, "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다."),
 
     // 403 Forbidden
     WITHDRAWN_USER(FORBIDDEN, "탈퇴한 계정입니다."),
@@ -35,7 +32,6 @@ public enum ErrorCode {
 
     // 404 Not Found
     NOT_FOUND_USER(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    NOT_FOUND_CLUB(NOT_FOUND, "동아리가 존재하지 않습니다."),
 
     // 409 Conflict
     CONFLICT_LOGIN_ID(CONFLICT, "이미 존재하는 로그인 아이디입니다."),

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -270,6 +270,16 @@ public interface ClubApi {
                     }
                     """)
             })),
+            @ApiResponse(
+                responseCode = "400", description = "상시 모집이 아닌데 모집 시작일 또는 종료일이 입력되지 않은 경우", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
+                        {
+                          "code": "RECRUITMENT_PERIOD_REQUIRED",
+                          "message": "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.",
+                          "errorTraceId": "b7f340c2-2d74-4f8e-9c84-94d2eaaa1d44"
+                        }
+                    """)
+            })),
             @ApiResponse(responseCode = "401", description = "동아리 매니저가 아닌 경우 모집글 작성 불가", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "비매니저 사용자가 모집글 작성한 경우", value = """
                     {
@@ -309,6 +319,7 @@ public interface ClubApi {
         ### 에러 코드(에러 메시지)
         - INVALID_RECRUITMENT_PERIOD (모집 마감일은 모집 시작일 이후여야 합니다.)
         - RECRUITMENT_PERIOD_MUST_BE_NULL (상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.)
+        - RECRUITMENT_PERIOD_REQUIRED (상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.)
         - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
         - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
         """)

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -264,7 +264,7 @@ public interface ClubApi {
             @ApiResponse(responseCode = "400", description = "상시 모집일 경우 모집 기간이 없어야 함", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
                     {
-                      "code": "RECRUITMENT_PERIOD_MUST_BE_NULL",
+                      "code": "MUST_BE_NULL_RECRUITMENT_PERIOD",
                       "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
                       "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
                     }
@@ -274,7 +274,7 @@ public interface ClubApi {
                 responseCode = "400", description = "상시 모집이 아닌데 모집 시작일 또는 종료일이 입력되지 않은 경우", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
                         {
-                          "code": "RECRUITMENT_PERIOD_REQUIRED",
+                          "code": "REQUIRED_RECRUITMENT_PERIOD",
                           "message": "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.",
                           "errorTraceId": "b7f340c2-2d74-4f8e-9c84-94d2eaaa1d44"
                         }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -404,7 +404,7 @@ public interface ClubApi {
         - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
         - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
         """)
-    @PostMapping("/{clubId}/recruitment")
+    @PutMapping("/{clubId}/recruitment")
     ResponseEntity<Void> modifyRecruitment(
         @RequestBody @Valid ClubRecruitmentModifyRequest request,
         @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -18,6 +18,7 @@ import in.koreatech.koin._common.auth.UserId;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -28,6 +29,7 @@ import in.koreatech.koin.domain.club.enums.ClubSortType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -166,7 +168,7 @@ public interface ClubApi {
             - authorId 확인하여 작성자 본인인 경우 삭제 버튼(x) 표시.
             - 닉네임은 존재 시 그대로 반환되며, 없는 경우 student의 익명 닉네임으로 반환.
             - 트리 구조는 대댓글 형태로 재귀적으로 구성됩니다.
-                        
+            
             ```java
             예시
             댓글 1
@@ -176,7 +178,7 @@ public interface ClubApi {
             │   └── 댓글 1-1-2
             ├── 댓글 1-2
             └── 댓글 1-3
-                        
+            
             댓글 2
             └── 댓글 2-1
                 └── 댓글 2-1-1
@@ -244,6 +246,75 @@ public interface ClubApi {
     @PutMapping("/empowerment")
     ResponseEntity<Void> empowermentClubManager(
         @RequestBody @Valid ClubManagerEmpowermentRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "동아리 모집 생성 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", description = "모집 종료일은 시작일 이후여야 함", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
+                    {
+                      "code": "INVALID_RECRUITMENT_PERIOD",
+                      "message": "모집 마감일은 모집 시작일 이후여야 합니다.",
+                      "errorTraceId": "0c790c6c-e323-40db-ba4b-6e0ab49e9f7d"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "400", description = "상시 모집일 경우 모집 기간이 없어야 함", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
+                    {
+                      "code": "RECRUITMENT_PERIOD_MUST_BE_NULL",
+                      "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "401", description = "동아리 매니저가 아닌 경우 모집글 작성 불가", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "비매니저 사용자가 모집글 작성한 경우", value = """
+                    {
+                      "code": "",
+                      "message": "권한이 없습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_CLUB",
+                      "message": "동아리가 존재하지 않습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_USER",
+                      "message": "해당 사용자를 찾을 수 없습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            }))
+        }
+    )
+    @Operation(summary = "동아리 모집 생성", description = """
+        ### 동아리 모집 생성
+        - 동아리 모집 생성을 합니다.
+        - 모집 시작 기간과 모집 마감 기간은 "yyyy-MM-dd" 형식입니다.
+        - 상시 모집 여부의 기본값은 false입니다.
+        - 상시 모집 여부가 true인 경우, 모집 시작 기간과 모집 마감 기간은 null로 요청하셔야 합니다.
+        
+        ### 에러 코드(에러 메시지)
+        - INVALID_RECRUITMENT_PERIOD (모집 마감일은 모집 시작일 이후여야 합니다.)
+        - RECRUITMENT_PERIOD_MUST_BE_NULL (상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.)
+        - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
+        - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
+        """)
+    @PostMapping("/recruitment")
+    ResponseEntity<Void> createRecruitment(
+        @RequestBody @Valid ClubRecruitmentCreateRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -333,7 +333,7 @@ public interface ClubApi {
 
     @ApiResponses(
         value = {
-            @ApiResponse(responseCode = "200", description = "동아리 모집 생성 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "200", description = "동아리 모집 수정 성공", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400", description = "모집 종료일은 시작일 이후여야 함", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
                     {
@@ -388,10 +388,19 @@ public interface ClubApi {
                       "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
                     }
                     """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 공고", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_CLUB_RECRUITMENT",
+                      "message": "동아리 모집 공고가 존재하지 않습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
             }))
         }
     )
-    @Operation(summary = "동아리 모집 생성", description = """
+    @Operation(summary = "동아리 모집 수정", description = """
         ### 동아리 모집 수정
         - 동아리 모집을 수정 합니다.
         - 모집 시작 기간과 모집 마감 기간은 "yyyy-MM-dd" 형식입니다.

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -312,9 +312,10 @@ public interface ClubApi {
         - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
         - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
         """)
-    @PostMapping("/recruitment")
+    @PostMapping("/{clubId}/recruitment")
     ResponseEntity<Void> createRecruitment(
         @RequestBody @Valid ClubRecruitmentCreateRequest request,
+        @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -253,26 +253,21 @@ public interface ClubApi {
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "200", description = "동아리 모집 생성 성공", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "400", description = "모집 종료일은 시작일 이후여야 함", content = @Content(mediaType = "application/json", examples = {
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
                     {
                       "code": "INVALID_RECRUITMENT_PERIOD",
                       "message": "모집 마감일은 모집 시작일 이후여야 합니다.",
                       "errorTraceId": "0c790c6c-e323-40db-ba4b-6e0ab49e9f7d"
                     }
-                    """)
-            })),
-            @ApiResponse(responseCode = "400", description = "상시 모집일 경우 모집 기간이 없어야 함", content = @Content(mediaType = "application/json", examples = {
+                    """),
                 @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
                     {
                       "code": "MUST_BE_NULL_RECRUITMENT_PERIOD",
                       "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
                       "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
                     }
-                    """)
-            })),
-            @ApiResponse(
-                responseCode = "400", description = "상시 모집이 아닌데 모집 시작일 또는 종료일이 입력되지 않은 경우", content = @Content(mediaType = "application/json", examples = {
+                    """),
                 @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
                         {
                           "code": "REQUIRED_RECRUITMENT_PERIOD",
@@ -290,16 +285,14 @@ public interface ClubApi {
                     }
                     """)
             })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
+            @ApiResponse(responseCode = "404", description = "조회 오류", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
                     {
                       "code": "NOT_FOUND_CLUB",
                       "message": "동아리가 존재하지 않습니다.",
                       "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
                     }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
+                    """),
                 @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
                     {
                       "code": "NOT_FOUND_USER",
@@ -334,70 +327,62 @@ public interface ClubApi {
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "200", description = "동아리 모집 수정 성공", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "400", description = "모집 종료일은 시작일 이후여야 함", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
-                    {
-                      "code": "INVALID_RECRUITMENT_PERIOD",
-                      "message": "모집 마감일은 모집 시작일 이후여야 합니다.",
-                      "errorTraceId": "0c790c6c-e323-40db-ba4b-6e0ab49e9f7d"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "400", description = "상시 모집일 경우 모집 기간이 없어야 함", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
-                    {
-                      "code": "MUST_BE_NULL_RECRUITMENT_PERIOD",
-                      "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(
-                responseCode = "400", description = "상시 모집이 아닌데 모집 시작일 또는 종료일이 입력되지 않은 경우", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
                         {
-                          "code": "REQUIRED_RECRUITMENT_PERIOD",
-                          "message": "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.",
-                          "errorTraceId": "b7f340c2-2d74-4f8e-9c84-94d2eaaa1d44"
+                          "code": "INVALID_RECRUITMENT_PERIOD",
+                          "message": "모집 마감일은 모집 시작일 이후여야 합니다.",
+                          "errorTraceId": "0c790c6c-e323-40db-ba4b-6e0ab49e9f7d"
                         }
-                    """)
-            })),
-            @ApiResponse(responseCode = "401", description = "동아리 매니저가 아닌 경우 모집글 작성 불가", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "비매니저 사용자가 모집글 작성한 경우", value = """
-                    {
-                      "code": "",
-                      "message": "권한이 없습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_CLUB",
-                      "message": "동아리가 존재하지 않습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_USER",
-                      "message": "해당 사용자를 찾을 수 없습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 공고", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_CLUB_RECRUITMENT",
-                      "message": "동아리 모집 공고가 존재하지 않습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            }))
+                        """),
+                    @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
+                        {
+                          "code": "MUST_BE_NULL_RECRUITMENT_PERIOD",
+                          "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """),
+                    @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
+                            {
+                              "code": "REQUIRED_RECRUITMENT_PERIOD",
+                              "message": "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.",
+                              "errorTraceId": "b7f340c2-2d74-4f8e-9c84-94d2eaaa1d44"
+                            }
+                        """),
+                    @ExampleObject(name = "비매니저 사용자가 모집글 작성한 경우", value = """
+                        {
+                          "code": "",
+                          "message": "권한이 없습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """)
+
+                })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_CLUB",
+                          "message": "동아리가 존재하지 않습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """),
+                    @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_USER",
+                          "message": "해당 사용자를 찾을 수 없습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """),
+                    @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_CLUB_RECRUITMENT",
+                          "message": "동아리 모집 공고가 존재하지 않습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """)
+                }))
         }
     )
     @Operation(summary = "동아리 모집 수정", description = """
@@ -424,33 +409,30 @@ public interface ClubApi {
     @ApiResponses(
         value = {
             @ApiResponse(responseCode = "204", description = "동아리 모집 삭제 성공", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_CLUB",
-                      "message": "동아리가 존재하지 않습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_USER",
-                      "message": "해당 사용자를 찾을 수 없습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            })),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 공고", content = @Content(mediaType = "application/json", examples = {
-                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
-                    {
-                      "code": "NOT_FOUND_CLUB_RECRUITMENT",
-                      "message": "동아리 모집 공고가 존재하지 않습니다.",
-                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
-                    }
-                    """)
-            }))
+            @ApiResponse(responseCode = "404", description = "조회 오류",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_CLUB",
+                          "message": "동아리가 존재하지 않습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """),
+                    @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_USER",
+                          "message": "해당 사용자를 찾을 수 없습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """),
+                    @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                        {
+                          "code": "NOT_FOUND_CLUB_RECRUITMENT",
+                          "message": "동아리 모집 공고가 존재하지 않습니다.",
+                          "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                        }
+                        """)
+                }))
         }
     )
     @Operation(summary = "동아리 모집 삭제", description = """

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -19,6 +19,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentModifyRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -326,6 +327,86 @@ public interface ClubApi {
     @PostMapping("/{clubId}/recruitment")
     ResponseEntity<Void> createRecruitment(
         @RequestBody @Valid ClubRecruitmentCreateRequest request,
+        @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "동아리 모집 생성 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "400", description = "모집 종료일은 시작일 이후여야 함", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "종료일이 시작일보다 빠른 경우", value = """
+                    {
+                      "code": "INVALID_RECRUITMENT_PERIOD",
+                      "message": "모집 마감일은 모집 시작일 이후여야 합니다.",
+                      "errorTraceId": "0c790c6c-e323-40db-ba4b-6e0ab49e9f7d"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "400", description = "상시 모집일 경우 모집 기간이 없어야 함", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "상시 모집인데 기간이 입력된 경우", value = """
+                    {
+                      "code": "MUST_BE_NULL_RECRUITMENT_PERIOD",
+                      "message": "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(
+                responseCode = "400", description = "상시 모집이 아닌데 모집 시작일 또는 종료일이 입력되지 않은 경우", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "상시 모집 아닌 경우 모집 기간 누락", value = """
+                        {
+                          "code": "REQUIRED_RECRUITMENT_PERIOD",
+                          "message": "상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.",
+                          "errorTraceId": "b7f340c2-2d74-4f8e-9c84-94d2eaaa1d44"
+                        }
+                    """)
+            })),
+            @ApiResponse(responseCode = "401", description = "동아리 매니저가 아닌 경우 모집글 작성 불가", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "비매니저 사용자가 모집글 작성한 경우", value = """
+                    {
+                      "code": "",
+                      "message": "권한이 없습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_CLUB",
+                      "message": "동아리가 존재하지 않습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_USER",
+                      "message": "해당 사용자를 찾을 수 없습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            }))
+        }
+    )
+    @Operation(summary = "동아리 모집 생성", description = """
+        ### 동아리 모집 수정
+        - 동아리 모집을 수정 합니다.
+        - 모집 시작 기간과 모집 마감 기간은 "yyyy-MM-dd" 형식입니다.
+        - 상시 모집 여부가 true인 경우, 모집 시작 기간과 모집 마감 기간은 null로 요청하셔야 합니다.
+        
+        ### 에러 코드(에러 메시지)
+        - INVALID_RECRUITMENT_PERIOD (모집 마감일은 모집 시작일 이후여야 합니다.)
+        - RECRUITMENT_PERIOD_MUST_BE_NULL (상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.)
+        - RECRUITMENT_PERIOD_REQUIRED (상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.)
+        - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
+        - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
+        """)
+    @PostMapping("/{clubId}/recruitment")
+    ResponseEntity<Void> modifyRecruitment(
+        @RequestBody @Valid ClubRecruitmentModifyRequest request,
         @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     );

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -423,7 +423,7 @@ public interface ClubApi {
 
     @ApiResponses(
         value = {
-            @ApiResponse(responseCode = "200", description = "동아리 모집 삭제 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "동아리 모집 삭제 성공", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
                     {

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -402,6 +402,7 @@ public interface ClubApi {
         - RECRUITMENT_PERIOD_MUST_BE_NULL (상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다.)
         - RECRUITMENT_PERIOD_REQUIRED (상시 모집이 아닌 경우, 모집 시작일과 종료일은 필수입니다.)
         - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
+        - NOT_FOUND_CLUB_RECRUITMENT (동아리 모집 공고가 존재하지 않습니다.)
         - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
         """)
     @PutMapping("/{clubId}/recruitment")

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -411,4 +411,51 @@ public interface ClubApi {
         @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200", description = "동아리 모집 삭제 성공", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 동아리 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_CLUB",
+                      "message": "동아리가 존재하지 않습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_USER",
+                      "message": "해당 사용자를 찾을 수 없습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동아리 공고", content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "없는 유저 ID로 요청한 경우", value = """
+                    {
+                      "code": "NOT_FOUND_CLUB_RECRUITMENT",
+                      "message": "동아리 모집 공고가 존재하지 않습니다.",
+                      "errorTraceId": "e13f4f4a-88a7-44a2-b1b5-2b14f4cdee12"
+                    }
+                    """)
+            }))
+        }
+    )
+    @Operation(summary = "동아리 모집 삭제", description = """
+        ### 동아리 모집 수정
+        - 동아리 모집을 삭제 합니다.
+        
+        ### 에러 코드(에러 메시지)
+        - NOT_FOUND_CLUB (동아리가 존재하지 않습니다.)
+        - NOT_FOUND_CLUB_RECRUITMENT (동아리 모집 공고가 존재하지 않습니다.)
+        - NOT_FOUND_USER (해당 사용자를 찾을 수 없습니다.)
+        """)
+    @DeleteMapping("/{clubId}/recruitment")
+    ResponseEntity<Void> deleteRecruitment(
+        @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -20,6 +20,7 @@ import in.koreatech.koin._common.auth.UserId;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -145,6 +146,16 @@ public class ClubController implements ClubApi {
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
         clubService.empowermentClubManager(request, studentId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{clubId}/recruitment")
+    public ResponseEntity<Void> createRecruitment(
+        @RequestBody @Valid ClubRecruitmentCreateRequest request,
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.createRecruitment(request, clubId, studentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -21,6 +21,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentModifyRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -152,10 +153,20 @@ public class ClubController implements ClubApi {
     @PostMapping("/{clubId}/recruitment")
     public ResponseEntity<Void> createRecruitment(
         @RequestBody @Valid ClubRecruitmentCreateRequest request,
-        @PathVariable Integer clubId,
+        @PathVariable(name = "clubId") Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
         clubService.createRecruitment(request, clubId, studentId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{clubId}/recruitment")
+    public ResponseEntity<Void> modifyRecruitment(
+        @RequestBody @Valid ClubRecruitmentModifyRequest request,
+        @PathVariable(name = "clubId") Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.modifyRecruitment(request, clubId, studentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -169,4 +169,13 @@ public class ClubController implements ClubApi {
         clubService.modifyRecruitment(request, clubId, studentId);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/{clubId}/recruitment")
+    public ResponseEntity<Void> deleteRecruitment(
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.deleteRecruitment(clubId, studentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ClubRecruitmentCreateRequest(
+    @Schema(description = "모집 시작 기간", example = "2025-07-01", requiredMode = NOT_REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate startData,
+
+    @Schema(description = "모집 마감 기간", example = "2025-07-02", requiredMode = NOT_REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate endData,
+
+    @Schema(description = "상시 모집 여부", example = "false", requiredMode = REQUIRED)
+    Boolean isAlwaysRecruiting,
+
+    @Schema(description = "모집 상세 설명", example = "BCSD LAB 모집", requiredMode = REQUIRED)
+    @NotNull(message = "모집 상세 설명은 필수 입력입니다.")
+    String content
+) {
+    // TODO. 생성자 검증 추가
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
@@ -1,14 +1,17 @@
 package in.koreatech.koin.domain.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static in.koreatech.koin._common.exception.errorcode.ErrorCode.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static java.lang.Boolean.TRUE;
 
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubRecruitment;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,7 +35,18 @@ public record ClubRecruitmentCreateRequest(
     String content
 ) {
     public ClubRecruitmentCreateRequest {
-        // TODO. 생성자 검증 추가
+        if (isAlwaysRecruiting && (startData != null || endData != null)) {
+            throw CustomException.of(MUST_BE_NULL_RECRUITMENT_PERIOD);
+        }
+
+        if (!TRUE.equals(isAlwaysRecruiting)) {
+            if (startData == null || endData == null) {
+                throw CustomException.of(REQUIRED_RECRUITMENT_PERIOD);
+            }
+            if (endData.isBefore(startData)) {
+                throw CustomException.of(INVALID_RECRUITMENT_PERIOD);
+            }
+        }
     }
 
     public ClubRecruitment toEntity(Club club) {

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
@@ -9,6 +9,8 @@ import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubRecruitment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -29,5 +31,17 @@ public record ClubRecruitmentCreateRequest(
     @NotNull(message = "모집 상세 설명은 필수 입력입니다.")
     String content
 ) {
-    // TODO. 생성자 검증 추가
+    public ClubRecruitmentCreateRequest {
+        // TODO. 생성자 검증 추가
+    }
+
+    public ClubRecruitment toEntity(Club club) {
+        return ClubRecruitment.builder()
+            .startDate(startData)
+            .endDate(endData)
+            .isAlwaysRecruiting(isAlwaysRecruiting)
+            .content(content)
+            .club(club)
+            .build();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentCreateRequest.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.domain.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import static in.koreatech.koin._common.exception.errorcode.ErrorCode.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static java.lang.Boolean.TRUE;
@@ -11,7 +10,6 @@ import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubRecruitment;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,15 +34,15 @@ public record ClubRecruitmentCreateRequest(
 ) {
     public ClubRecruitmentCreateRequest {
         if (isAlwaysRecruiting && (startData != null || endData != null)) {
-            throw CustomException.of(MUST_BE_NULL_RECRUITMENT_PERIOD);
+            // 예외
         }
 
         if (!TRUE.equals(isAlwaysRecruiting)) {
             if (startData == null || endData == null) {
-                throw CustomException.of(REQUIRED_RECRUITMENT_PERIOD);
+                // 예외
             }
             if (endData.isBefore(startData)) {
-                throw CustomException.of(INVALID_RECRUITMENT_PERIOD);
+                // 예외
             }
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubRecruitmentModifyRequest.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.domain.club.dto.request;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static java.lang.Boolean.TRUE;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ClubRecruitmentModifyRequest(
+    @Schema(description = "모집 시작 기간", example = "2025-07-01", requiredMode = NOT_REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate startData,
+
+    @Schema(description = "모집 마감 기간", example = "2025-07-02", requiredMode = NOT_REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate endData,
+
+    @Schema(description = "상시 모집 여부", example = "false", requiredMode = REQUIRED)
+    Boolean isAlwaysRecruiting,
+
+    @Schema(description = "모집 상세 설명", example = "BCSD LAB 모집", requiredMode = REQUIRED)
+    @NotNull(message = "모집 상세 설명은 필수 입력입니다.")
+    String content
+) {
+    public ClubRecruitmentModifyRequest {
+        if (isAlwaysRecruiting && (startData != null || endData != null)) {
+            // 예외
+        }
+
+        if (!TRUE.equals(isAlwaysRecruiting)) {
+            if (startData == null || endData == null) {
+                // 예외
+            }
+            if (endData.isBefore(startData)) {
+                // 예외
+            }
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/exception/ClubRecruitmentNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/domain/club/exception/ClubRecruitmentNotFoundException.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.club.exception;
+
+import in.koreatech.koin._common.exception.custom.DataNotFoundException;
+
+public class ClubRecruitmentNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "동아리 모집 공고가 존재하지 않습니다.";
+
+    public ClubRecruitmentNotFoundException(String message) {
+        super(message);
+    }
+
+    public ClubRecruitmentNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static ClubRecruitmentNotFoundException withDetail(String detail) {
+        return new ClubRecruitmentNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
@@ -69,4 +69,11 @@ public class ClubRecruitment extends BaseEntity {
         this.content = content;
         this.club = club;
     }
+
+    public void modifyClubRecruitment(LocalDate startDate, LocalDate endDate, Boolean isAlwaysRecruiting, String content) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isAlwaysRecruiting = isAlwaysRecruiting;
+        this.content = content;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.domain.club.repository;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.model.ClubRecruitment;
+
+public interface ClubRecruitmentRepository extends Repository<ClubRecruitment, Integer> {
+
+    void save(ClubRecruitment clubRecruitment);
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
@@ -1,10 +1,21 @@
 package in.koreatech.koin.domain.club.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.club.exception.ClubRecruitmentNotFoundException;
+import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubRecruitment;
 
 public interface ClubRecruitmentRepository extends Repository<ClubRecruitment, Integer> {
 
     void save(ClubRecruitment clubRecruitment);
+
+    Optional<ClubRecruitment> findByClub(Club club);
+
+    default ClubRecruitment getByClub(Club club) {
+        return findByClub(club)
+            .orElseThrow(() -> ClubRecruitmentNotFoundException.withDetail("clubId : " + club.getId()));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentRepository.java
@@ -18,4 +18,6 @@ public interface ClubRecruitmentRepository extends Repository<ClubRecruitment, I
         return findByClub(club)
             .orElseThrow(() -> ClubRecruitmentNotFoundException.withDetail("clubId : " + club.getId()));
     }
+
+    void delete(ClubRecruitment clubRecruitment);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -14,6 +14,7 @@ import in.koreatech.koin._common.event.ClubCreateEvent;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -39,6 +40,7 @@ import in.koreatech.koin.domain.club.repository.ClubHotRepository;
 import in.koreatech.koin.domain.club.repository.ClubLikeRepository;
 import in.koreatech.koin.domain.club.repository.ClubManagerRepository;
 import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
+import in.koreatech.koin.domain.club.repository.ClubRecruitmentRepository;
 import in.koreatech.koin.domain.club.repository.ClubRepository;
 import in.koreatech.koin.domain.club.repository.ClubSNSRepository;
 import in.koreatech.koin.domain.club.repository.redis.ClubCreateRedisRepository;
@@ -69,6 +71,7 @@ public class ClubService {
     private final ClubCreateRedisRepository clubCreateRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final ClubHitsRedisRepository clubHitsRedisRepository;
+    private final ClubRecruitmentRepository clubRecruitmentRepository;
 
     @Transactional
     public void createClubRequest(ClubCreateRequest request, Integer studentId) {
@@ -274,5 +277,14 @@ public class ClubService {
             .build();
 
         clubManagerRepository.save(newClubManager);
+    }
+
+    @Transactional
+    public void createRecruitment(ClubRecruitmentCreateRequest request, Integer clubId, Integer studentId) {
+        Club club = clubRepository.getById(clubId);
+        Student student = studentRepository.getById(studentId);
+        isClubManager(clubId, studentId);
+
+        clubRecruitmentRepository.save(request.toEntity(club));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -15,6 +15,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentModifyRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.QnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
@@ -32,6 +33,7 @@ import in.koreatech.koin.domain.club.model.ClubCategory;
 import in.koreatech.koin.domain.club.model.ClubLike;
 import in.koreatech.koin.domain.club.model.ClubManager;
 import in.koreatech.koin.domain.club.model.ClubQna;
+import in.koreatech.koin.domain.club.model.ClubRecruitment;
 import in.koreatech.koin.domain.club.model.ClubSNS;
 import in.koreatech.koin.domain.club.model.redis.ClubCreateRedis;
 import in.koreatech.koin.domain.club.model.redis.ClubHotRedis;
@@ -283,8 +285,23 @@ public class ClubService {
     public void createRecruitment(ClubRecruitmentCreateRequest request, Integer clubId, Integer studentId) {
         Club club = clubRepository.getById(clubId);
         Student student = studentRepository.getById(studentId);
-        isClubManager(clubId, studentId);
+        isClubManager(club.getId(), student.getId());
 
         clubRecruitmentRepository.save(request.toEntity(club));
+    }
+
+    @Transactional
+    public void modifyRecruitment(ClubRecruitmentModifyRequest request, Integer clubId, Integer studentId) {
+        Club club = clubRepository.getById(clubId);
+        ClubRecruitment clubRecruitment = clubRecruitmentRepository.getByClub(club);
+        Student student = studentRepository.getById(studentId);
+        isClubManager(club.getId(), student.getId());
+
+        clubRecruitment.modifyClubRecruitment(
+            request.startData(),
+            request.endData(),
+            request.isAlwaysRecruiting(),
+            request.content()
+        );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -304,4 +304,14 @@ public class ClubService {
             request.content()
         );
     }
+
+    @Transactional
+    public void deleteRecruitment(Integer clubId, Integer studentId) {
+        Club club = clubRepository.getById(clubId);
+        ClubRecruitment clubRecruitment = clubRecruitmentRepository.getByClub(club);
+        Student student = studentRepository.getById(studentId);
+        isClubManager(club.getId(), student.getId());
+
+        clubRecruitmentRepository.delete(clubRecruitment);
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1713 

# 🚀 작업 내용

- 부장 전용 동아리 모집 API를 추가했습니다.
  - 생성, 수정, 삭제 총 3가지를 구현했습니다.
  - 요청 값으로 들어오는 `시작 날짜, 마감 날짜, 상시 모집 여부`에 대한 예외 처리는 [에러 코드 PR](https://github.com/BCSDLab/KOIN_API_V2/pull/1714)이 머지 되면 추가 작업하겠습니다.
    - 상시 여부가 true일 때, 시작 날짜와 마감 날짜 중 하나라도 null인 경우
    - 상시 여부가 false일 때, 시작 날짜와 마감 날짜가 모두 null이 아닌 경우
    - 상시 여부가 false일 때, 마감 날짜가 시작 날짜보다 빠른 경우

# 💬 리뷰 중점사항
패키지를 나눠야할 거 같은데, 어떻게 생각하시나요 ??
나눈다면 개발이 끝나고 스테이지 올리기 전에 나누면 좋을 거 같아요