### PR TITLE
hotfix: 2019년 1학기, 여름학기 강의 조회 시 NPE 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/dto/response/TimetableLectureResponse.java
@@ -88,7 +88,7 @@ public record TimetableLectureResponse(
         ) {
             public static List<ClassInfo> of(String classTime, String classPlace) {
                 // 온라인 강의인 경우
-                if (Objects.equals(classTime, "[]")) {
+                if (Objects.equals(classTime, "[]") || Objects.isNull(classTime)) {
                     return Collections.emptyList();
                 }
 


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

1. 졸업학점계산기로 2019년 1학기, 여름학기 강의 데이터가 들어갑니다.
2. 코인은 2019년 1학기, 여름학기 강의 데이터가 없어서 강의 시간 등 강의 정보가 없습니다. (졸업학점계산기에서는 이수구분과 같은 졸업 요건 데이터만 필요하기 때문에 강의 시간과 같은 강의 정보는 NULL로 처리했습니다.)
3. 2019년 1학기, 여름학기 시간표를 조회하면 NPE 발생
4. 두 학기 강의를 온라인 강의처럼 시간표에 안 보이게 예외 처리하겠습니다. 

# 💬 리뷰 중점사항
# 해당 PR은 main 브랜치를 바라보고 있습니다.