### PR TITLE
fix: 동아리 행사 생성/수정 시작-종료날짜 입력 오류 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
@@ -1,14 +1,17 @@
 package in.koreatech.koin.domain.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static in.koreatech.koin._common.code.ApiResponseCode.*;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static java.lang.Boolean.TRUE;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin._common.validation.UniqueUrl;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubEvent;
@@ -25,8 +28,8 @@ public record ClubEventCreateRequest(
     String name,
 
     @Schema(description = "행사 이미지 URL 리스트", example = """
-    ["https://image1.com", "https://image2.com"]
-    """, requiredMode = NOT_REQUIRED)
+        ["https://image1.com", "https://image2.com"]
+        """, requiredMode = NOT_REQUIRED)
     @UniqueUrl(message = "이미지 URL은 중복될 수 없습니다.")
     List<String> imageUrls,
 
@@ -46,6 +49,12 @@ public record ClubEventCreateRequest(
     @Schema(description = "행사 상세 내용", example = "여러 동아리원들과 자신의 생각, 경험에 대해 나눠요,", requiredMode = NOT_REQUIRED)
     String content
 ) {
+    public ClubEventCreateRequest {
+        if (endDate.isBefore(startDate)) {
+            throw CustomException.of(INVALID_CLUB_EVENT_PERIOD);
+        }
+    }
+
     public ClubEvent toEntity(Club club) {
         return ClubEvent.builder()
             .club(club)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
@@ -34,11 +34,11 @@ public record ClubEventCreateRequest(
     List<String> imageUrls,
 
     @Schema(description = "행사 시작일", example = "2025-07-01T09:00:00", requiredMode = REQUIRED)
-    @NotNull(message = "시작일은 필수입니다.")
+    @NotNull(message = "행사 시작일은 필수입니다.")
     LocalDateTime startDate,
 
     @Schema(description = "행사 종료일", example = "2025-07-02T18:00:00", requiredMode = REQUIRED)
-    @NotNull(message = "종료일은 필수입니다.")
+    @NotNull(message = "행사 종료일은 필수입니다.")
     LocalDateTime endDate,
 
     @Schema(description = "행사 소개 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventModifyRequest.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.club.dto.request;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import static in.koreatech.koin._common.code.ApiResponseCode.INVALID_CLUB_EVENT_PERIOD;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin._common.validation.UniqueUrl;
 import in.koreatech.koin.domain.club.model.Club;
 import in.koreatech.koin.domain.club.model.ClubEvent;
@@ -46,4 +48,9 @@ public record ClubEventModifyRequest(
     @Schema(description = "행사 상세 내용", example = "여러 동아리원들과 자신의 생각, 경험에 대해 나눠요,", requiredMode = NOT_REQUIRED)
     String content
 ) {
+    public ClubEventModifyRequest {
+        if (endDate.isBefore(startDate)) {
+            throw CustomException.of(INVALID_CLUB_EVENT_PERIOD);
+        }
+    }
 }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1803 

# 🚀 작업 내용

1. INVALID_CLUB_EVENT_RERIOD가 작동하지 않는 문제를 수정했습니다.

# 💬 리뷰 중점사항
오류 코드 만들고 적용 안 시킨 사람이 있다?