### PR TITLE
refactor: SQL 검증 실패 시 파일위치 및 SQL문 출력, 에러 스택 트레이스 추가, Swagger 성공 응답값 표시

### DIFF
--- a/.github/workflows/flyway-dangerous-sql-validator.yml
+++ b/.github/workflows/flyway-dangerous-sql-validator.yml
@@ -18,27 +18,32 @@ jobs:
 
       - name: Validate Dangerous SQL and Non-Flyway Changes
         run: |
-          CHANGED_FILES=$(
-            git diff --name-only \
-              ${{ github.event.pull_request.base.sha }} \
-              ${{ github.event.pull_request.head.sha }}
-          )
-          NON_FLYWAY_FILES_CHANGES=$(
-            echo "$CHANGED_FILES" \
-             | grep -v '^src/main/resources/db/migration/' \
-             || true
-          )
-          
-          DANGEROUS_SQL_COMMANDS=$(
-            git diff --unified=0 \
-              ${{ github.event.pull_request.base.sha }} \
-              ${{ github.event.pull_request.head.sha }} \
-              -- src/main/resources/db/migration/*.sql \
-              | grep -i -wE "^\+.*\b(DROP|TRUNCATE|RENAME|CHANGE)\b" \
-              || true
-          )
-          
-          if [[ -n "$DANGEROUS_SQL_COMMANDS" && -n "$NON_FLYWAY_FILES_CHANGES" ]]; then
-            echo "::error::코드 변경사항과 파괴적 SQL 명령이 동시에 감지되었습니다. PR을 분리하거나 위험 SQL을 제거한 후 다시 시도해주세요."
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          CHANGED_FILES=$(git diff --name-only "$BASE" "$HEAD")
+
+          NON_FLYWAY_FILES_CHANGES=$(echo "$CHANGED_FILES" \
+            | grep -v '^src/main/resources/db/migration/' || true)
+
+          echo "🔍 변경된 Flyway SQL 파일 검사 중..."
+
+          DANGEROUS_FOUND=0
+
+          for file in $(git diff --name-only "$BASE" "$HEAD" -- src/main/resources/db/migration/*.sql); do
+            ADDED_SQL=$(git diff "$BASE" "$HEAD" -- "$file" \
+              | grep -i -wE "^\+.*\b(DROP|TRUNCATE|RENAME|CHANGE)\b" || true)
+
+            if [[ -n "$ADDED_SQL" ]]; then
+              echo "::error::⚠️ 위험 SQL 감지됨"
+              echo "파일: $file"
+              echo "$ADDED_SQL" | sed 's/^/    /'
+              DANGEROUS_FOUND=1
+            fi
+          done
+
+          if [[ "$DANGEROUS_FOUND" -eq 1 && -n "$NON_FLYWAY_FILES_CHANGES" ]]; then
+            echo ""
+            echo "::error::블루그린 배포에서 스키마 충돌로 인해 서버 안정성을 보장할 수 없습니다."
             exit 1
           fi

--- a/src/main/java/in/koreatech/koin/_common/code/ApiResponseCodesOperationCustomizer.java
+++ b/src/main/java/in/koreatech/koin/_common/code/ApiResponseCodesOperationCustomizer.java
@@ -5,6 +5,7 @@ import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.method.HandlerMethod;
@@ -23,6 +25,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 
 import in.koreatech.koin._common.exception.ErrorResponse;
 import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -35,8 +38,7 @@ import jakarta.validation.Valid;
 @Component
 public class ApiResponseCodesOperationCustomizer implements OperationCustomizer {
 
-    private static final String TRACE_ID_EXAMPLE =
-        "123e4567-e89b-12d3-a456-426614174000";
+    private static final String TRACE_ID_EXAMPLE = "123e4567-e89b-12d3-a456-426614174000";
 
     // 에러 스키마를 미리 생성하여 최적화
     private final Schema<?> errorSchema = loadSchema(ErrorResponse.class);
@@ -49,11 +51,10 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
             return operation;
         }
 
-        // 기존 응답 정의를 모두 지우고, @ApiResponseCodes에 정의된 순서대로 다시 추가
         ApiResponses responses = operation.getResponses();
         responses.clear();
 
-        Type returnType = handler.getMethod().getGenericReturnType();
+        Type returnType = getActualResponseType(handler);
         ApiResponseCode[] codes = ann.value();
         for (int i = 0; i < codes.length; i++) {
             ApiResponseCode code = codes[i];
@@ -67,11 +68,17 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
         return operation;
     }
 
-    /**
-     * 단일 HTTP 상태 코드에 대한 ApiResponse를 생성합니다.
-     * @param description 응답 설명 (예: "OK", "잘못된 요청 바디" 등)
-     * @param supplier    실제 바디 구조(MediaType)를 반환할 함수
-     */
+    private Type getActualResponseType(HandlerMethod handler) {
+        Type returnType = handler.getMethod().getGenericReturnType();
+
+        if (returnType instanceof ParameterizedType parameterizedType) {
+            if (parameterizedType.getRawType().equals(ResponseEntity.class)) {
+                return parameterizedType.getActualTypeArguments()[0];
+            }
+        }
+        return returnType;
+    }
+
     private ApiResponse createApiResponse(
         String description,
         Supplier<MediaType> supplier
@@ -81,12 +88,6 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
             .content(new Content().addMediaType(APPLICATION_JSON_VALUE, supplier.get()));
     }
 
-    /**
-     * HTTP 상태 코드에 따라
-     *  - 2xx 성공: 실제 반환될 DTO 스키마
-     *  - INVALID_REQUEST_BODY: 필드 검증 오류 스키마
-     *  - 기타 에러: 공통 에러 스키마
-     */
     private MediaType createResponseBody(
         ApiResponseCode code,
         HandlerMethod handler,
@@ -96,19 +97,11 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
             return new MediaType().schema(loadSchema(returnType));
         }
         if (code == ApiResponseCode.INVALID_REQUEST_BODY) {
-            return createErrorMediaType(createValidationErrorExample(code, handler));
+            return createErrorMediaType(createInvalidRequestBodyErrorExample(code, handler));
         }
         return createErrorMediaType(createGenericErrorExample(code));
     }
 
-    /**
-     * 공통 에러 응답 예시 JSON 객체를 만듭니다.
-     * {
-     *   "code": ...,
-     *   "message": ...,
-     *   "errorTraceId": ...
-     * }
-     */
     private Map<String,Object> createGenericErrorExample(ApiResponseCode code) {
         return Map.of(
             "code", code.getCode(),
@@ -117,16 +110,7 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
         );
     }
 
-    /**
-     * INVALID_REQUEST_BODY 에러 예시 JSON 객체를 만듭니다.
-     * {
-     *   "code": ...,
-     *   "message": 첫 번째 필드 오류 메시지 또는 code.message,
-     *   "errorTraceId": ...,
-     *   "fieldErrors": [ { field, constraint, message }, ... ]
-     * }
-     */
-    private Map<String,Object> createValidationErrorExample(
+    private Map<String,Object> createInvalidRequestBodyErrorExample(
         ApiResponseCode code,
         HandlerMethod handler
     ) {
@@ -146,7 +130,7 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
 
     /**
      * 핸들러 메서드의 @RequestBody DTO 필드에 붙은
-     * jakarta.validation 제약조건(@Constraint) 어노테이션 정보를 꺼내,
+     * jakarta.validation 제약조건(@Constraint) 검증 어노테이션 정보를 꺼내,
      * JSON 객체 리스트로 반환합니다.
      */
     private List<Map<String,Object>> extractFieldErrors(HandlerMethod handler) {
@@ -182,10 +166,6 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
             .toList();
     }
 
-    /**
-     * 단일 필드 + 검증 어노테이션 정보를
-     * { "field": ..., "constraint": ..., "message": ... } 형태로 만듭니다.
-     */
     private Map<String,Object> fieldErrorEntry(Field field, Annotation ann) {
         String name = snake.translate(field.getName());
         String constraint = ann.annotationType().getSimpleName();
@@ -199,8 +179,7 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
     }
 
     /**
-     * @Constraint 어노테이션의 message() 값을 리플렉션으로 얻어옵니다.
-     * 실패 시 기본 문구를 사용합니다.
+     * 검증 어노테이션의 message 값을 가져오고, 없을 경우 기본 문구를 사용합니다.
      */
     private String getConstraintMessage(Annotation ann, String fieldName) {
         try {
@@ -211,20 +190,19 @@ public class ApiResponseCodesOperationCustomizer implements OperationCustomizer 
         }
     }
 
-    /**
-     * Jackson 모델 컨버터를 사용해 특정 타입의
-     * Swagger Schema(응답 바디 구조)를 생성합니다.
-     */
     private static Schema<?> loadSchema(Type type) {
-        return ModelConverters.getInstance()
-            .readAllAsResolvedSchema(type)
-            .schema;
+        if (type.equals(Void.class) || type.equals(void.class)) {
+            return new Schema<>().type("object");
+        }
+
+        ResolvedSchema resolvedSchema = ModelConverters.getInstance().readAllAsResolvedSchema(type);
+        if (resolvedSchema == null) {
+            return new Schema<>().type("object");
+        }
+
+        return resolvedSchema.schema;
     }
 
-    /**
-     * 에러 스키마 + 예시 JSON 객체를 묶어서
-     * MediaType(application/json)으로 반환합니다.
-     */
     private MediaType createErrorMediaType(Map<String,Object> example) {
         MediaType mt = new MediaType().schema(errorSchema);
         mt.example(example);

--- a/src/main/java/in/koreatech/koin/_common/exception/CustomException.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/CustomException.java
@@ -19,12 +19,23 @@ public class CustomException extends RuntimeException {
         this.detail = detail;
     }
 
+    private CustomException(ApiResponseCode errorCode, String detail, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+
     public static CustomException of(ApiResponseCode errorCode) {
         return new CustomException(errorCode, "");
     }
 
-    public static CustomException of(ApiResponseCode errorCode, Object errorObject) {
-        return new CustomException(errorCode, Objects.toString(errorObject, ""));
+    public static CustomException of(ApiResponseCode errorCode, String detail) {
+        return new CustomException(errorCode, detail);
+    }
+
+    public static CustomException of(ApiResponseCode errorCode, String detail, Throwable cause) {
+        return new CustomException(errorCode, detail, cause);
     }
 
     public String getFullMessage() {

--- a/src/main/java/in/koreatech/koin/domain/user/model/User.java
+++ b/src/main/java/in/koreatech/koin/domain/user/model/User.java
@@ -173,19 +173,19 @@ public class User extends BaseEntity {
 
     public void requireSamePhoneNumber(String phoneNumber) {
         if (isNotSamePhoneNumber(phoneNumber)) {
-            throw CustomException.of(ApiResponseCode.NOT_MATCHED_PHONE_NUMBER, this);
+            throw CustomException.of(ApiResponseCode.NOT_MATCHED_PHONE_NUMBER, "phoneNumber: " + phoneNumber);
         }
     }
 
     public void requireSameEmail(String email) {
         if (isNotSameEmail(email)) {
-            throw CustomException.of(ApiResponseCode.NOT_MATCHED_EMAIL, this);
+            throw CustomException.of(ApiResponseCode.NOT_MATCHED_EMAIL, "email: " + email);
         }
     }
 
     public void requireSameLoginPw(PasswordEncoder passwordEncoder, String loginPw) {
         if (isNotSameLoginPw(passwordEncoder, loginPw)) {
-            throw CustomException.of(ApiResponseCode.NOT_MATCHED_PASSWORD, this);
+            throw CustomException.of(ApiResponseCode.NOT_MATCHED_PASSWORD, "loginPw: " + loginPw);
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
+++ b/src/main/java/in/koreatech/koin/domain/user/service/UserValidationService.java
@@ -45,28 +45,28 @@ public class UserValidationService {
     public void requireUniqueNickname(String nickname) {
         if (StringUtils.hasText(nickname)
             && userRepository.existsByNicknameAndUserTypeIn(nickname, KOIN_USER_TYPES)) {
-            throw CustomException.of(ApiResponseCode.DUPLICATE_NICKNAME, this);
+            throw CustomException.of(ApiResponseCode.DUPLICATE_NICKNAME, "nickname: " + nickname);
         }
     }
 
     public void requireUniquePhoneNumber(String phoneNumber) {
         if (StringUtils.hasText(phoneNumber)
             && userRepository.existsByPhoneNumberAndUserTypeIn(phoneNumber, KOIN_USER_TYPES)) {
-            throw CustomException.of(ApiResponseCode.DUPLICATE_PHONE_NUMBER, this);
+            throw CustomException.of(ApiResponseCode.DUPLICATE_PHONE_NUMBER, "phoneNumber: " + phoneNumber);
         }
     }
 
     public void requireUniqueEmail(String email) {
         if (StringUtils.hasText(email)
             && userRepository.existsByEmailAndUserTypeIn(email, KOIN_USER_TYPES)) {
-            throw CustomException.of(ApiResponseCode.DUPLICATE_EMAIL, this);
+            throw CustomException.of(ApiResponseCode.DUPLICATE_EMAIL, "email: " + email);
         }
     }
 
     public void requireUniqueLoginId(String loginId) {
         if (StringUtils.hasText(loginId)
             && userRepository.existsByLoginIdAndUserTypeIn(loginId, KOIN_USER_TYPES)) {
-            throw CustomException.of(ApiResponseCode.DUPLICATE_LOGIN_ID, this);
+            throw CustomException.of(ApiResponseCode.DUPLICATE_LOGIN_ID, "loginId: " + loginId);
         }
     }
 
@@ -81,21 +81,21 @@ public class UserValidationService {
         if (userRepository.existsByLoginIdAndUserTypeIn(loginId, KOIN_USER_TYPES)) {
             return;
         }
-        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, this);
+        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, "loginId: " + loginId);
     }
 
     public void requirePhoneNumberExists(String phoneNumber) {
         if (userRepository.existsByPhoneNumberAndUserTypeIn(phoneNumber, KOIN_USER_TYPES)) {
             return;
         }
-        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, this);
+        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, "phoneNumber: " + phoneNumber);
     }
 
     public void requireEmailExists(String email) {
         if (userRepository.existsByEmailAndUserTypeIn(email, KOIN_USER_TYPES)) {
             return;
         }
-        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, this);
+        throw CustomException.of(ApiResponseCode.NOT_FOUND_USER, "email: " + email);
     }
 
     public void matchLoginIdWithPhoneNumber(UserMatchLoginIdWithPhoneNumberRequest request) {

--- a/src/main/java/in/koreatech/koin/domain/user/verification/model/VerificationCode.java
+++ b/src/main/java/in/koreatech/koin/domain/user/verification/model/VerificationCode.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 @Getter
 @RedisHash(value = "userVerificationStatus")
-@ToString
 public class VerificationCode {
 
     private static final long SMS_VERIFICATION_EXPIRATION_SECONDS = 60 * 3L; // 3분
@@ -51,14 +50,14 @@ public class VerificationCode {
 
     public void detectAbnormalUsage() {
         if (trialCount >= MAX_TRIAL_COUNT) {
-            throw CustomException.of(ApiResponseCode.NOT_MATCHED_VERIFICATION_CODE, this);
+            throw CustomException.of(ApiResponseCode.NOT_MATCHED_VERIFICATION_CODE, "trialCount: " + trialCount);
         }
     }
 
     public void verify(String inputCode) {
         if (isCodeMismatched(inputCode)) {
             trialCount++;
-            throw CustomException.of(ApiResponseCode.NOT_MATCHED_VERIFICATION_CODE, this);
+            throw CustomException.of(ApiResponseCode.NOT_MATCHED_VERIFICATION_CODE, "inputCode: " + inputCode);
         }
         this.isVerified = true;
         this.expiration = VERIFIED_EXPIRATION_SECONDS;
@@ -66,7 +65,7 @@ public class VerificationCode {
 
     public void requireVerified() {
         if (isNotVerified()) {
-            throw CustomException.of(ApiResponseCode.FORBIDDEN_VERIFICATION, this);
+            throw CustomException.of(ApiResponseCode.FORBIDDEN_VERIFICATION, "VerificationCodeId: " + id);
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/verification/model/VerificationCount.java
+++ b/src/main/java/in/koreatech/koin/domain/user/verification/model/VerificationCount.java
@@ -45,7 +45,7 @@ public class VerificationCount {
 
     public void incrementVerificationCount() {
         if (verificationCount >= maxVerificationCount) {
-            throw CustomException.of(ApiResponseCode.TOO_MANY_REQUESTS_VERIFICATION, this);
+            throw CustomException.of(ApiResponseCode.TOO_MANY_REQUESTS_VERIFICATION, "count: " + verificationCount);
         }
         verificationCount++;
     }

--- a/src/main/java/in/koreatech/koin/infrastructure/config/FcmConfig.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/config/FcmConfig.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import javax.annotation.PostConstruct;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -16,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
+@Profile("!local & !test")
 public class FcmConfig {
 
     @PostConstruct

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
     value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} : %msg%n"/>
   <property name="slackLogPattern" value="%msg%n"/>
 
-  <springProfile name="test">
+  <springProfile name="local, test">
     <conversionRule conversionWord="clr"
       converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1830 

# 🚀 작업 내용

1. SQL 검증 실패 시 파일 위치 및 SQL문 출력
PR에 포함된 Flyway SQL에서 위험한 명령(DROP, RENAME 등)이 감지되면, 해당 파일 경로와 문제가 된 SQL문을 출력합니다.

2. 에러 스택 트레이스 추가
GitHub Actions 실패 시 발생한 오류에 대해 에러 메시지와 함께 스택 트레이스를 출력합니다.
이를 사용하지 않을 경우, try-catch문으로 CustomError를 반환하였을 때, catch한 Error의 로그가 출력되지 않아 디버깅이 어려워질 우려가 있기에 추가하였습니다.

3. Swagger 성공 응답값 표시
기존에는 200 응답이 "string"으로 잘못 표시되던 문제를 수정했습니다.

4. 로컬환경에서 fcm과 slack 연동 실패로 인한 콘솔창이 오류 로그로 채워지는 것을 방지하였습니다.

