### PR TITLE
feat: 교외 배달 주소 검증 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/_common/code/ApiResponseCode.java
@@ -25,6 +25,7 @@ public enum ApiResponseCode {
     INVALID_DATE_TIME(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식입니다."),
     INVALID_GENDER_INDEX(HttpStatus.BAD_REQUEST, "올바르지 않은 성별 인덱스입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "올바르지 않은 인증 토큰입니다."),
+    INVALID_DELIVERY_AREA(HttpStatus.BAD_REQUEST, "배달이 불가능한 지역이에요."),
     NOT_MATCHED_EMAIL(HttpStatus.BAD_REQUEST, "이메일이 일치하지 않습니다."),
     NOT_MATCHED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "전화번호가 일치하지 않습니다."),
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/controller/DeliveryApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/controller/DeliveryApi.java
@@ -9,10 +9,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import in.koreatech.koin._common.auth.Auth;
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.code.ApiResponseCodes;
 import in.koreatech.koin.domain.order.delivery.dto.RiderMessageResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserCampusDeliveryAddressRequest;
 import in.koreatech.koin.domain.order.delivery.dto.UserDeliveryAddressResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserOffCampusDeliveryAddressRequest;
+import in.koreatech.koin.domain.order.delivery.dto.UserOffCampusDeliveryAddressValidateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -142,6 +145,20 @@ public interface DeliveryApi {
     ResponseEntity<UserDeliveryAddressResponse> addCampusDeliveryAddress(
         @RequestBody @Valid UserCampusDeliveryAddressRequest request,
         @Parameter(hidden = true) @Auth(permit = {GENERAL, STUDENT}) Integer userId
+    );
+
+    @Operation(summary = "교외 배달 주소 검증", description = """
+        ### 사용자가 선택한 교외 배달 주소를 검증
+        - 사용자가 입력한 주소가 배달 가능 주소인지 검증합니다.
+        - 주소가 **충청남도 천안시 동남구 병천면** 이 아닌 경우 예외 발생
+        """)
+    @ApiResponseCodes({
+        ApiResponseCode.OK,
+        ApiResponseCode.INVALID_DELIVERY_AREA
+    })
+    @PostMapping("/delivery/address/off-campus/validate")
+    ResponseEntity<Void> validateOffCampusDeliveryAddress(
+        @RequestBody @Valid UserOffCampusDeliveryAddressValidateRequest request
     );
 
     @ApiResponses(value = {

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/controller/DeliveryController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/controller/DeliveryController.java
@@ -14,6 +14,7 @@ import in.koreatech.koin.domain.order.delivery.dto.RiderMessageResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserCampusDeliveryAddressRequest;
 import in.koreatech.koin.domain.order.delivery.dto.UserDeliveryAddressResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserOffCampusDeliveryAddressRequest;
+import in.koreatech.koin.domain.order.delivery.dto.UserOffCampusDeliveryAddressValidateRequest;
 import in.koreatech.koin.domain.order.delivery.service.DeliveryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,14 @@ public class DeliveryController implements DeliveryApi {
         UserDeliveryAddressResponse response = deliveryService.addCampusDeliveryAddress(
             request, userId);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/delivery/address/off-campus/validate")
+    public ResponseEntity<Void> validateOffCampusDeliveryAddress(
+        @RequestBody @Valid UserOffCampusDeliveryAddressValidateRequest request
+    ) {
+        deliveryService.validateOffCampusAddress(request.toOffCampusAddress());
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/delivery/rider-message")

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/dto/UserOffCampusDeliveryAddressValidateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/dto/UserOffCampusDeliveryAddressValidateRequest.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.domain.order.delivery.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.order.delivery.model.OffCampusDeliveryAddress;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record UserOffCampusDeliveryAddressValidateRequest(
+
+    @Schema(description = "시/도", example = "충청남도")
+    @NotBlank(message = "시/도는 필수입니다.")
+    String siDo,
+
+    @Schema(description = "시/군/구", example = "천안시 동남구")
+    @NotBlank(message = "시/군/구는 필수입니다.")
+    String siGunGu,
+
+    @Schema(description = "읍/면/동", example = "병천면", nullable = true)
+    String eupMyeonDong
+
+) {
+
+    public OffCampusDeliveryAddress toOffCampusAddress() {
+        return OffCampusDeliveryAddress.builder()
+            .siDo(siDo)
+            .siGunGu(siGunGu)
+            .eupMyeonDong(eupMyeonDong)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryAddressValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryAddressValidator.java
@@ -2,8 +2,8 @@ package in.koreatech.koin.domain.order.delivery.service;
 
 import org.springframework.stereotype.Component;
 
-import in.koreatech.koin.domain.order.delivery.exception.DeliveryErrorCode;
-import in.koreatech.koin.domain.order.delivery.exception.DeliveryException;
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.order.delivery.model.OffCampusDeliveryAddress;
 
 @Component
@@ -18,7 +18,7 @@ public class DeliveryAddressValidator {
      * */
     public void validateOffCampusAddress(OffCampusDeliveryAddress address) {
         if (!address.isValidDeliveryArea(ALLOWED_SI_DO, ALLOWED_SI_GUN_GU, ALLOWED_EUP_MYEON_DONG)) {
-            throw new DeliveryException(DeliveryErrorCode.INVALID_DELIVERY_AREA);
+            throw CustomException.of(ApiResponseCode.INVALID_DELIVERY_AREA);
         }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryService.java
@@ -6,14 +6,14 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.order.address.model.CampusDeliveryAddress;
+import in.koreatech.koin.domain.order.address.repository.CampusDeliveryAddressRepository;
 import in.koreatech.koin.domain.order.delivery.dto.RiderMessageResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserCampusDeliveryAddressRequest;
 import in.koreatech.koin.domain.order.delivery.dto.UserDeliveryAddressResponse;
 import in.koreatech.koin.domain.order.delivery.dto.UserOffCampusDeliveryAddressRequest;
-import in.koreatech.koin.domain.order.address.model.CampusDeliveryAddress;
 import in.koreatech.koin.domain.order.delivery.model.OffCampusDeliveryAddress;
 import in.koreatech.koin.domain.order.delivery.model.UserDeliveryAddress;
-import in.koreatech.koin.domain.order.address.repository.CampusDeliveryAddressRepository;
 import in.koreatech.koin.domain.order.delivery.repository.RiderMessageRepository;
 import in.koreatech.koin.domain.order.delivery.repository.UserDeliveryAddressRepository;
 import in.koreatech.koin.domain.user.model.User;
@@ -34,9 +34,9 @@ public class DeliveryService {
     public UserDeliveryAddressResponse addOffCampusDeliveryAddress(UserOffCampusDeliveryAddressRequest request,
         Integer userId) {
         User user = userRepository.getById(userId);
-
         OffCampusDeliveryAddress offCampusDeliveryAddress = request.toOffCampusAddress();
-        deliveryAddressValidator.validateOffCampusAddress(offCampusDeliveryAddress);
+
+        validateOffCampusAddress(offCampusDeliveryAddress);
 
         UserDeliveryAddress userDeliveryAddress = deliveryAddressRepository.save(
             UserDeliveryAddress.ofOffCampus(user, offCampusDeliveryAddress)
@@ -58,6 +58,10 @@ public class DeliveryService {
         );
 
         return UserDeliveryAddressResponse.of(userDeliveryAddress.getId(), userDeliveryAddress.getFullDeliveryAddress());
+    }
+
+    public void validateOffCampusAddress(OffCampusDeliveryAddress offCampusDeliveryAddress) {
+        deliveryAddressValidator.validateOffCampusAddress(offCampusDeliveryAddress);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/in/koreatech/koin/unit/domain/address/DeliveryAddressValidatorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/address/DeliveryAddressValidatorTest.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.unit.domain.address;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.order.delivery.exception.DeliveryErrorCode;
 import in.koreatech.koin.domain.order.delivery.exception.DeliveryException;
 import in.koreatech.koin.domain.order.delivery.model.OffCampusDeliveryAddress;
@@ -39,11 +42,10 @@ public class DeliveryAddressValidatorTest {
 
         @Test
         void 교외_배달_불가_지역_주소를_검증시_예외가_발생한다() {
-            DeliveryException exception = assertThrows(DeliveryException.class, () -> {
+            CustomException exception = assertThrows(CustomException.class, () -> {
                 deliveryAddressValidator.validateOffCampusAddress(invalidAddress);
             });
-
-            assertThat(exception.getErrorCode()).isEqualTo(DeliveryErrorCode.INVALID_DELIVERY_AREA);
+            assertEquals(ApiResponseCode.INVALID_DELIVERY_AREA, exception.getErrorCode());
         }
     }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- #1718 
# 🚀 작업 내용

### 교외 배달 주소 검증 API 추가
![image](https://github.com/user-attachments/assets/e3de48b5-d5a7-4337-a720-8c737adde18d)

### GlobalExceptionHandler buildErrorResponse 수정
- requestLogging 메서드에서 생성된 errorTraceId를 ErrorResponse에서 반환

# 💬 리뷰 중점사항
