### PR TITLE
hotfix: 동아리 검색어에 따른 연관검색어 조회 쿼리 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -44,8 +44,12 @@ public interface ClubRepository extends Repository<Club, Integer> {
         return club;
     }
 
-    @Query("SELECT c FROM Club c WHERE c.isActive = true AND c.name LIKE CONCAT(:query, '%') ORDER BY c.name")
-    List<Club> findByNamePrefix(String query, Pageable pageable);
+    @Query(value = """
+        SELECT * FROM club c 
+        WHERE c.is_active = true AND REPLACE(c.name, ' ', '') LIKE CONCAT(:query, '%') 
+        ORDER BY c.name
+        """, nativeQuery = true)
+    List<Club> findByNamePrefix(@Param("query") String query, Pageable pageable);
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + :value WHERE c.id = :id")

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -46,10 +46,11 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
     @Query(value = """
         SELECT * FROM club c 
-        WHERE c.is_active = true AND REPLACE(c.name, ' ', '') LIKE CONCAT(:query, '%') 
+        WHERE c.is_active = true 
+          AND LOWER(REPLACE(c.name, ' ', '')) LIKE CONCAT(:query, '%') 
         ORDER BY c.name
         """, nativeQuery = true)
-    List<Club> findByNamePrefix(@Param("query") String query, Pageable pageable);
+    List<Club> findByNamePrefix(@Param("query") String normalizedQuery, Pageable pageable);
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + :value WHERE c.id = :id")


### PR DESCRIPTION
# 🔥 연관 이슈

# 🚀 작업 내용

- 동아리 검색어에 따른 연관검색어 조회 쿼리를 수정했습니다.
  - 공백, 대소문자 구분이 되는 오류를 수정했습니다.
<img width="1406" height="681" alt="image" src="https://github.com/user-attachments/assets/40a7aff8-0739-48f4-9125-ba7232857793" />


# 💬 리뷰 중점사항
# 해당 PR은 main 브랜치를 향하고 있습니다.