### PR TITLE
fix: 동아리 행사 조회 응답값 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
+++ b/src/main/java/in/koreatech/koin/domain/club/controller/ClubApi.java
@@ -466,6 +466,13 @@ public interface ClubApi {
     @Operation(summary = "동아리 행사를 단일 조회한다.", description = """
         ### 동아리 행사 단일 조회
         - 동아리 행사를 단일 조회합니다.
+        
+        ### 응답값
+        - status
+            - SOON : 곧 행사 진행
+            - ONGOING : 행사 진행 중
+            - UPCOMING : 행사 예정
+            - ENDED : 종료된 행사
         """)
     @GetMapping("/{clubId}/event/{eventId}")
     ResponseEntity<ClubEventResponse> getClubEvent(
@@ -489,6 +496,13 @@ public interface ClubApi {
             - ONGOING : 행사 시작 1시간 전과 진행 중인 행사가 조회됩니다.
             - UPCOMING : 행사 시작 시간이 1시간 이상인 행사가 조회됩니다.
             - ENDED : 행사가 종료되고 1분이 지난 시점의 행사가 조회됩니다.
+        
+        ### 응답값
+        - status
+            - SOON : 곧 행사 진행
+            - ONGOING : 행사 진행 중
+            - UPCOMING : 행사 예정
+            - ENDED : 종료된 행사
         """)
     @GetMapping("/{clubId}/event")
     ResponseEntity<List<ClubEventsResponse>> getClubEvents(

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventResponse.java
@@ -55,7 +55,7 @@ public record ClubEventResponse(
             event.getEndDate(),
             event.getIntroduce(),
             event.getContent(),
-            calculateStatus(event.getStartDate(), event.getEndDate(), now).getDisplayName()
+            calculateStatus(event.getStartDate(), event.getEndDate(), now).name()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
@@ -58,7 +58,7 @@ public record ClubEventsResponse(
             event.getEndDate(),
             event.getIntroduce(),
             event.getContent(),
-            calculateStatus(event.getStartDate(), event.getEndDate(), now).getDisplayName(),
+            calculateStatus(event.getStartDate(), event.getEndDate(), now).name(),
             isSubscribed
         );
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1773 

# 🚀 작업 내용

- 동아리 행사 조회 시 `행사 상태` 응답값을 수정했습니다.
  - 예시와 달리, enum의 name이 아닌 displayname으로 반환하는 로직을 수정했습니다.
  - API 설명도 수정했습니다.

# 💬 리뷰 중점사항
