### PR TITLE
fix: 동아리 전체 조회 시 정렬 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubRecruitmentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubRecruitmentResponse.java
@@ -44,7 +44,7 @@ public record ClubRecruitmentResponse(
         return new ClubRecruitmentResponse(
             clubRecruitment.getId(),
             clubRecruitment.getClubRecruitmentStatus().name(),
-            clubRecruitment.getDday(),
+            clubRecruitment.getClubRecruitmentDday().getDday(),
             clubRecruitment.getStartDate(),
             clubRecruitment.getEndDate(),
             clubRecruitment.getImageUrl(),

--- a/src/main/java/in/koreatech/koin/domain/club/enums/ClubRecruitmentStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/club/enums/ClubRecruitmentStatus.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.domain.club.enums;
 
+import java.time.LocalDate;
+
 import lombok.Getter;
 
 @Getter
@@ -10,4 +12,30 @@ public enum ClubRecruitmentStatus {
     CLOSED,
     ALWAYS,
     ;
+
+    public static ClubRecruitmentStatus resolve(
+        Boolean isAlwaysRecruiting,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        LocalDate today = LocalDate.now();
+
+        if (isAlwaysRecruiting == null && startDate == null && endDate == null) {
+            return NONE;
+        }
+
+        if (Boolean.TRUE.equals(isAlwaysRecruiting)) {
+            return ALWAYS;
+        }
+
+        if (startDate != null && today.isBefore(startDate)) {
+            return BEFORE;
+        }
+
+        if (endDate != null && today.isAfter(endDate)) {
+            return CLOSED;
+        }
+
+        return RECRUITING;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/enums/ClubRecruitmentStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/club/enums/ClubRecruitmentStatus.java
@@ -13,7 +13,7 @@ public enum ClubRecruitmentStatus {
     ALWAYS,
     ;
 
-    public static ClubRecruitmentStatus resolve(
+    public static ClubRecruitmentStatus from(
         Boolean isAlwaysRecruiting,
         LocalDate startDate,
         LocalDate endDate

--- a/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
+++ b/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
@@ -54,10 +54,7 @@ public enum ClubSortType {
                 clubRecruitment.endDate
             );
 
-            return List.of(
-                deadlineGap.asc(),
-                clubRecruitment.isAlwaysRecruiting.desc()
-            );
+            return List.of(deadlineGap.asc());
         }
 
         @Override

--- a/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
+++ b/src/main/java/in/koreatech/koin/domain/club/enums/ClubSortType.java
@@ -48,13 +48,32 @@ public enum ClubSortType {
     RECRUITING_DEADLINE_ASC {
         @Override
         public List<OrderSpecifier<?>> getOrderSpecifiers() {
+            /**
+             * 우선순위
+             * 1. 마감일이 짧은 동아리
+             * 2. 상시 모집인 동아리
+             * 3. 모집 전인 동아리
+             */
+            NumberTemplate<Integer> recruitmentStatusPriority = Expressions.numberTemplate(
+                Integer.class,
+                """
+                    case
+                        when {0} = true then 1
+                        when {1} > current_date then 2
+                        else 0
+                    end
+                    """,
+                clubRecruitment.isAlwaysRecruiting,
+                clubRecruitment.startDate
+            );
+
             NumberTemplate<Integer> deadlineGap = Expressions.numberTemplate(
                 Integer.class,
                 "datediff({0}, current_date)",
                 clubRecruitment.endDate
             );
 
-            return List.of(deadlineGap.asc());
+            return List.of(recruitmentStatusPriority.asc(), deadlineGap.asc());
         }
 
         @Override

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
@@ -1,8 +1,5 @@
 package in.koreatech.koin.domain.club.model;
 
-import static in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus.*;
-import static java.time.temporal.ChronoUnit.DAYS;
-
 import java.time.LocalDate;
 
 import in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus;
@@ -20,43 +17,11 @@ public record ClubBaseInfo(
     Boolean isAlwaysRecruiting
 ) {
     public ClubRecruitmentStatus getRecruitmentStatus() {
-        LocalDate today = LocalDate.now();
-
-        if (isUndefined()) {
-            return NONE;
-        }
-
-        if (Boolean.TRUE.equals(isAlwaysRecruiting)) {
-            return ALWAYS;
-        }
-
-        if (startDate != null && today.isBefore(startDate)) {
-            return BEFORE;
-        }
-
-        if (endDate != null && today.isAfter(endDate)) {
-            return CLOSED;
-        }
-
-        return RECRUITING;
+        return ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
     }
 
     public Integer getRecruitmentPeriod() {
-        LocalDate today = LocalDate.now();
-
-        if (isUndefined() || Boolean.TRUE.equals(isAlwaysRecruiting)) {
-            return null;
-        }
-
-        if (startDate == null || endDate == null || today.isAfter(endDate)) {
-            return null;
-        }
-
-        int period = (int) DAYS.between(today, endDate);
-        return period >= 0 ? period : null;
-    }
-
-    private boolean isUndefined() {
-        return isAlwaysRecruiting == null && startDate == null && endDate == null;
+        ClubRecruitmentStatus clubRecruitmentStatus = ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
+        return ClubRecruitmentDday.from(clubRecruitmentStatus, endDate).getDday();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubBaseInfo.java
@@ -17,11 +17,11 @@ public record ClubBaseInfo(
     Boolean isAlwaysRecruiting
 ) {
     public ClubRecruitmentStatus getRecruitmentStatus() {
-        return ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
+        return ClubRecruitmentStatus.from(isAlwaysRecruiting, startDate, endDate);
     }
 
     public Integer getRecruitmentPeriod() {
-        ClubRecruitmentStatus clubRecruitmentStatus = ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
+        ClubRecruitmentStatus clubRecruitmentStatus = ClubRecruitmentStatus.from(isAlwaysRecruiting, startDate, endDate);
         return ClubRecruitmentDday.from(clubRecruitmentStatus, endDate).getDday();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
@@ -101,7 +101,7 @@ public class ClubRecruitment extends BaseEntity {
 
     @PostLoad
     private void calculateRecruitmentInfo() {
-        this.clubRecruitmentStatus = ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
+        this.clubRecruitmentStatus = ClubRecruitmentStatus.from(isAlwaysRecruiting, startDate, endDate);
         this.clubRecruitmentDday = ClubRecruitmentDday.from(clubRecruitmentStatus, endDate);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitment.java
@@ -1,12 +1,10 @@
 package in.koreatech.koin.domain.club.model;
 
-import static in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus.*;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 
 import in.koreatech.koin._common.model.BaseEntity;
 import in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus;
@@ -65,7 +63,7 @@ public class ClubRecruitment extends BaseEntity {
     private Club club;
 
     @Transient
-    private Integer Dday;
+    private ClubRecruitmentDday clubRecruitmentDday;
 
     @Transient
     private ClubRecruitmentStatus clubRecruitmentStatus;
@@ -103,24 +101,7 @@ public class ClubRecruitment extends BaseEntity {
 
     @PostLoad
     private void calculateRecruitmentInfo() {
-        LocalDate today = LocalDate.now();
-
-        if (this.isAlwaysRecruiting) {
-            this.clubRecruitmentStatus = ALWAYS;
-            this.Dday = null;
-            return;
-        }
-
-        if (today.isBefore(this.startDate)) {
-            this.clubRecruitmentStatus = BEFORE;
-            this.Dday = null;
-        }
-        else if (!today.isAfter(this.endDate)) {
-            this.clubRecruitmentStatus = RECRUITING;
-            this.Dday = (int)ChronoUnit.DAYS.between(today, endDate);
-        } else {
-            this.clubRecruitmentStatus = CLOSED;
-            this.Dday = null;
-        }
+        this.clubRecruitmentStatus = ClubRecruitmentStatus.resolve(isAlwaysRecruiting, startDate, endDate);
+        this.clubRecruitmentDday = ClubRecruitmentDday.from(clubRecruitmentStatus, endDate);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitmentDday.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/ClubRecruitmentDday.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.domain.club.model;
+
+import static in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus.RECRUITING;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus;
+import lombok.Getter;
+
+@Getter
+public class ClubRecruitmentDday {
+
+    private Integer dday;
+
+    private ClubRecruitmentDday(Integer dday) {
+        this.dday = dday;
+    }
+
+    public static ClubRecruitmentDday from(ClubRecruitmentStatus status, LocalDate endDate) {
+        if (status == RECRUITING) {
+            int days = (int)ChronoUnit.DAYS.between(LocalDate.now(), endDate);
+            return new ClubRecruitmentDday(days);
+        }
+        return new ClubRecruitmentDday(null);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubListQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubListQueryRepository.java
@@ -51,10 +51,7 @@ public class ClubListQueryRepository {
             .leftJoin(clubRecruitment).on(clubRecruitment.club.id.eq(club.id));
 
         if (userId != null) {
-            baseQuery.leftJoin(clubLike).on(
-                clubLike.club.id.eq(club.id)
-                    .and(clubLike.user.id.eq(userId))
-            );
+            baseQuery.leftJoin(clubLike).on(clubLike.club.id.eq(club.id).and(clubLike.user.id.eq(userId)));
         }
 
         return baseQuery
@@ -72,10 +69,7 @@ public class ClubListQueryRepository {
 
         if (isRecruiting) {
             builder.and(clubRecruitment.id.isNotNull());
-            builder.and(
-                clubRecruitment.endDate.goe(LocalDate.now())
-                    .or(clubRecruitment.isAlwaysRecruiting.isTrue())
-            );
+            builder.and(clubRecruitment.endDate.goe(LocalDate.now()).or(clubRecruitment.isAlwaysRecruiting.isTrue()));
         }
 
         builder.and(Expressions.stringTemplate("LOWER(REPLACE({0}, ' ', ''))", club.name).contains(normalizedQuery));


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1822

# 🚀 작업 내용

- 동아리 전체 조회 시 정렬 로직을 수정했습니다.
  - 모집 마감 순에서 제대로 정렬이 안되는 문제가 발생했습니다.
  - `case end`으로 우선 순위를 주고, 정렬하도록 수정했습니다. (주석 참고)
  ```sql
    select
        c1_0.id,
        c1_0.name,
        c4_0.name,
        c1_0.likes,
        c1_0.image_url,
        abs(sign(?))=abs(sign(?)),
        c1_0.is_like_hidden,
        c2_0.start_date,
        c2_0.end_date,
        c2_0.is_always_recruiting 
    from
        club c1_0 
    left join
        club_recruitment c2_0 
            on c2_0.club_id=c1_0.id 
    join
        club_category c4_0 
            on c4_0.id=c1_0.club_category_id 
    where
        c2_0.id is not null 
        and (
            c2_0.end_date>=? 
            or c2_0.is_always_recruiting=?
        ) 
        and lower(replace(c1_0.name,' ','')) like ? escape '!' 
        and c1_0.is_active=? 
    order by
        datediff(c2_0.end_date,current_date),
        c2_0.is_always_recruiting desc
- 동아리 모집 D-Day, 상태 계산 로직을 리펙토링했습니다.
  - 상태 계산 로직의 경우 enum 내부로 옮겼습니다.
  - D-Day의 경우 `ClubRecruitmentDday` 개념 객체를 만들어서 내부에 메소드를 추가 했습니다.

# 💬 리뷰 중점사항
