### PR TITLE
feat: 상점 요약 정보 조회 API 이미지 필드 추가 및 응답 캐시 적용

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/cache/CacheConfig.java
+++ b/src/main/java/in/koreatech/koin/_common/cache/CacheConfig.java
@@ -99,6 +99,11 @@ public class CacheConfig {
             defaultConfiguration().entryTtl(Duration.ofMinutes(CacheKey.RIDER_MESSAGES.getTtl()))
         );
 
+        customConfigurationMap.put(
+            CacheKey.ORDERABLE_SHOP_INFO_SUMMARY.getCacheNames(),
+            defaultConfiguration().entryTtl(Duration.ofMinutes(CacheKey.ORDERABLE_SHOP_INFO_SUMMARY.getTtl()))
+        );
+
         return customConfigurationMap;
     }
 }

--- a/src/main/java/in/koreatech/koin/_common/cache/CacheKey.java
+++ b/src/main/java/in/koreatech/koin/_common/cache/CacheKey.java
@@ -9,11 +9,13 @@ public enum CacheKey {
 
     ORDERABLE_SHOP_MENUS("orderableShopMenus", 15L),
     CAMPUS_DELIVERY_ADDRESS("campusDeliveryAddress", 1440L),
-    RIDER_MESSAGES("riderMessages", 1440L);
+    RIDER_MESSAGES("riderMessages", 1440L),
+    ORDERABLE_SHOP_INFO_SUMMARY("orderableShopInfoSummary", 15L);
 
     public static final String ORDERABLE_SHOP_MENUS_CACHE = "orderableShopMenus";
     public static final String CAMPUS_DELIVERY_ADDRESS_CACHE = "campusDeliveryAddress";
     public static final String RIDER_MESSAGES_CACHE = "riderMessages";
+    public static final String ORDERABLE_SHOP_INFO_SUMMARY_CACHE = "orderableShopInfoSummary";
 
     private final String cacheNames;
     private final Long ttl;

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -158,7 +158,8 @@ public interface OrderableShopApi {
                           "rating_average": 4.5,
                           "review_count": 120,
                           "minimum_delivery_tip": 2000,
-                          "maximum_delivery_tip": 5000
+                          "maximum_delivery_tip": 5000,
+                          "image_url": "https://static.koreatech.in/upload/market/2022/03/26/0e650fe1-811b-411e-9a82-0dd4f43c42ca-1648289492264.jpg"
                         }
                         """
                     )

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -9,6 +9,9 @@ import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+/**
+ * record 관련 레디스 캐시 직렬화 문제가 있어서 class 로 구현
+ */
 @Getter
 @JsonNaming(value = SnakeCaseStrategy.class)
 public class OrderableShopInfoSummaryResponse {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shopinfo/OrderableShopInfoSummaryResponse.java
@@ -1,52 +1,93 @@
 package in.koreatech.koin.domain.order.shop.dto.shopinfo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopInfoSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
+@Getter
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record OrderableShopInfoSummaryResponse(
+public class OrderableShopInfoSummaryResponse {
+
     @Schema(description = "상점 ID", example = "14")
-    Integer shopId,
+    Integer shopId;
 
     @Schema(description = "주문 가능 상점 ID", example = "1")
-    Integer orderableShopId,
+    Integer orderableShopId;
 
     @Schema(description = "상점 이름", example = "멕시카나 치킨 - 병천점")
-    String name,
+    String name;
 
     @Schema(description = "상점 소개", example = "안녕하세요 멕시카나 치킨입니다.")
-    String introduction,
+    String introduction;
 
     @Schema(description = "배달 가능 여부", example = "true")
-    Boolean isDeliveryAvailable,
+    Boolean isDeliveryAvailable;
 
     @Schema(description = "포장 가능 여부", example = "false")
-    Boolean isTakeoutAvailable,
+    Boolean isTakeoutAvailable;
 
     @Schema(description = "카드 결제 가능 여부", example = "false")
-    Boolean payCard,
+    Boolean payCard;
 
     @Schema(description = "계좌 이체 가능 여부", example = "false")
-    Boolean payBank,
+    Boolean payBank;
 
     @Schema(description = "최소 주문 금액", example = "15000")
-    Integer minimumOrderAmount,
+    Integer minimumOrderAmount;
 
     @Schema(description = "리뷰 평균 평점", example = "4.5")
-    Double ratingAverage,
+    Double ratingAverage;
 
     @Schema(description = "리뷰 수", example = "120")
-    Integer reviewCount,
+    Integer reviewCount;
 
     @Schema(description = "최소 배달비", example = "0")
-    Integer minimumDeliveryTip,
+    Integer minimumDeliveryTip;
 
     @Schema(description = "최대 배달비", example = "3000")
-    Integer maximumDeliveryTip
-) {
+    Integer maximumDeliveryTip;
+
+    @Schema(description = "상점 이미지", example = "https://static.koreatech.in/upload/market/2022/03/26/0e650fe1-811b-411e-9a82-0dd4f43c42ca-1648289492264.jpg")
+    String imageUrl;
+
+    @JsonCreator
+    public OrderableShopInfoSummaryResponse(
+        @JsonProperty("shop_id") Integer shopId,
+        @JsonProperty("orderable_shop_id") Integer orderableShopId,
+        @JsonProperty("name") String name,
+        @JsonProperty("introduction") String introduction,
+        @JsonProperty("is_delivery_available") Boolean isDeliveryAvailable,
+        @JsonProperty("is_takeout_available") Boolean isTakeoutAvailable,
+        @JsonProperty("pay_card") Boolean payCard,
+        @JsonProperty("pay_bank") Boolean payBank,
+        @JsonProperty("minimum_order_amount") Integer minimumOrderAmount,
+        @JsonProperty("rating_average") Double ratingAverage,
+        @JsonProperty("review_count") Integer reviewCount,
+        @JsonProperty("minimum_delivery_tip") Integer minimumDeliveryTip,
+        @JsonProperty("maximum_delivery_tip") Integer maximumDeliveryTip,
+        @JsonProperty("image_url") String imageUrl
+    ) {
+        this.shopId = shopId;
+        this.orderableShopId = orderableShopId;
+        this.name = name;
+        this.introduction = introduction;
+        this.isDeliveryAvailable = isDeliveryAvailable;
+        this.isTakeoutAvailable = isTakeoutAvailable;
+        this.payCard = payCard;
+        this.payBank = payBank;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.ratingAverage = ratingAverage;
+        this.reviewCount = reviewCount;
+        this.minimumDeliveryTip = minimumDeliveryTip;
+        this.maximumDeliveryTip = maximumDeliveryTip;
+        this.imageUrl = imageUrl;
+    }
+
     public static OrderableShopInfoSummaryResponse from(OrderableShopInfoSummary entity) {
         return new OrderableShopInfoSummaryResponse(
             entity.shopId(),
@@ -61,7 +102,8 @@ public record OrderableShopInfoSummaryResponse(
             entity.ratingAverage(),
             entity.reviewCount(),
             entity.minimumDeliveryTip(),
-            entity.maximumDeliveryTip()
+            entity.maximumDeliveryTip(),
+            entity.imageUrl()
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/domain/OrderableShopInfoSummary.java
@@ -15,6 +15,7 @@ public record OrderableShopInfoSummary(
     Double ratingAverage,
     Integer reviewCount,
     Integer minimumDeliveryTip,
-    Integer maximumDeliveryTip
+    Integer maximumDeliveryTip,
+    String imageUrl
 ) {
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -26,7 +26,20 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
                 CAST(COALESCE(AVG(r.rating), 0.0) AS double),
                 CAST(COUNT(DISTINCT r.id) AS int),
                 CAST(COALESCE(MIN(bdt.fee), 0) AS int),
-                CAST(COALESCE(MAX(bdt.fee), 0) AS int)
+                CAST(COALESCE(MAX(bdt.fee), 0) AS int),
+                COALESCE(
+                    (SELECT thumbnail.imageUrl
+                     FROM OrderableShopImage thumbnail
+                     WHERE thumbnail.orderableShop.id = os.id
+                     AND thumbnail.isThumbnail = true
+                     AND thumbnail.isDeleted = false),
+                    (SELECT normal.imageUrl
+                     FROM OrderableShopImage normal
+                     WHERE normal.orderableShop.id = os.id
+                     AND normal.isDeleted = false
+                     ORDER BY normal.id ASC LIMIT 1
+                    )
+                )
             )
             FROM OrderableShop os
             JOIN os.shop s

--- a/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/service/OrderableShopInformationService.java
@@ -1,5 +1,9 @@
 package in.koreatech.koin.domain.order.shop.service;
 
+import static in.koreatech.koin._common.cache.CacheKey.ORDERABLE_SHOP_INFO_SUMMARY_CACHE;
+import static in.koreatech.koin._common.cache.CacheKey.ORDERABLE_SHOP_MENUS_CACHE;
+
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,7 @@ public class OrderableShopInformationService {
 
     private final OrderableShopRepository orderableShopRepository;
 
+    @Cacheable(value = ORDERABLE_SHOP_INFO_SUMMARY_CACHE, key = "#orderableShopId")
     public OrderableShopInfoSummaryResponse getOrderableShopInfoSummaryById(Integer orderableShopId) {
         return OrderableShopInfoSummaryResponse.from(
             orderableShopRepository.getOrderableShopInfoSummaryById(orderableShopId));


### PR DESCRIPTION
# 🔥 연관 이슈

- #1743

# 🚀 작업 내용

## 이미지 URL 추가
- JPA DTO 프로젝션으로 구현한거 그대로 사용하려고 서브쿼리를 사용했습니다.
- 사장님 앱 요구사항이 나오지 않아서 이미지 등록이 몇 개 허용되는지, thumbnail 이미지는 하나인지 여러개인지, thumbnail 이미지는 최소 하나는 설정해야 하는지 등 결정된게 없는 상황입니다.
- COALESCE() 사용해서 **썸네일 이미지가 있으면 id 가 낮은 데이터를 우선 반환**하고 없다면 **일반 이미지 중 id가 낮은 데이터 반환**하고, **둘 다 검색되지 않는다면 null을 반환**하도록 했습니다.

```sql
COALESCE(
        (SELECT thumbnail.imageUrl
         FROM OrderableShopImage thumbnail
         WHERE thumbnail.orderableShop.id = os.id
         AND thumbnail.isThumbnail = true
         AND thumbnail.isDeleted = false
         ORDER BY thumbnail.id ASC LIMIT 1
         ),
         (SELECT normal.imageUrl
          FROM OrderableShopImage normal
          WHERE normal.orderableShop.id = os.id
          AND normal.isDeleted = false
          ORDER BY normal.id ASC LIMIT 1
          )
)
```
## 캐싱 적용
![image](https://github.com/user-attachments/assets/bbf822b5-1817-4877-8623-adbe062db66f)

- 서브쿼리가 추가되면서 쿼리 크기가 더 커졌습니다. 단일 쿼리라서 조회 성능에 크게 문제가 있을 것 같지는 않지만 상점에 대한 정적 정보를 반환하는 API 이므로 정보가 자주 변경되지 않을 것으로 판단했고, 캐싱에 적합하다고 판단하여 적용했습니다. (TTL 15분)

![image](https://github.com/user-attachments/assets/4c7c2f14-da33-49f0-90c6-cfc3489903e1)

- 사장님 쪽 API 개발 할 때 여기서 반환하는 정보 변경 API 실행 시  **`@CacheEvict` 로 캐시 지워주는거 기억하기**
- record 사용하면 캐시 직렬화 이슈가 있어서 class 로 변경하고 있는데, 이거 해결방법 없는지 더 알아보겠습니다...

# 💬 리뷰 중점사항
