### PR TITLE
feat: 동아리 대표 전화번호 검증 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -63,6 +64,7 @@ public record AdminClubCreateRequest(
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
     @NotBlank(message = "전화번호는 필수 입력사항입니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubModifyRequest.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -65,6 +66,7 @@ public record AdminClubModifyRequest(
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
     @NotBlank(message = "전화번호는 필수 입력사항입니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber
 ) {
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -63,6 +64,7 @@ public record ClubCreateRequest(
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
     @NotBlank(message = "전화번호는 필수 입력사항입니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @Schema(description = "동아리 내 역할", example = "회장", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubUpdateRequest.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -56,6 +57,7 @@ public record ClubUpdateRequest(
     @Schema(description = "전화번호", example = "01012345678", requiredMode = NOT_REQUIRED)
     @Size(max = 255, message = "전화번호는 최대 255자 입니다.")
     @NotBlank(message = "전화번호는 필수 입력사항입니다.")
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호 형식이 올바르지 않습니다. 11자리 숫자로 입력해 주세요.")
     String phoneNumber,
 
     @Schema(description = "동아리 좋아요 숨김 여부", example = "false", requiredMode = REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1779 

# 🚀 작업 내용

- 동아리 대표 전화번호 검증 로직을 추가했습니다.

# 💬 리뷰 중점사항
