### PR TITLE
fix: 어드민 상점 카테고리 이미지 url 유효성 검증 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/shop/dto/shop/AdminModifyShopCategoryRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/dto/shop/AdminModifyShopCategoryRequest.java
@@ -15,7 +15,7 @@ import jakarta.validation.constraints.Size;
 public record AdminModifyShopCategoryRequest(
     @Schema(description = "이미지 URL", example = "https://static.koreatech.in/test.png", requiredMode = RequiredMode.REQUIRED)
     @NotBlank(message = "이미지 URL은 필수입니다.")
-    @Size(max = 100, message = "이미지 URL은 255자 이하로 입력해주세요.")
+    @Size(max = 255, message = "이미지 URL은 255자 이하로 입력해주세요.")
     String imageUrl,
 
     @Schema(description = "이름", example = "햄버거", requiredMode = RequiredMode.REQUIRED)


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1789 

# 🚀 작업 내용

- 어드민 상점 카테고리를 수정하는 과정에서 이미지 url에 걸려있는 유효성 조건을 수정했습니다.

# 💬 리뷰 중점사항
