### PR TITLE
fix: 동시성 방지 어노테이션 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin._common.concurrent.ConcurrencyGuard;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureCreateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.request.TimetableLectureUpdateRequest;
 import in.koreatech.koin.domain.timetableV2.dto.response.TimetableLectureResponse;
@@ -36,6 +37,7 @@ public class TimetableLectureService {
     private final TimetableLectureCreator timetableLectureCreator;
 
     @Transactional
+    @ConcurrencyGuard(lockName = "createTimetableLectures")
     public TimetableLectureResponse createTimetableLectures(Integer userId, TimetableLectureCreateRequest request) {
         TimetableFrame frame = timetableFrameRepositoryV2.getById(request.timetableFrameId());
         validateUserOwnsFrame(frame.getUser().getId(), userId);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1784 

# 🚀 작업 내용

1. 일단 급한 불을 끄기 위해 동시성 처리 어노테이션을 걸어두었습니다.

# 💬 리뷰 중점사항

- 추후 리팩터링하며 isDeleted 를 삭제하든, isDeleted된 강의가 있으면 전환하든 해야합니다.
- niginx로 rateLimit을 2일 내로 추가해두겠습니다.