### PR TITLE
fix: 동아리 행사 QA 내용 반영

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventCreateRequest.java
@@ -41,7 +41,7 @@ public record ClubEventCreateRequest(
     @NotNull(message = "행사 종료일은 필수입니다.")
     LocalDateTime endDate,
 
-    @Schema(description = "행사 내용 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.", requiredMode = REQUIRED)
+    @Schema(description = "행사 내용", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.", requiredMode = REQUIRED)
     @NotBlank(message = "행사 내용은 필수입니다.")
     @Size(max = 70, message = "행사 내용은 70자 이내여야 합니다.")
     String introduce,

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventModifyRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubEventModifyRequest.java
@@ -40,7 +40,7 @@ public record ClubEventModifyRequest(
     @NotNull(message = "행사 종료일은 필수입니다.")
     LocalDateTime endDate,
 
-    @Schema(description = "행사 내용 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.", requiredMode = REQUIRED)
+    @Schema(description = "행사 내용", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.", requiredMode = REQUIRED)
     @NotBlank(message = "행사 내용은 필수입니다.")
     @Size(max = 70, message = "행사 내용은 70자 이내여야 합니다.")
     String introduce,

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventResponse.java
@@ -32,7 +32,7 @@ public record ClubEventResponse(
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime endDate,
 
-    @Schema(description = "행사 소개 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.")
+    @Schema(description = "행사 내용", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.")
     String introduce,
 
     @Schema(description = "행사 상세 내용", example = "여러 동아리원들과 자신의 생각, 경험에 대해 나눠요,")

--- a/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/response/ClubEventsResponse.java
@@ -32,7 +32,7 @@ public record ClubEventsResponse(
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime endDate,
 
-    @Schema(description = "행사 소개 (요약)", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.")
+    @Schema(description = "행사 내용", example = "BCSDLab의 멘토 혹은 레귤러들의 경험을 공유해요.")
     String introduce,
 
     @Schema(description = "행사 상세 내용", example = "여러 동아리원들과 자신의 생각, 경험에 대해 나눠요,")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1824 

# 🚀 작업 내용

1. 행사 생성/수정간 시작-종료일 간 검증 방법을 수정했습니다.
2. 행사 생성/수정간 행사 소개 컬럼 이름과 설명을 수정했습니다.
- 행사 소개(요약) -> 행사 내용으로 수정했습니다.

# 💬 리뷰 중점사항
이 사람 이슈 안 파고 브랜치 잘못 파서 새로 만들어 왔습니다.