### PR TITLE
fix: fieldErrors 비활성화

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/code/ApiResponseCodesOperationCustomizer.java
+++ b/src/main/java/in/koreatech/koin/_common/code/ApiResponseCodesOperationCustomizer.java
@@ -94,7 +94,7 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
         ex.put("code", code.getCode());
         ex.put("message", topMessage);
         ex.put("errorTraceId", UUID_EXAMPLE);
-        ex.put("fieldErrors", fieldErrors);
+        ex.put("fieldErrors", fieldErrors + "(안드로이드 호환성 문제로 당분간 비활성화됩니다.)");
         return ex;
     }
 

--- a/src/main/java/in/koreatech/koin/_common/exception/ErrorResponse.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/ErrorResponse.java
@@ -23,6 +23,7 @@ public record ErrorResponse(
     @Schema(description = "에러 추적용 UUID")
     String errorTraceId,
 
+    @JsonIgnore // TODO: 안드로이드 라이브러리 호환성 문제로 강업 전까지 제외합니다.
     @Schema(description = "필드별 검증 오류 목록")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     List<FieldError> fieldErrors


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1760 

# 🚀 작업 내용

1. 필드에러 관련해서 안드로이드쪽에서 특정 에러필드의 라이브러리가 직렬화가 안되는 문제가 있어서, 강업 전까지 필드에러부분(fieldErros)만 닫아놓았습니다.
