### PR TITLE
feat: 교내 배달 주소 위도 & 경도 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/controller/AddressApi.java
@@ -110,13 +110,17 @@ public interface AddressApi {
                             "id": 1,
                             "type": "기숙사",
                             "full_address": "충남 천안시 동남구 병천면 충절로 1600 한국기술교육대학교 제1캠퍼스 생활관 101동",
-                            "short_address": "101동(해울)"
+                            "short_address": "101동(해울)",
+                            "latitude": 36.76125794,
+                            "longitude": 127.28372942
                           },
                           {
                             "id": 2,
                             "type": "기숙사",
                             "full_address": "충남 천안시 동남구 병천면 충절로 1600 한국기술교육대학교 제1캠퍼스 생활관 102동",
-                            "short_address": "102동(예지)"
+                            "short_address": "102동(예지)",
+                            "latitude": 36.76156794,
+                            "longitude": 127.28315659
                           }
                         ]
                     }

--- a/src/main/java/in/koreatech/koin/domain/order/address/dto/CampusDeliveryAddressResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/dto/CampusDeliveryAddressResponse.java
@@ -1,15 +1,13 @@
 package in.koreatech.koin.domain.order.address.dto;
 
+import java.math.BigDecimal;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.order.address.model.CampusDeliveryAddress;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record CampusDeliveryAddressResponse(
@@ -28,14 +26,20 @@ public record CampusDeliveryAddressResponse(
         @Schema(description = "전체 주소", example = "충남 천안시 동남구 병천면 충절로 1600 한국기술교육대학교 제1캠퍼스 생활관 101동")
         String fullAddress,
         @Schema(description = "요약 주소", example = "101동(해울)")
-        String shortAddress)
+        String shortAddress,
+        @Schema(description = "위도", example = "36.76125794")
+        BigDecimal latitude,
+        @Schema(description = "경도", example = "127.28372942")
+        BigDecimal longitude)
     {
         public static InnerCampusDeliveryAddressResponse from(CampusDeliveryAddress address) {
             return new InnerCampusDeliveryAddressResponse(
                 address.getId(),
                 address.getCampusAddressType().getName(),
                 address.getFullAddress(),
-                address.getShortAddress()
+                address.getShortAddress(),
+                address.getLatitude(),
+                address.getLongitude()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/address/model/CampusDeliveryAddress.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/model/CampusDeliveryAddress.java
@@ -41,6 +41,6 @@ public class CampusDeliveryAddress extends BaseEntity {
     @Column(name = "latitude", nullable = false, precision = 10, scale = 8)
     private BigDecimal latitude;
 
-    @Column(name = "longitude", nullable = false,precision = 11, scale = 8)
+    @Column(name = "longitude", nullable = false, precision = 11, scale = 8)
     private BigDecimal longitude;
 }

--- a/src/main/java/in/koreatech/koin/domain/order/address/model/CampusDeliveryAddress.java
+++ b/src/main/java/in/koreatech/koin/domain/order/address/model/CampusDeliveryAddress.java
@@ -2,6 +2,8 @@ package in.koreatech.koin.domain.order.address.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.math.BigDecimal;
+
 import in.koreatech.koin._common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,4 +37,10 @@ public class CampusDeliveryAddress extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "campus_address_type_id", nullable = false)
     private CampusDeliveryAddressType campusAddressType;
+
+    @Column(name = "latitude", nullable = false, precision = 10, scale = 8)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", nullable = false,precision = 11, scale = 8)
+    private BigDecimal longitude;
 }

--- a/src/main/resources/db/migration/V200__add_campus_delivery_address_x_y_position.sql
+++ b/src/main/resources/db/migration/V200__add_campus_delivery_address_x_y_position.sql
@@ -1,0 +1,91 @@
+ALTER TABLE `koin`.`campus_delivery_address`
+    ADD COLUMN `latitude` DECIMAL(10, 8) NULL COMMENT '위도' AFTER `short_address`,
+    ADD COLUMN `longitude` DECIMAL(11, 8) NULL COMMENT '경도' AFTER `latitude`;
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76125794, `longitude` = 127.28372942
+WHERE `short_address` = '101동(해울)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76156794, `longitude` = 127.28315659
+WHERE `short_address` = '102동(예지)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76186385, `longitude` = 127.28376805
+WHERE `short_address` = '103동(예솔)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76242319, `longitude` = 127.28349572
+WHERE `short_address` = '104동(다솔)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76202833, `longitude` = 127.28281109
+WHERE `short_address` = '105동(함지)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76163337, `longitude` = 127.28216566
+WHERE `short_address` = '106동(한울)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76130110, `longitude` = 127.28168287
+WHERE `short_address` = '201동(솔빛)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76084201, `longitude` = 127.28147960
+WHERE `short_address` = '202동(청솔)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76049078, `longitude` = 127.28139432
+WHERE `short_address` = '203동(IH)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76015392, `longitude` = 127.28094511
+WHERE `short_address` = '204동(은솔)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76083418, `longitude` = 127.28098119
+WHERE `short_address` = '205동(참빛)';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76548530, `longitude` = 127.28040455
+WHERE `short_address` = '공학 1관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76674321, `longitude` = 127.28194918
+WHERE `short_address` = '공학 2관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76483840, `longitude` = 127.27959579
+WHERE `short_address` = '공학 3관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76146765, `longitude` = 127.27984115
+WHERE `short_address` = '공학4관 A동';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76174156, `longitude` = 127.28023413
+WHERE `short_address` = '공학4관 B동';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76590843, `longitude` = 127.28247253
+WHERE `short_address` = '담헌실학관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76498642, `longitude` = 127.28178594
+WHERE `short_address` = '인문경영관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76282473, `longitude` = 127.28326760
+WHERE `short_address` = '테니스장';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76302056, `longitude` = 127.28238914
+WHERE `short_address` = '학생회관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76362895, `longitude` = 127.28042579
+WHERE `short_address` = '다산정보관';
+
+UPDATE `koin`.`campus_delivery_address`
+SET `latitude` = 36.76303229, `longitude` = 127.28124121
+WHERE `short_address` = '복지관';


### PR DESCRIPTION
# 🔥 연관 이슈

- #1762 

# 🚀 작업 내용

1. 노가다로 넣었습니다. 
https://apis.map.kakao.com/web/sample/addMapClickEventWithMarker/

2. 부동 소수점 오차 때문에 좌표 저장할때는 DECIMAL 쓰라고 해서 사용했습니다. 엔티티 매핑은 BigDecimal 사용했는데 이거 또 서버에 올리면 오류 나는거 아닌지 걱정되네요

# 💬 리뷰 중점사항
