### PR TITLE
fix: 동아리 전제 조회 시 모집 D-day 계산 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
@@ -52,7 +52,7 @@ public record ClubBaseInfo(
             return null;
         }
 
-        int period = (int) DAYS.between(startDate, endDate);
+        int period = (int) DAYS.between(today, endDate);
         return period >= 0 ? period : null;
     }
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1820

# 🚀 작업 내용

- 동아리 전체 조회 시 모집 D-day 계산 로직을 수정했습니다.
  - `endDate - startDate`가 아닌 `endDate - now`으로 수정해야 정상적으로 디데이 계산이 됩니다.

# 💬 리뷰 중점사항
