### PR TITLE
feat: 동아리 모집 알림 추가 및 특정 동아리 모집알림 구독/구독취소 API

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/event/ClubRecruitmentChangeEvent.java
+++ b/src/main/java/in/koreatech/koin/_common/event/ClubRecruitmentChangeEvent.java
@@ -1,0 +1,7 @@
+package in.koreatech.koin._common.event;
+
+public record ClubRecruitmentChangeEvent(
+    String clubName,
+    Integer clubId
+) {
+}

--- a/src/main/java/in/koreatech/koin/_common/model/MobileAppPath.java
+++ b/src/main/java/in/koreatech/koin/_common/model/MobileAppPath.java
@@ -9,7 +9,8 @@ public enum MobileAppPath {
     SHOP("shop"),
     DINING("dining"),
     KEYWORD("keyword"),
-    CHAT("chat")
+    CHAT("chat"),
+    CLUB("club")
     ;
 
     private final String path;

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -494,4 +494,34 @@ public interface ClubApi {
         @Parameter(description = "동아리 고유 식별자(clubId)", example = "1") @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 동아리의 모집알림 구독")
+    @PostMapping("{clubId}/recruitment/notification")
+    ResponseEntity<Void> subscribeRecruitmentNotification(
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 동아리의 모집알림 구독취소")
+    @DeleteMapping("{clubId}/recruitment/notification")
+    ResponseEntity<Void> rejectRecruitmentNotification(
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
 }

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin._common.auth.UserId;
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.code.ApiResponseCodes;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubManagerEmpowermentRequest;
@@ -495,30 +497,26 @@ public interface ClubApi {
         @Auth(permit = {STUDENT}) Integer studentId
     );
 
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "201"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
-        }
-    )
     @Operation(summary = "특정 동아리의 모집알림 구독")
+    @ApiResponseCodes({
+        ApiResponseCode.CREATED,
+        ApiResponseCode.NOT_FOUND_USER,
+        ApiResponseCode.NOT_FOUND_CLUB,
+        ApiResponseCode.FORBIDDEN_USER_TYPE
+    })
     @PostMapping("{clubId}/recruitment/notification")
     ResponseEntity<Void> subscribeRecruitmentNotification(
         @PathVariable Integer clubId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "204"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
-        }
-    )
     @Operation(summary = "특정 동아리의 모집알림 구독취소")
+    @ApiResponseCodes({
+        ApiResponseCode.NO_CONTENT,
+        ApiResponseCode.NOT_FOUND_USER,
+        ApiResponseCode.NOT_FOUND_CLUB,
+        ApiResponseCode.FORBIDDEN_USER_TYPE
+    })
     @DeleteMapping("{clubId}/recruitment/notification")
     ResponseEntity<Void> rejectRecruitmentNotification(
         @PathVariable Integer clubId,

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -188,4 +188,22 @@ public class ClubController implements ClubApi {
         clubService.deleteRecruitment(clubId, studentId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("{clubId}/recruitment/notification")
+    public ResponseEntity<Void> subscribeRecruitmentNotification(
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.subscribeRecruitmentNotification(clubId, studentId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("{clubId}/recruitment/notification")
+    public ResponseEntity<Void> rejectRecruitmentNotification(
+        @PathVariable Integer clubId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        clubService.rejectRecruitmentNotification(clubId, studentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubResponse.java
@@ -58,6 +58,9 @@ public record ClubResponse(
     @Schema(description = "동아리 좋아요 여부", example = "true", requiredMode = REQUIRED)
     Boolean isLiked,
 
+    @Schema(description = "동아리 모집알림 구독 여부", example = "true", requiredMode = REQUIRED)
+    Boolean isRecruitSubscribed,
+
     @JsonFormat(pattern = "yyyy.MM.dd.")
     @Schema(description = "업데이트 날짜", example = "2025.05.11.", requiredMode = REQUIRED)
     LocalDate updatedAt,
@@ -65,7 +68,13 @@ public record ClubResponse(
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)
     Boolean isLikeHidden
 ) {
-    public static ClubResponse from(Club club, List<ClubSNS> clubSNSs, Boolean manager, Boolean isLiked) {
+    public static ClubResponse from(
+        Club club,
+        List<ClubSNS> clubSNSs,
+        Boolean manager,
+        Boolean isLiked,
+        Boolean isRecruitSubscribed
+    ) {
         Optional<String> instagram = Optional.empty();
         Optional<String> googleForm = Optional.empty();
         Optional<String> openChat = Optional.empty();
@@ -95,6 +104,7 @@ public record ClubResponse(
             phoneNumber,
             manager,
             isLiked,
+            isRecruitSubscribed,
             club.getUpdatedAt().toLocalDate(),
             club.getIsLikeHidden()
         );

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentSubscriptionRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentSubscriptionRepository.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.domain.club.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.club.model.ClubRecruitmentSubscription;
+
+public interface ClubRecruitmentSubscriptionRepository extends Repository<ClubRecruitmentSubscription, Integer> {
+
+    @Query("""
+        SELECT s FROM ClubRecruitmentSubscription s
+        JOIN FETCH s.user
+        WHERE s.club.id = :clubId
+        """)
+    List<ClubRecruitmentSubscription> findAllWithUserByClubId(Integer clubId);
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentSubscriptionRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRecruitmentSubscriptionRepository.java
@@ -15,4 +15,10 @@ public interface ClubRecruitmentSubscriptionRepository extends Repository<ClubRe
         WHERE s.club.id = :clubId
         """)
     List<ClubRecruitmentSubscription> findAllWithUserByClubId(Integer clubId);
+
+    boolean existsByClubIdAndUserId(Integer clubId, Integer userId);
+
+    void save(ClubRecruitmentSubscription subscription);
+
+    void deleteByClubIdAndUserId(Integer clubId, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -105,8 +105,9 @@ public class ClubService {
         List<ClubSNS> newSNS = updateClubSNS(request, club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, studentId);
         Boolean isLiked = clubLikeRepository.existsByClubIdAndUserId(clubId, studentId);
+        Boolean isRecruitSubscribed = clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId);
 
-        return ClubResponse.from(club, newSNS, manager, isLiked);
+        return ClubResponse.from(club, newSNS, manager, isLiked, isRecruitSubscribed);
     }
 
     private List<ClubSNS> updateClubSNS(ClubUpdateRequest request, Club club) {
@@ -136,10 +137,10 @@ public class ClubService {
         club.updateIntroduction(request.introduction());
         List<ClubSNS> clubSNSs = club.getClubSNSs();
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, studentId);
-
         Boolean isLiked = clubLikeRepository.existsByClubIdAndUserId(clubId, studentId);
+        Boolean isRecruitSubscribed = clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId);
 
-        return ClubResponse.from(club, clubSNSs, manager, isLiked);
+        return ClubResponse.from(club, clubSNSs, manager, isLiked, isRecruitSubscribed);
     }
 
     private void isClubManager(Integer clubId, Integer studentId) {
@@ -159,8 +160,9 @@ public class ClubService {
         List<ClubSNS> clubSNSs = clubSNSRepository.findAllByClub(club);
         Boolean manager = clubManagerRepository.existsByClubIdAndUserId(clubId, userId);
         Boolean isLiked = clubLikeRepository.existsByClubIdAndUserId(clubId, userId);
+        Boolean isRecruitSubscribed = clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, userId);
 
-        return ClubResponse.from(club, clubSNSs, manager, isLiked);
+        return ClubResponse.from(club, clubSNSs, manager, isLiked, isRecruitSubscribed);
     }
 
     public ClubsByCategoryResponse getClubByCategory(

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin._common.auth.exception.AuthorizationException;
 import in.koreatech.koin._common.event.ClubCreateEvent;
+import in.koreatech.koin._common.event.ClubRecruitmentChangeEvent;
 import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
@@ -326,6 +327,7 @@ public class ClubService {
         }
 
         clubRecruitmentRepository.save(request.toEntity(club));
+        eventPublisher.publishEvent(new ClubRecruitmentChangeEvent(club.getName(), club.getId()));
     }
 
     @Transactional
@@ -342,6 +344,7 @@ public class ClubService {
             request.imageUrl(),
             request.content()
         );
+        eventPublisher.publishEvent(new ClubRecruitmentChangeEvent(club.getName(), club.getId()));
     }
 
     @Transactional

--- a/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
+++ b/src/main/java/in/koreatech/koin/domain/club/service/ClubService.java
@@ -367,7 +367,8 @@ public class ClubService {
         Club club = clubRepository.getById(clubId);
         User user = userRepository.getById(studentId);
 
-        if (verifyAlreadySubscribedRecruitment(clubId, studentId))   return;
+        if (verifyAlreadySubscribedRecruitment(clubId, studentId))
+            return;
 
         ClubRecruitmentSubscription clubRecruitmentSubscription = ClubRecruitmentSubscription.builder()
             .club(club)
@@ -381,7 +382,8 @@ public class ClubService {
         Club club = clubRepository.getById(clubId);
         User user = userRepository.getById(studentId);
 
-        if (!verifyAlreadySubscribedRecruitment(clubId, studentId))  return;
+        if (!verifyAlreadySubscribedRecruitment(clubId, studentId))
+            return;
 
         clubRecruitmentSubscriptionRepository.deleteByClubIdAndUserId(clubId, studentId);
     }

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ClubRecruitmentEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ClubRecruitmentEventListener.java
@@ -1,0 +1,48 @@
+package in.koreatech.koin.domain.notification.eventlistener;
+
+import static in.koreatech.koin._common.model.MobileAppPath.CLUB;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin._common.event.ClubRecruitmentChangeEvent;
+import in.koreatech.koin.domain.club.model.ClubRecruitmentSubscription;
+import in.koreatech.koin.domain.club.repository.ClubRecruitmentSubscriptionRepository;
+import in.koreatech.koin.domain.notification.model.Notification;
+import in.koreatech.koin.domain.notification.model.NotificationFactory;
+import in.koreatech.koin.domain.notification.service.NotificationService;
+import in.koreatech.koin.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Profile("!test")
+public class ClubRecruitmentEventListener {
+
+    private final ClubRecruitmentSubscriptionRepository subscriptionRepository;
+    private final NotificationFactory notificationFactory;
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener
+    public void onClubRecruitmentChange(ClubRecruitmentChangeEvent event) {
+        List<ClubRecruitmentSubscription> subscriptions = subscriptionRepository.findAllWithUserByClubId(event.clubId());
+        if (subscriptions.isEmpty()) return;
+
+        List<Notification> notifications = subscriptions.stream()
+            .map(sub -> createClubRecruitmentNotification(event.clubId(), event.clubName(), sub.getUser()))
+            .toList();
+        notificationService.pushNotifications(notifications);
+    }
+
+    private Notification createClubRecruitmentNotification(Integer clubId, String clubName, User user) {
+        return notificationFactory.generateClubRecruitmentNotification(
+            CLUB,
+            clubId,
+            clubName,
+            user
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
@@ -8,6 +8,23 @@ import in.koreatech.koin._common.model.MobileAppPath;
 @Component
 public class NotificationFactory {
 
+    public Notification generateClubRecruitmentNotification(
+        MobileAppPath path,
+        Integer clubId,
+        String clubName,
+        User target
+    ) {
+        return new Notification(
+            path,
+            generateSchemeUri(path, clubId), //검토필요
+            "[코인동아리] %s 모집 공고가 갱신되었어요!".formatted(clubName),
+            "%s에 모집 정보가 새로 업데이트되었어요.\n행사 내용 둘러보기".formatted(clubName),
+            null,
+            NotificationType.MESSAGE,
+            target
+        );
+    }
+
     public Notification generateReviewPromptNotification(
         MobileAppPath path,
         Integer eventShopId,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1734 

# 🚀 작업 내용

- 모집 생성, 수정 시 이벤트발행
  - 이벤트 리스너에서 알림 보냄 
- 특정 동아리 모집알림 구독 API 구현
- 특정 동아리 모집알림 구독취소 API 구현

# 💬 리뷰 중점사항
- 특정 동아리 상세조회 API에서 유저의 특정 동아리 모집알림 구독여부를 같이 반환해주는 것 추가 필요 (완료)