### PR TITLE
feat: 특정 동아리 행사 전체조회 반환값에 구독여부 추가 및 모집 알림 scheme 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -29,6 +29,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentCreateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentModifyRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubEventResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubEventsResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubQnasResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubRecruitmentResponse;
@@ -475,9 +476,10 @@ public interface ClubApi {
             - ENDED : 행사가 종료되고 1분이 지난 시점의 행사가 조회됩니다.
         """)
     @GetMapping("/{clubId}/event")
-    ResponseEntity<List<ClubEventResponse>> getClubEvents(
+    ResponseEntity<List<ClubEventsResponse>> getClubEvents(
         @PathVariable Integer clubId,
-        @RequestParam(defaultValue = "RECENT") ClubEventType eventType
+        @RequestParam(defaultValue = "RECENT") ClubEventType eventType,
+        @UserId Integer userId
     );
 
     @Operation(summary = "특정 동아리의 특정 행사알림 구독")

--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubController.java
@@ -29,6 +29,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubRecruitmentModifyRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubQnaCreateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubEventResponse;
+import in.koreatech.koin.domain.club.dto.response.ClubEventsResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubHotResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubRecruitmentResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubRelatedKeywordResponse;
@@ -265,11 +266,12 @@ public class ClubController implements ClubApi {
     }
 
     @GetMapping("/{clubId}/events")
-    public ResponseEntity<List<ClubEventResponse>> getClubEvents(
+    public ResponseEntity<List<ClubEventsResponse>> getClubEvents(
         @PathVariable Integer clubId,
-        @RequestParam(defaultValue = "RECENT") ClubEventType eventType
+        @RequestParam(defaultValue = "RECENT") ClubEventType eventType,
+        @UserId Integer userId
     ) {
-        List<ClubEventResponse> responses = clubService.getClubEvents(clubId, eventType);
+        List<ClubEventsResponse> responses = clubService.getClubEvents(clubId, eventType, userId);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
@@ -1,0 +1,78 @@
+package in.koreatech.koin.domain.club.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.club.enums.ClubEventStatus;
+import in.koreatech.koin.domain.club.model.ClubEvent;
+import in.koreatech.koin.domain.club.model.ClubEventImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ClubEventsResponse(
+    @Schema(description = "동아리 행사 ID", example = "12")
+    Integer id,
+
+    @Schema(description = "행사 이름", example = "B-CON")
+    String name,
+
+    @Schema(description = "행사 이미지 URL 목록")
+    List<String> imageUrls,
+
+    @Schema(description = "행사 시작일", example = "2025-07-01T09:00:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime startDate,
+
+    @Schema(description = "행사 종료일", example = "2025-07-02T18:00:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime endDate,
+
+    @Schema(description = "행사 소개 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.")
+    String introduce,
+
+    @Schema(description = "행사 상세 내용", example = "여러 동아리원들과 자신의 생각, 경험에 대해 나눠요,")
+    String content,
+
+    @Schema(description = "현재 행사 상태", example = "UPCOMING")
+    String status,
+
+    @Schema(description = "행사 구독 여부", example = "false")
+    boolean subscribed
+) {
+
+    public static ClubEventsResponse from(ClubEvent event, LocalDateTime now, boolean subscribed) {
+        List<String> imageUrls = event.getImages().stream()
+            .map(ClubEventImage::getImageUrl)
+            .toList();
+
+        return new ClubEventsResponse(
+            event.getId(),
+            event.getName(),
+            imageUrls,
+            event.getStartDate(),
+            event.getEndDate(),
+            event.getIntroduce(),
+            event.getContent(),
+            calculateStatus(event.getStartDate(), event.getEndDate(), now).getDisplayName(),
+            subscribed
+        );
+    }
+
+    public static ClubEventStatus calculateStatus(LocalDateTime start, LocalDateTime end, LocalDateTime now) {
+        if (now.isBefore(start.minusHours(1))) {
+            return ClubEventStatus.UPCOMING;
+        }
+        if (now.isBefore(start)) {
+            return ClubEventStatus.SOON;
+        }
+        if (now.isBefore(end.plusMinutes(1))) {
+            return ClubEventStatus.ONGOING;
+        }
+        return ClubEventStatus.ENDED;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
@@ -42,10 +42,10 @@ public record ClubEventsResponse(
     String status,
 
     @Schema(description = "행사 구독 여부", example = "false")
-    boolean subscribed
+    boolean isSubscribed
 ) {
 
-    public static ClubEventsResponse from(ClubEvent event, LocalDateTime now, boolean subscribed) {
+    public static ClubEventsResponse from(ClubEvent event, LocalDateTime now, boolean isSubscribed) {
         List<String> imageUrls = event.getImages().stream()
             .map(ClubEventImage::getImageUrl)
             .toList();
@@ -59,7 +59,7 @@ public record ClubEventsResponse(
             event.getIntroduce(),
             event.getContent(),
             calculateStatus(event.getStartDate(), event.getEndDate(), now).getDisplayName(),
-            subscribed
+            isSubscribed
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubEventSubscriptionRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubEventSubscriptionRepository.java
@@ -17,4 +17,7 @@ public interface ClubEventSubscriptionRepository extends Repository<ClubEventSub
     void deleteByClubEventIdAndUserId(Integer eventId, Integer userId);
 
     void save(ClubEventSubscription subscription);
+
+    @Query("SELECT e.clubEvent.id FROM ClubEventSubscription e WHERE e.user.id = :userId AND e.clubEvent.id IN :eventIds")
+    List<Integer> findSubscribedEventIds(Integer userId, List<Integer> eventIds);
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
@@ -19,7 +19,7 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
-            generateSchemeUri(path, clubId), //검토필요
+            generateClubRecruitmentSchemeUri(path, clubId), //검토필요
             "[코인동아리] %s 모집 공고가 갱신되었어요!".formatted(clubName),
             "%s에 모집 정보가 새로 업데이트되었어요.\n행사 내용 둘러보기".formatted(clubName),
             null,
@@ -182,6 +182,10 @@ public class NotificationFactory {
     private String formatEventDateTime(LocalDateTime dateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M월 d일 HH시 mm분");
         return dateTime.format(formatter);
+    }
+
+    private String generateClubRecruitmentSchemeUri(MobileAppPath path, Integer clubId) {
+        return String.format("%s-recruitment?id=%d", path, clubId);
     }
 
     private String generateSchemeUri(MobileAppPath path, Integer eventId) {

--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
@@ -19,7 +19,7 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
-            generateClubRecruitmentSchemeUri(path, clubId), //검토필요
+            generateClubRecruitmentSchemeUri(path, clubId),
             "[코인동아리] %s 모집 공고가 갱신되었어요!".formatted(clubName),
             "%s에 모집 정보가 새로 업데이트되었어요.\n행사 내용 둘러보기".formatted(clubName),
             null,
@@ -39,7 +39,7 @@ public class NotificationFactory {
     ) {
         return new Notification(
             path,
-            generateClubEventSchemeUri(path, clubId, eventId), // 검토필요
+            generateClubEventSchemeUri(path, clubId, eventId),
             "[코인 동아리] %s에 내일 예정된 행사가 있어요!".formatted(clubName),
             "%s - %s의 행사가 %s에 진행 될 예정이에요.\n행사 내용 둘러보기"
                 .formatted(eventName, clubName, formatEventDateTime(eventDateTime)),


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1740 

# 🚀 작업 내용

- 특정 동아리 행사 전체조회 API에서 유저의 각 행사 구독여부를 함께 반환하도록 추가했습니다.
- 모집 알림 scheme를 club-recruitment?id={clubid}로 변경했습니다.

# 💬 리뷰 중점사항
- 