### PR TITLE
feat: 장바구니(CartService) 단위 테스트 작성 + 담긴 상품 수량 정보 API 등

### DIFF
--- a/src/main/java/in/koreatech/koin/_common/exception/CustomException.java
+++ b/src/main/java/in/koreatech/koin/_common/exception/CustomException.java
@@ -1,15 +1,13 @@
 package in.koreatech.koin._common.exception;
 
-import java.util.Objects;
-
 import org.springframework.util.StringUtils;
 
 import in.koreatech.koin._common.code.ApiResponseCode;
 import lombok.Getter;
 
+@Getter
 public class CustomException extends RuntimeException {
 
-    @Getter
     private final ApiResponseCode errorCode;
     private final String detail;
 

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -205,6 +205,48 @@ public interface CartApi {
                       "message": "상점의 영업시간이 아닙니다.",
                       "errorTraceId": "ae4feff5-5f37-4f91-b8b6-a5957fd5bb10"
                     }
+                    """),
+                @ExampleObject(name = "추가 수량 1 미만", summary = "추가 수량 1 미만", value = """
+                    {
+                      "code": "INVALID_REQUEST_BODY",
+                      "message": "수량은 최소 1 입니다.",
+                      "errorTraceId": "b5327d2e-77a4-4d76-88f0-fc3e6f829512",
+                      "fieldErrors": [
+                        {
+                          "field": "quantity",
+                          "message": "수량은 최소 1 입니다.",
+                          "constraint": "Min"
+                        }
+                      ]
+                    }
+                    """),
+                @ExampleObject(name = "추가 수량 10 초과", summary = "추가 수량 10 초과", value = """
+                    {
+                      "code": "INVALID_REQUEST_BODY",
+                      "message": "수량은 최대 10 입니다.",
+                      "errorTraceId": "13780c0b-b15c-459c-b854-fcdca7e68489",
+                      "fieldErrors": [
+                        {
+                          "field": "quantity",
+                          "message": "수량은 최대 10 입니다.",
+                          "constraint": "Max"
+                        }
+                      ]
+                    }
+                    """),
+                @ExampleObject(name = "추가 수량 null", summary = "추가 수량 null", value = """
+                    {
+                      "code": "INVALID_REQUEST_BODY",
+                      "message": "quantity는 필수값입니다.",
+                      "errorTraceId": "5969c702-ab15-40d3-b71a-6dec2a16a4c1",
+                      "fieldErrors": [
+                        {
+                          "field": "quantity",
+                          "message": "quantity는 필수값입니다.",
+                          "constraint": "NotNull"
+                        }
+                      ]
+                    }
                     """)
             })
         ),
@@ -261,6 +303,7 @@ public interface CartApi {
         - **orderableShopMenuOptionIds**: 선택한 옵션 목록 (선택 사항)
           - **optionGroupId**: 옵션 그룹 ID
           - **optionId**: 옵션 ID
+        - **quantity**: 추가 수량 (null, 0 이하의 값, 11 이상의 값을 허용하지 않습니다.)
         
         ### 중복 요청 처리
         - 0.1초 이내에 같은 요청이 도착한 경우, 둘 중 하나는 중복 요청으로 판단하여 409 에러가 반환됩니다.

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -16,6 +16,7 @@ import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin._common.duplicate.DuplicateGuard;
 import in.koreatech.koin.domain.order.cart.dto.CartAddItemRequest;
 import in.koreatech.koin.domain.order.cart.dto.CartAmountSummaryResponse;
+import in.koreatech.koin.domain.order.cart.dto.CartItemsCountSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartPaymentSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartMenuItemEditResponse;
@@ -856,5 +857,51 @@ public interface CartApi {
     @GetMapping("/cart/validate")
     ResponseEntity<Void> getCartValidateResult(
         @Parameter(hidden = true) @Auth(permit = {GENERAL, STUDENT}) Integer userId
+    );
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "장바구니 상품 개수 정보 조회 성공",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "장바구니에 상품이 존재하는 경우", value = """
+                        {
+                          "itemTypeCount": 2,
+                          "totalQuantity": 7
+                        }
+                        """
+                ),
+                @ExampleObject(name = "장바구니에 상품이 비어있는 경우", value = """
+                        {
+                          "itemTypeCount": 0,
+                          "totalQuantity": 0
+                        }
+                        """
+                )
+            })
+        ),
+        @ApiResponse(responseCode = "401", description = "인증 정보 오류",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "인증 정보 오류", summary = "인증 정보 오류", value = """
+                    {
+                      "code": "",
+                      "message": "올바르지 않은 인증정보입니다.",
+                      "errorTraceId": "5ba40351-6d27-40e5-90e3-80c5cf08a1ac"
+                    }
+                    """)
+            })
+        )
+    })
+    @Operation(
+        summary = "장바구니에 담긴 상품 개수 조회",
+        description = """
+            ## 장바구니 상품 개수 조회
+            - 상점의 배달/포장 가능 여부와 관계 없이 장바구니에 담긴 상품의 종류와 총 수량 정보를 반환합니다.
+            - EX) 담긴 상품의 종류가 2개고 각각 3개, 4개의 수량 이라면
+              - **itemTypeCount** : 2
+              - **totalQuantity** : 7
+            """
+    )
+    @GetMapping("/cart/items/count")
+    ResponseEntity<CartItemsCountSummaryResponse> getCartItemsTotalCount(
+        @Auth(permit = {GENERAL, STUDENT}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
@@ -17,6 +17,7 @@ import in.koreatech.koin._common.auth.Auth;
 import in.koreatech.koin._common.duplicate.DuplicateGuard;
 import in.koreatech.koin.domain.order.cart.dto.CartAddItemRequest;
 import in.koreatech.koin.domain.order.cart.dto.CartAmountSummaryResponse;
+import in.koreatech.koin.domain.order.cart.dto.CartItemsCountSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartPaymentSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartMenuItemEditResponse;
@@ -123,5 +124,13 @@ public class CartController implements CartApi {
     ) {
         cartQueryService.validateCart(userId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/cart/items/count")
+    public ResponseEntity<CartItemsCountSummaryResponse> getCartItemsTotalCount(
+        @Auth(permit = {GENERAL, STUDENT}) Integer userId
+    ) {
+        CartItemsCountSummaryResponse cartItemsTotalCount = cartQueryService.getCartItemsCountSummary(userId);
+        return ResponseEntity.ok(cartItemsTotalCount);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartAddItemCommand.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartAddItemCommand.java
@@ -7,7 +7,8 @@ public record CartAddItemCommand(
     Integer shopId,
     Integer shopMenuId,
     Integer shopMenuPriceId,
-    List<Option> options
+    List<Option> options,
+    Integer quantity
 ) {
 
     public record Option(

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartAddItemRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartAddItemRequest.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
@@ -24,7 +26,13 @@ public record CartAddItemRequest(
     @NotNull(message = "orderableShopMenuPriceId는 필수값입니다.")
     Integer orderableShopMenuPriceId,
     @Schema(description = "주문 가능 상점 메뉴 옵션 가격 ID")
-    List<InnerOptionRequest> orderableShopMenuOptionIds
+    List<InnerOptionRequest> orderableShopMenuOptionIds,
+
+    @Schema(description = "메뉴 개수", example = "1", requiredMode = REQUIRED)
+    @NotNull(message = "quantity는 필수값입니다.")
+    @Min(value = 1, message = "수량은 최소 1 입니다.")
+    @Max(value = 10, message = "수량은 최대 10 입니다.")
+    Integer quantity
 ) {
 
     public CartAddItemCommand toCommand(Integer userId) {
@@ -35,7 +43,7 @@ public record CartAddItemRequest(
             : List.of();
 
         return new CartAddItemCommand(userId, orderableShopId, orderableShopMenuId, orderableShopMenuPriceId,
-            options);
+            options, quantity);
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartItemsCountSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartItemsCountSummaryResponse.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.order.cart.dto;
+
+import in.koreatech.koin.domain.order.cart.model.Cart;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CartItemsCountSummaryResponse(
+
+    @Schema(description = "장바구니에 담긴 상품 종류 개수", example = "2")
+    Integer itemTypeCount,
+    @Schema(description = "장바구니에 담긴 상품의 총 수량", example = "7")
+    Integer totalQuantity
+) {
+
+    public static CartItemsCountSummaryResponse from(Cart cart) {
+        return new CartItemsCountSummaryResponse(cart.getItemTypeCount(), cart.getTotalQuantity());
+    }
+
+    public static CartItemsCountSummaryResponse empty() {
+        return new CartItemsCountSummaryResponse(0, 0);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartUpdateItemRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartUpdateItemRequest.java
@@ -29,7 +29,7 @@ public record CartUpdateItemRequest(
     }
 
     @JsonNaming(value = SnakeCaseStrategy.class)
-    private record InnerOptionRequest(
+    public record InnerOptionRequest(
         @Schema(description = "옵션 그룹 ID", example = "1")
         Integer optionGroupId,
         @Schema(description = "옵션 ID", example = "2")

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -27,6 +27,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -125,6 +126,7 @@ public class Cart extends BaseEntity {
         }
     }
 
+    @Builder
     private Cart(
         User user,
         OrderableShop orderableShop

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -126,6 +126,16 @@ public class Cart extends BaseEntity {
         }
     }
 
+    public Integer getItemTypeCount() {
+        return this.cartMenuItems.size();
+    }
+
+    public Integer getTotalQuantity() {
+        return this.cartMenuItems.stream()
+            .mapToInt(CartMenuItem::getQuantity)
+            .sum();
+    }
+
     @Builder
     private Cart(
         User user,

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -59,14 +59,14 @@ public class Cart extends BaseEntity {
         }
     }
 
-    public void addItem(OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options) {
-        // 장바구니에 옵션 까지 전부 동일한 메뉴가 이미 존재 하는 경우, 수량 1 증가
+    public void addItem(OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options, Integer quantity) {
+        // 장바구니에 옵션 까지 전부 동일한 메뉴가 이미 존재 하는 경우, 담긴 상품 수량 증가
         Optional<CartMenuItem> existingItem = findSameItem(menu, price, options);
 
         if (existingItem.isPresent()) {
-            existingItem.get().increaseQuantity();
+            existingItem.get().increaseQuantity(quantity);
         } else {
-            CartMenuItem newItem = CartMenuItem.create(this, menu, price, options);
+            CartMenuItem newItem = CartMenuItem.create(this, menu, price, options, quantity);
             this.cartMenuItems.add(newItem);
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
@@ -73,12 +73,14 @@ public class CartMenuItem extends BaseEntity {
         this.isModified = isModified;
     }
 
-    public static CartMenuItem create(Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options) {
+    public static CartMenuItem create(Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options, Integer quantity) {
+        validateQuantity(quantity); // 수량 검증
+
         CartMenuItem cartMenuItem = CartMenuItem.builder()
             .cart(cart)
             .orderableShopMenu(menu)
             .orderableShopMenuPrice(price)
-            .quantity(1)
+            .quantity(quantity)
             .isModified(false)
             .build();
 
@@ -98,6 +100,16 @@ public class CartMenuItem extends BaseEntity {
             throw CustomException.of(ApiResponseCode.INVALID_CART_ITEM_QUANTITY, "수량은 1 이상이어야 합니다.");
         }
         this.quantity = quantity;
+    }
+
+
+    private static void validateQuantity(Integer quantity) {
+        if (quantity == null) {
+            throw CustomException.of(ApiResponseCode.ILLEGAL_STATE, "수량은 null일 수 없습니다.");
+        }
+        if (quantity <= 0) {
+            throw CustomException.of(ApiResponseCode.ILLEGAL_STATE, "수량은 1 이상이어야 합니다.");
+        }
     }
 
     public void increaseQuantity() {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/service/CartQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/service/CartQueryService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin._common.code.ApiResponseCode;
 import in.koreatech.koin._common.exception.CustomException;
 import in.koreatech.koin.domain.order.cart.dto.CartAmountSummaryResponse;
+import in.koreatech.koin.domain.order.cart.dto.CartItemsCountSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartMenuItemEditResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartPaymentSummaryResponse;
 import in.koreatech.koin.domain.order.cart.dto.CartResponse;
@@ -82,6 +83,11 @@ public class CartQueryService {
         OrderableShop orderableShop = cart.getOrderableShop();
         orderableShop.requireShopOpen();
         orderableShop.requireMinimumOrderAmount(cart.calculateItemsAmount());
+    }
+
+    public CartItemsCountSummaryResponse getCartItemsCountSummary(Integer userId) {
+        Optional<Cart> cart = cartRepository.findCartByUserId(userId);
+        return cart.map(CartItemsCountSummaryResponse::from).orElseGet(CartItemsCountSummaryResponse::empty);
     }
 
     private Cart getCartOrThrow(Integer userId) {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/service/CartService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/service/CartService.java
@@ -44,7 +44,7 @@ public class CartService {
         OrderableShopMenu menu = validateAndGetMenu(addItemCommand);
         List<OrderableShopMenuOption> selectedOptions = validateAndGetOptions(addItemCommand);
 
-        cart.addItem(menu, menu.getMenuPriceById(addItemCommand.shopMenuPriceId()), selectedOptions);
+        cart.addItem(menu, menu.getMenuPriceById(addItemCommand.shopMenuPriceId()), selectedOptions, addItemCommand.quantity());
         em.persist(cart);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopApi.java
@@ -63,8 +63,18 @@ public interface OrderableShopApi {
                     )
                 })
             ),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "400", description = "잘못된 카테고리 ID",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "잘못된 카테고리 ID", value = """
+                        {
+                          "code": "ILLEGAL_ARGUMENT",
+                          "message": "잘못된 인자가 전달되었습니다.",
+                          "errorTraceId": "ff8c3490-754e-4ba9-b805-e15132e7f478"
+                        }
+                        """
+                    )
+                })
+            )
         }
     )
     @Operation(summary = "주문 가능한 모든 상점 조회", description = """
@@ -83,6 +93,19 @@ public interface OrderableShopApi {
             - **DELIVERY_AVAILABLE**: 배달 가능한 상점
             - **TAKEOUT_AVAILABLE**: 포장 가능한 상점
             - **FREE_DELIVERY_TIP**: 배달비 무료 상점
+        - **카테고리 필터**: category_filter. 카테고리 ID로 상점을 필터링
+            - **null**: 전체 카테고리 (기본)
+            - **2**: 치킨
+            - **3**: 피자/버거
+            - **4**: 도시락/분식
+            - **5**: 족발
+            - **6**: 중국집
+            - **7**: 고깃집
+            - **8**: 한식
+            - **9**: 주점
+            - **10**: 카페
+            - **11**: 콜밴
+            - **12**: 기타
         - **최소 주문 금액 필터**: minimum_order_amount. 해당 최소 주문 금액 이하의 상점을 반환
         - **open_status**: 현재 요일과 시간을 고려 하여 상점의 영업 상태를 결정.
             - **OPERATING**: 영업중
@@ -98,7 +121,7 @@ public interface OrderableShopApi {
         @RequestParam(name = "filter", required = false) List<OrderableShopsFilterCriteria> orderableShopsSortCriteria,
 
         @Parameter(description = "카테고리 필터 목록")
-        @RequestParam(name = "category_filter", required = false, defaultValue = "ALL") OrderableShopCategoryFilterCriteria orderableShopCategoryFilterCriteria,
+        @RequestParam(name = "category_filter", required = false) Integer categoryFilterId,
 
         @Parameter(description = "최소 주문 금액 필터 (단위: 원). null 가능")
         @RequestParam(name = "minimum_order_amount", required = false) Integer minimumOrderAmount

--- a/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/controller/OrderableShopController.java
@@ -30,9 +30,12 @@ public class OrderableShopController implements OrderableShopApi {
     public ResponseEntity<List<OrderableShopsResponse>> getOrderableShops(
         @RequestParam(name = "sorter", defaultValue = "NONE") OrderableShopsSortCriteria sortBy,
         @RequestParam(name = "filter", required = false) List<OrderableShopsFilterCriteria> orderableShopsFilterCriteria,
-        @RequestParam(name = "category_filter", required = false, defaultValue = "ALL") OrderableShopCategoryFilterCriteria orderableShopCategoryFilterCriteria,
+        @RequestParam(name = "category_filter", required = false) Integer categoryFilterId,
         @RequestParam(name = "minimum_order_amount", required = false) Integer minimumOrderAmount
     ) {
+        OrderableShopCategoryFilterCriteria orderableShopCategoryFilterCriteria =
+            OrderableShopCategoryFilterCriteria.fromValue(categoryFilterId);
+
         List<OrderableShopsResponse> orderableShops = orderableShopListService.getOrderableShops(sortBy,
             orderableShopsFilterCriteria, orderableShopCategoryFilterCriteria, minimumOrderAmount);
         return ResponseEntity.ok(orderableShops);

--- a/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopCategoryFilterCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/dto/shoplist/OrderableShopCategoryFilterCriteria.java
@@ -1,7 +1,9 @@
 package in.koreatech.koin.domain.order.shop.dto.shoplist;
 
-import java.util.List;
+import java.util.Objects;
 
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.exception.CustomException;
 import lombok.Getter;
 
 @Getter
@@ -27,5 +29,18 @@ public enum OrderableShopCategoryFilterCriteria {
     OrderableShopCategoryFilterCriteria(String name, Integer value) {
         this.name = name;
         this.value = value;
+    }
+
+    public static OrderableShopCategoryFilterCriteria fromValue(Integer value) {
+        if (value == null) {
+            return ALL;
+        }
+
+        for (OrderableShopCategoryFilterCriteria criteria : values()) {
+            if (Objects.equals(criteria.value, value)) {
+                return criteria;
+            }
+        }
+        throw CustomException.of(ApiResponseCode.ILLEGAL_ARGUMENT);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroup.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroup.java
@@ -22,6 +22,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -77,5 +78,23 @@ public class OrderableShopMenuOptionGroup extends BaseEntity {
         if (maxSelect != null && selectionCount > maxSelect) {
             throw CustomException.of(ApiResponseCode.MAX_SELECTION_EXCEEDED);
         }
+    }
+
+    public void addMenuOption(OrderableShopMenuOption orderableShopMenuOption) {
+        menuOptions.add(orderableShopMenuOption);
+    }
+
+    @Builder
+    public OrderableShopMenuOptionGroup(OrderableShop orderableShop, String name, String description,
+        Boolean isRequired,
+        Integer minSelect, Integer maxSelect, Boolean isDeleted, List<OrderableShopMenuOption> menuOptions) {
+        this.orderableShop = orderableShop;
+        this.name = name;
+        this.description = description;
+        this.isRequired = isRequired;
+        this.minSelect = minSelect;
+        this.maxSelect = maxSelect;
+        this.isDeleted = isDeleted;
+        this.menuOptions = menuOptions;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroupMap.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/menu/OrderableShopMenuOptionGroupMap.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,4 +40,11 @@ public class OrderableShopMenuOptionGroupMap {
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
 
+    @Builder
+    public OrderableShopMenuOptionGroupMap(OrderableShopMenuOptionGroup optionGroup, OrderableShopMenu menu,
+        Boolean isDeleted) {
+        this.optionGroup = optionGroup;
+        this.menu = menu;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/ShopOperation.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/ShopOperation.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,4 +40,11 @@ public class ShopOperation {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
+
+    @Builder
+    public ShopOperation(Shop shop, boolean isOpen, boolean isDeleted) {
+        this.shop = shop;
+        this.isOpen = isOpen;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/usecase/OrderableShopSearchUseCase.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/usecase/OrderableShopSearchUseCase.java
@@ -10,8 +10,8 @@ import in.koreatech.koin.domain.order.shop.dto.shopsearch.OrderableShopSearchRel
 import in.koreatech.koin.domain.order.shop.dto.shopsearch.OrderableShopSearchResultResponse;
 import in.koreatech.koin.domain.order.shop.dto.shopsearch.OrderableShopSearchResultSortCriteria;
 import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopOpenStatus;
-import in.koreatech.koin.domain.order.shop.service.SearchKeywordProcessor;
 import in.koreatech.koin.domain.order.shop.service.OrderableShopSearchService;
+import in.koreatech.koin.domain.order.shop.service.SearchKeywordProcessor;
 import in.koreatech.koin.domain.order.shop.service.ShopOpenScheduleService;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -183,7 +183,8 @@ public class Shop extends BaseEntity {
         Integer hit,
         String bank,
         String accountNumber,
-        ShopCategory shopMainCategory
+        ShopCategory shopMainCategory,
+        ShopOperation shopOperation
     ) {
         this.owner = owner;
         this.name = name;
@@ -203,6 +204,7 @@ public class Shop extends BaseEntity {
         this.bank = bank;
         this.accountNumber = accountNumber;
         this.shopMainCategory = shopMainCategory;
+        this.shopOperation = shopOperation;
     }
 
     public void modifyShop(

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
@@ -1,0 +1,850 @@
+package in.koreatech.koin.unit.domain.cart;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin._common.code.ApiResponseCode;
+import in.koreatech.koin._common.exception.CustomException;
+import in.koreatech.koin.domain.order.cart.dto.CartAddItemCommand;
+import in.koreatech.koin.domain.order.cart.dto.CartUpdateItemRequest;
+import in.koreatech.koin.domain.order.cart.model.Cart;
+import in.koreatech.koin.domain.order.cart.model.CartMenuItem;
+import in.koreatech.koin.domain.order.cart.model.OrderableShopMenuOptions;
+import in.koreatech.koin.domain.order.cart.model.OrderableShopMenus;
+import in.koreatech.koin.domain.order.cart.repository.CartRepository;
+import in.koreatech.koin.domain.order.cart.service.CartService;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOption;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOptionGroup;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOptionGroupMap;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.koin.domain.order.shop.repository.OrderableShopRepository;
+import in.koreatech.koin.domain.order.shop.repository.menu.OrderableShopMenuOptionRepository;
+import in.koreatech.koin.domain.order.shop.repository.menu.OrderableShopMenuRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.unit.fixutre.CartFixture;
+import in.koreatech.koin.unit.fixutre.OrderableShopFixture;
+import in.koreatech.koin.unit.fixutre.OrderableShopMenuFixture;
+import in.koreatech.koin.unit.fixutre.UserFixture;
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(MockitoExtension.class)
+public class CartServiceTest {
+
+    @InjectMocks
+    private CartService cartService;
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private OrderableShopMenuOptionRepository orderableShopMenuOptionRepository;
+
+    @Mock
+    private OrderableShopRepository orderableShopRepository;
+
+    @Mock
+    private OrderableShopMenuRepository orderableShopMenuRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EntityManager em;
+
+    private User user;
+    private OrderableShop orderableShop;
+    private OrderableShopMenu menuA;
+    private OrderableShopMenu menuB;
+    private OrderableShopMenu menuSoldOut;
+    private OrderableShopMenuPrice menuPriceA;
+    private OrderableShopMenuPrice menuPriceB;
+    private OrderableShopMenuPrice menuPriceC;
+    private OrderableShopMenuOption option1;
+    private OrderableShopMenuOption option2;
+    private OrderableShopMenuOption option3;
+    private OrderableShopMenuOption option4;
+    private OrderableShopMenuOption option5;
+    private OrderableShopMenuOption option6;
+    private OrderableShopMenuOption option7;
+    private OrderableShopMenuOption option8;
+    private OrderableShopMenuOptionGroup toppingGroup;
+    private OrderableShopMenuOptionGroup sourceGroup;
+    private OrderableShopMenuOptionGroup alcoholGroup;
+    private OrderableShopMenuOptionGroupMap optionGroupMap;
+    private OrderableShopMenuOptionGroupMap optionGroupMapB;
+    private OrderableShopMenuOptionGroupMap optionGroupMapC;
+    private Cart cart;
+
+    @BeforeEach
+    void setUp() {
+        user = UserFixture.코인_유저();
+        ReflectionTestUtils.setField(user, "id", 1);
+
+        orderableShop = OrderableShopFixture.김밥천국();
+        ReflectionTestUtils.setField(orderableShop, "id", 101);
+
+        menuA = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 201);
+        menuB = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 202);
+        menuSoldOut = OrderableShopMenuFixture.createSoldOutMenu(orderableShop, "떡볶이", 203);
+
+        menuPriceA = OrderableShopMenuFixture.createMenuPrice(menuA, "소고기 김밥", 6000, 301);
+        menuPriceB = OrderableShopMenuFixture.createMenuPrice(menuA, "참치 김밥", 5500, 302);
+        ReflectionTestUtils.setField(menuA, "menuPrices", List.of(menuPriceA, menuPriceB));
+
+        menuPriceC = OrderableShopMenuFixture.createMenuPrice(menuB, "신라면", 5500, 303);
+        ReflectionTestUtils.setField(menuB, "menuPrices", List.of(menuPriceC));
+
+        toppingGroup = OrderableShopMenuFixture.createMenuOptionGroupWithEmptyMenuOption(
+            orderableShop, "토핑 추가", 0, 2, false, 401
+        );
+
+        sourceGroup = OrderableShopMenuFixture.createMenuOptionGroupWithEmptyMenuOption(
+            orderableShop, "소스 추가", 1, 2, true, 402
+        );
+
+        alcoholGroup = OrderableShopMenuFixture.createMenuOptionGroupWithEmptyMenuOption(
+            orderableShop, "술 추가", 2, 3, false, 403
+        );
+
+        option1 = OrderableShopMenuFixture.createMenuOption(toppingGroup, "치즈 추가", 500, 501);
+        option2 = OrderableShopMenuFixture.createMenuOption(toppingGroup, "단무지 추가",300, 502);
+        option3 = OrderableShopMenuFixture.createMenuOption(sourceGroup, "캡사이신 추가",300, 503);
+        option4 = OrderableShopMenuFixture.createMenuOption(sourceGroup, "겨자 추가",300, 504);
+        option5 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "참이슬",4500, 505);
+        option6 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "테라",2500, 506);
+        option7 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "처음처럼",2500, 507);
+        option8 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "카스",2500, 508);
+
+        ReflectionTestUtils.setField(toppingGroup, "menuOptions", List.of(option1, option2));
+        ReflectionTestUtils.setField(sourceGroup, "menuOptions", List.of(option3, option4));
+        ReflectionTestUtils.setField(alcoholGroup, "menuOptions", List.of(option5, option6, option7, option8));
+
+        optionGroupMap = OrderableShopMenuFixture.createMenuOptionGroupMap(toppingGroup, menuA, 601);
+        ReflectionTestUtils.setField(menuA, "menuOptionGroupMap", List.of(optionGroupMap));
+
+        optionGroupMapB = OrderableShopMenuFixture.createMenuOptionGroupMap(sourceGroup, menuB, 602);
+        ReflectionTestUtils.setField(menuB, "menuOptionGroupMap", List.of(optionGroupMapB));
+
+        optionGroupMapC = OrderableShopMenuFixture.createMenuOptionGroupMap(alcoholGroup, menuB, 603);
+        ReflectionTestUtils.setField(menuB, "menuOptionGroupMap", List.of(optionGroupMapC));
+
+        cart = CartFixture.createCart(user, orderableShop);
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 성공")
+    void addItem_Success() {
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(), List.of()
+        );
+
+        // When
+        cartService.addItem(command);
+
+        // Then
+        verify(em).persist(cart);
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem existItem = cart.getCartMenuItems().get(0);
+        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuA.getId());
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 상점이 영업중이지 않은 경우")
+    void addItem_Fail_ShopClosed() {
+        // Given
+        OrderableShop orderableShopA = OrderableShopFixture.김밥천국_영업_안함();
+        when(orderableShopRepository.getById(orderableShopA.getId())).thenReturn(orderableShopA);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShopA.getId(), 1, 1, List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.SHOP_CLOSED);
+        assertThat(exception.getMessage()).isEqualTo("상점의 영업시간이 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 다른 상점의 상품이 이미 장바구니에 담겨있는 경우")
+    void addItem_Fail_DifferentShopItemInCart() {
+        // Given
+        // 새로 추가하려는 상점 (다른 상점)
+        OrderableShop newShop = OrderableShopFixture.마슬랜();
+
+        Cart existingCart = CartFixture.createCart(user, orderableShop);
+
+        when(orderableShopRepository.getById(newShop.getId())).thenReturn(newShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), newShop.getId(), 1, 1, List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.DIFFERENT_SHOP_ITEM_IN_CART);
+        assertThat(exception.getMessage()).isEqualTo("장바구니에는 동일한 상점의 상품만 담을 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 해당 메뉴가 존재하지 않는 경우")
+    void addItem_Fail_NotFoundMenu() {
+        // Given
+        Cart existingCart = CartFixture.createCart(user, orderableShop);
+
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId()))
+            .thenThrow(CustomException.of(
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU,
+                "해당 상점에 메뉴가 존재하지 않습니다 : " + orderableShop.getId()
+            ));
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), 1, 1, List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU);
+        assertThat(exception.getDetail()).contains("메뉴가 존재하지 않습니다 : 1");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 해당 메뉴가 상점에 속해 있지 않은 경우")
+    void addItem_Fail_InvalidMenu() {
+        // Given
+        // 장바구니에 이미 담겨있는 상점 (김밥천국)
+        OrderableShop existingShop = OrderableShopFixture.김밥천국();
+
+        Cart existingCart = CartFixture.createCart(user, existingShop);
+
+        when(orderableShopRepository.getById(existingShop.getId())).thenReturn(existingShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(existingShop.getId(), List.of(menuA));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(existingShop.getId())).thenReturn(orderableShopMenus);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), existingShop.getId(), 99, 1, List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_MENU_IN_SHOP);
+        assertThat(exception.getMessage()).isEqualTo("선택한 메뉴는 해당 상점에 속해있지 않습니다");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 해당 메뉴가 품절 상태인 경우")
+    void addItem_Fail_SoldOutMenu() {
+        // Given
+        Cart existingCart = CartFixture.createCart(user, orderableShop);
+
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuSoldOut));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuSoldOut.getId(), 1, List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MENU_SOLD_OUT);
+        assertThat(exception.getMessage()).isEqualTo("상품이 매진되었습니다");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 해당 메뉴의 가격 옵션이 잘못된 경우")
+    void addItem_Fail_MenuPriceNotFound() {
+        // Given
+        Cart existingCart = CartFixture.createCart(user, orderableShop);
+
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceC.getId(), List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE);
+        assertThat(exception.getMessage()).isEqualTo("유효하지 않은 가격 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 필수 옵션 그룹이 선택되지 않은 경우")
+    void addItem_Fail_RequiredOptionGroupMissing() {
+        // Given
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(), List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING);
+        assertThat(exception.getMessage()).isEqualTo("필수 옵션 그룹을 선택하지 않았습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 해당 메뉴에 존재하지 않는 옵션 ID인 경우")
+    void addItem_Fail_InvalidOption() {
+        // Given
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(),
+            List.of(new CartAddItemCommand.Option(toppingGroup.getId(), option3.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION);
+        assertThat(exception.getMessage()).isEqualTo("유효하지 않은 옵션 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 요청한 옵션 그룹 ID가 실제 옵션의 그룹 ID와 일치하지 않는 경우")
+    void addItem_Fail_InvalidOptionInGroup() {
+        // Given
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(),
+            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), option1.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_OPTION_IN_GROUP);
+        assertThat(exception.getMessage()).isEqualTo("선택한 옵션이 해당 옵션 그룹에 속해있지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 옵션 그룹의 최소 선택 개수를 만족하지 못한 경우")
+    void addItem_Fail_MinSelectionNotMet() {
+        // Given
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(),
+            List.of(
+                new CartAddItemCommand.Option(sourceGroup.getId(), option3.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), option5.getId())
+            )
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MIN_SELECTION_NOT_MET);
+        assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최소 선택 개수를 만족하지 못했습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 실패 - 옵션 그룹의 최대 선택 개수를 초과한 경우")
+    void addItem_Fail_MaxSelectionExceeded() {
+        // Given
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(),
+            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), option3.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), option5.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), option6.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), option7.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), option8.getId())
+            )
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MAX_SELECTION_EXCEEDED);
+        assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최대 선택 개수를 초과했습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 성공 - 장바구니에 동일 구성 상품이 없어 기존 아이템이 직접 수정되는 경우")
+    void updateItem_Success_UpdateCartItemDirectly() {
+        // Given
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 7);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        // 장바구니에 담긴 상품의 가격 옵션과 선택 옵션을 모두 변경 - 모두 유효한 값으로 변경
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option2.getId()))
+        );
+
+        // When
+        cartService.updateItem(request, itemToUpdate.getId(), user.getId());
+
+        // Then
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem updatedItem = cart.getCartMenuItems().get(0);
+
+        assertThat(updatedItem.getOrderableShopMenuPrice().getId()).isEqualTo(menuPriceB.getId());
+        assertThat(updatedItem.getIsModified()).isTrue();
+        assertThat(updatedItem.getCartMenuItemOptions()).hasSize(1);
+        assertThat(updatedItem.getCartMenuItemOptions().get(0).getOrderableShopMenuOption().getId()).isEqualTo(option2.getId());
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 성공 - 장바구니에 동일 구성 상품이 있어 해당 상품의 수량이 증가되고 기존 상품은 삭제되는 경우")
+    void updateItem_Success_UpdateCartItemMerged() {
+        // Given
+        // 장바구니에 상품 2개 미리 담기. menuA - 수정 대상, menuB - 병합 대상
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 777);
+
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        ReflectionTestUtils.setField(existingItem, "id", 888);
+
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate, existingItem)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        // 장바구니에 담긴 상품(itemToUpdate)의 가격 옵션과 선택 옵션을 existingItem 과 동일하게 변경
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option2.getId()))
+        );
+
+        // When
+        cartService.updateItem(request, itemToUpdate.getId(), user.getId());
+
+        // Then
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem mergedItem = cart.getCartMenuItems().get(0);
+
+        // itemToUpdate은 없어지고 existingItem의 수량이 1 증가해야 함
+        assertThat(mergedItem.getId()).isEqualTo(existingItem.getId());
+        assertThat(mergedItem.getQuantity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 수정 시도한 가격 옵션이 해당 메뉴에 속해 있지 않은 경우")
+    void updateItem_Fail_InvalidMenuPriceOption() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // 장바구니에 담긴 상품의 가격 옵션을 유효하지 않은 ID로 변경 시도
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceC.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE);
+        assertThat(exception.getMessage()).isEqualTo("유효하지 않은 가격 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 필수적으로 선택되어야 하는 옵션 그룹이 선택되지 않은 경우")
+    void updateItem_Fail_RequiredOptionGroupSelectedMissing() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        // 필수 옵션 그룹 선택을 누락한 요청 생성
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceC.getId(),
+            List.of()
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING);
+        assertThat(exception.getMessage()).isEqualTo("필수 옵션 그룹을 선택하지 않았습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 메뉴에 존재하지 않는 옵션 ID인 경우")
+    void updateItem_Fail_InvalidOption() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+
+        // 메뉴에 속하지 않는 옵션 으로 변경 하는 요청 생성
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option3.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION);
+        assertThat(exception.getMessage()).isEqualTo("유효하지 않은 옵션 ID 입니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 요청한 옵션 그룹 ID가 실제 해당 옵션의 옵션 그룹 ID와 일치 하지 않는 경우")
+    void updateItem_Fail_InvalidOptionInGroup() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        // 옵션 그룹과 옵션 ID가 일치하지 않는 요청 생성
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceC.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option4.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_OPTION_IN_GROUP);
+        assertThat(exception.getMessage()).isEqualTo("선택한 옵션이 해당 옵션 그룹에 속해있지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 옵션 그룹의 최소 선택 개수를 만족하지 못한 경우")
+    void updateItem_Fail_MaxSelectionNotMet() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(
+            List.of(option3, option4, option5, option6, option7, option8)
+        );
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceC.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option5.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option6.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option7.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option8.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MAX_SELECTION_EXCEEDED);
+        assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최대 선택 개수를 초과했습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수정 실패 - 옵션 그룹의 최대 선택 개수를 만족하지 못한 경우")
+    void updateItem_Fail_MinSelectionNotMet() {
+        // Given
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        ReflectionTestUtils.setField(itemA, "id", 777);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+
+        CartUpdateItemRequest request = new CartUpdateItemRequest(
+            menuPriceC.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option5.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItem(request, itemA.getId(), user.getId());;
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MIN_SELECTION_NOT_MET);
+        assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최소 선택 개수를 만족하지 못했습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수량 변경 성공 - 정상적인 수량으로 변경하는 경우")
+    void updateItemQuantity_Success() {
+        // Given
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 7);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When
+        cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), 9999);
+
+        // Then
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem quantityUpdatedItem = cart.getCartMenuItems().get(0);
+
+        assertThat(quantityUpdatedItem.getId()).isEqualTo(itemToUpdate.getId());
+        assertThat(quantityUpdatedItem.getQuantity()).isEqualTo(9999);
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 Null인 경우")
+    void updateItemQuantity_Fail_QuantityValueInvalid_Null() {
+        // Given
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 7);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), null);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
+        assertThat(exception.getDetail()).isEqualTo("수량은 null일 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 0인 경우")
+    void updateItemQuantity_Fail_QuantityValueInvalid_Zero() {
+        // Given
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 7);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), 0);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
+        assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 음수인 경우")
+    void updateItemQuantity_Fail_QuantityValueInvalid_Negative () {
+        // Given
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        ReflectionTestUtils.setField(itemToUpdate, "id", 7);
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), -999);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
+        assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
+    }
+
+
+    @Test
+    @DisplayName("장바구니 상품 삭제 성공 - 유효한 상품 ID인 경우")
+    void deleteItem_Success_ValidCartItemId() {
+        // Given
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(existingItem, "id", 777);
+
+        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        ReflectionTestUtils.setField(deletedItem, "id", 888);
+
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(existingItem, deletedItem)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When
+        cartService.deleteItem(user.getId(), deletedItem.getId());
+
+        //Then
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem existItem = cart.getCartMenuItems().get(0);
+
+        assertThat(existItem.getId()).isEqualTo(existingItem.getId());
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 삭제 실패 - 유효하지 않은 상품 ID인 경우")
+    void deleteItem_Fail_InvalidCartItemId() {
+        // Given
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        ReflectionTestUtils.setField(existingItem, "id", 777);
+
+        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        ReflectionTestUtils.setField(deletedItem, "id", 888);
+
+        ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(existingItem, deletedItem)));
+
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.deleteItem(user.getId(), 9999);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_CART_ITEM);
+        assertThat(exception.getMessage()).isEqualTo("장바구니에 담긴 상품이 존재하지 않습니다");
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
@@ -40,7 +40,6 @@ import in.koreatech.koin.domain.order.shop.repository.menu.OrderableShopMenuRepo
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.unit.fixutre.CartFixture;
-import in.koreatech.koin.unit.fixutre.CartMenuItemFixture;
 import in.koreatech.koin.unit.fixutre.OrderableShopFixture;
 import in.koreatech.koin.unit.fixutre.OrderableShopMenuFixture;
 import in.koreatech.koin.unit.fixutre.UserFixture;

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
@@ -40,6 +40,7 @@ import in.koreatech.koin.domain.order.shop.repository.menu.OrderableShopMenuRepo
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.unit.fixutre.CartFixture;
+import in.koreatech.koin.unit.fixutre.CartMenuItemFixture;
 import in.koreatech.koin.unit.fixutre.OrderableShopFixture;
 import in.koreatech.koin.unit.fixutre.OrderableShopMenuFixture;
 import in.koreatech.koin.unit.fixutre.UserFixture;
@@ -71,26 +72,26 @@ public class CartServiceTest {
 
     private User user;
     private OrderableShop orderableShop;
-    private OrderableShopMenu menuA;
-    private OrderableShopMenu menuB;
+    private OrderableShopMenu menuGimbap;
+    private OrderableShopMenu menuRamen;
     private OrderableShopMenu menuSoldOut;
-    private OrderableShopMenuPrice menuPriceA;
-    private OrderableShopMenuPrice menuPriceB;
-    private OrderableShopMenuPrice menuPriceC;
-    private OrderableShopMenuOption option1;
-    private OrderableShopMenuOption option2;
-    private OrderableShopMenuOption option3;
-    private OrderableShopMenuOption option4;
-    private OrderableShopMenuOption option5;
-    private OrderableShopMenuOption option6;
-    private OrderableShopMenuOption option7;
-    private OrderableShopMenuOption option8;
+    private OrderableShopMenuPrice gimbapPriceA;
+    private OrderableShopMenuPrice gimbapPriceB;
+    private OrderableShopMenuPrice ramenPriceA;
     private OrderableShopMenuOptionGroup toppingGroup;
     private OrderableShopMenuOptionGroup sourceGroup;
     private OrderableShopMenuOptionGroup alcoholGroup;
-    private OrderableShopMenuOptionGroupMap optionGroupMap;
-    private OrderableShopMenuOptionGroupMap optionGroupMapB;
-    private OrderableShopMenuOptionGroupMap optionGroupMapC;
+    private OrderableShopMenuOption toppingOptionA;
+    private OrderableShopMenuOption toppingOptionB;
+    private OrderableShopMenuOption sourceOptionA;
+    private OrderableShopMenuOption sourceOptionB;
+    private OrderableShopMenuOption alcoholOptionA;
+    private OrderableShopMenuOption alcoholOptionB;
+    private OrderableShopMenuOption alcoholOptionC;
+    private OrderableShopMenuOption alcoholOptionD;
+    private OrderableShopMenuOptionGroupMap toppingOptionGroupMap;
+    private OrderableShopMenuOptionGroupMap sourceOptionGroupMap;
+    private OrderableShopMenuOptionGroupMap alcoholOptionGroupMap;
     private Cart cart;
 
     @BeforeEach
@@ -101,16 +102,16 @@ public class CartServiceTest {
         orderableShop = OrderableShopFixture.김밥천국();
         ReflectionTestUtils.setField(orderableShop, "id", 101);
 
-        menuA = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 201);
-        menuB = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 202);
+        menuGimbap = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 201);
+        menuRamen = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 202);
         menuSoldOut = OrderableShopMenuFixture.createSoldOutMenu(orderableShop, "떡볶이", 203);
 
-        menuPriceA = OrderableShopMenuFixture.createMenuPrice(menuA, "소고기 김밥", 6000, 301);
-        menuPriceB = OrderableShopMenuFixture.createMenuPrice(menuA, "참치 김밥", 5500, 302);
-        ReflectionTestUtils.setField(menuA, "menuPrices", List.of(menuPriceA, menuPriceB));
+        gimbapPriceA = OrderableShopMenuFixture.createMenuPrice(menuGimbap, "소고기 김밥", 6000, 301);
+        gimbapPriceB = OrderableShopMenuFixture.createMenuPrice(menuGimbap, "참치 김밥", 5500, 302);
+        ReflectionTestUtils.setField(menuGimbap, "menuPrices", List.of(gimbapPriceA, gimbapPriceB));
 
-        menuPriceC = OrderableShopMenuFixture.createMenuPrice(menuB, "신라면", 5500, 303);
-        ReflectionTestUtils.setField(menuB, "menuPrices", List.of(menuPriceC));
+        ramenPriceA = OrderableShopMenuFixture.createMenuPrice(menuRamen, "신라면", 5500, 303);
+        ReflectionTestUtils.setField(menuRamen, "menuPrices", List.of(ramenPriceA));
 
         toppingGroup = OrderableShopMenuFixture.createMenuOptionGroupWithEmptyMenuOption(
             orderableShop, "토핑 추가", 0, 2, false, 401
@@ -124,46 +125,46 @@ public class CartServiceTest {
             orderableShop, "술 추가", 2, 3, false, 403
         );
 
-        option1 = OrderableShopMenuFixture.createMenuOption(toppingGroup, "치즈 추가", 500, 501);
-        option2 = OrderableShopMenuFixture.createMenuOption(toppingGroup, "단무지 추가",300, 502);
-        option3 = OrderableShopMenuFixture.createMenuOption(sourceGroup, "캡사이신 추가",300, 503);
-        option4 = OrderableShopMenuFixture.createMenuOption(sourceGroup, "겨자 추가",300, 504);
-        option5 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "참이슬",4500, 505);
-        option6 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "테라",2500, 506);
-        option7 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "처음처럼",2500, 507);
-        option8 = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "카스",2500, 508);
+        toppingOptionA = OrderableShopMenuFixture.createMenuOption(toppingGroup, "치즈 추가", 500, 501);
+        toppingOptionB = OrderableShopMenuFixture.createMenuOption(toppingGroup, "단무지 추가",300, 502);
+        sourceOptionA = OrderableShopMenuFixture.createMenuOption(sourceGroup, "캡사이신 추가",300, 503);
+        sourceOptionB = OrderableShopMenuFixture.createMenuOption(sourceGroup, "겨자 추가",300, 504);
+        alcoholOptionA = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "참이슬",4500, 505);
+        alcoholOptionB = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "테라",2500, 506);
+        alcoholOptionC = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "처음처럼",2500, 507);
+        alcoholOptionD = OrderableShopMenuFixture.createMenuOption(alcoholGroup, "카스",2500, 508);
 
-        ReflectionTestUtils.setField(toppingGroup, "menuOptions", List.of(option1, option2));
-        ReflectionTestUtils.setField(sourceGroup, "menuOptions", List.of(option3, option4));
-        ReflectionTestUtils.setField(alcoholGroup, "menuOptions", List.of(option5, option6, option7, option8));
+        ReflectionTestUtils.setField(toppingGroup, "menuOptions", List.of(toppingOptionA, toppingOptionB));
+        ReflectionTestUtils.setField(sourceGroup, "menuOptions", List.of(sourceOptionA, sourceOptionB));
+        ReflectionTestUtils.setField(alcoholGroup, "menuOptions", List.of(alcoholOptionA, alcoholOptionB, alcoholOptionC, alcoholOptionD));
 
-        optionGroupMap = OrderableShopMenuFixture.createMenuOptionGroupMap(toppingGroup, menuA, 601);
-        ReflectionTestUtils.setField(menuA, "menuOptionGroupMap", List.of(optionGroupMap));
+        toppingOptionGroupMap = OrderableShopMenuFixture.createMenuOptionGroupMap(toppingGroup, menuGimbap, 601);
+        ReflectionTestUtils.setField(menuGimbap, "menuOptionGroupMap", List.of(toppingOptionGroupMap));
 
-        optionGroupMapB = OrderableShopMenuFixture.createMenuOptionGroupMap(sourceGroup, menuB, 602);
-        ReflectionTestUtils.setField(menuB, "menuOptionGroupMap", List.of(optionGroupMapB));
+        sourceOptionGroupMap = OrderableShopMenuFixture.createMenuOptionGroupMap(sourceGroup, menuRamen, 602);
+        ReflectionTestUtils.setField(menuRamen, "menuOptionGroupMap", List.of(sourceOptionGroupMap));
 
-        optionGroupMapC = OrderableShopMenuFixture.createMenuOptionGroupMap(alcoholGroup, menuB, 603);
-        ReflectionTestUtils.setField(menuB, "menuOptionGroupMap", List.of(optionGroupMapC));
+        alcoholOptionGroupMap = OrderableShopMenuFixture.createMenuOptionGroupMap(alcoholGroup, menuRamen, 603);
+        ReflectionTestUtils.setField(menuRamen, "menuOptionGroupMap", List.of(alcoholOptionGroupMap));
 
         cart = CartFixture.createCart(user, orderableShop);
     }
 
     @Test
-    @DisplayName("장바구니 상품 추가 성공")
+    @DisplayName("장바구니 상품 추가 성공 - 장바구니에 담긴 상품이 없을 때")
     void addItem_Success() {
         when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(), List.of()
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(), List.of(), 1
         );
 
         // When
@@ -174,7 +175,103 @@ public class CartServiceTest {
         assertThat(cart.getCartMenuItems()).hasSize(1);
 
         CartMenuItem existItem = cart.getCartMenuItems().get(0);
-        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuA.getId());
+        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuGimbap.getId());
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 성공 - 장바구니에 담긴 상품이 있을 때")
+    void addItem_Success_CartItemExist() {
+        Cart existItemCart = CartFixture.createCart(user, orderableShop);
+        existItemCart.addItem(menuRamen, ramenPriceA, List.of(), 2);
+
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existItemCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(), List.of(), 1
+        );
+
+        // When
+        cartService.addItem(command);
+
+        // Then
+        verify(em).persist(existItemCart);
+        assertThat(existItemCart.getCartMenuItems()).hasSize(2);
+
+        CartMenuItem existItem = existItemCart.getCartMenuItems().get(0);
+        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuRamen.getId());
+        assertThat(existItem.getQuantity()).isEqualTo(2);
+
+        CartMenuItem addedItem = existItemCart.getCartMenuItems().get(1);
+        assertThat(addedItem.getOrderableShopMenu().getId()).isEqualTo(menuGimbap.getId());
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 성공 - 추가 하는 상품의 개수가 2개 이상인 경우")
+    void addItem_Success_ExtraQuantity() {
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(), List.of(), 7
+        );
+
+        // When
+        cartService.addItem(command);
+
+        // Then
+        verify(em).persist(cart);
+        assertThat(cart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem existItem = cart.getCartMenuItems().get(0);
+        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuGimbap.getId());
+        assertThat(existItem.getQuantity()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 추가 성공 - 이미 존재하는 상품의 수량이 증가하는 경우")
+    void addItem_Success_AddCartItemMerged() {
+        Cart existItemCart = CartFixture.createCart(user, orderableShop);
+        existItemCart.addItem(menuGimbap, gimbapPriceA, List.of(), 2);
+
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existItemCart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(), List.of(), 7
+        );
+
+        // When
+        cartService.addItem(command);
+
+        // Then
+        verify(em).persist(existItemCart);
+        assertThat(existItemCart.getCartMenuItems()).hasSize(1);
+
+        CartMenuItem existItem = existItemCart.getCartMenuItems().get(0);
+        assertThat(existItem.getOrderableShopMenu().getId()).isEqualTo(menuGimbap.getId());
+        assertThat(existItem.getQuantity()).isEqualTo(9);
     }
 
     @Test
@@ -185,7 +282,7 @@ public class CartServiceTest {
         when(orderableShopRepository.getById(orderableShopA.getId())).thenReturn(orderableShopA);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShopA.getId(), 1, 1, List.of()
+            user.getId(), orderableShopA.getId(), 1, 1, List.of(), 1
         );
 
         // When & Then
@@ -211,7 +308,7 @@ public class CartServiceTest {
         when(userRepository.getById(user.getId())).thenReturn(user);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), newShop.getId(), 1, 1, List.of()
+            user.getId(), newShop.getId(), 1, 1, List.of(), 1
         );
 
         // When & Then
@@ -240,7 +337,7 @@ public class CartServiceTest {
             ));
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), 1, 1, List.of()
+            user.getId(), orderableShop.getId(), 1, 1, List.of(), 1
         );
 
         // When & Then
@@ -265,11 +362,11 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(existingShop.getId(), List.of(menuA));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(existingShop.getId(), List.of(menuGimbap));
         when(orderableShopMenuRepository.getAllByOrderableShopId(existingShop.getId())).thenReturn(orderableShopMenus);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), existingShop.getId(), 99, 1, List.of()
+            user.getId(), existingShop.getId(), 99, 1, List.of(), 1
         );
 
         // When & Then
@@ -295,7 +392,7 @@ public class CartServiceTest {
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuSoldOut.getId(), 1, List.of()
+            user.getId(), orderableShop.getId(), menuSoldOut.getId(), 1, List.of(), 1
         );
 
         // When & Then
@@ -317,11 +414,11 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(existingCart));
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceC.getId(), List.of()
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), ramenPriceA.getId(), List.of(), 1
         );
 
         // When & Then
@@ -341,14 +438,14 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuRamen));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB, alcoholOptionC, alcoholOptionD));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(), List.of()
+            user.getId(), orderableShop.getId(), menuRamen.getId(), ramenPriceA.getId(), List.of(), 1
         );
 
         // When & Then
@@ -368,15 +465,15 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(),
-            List.of(new CartAddItemCommand.Option(toppingGroup.getId(), option3.getId()))
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(),
+            List.of(new CartAddItemCommand.Option(toppingGroup.getId(), sourceOptionA.getId())), 1
         );
 
         // When & Then
@@ -396,15 +493,15 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuA));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuA.getId(), menuPriceA.getId(),
-            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), option1.getId()))
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(),
+            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), toppingOptionA.getId())), 1
         );
 
         // When & Then
@@ -424,18 +521,18 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuRamen));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB, alcoholOptionC, alcoholOptionD));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(),
+            user.getId(), orderableShop.getId(), menuRamen.getId(), ramenPriceA.getId(),
             List.of(
-                new CartAddItemCommand.Option(sourceGroup.getId(), option3.getId()),
-                new CartAddItemCommand.Option(alcoholGroup.getId(), option5.getId())
-            )
+                new CartAddItemCommand.Option(sourceGroup.getId(), sourceOptionA.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), alcoholOptionA.getId())
+            ), 1
         );
 
         // When & Then
@@ -455,20 +552,20 @@ public class CartServiceTest {
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.empty());
         when(userRepository.getById(user.getId())).thenReturn(user);
 
-        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuB));
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuRamen));
         when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6, option7, option8));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB, alcoholOptionC, alcoholOptionD));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         CartAddItemCommand command = new CartAddItemCommand(
-            user.getId(), orderableShop.getId(), menuB.getId(), menuPriceC.getId(),
-            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), option3.getId()),
-                new CartAddItemCommand.Option(alcoholGroup.getId(), option5.getId()),
-                new CartAddItemCommand.Option(alcoholGroup.getId(), option6.getId()),
-                new CartAddItemCommand.Option(alcoholGroup.getId(), option7.getId()),
-                new CartAddItemCommand.Option(alcoholGroup.getId(), option8.getId())
-            )
+            user.getId(), orderableShop.getId(), menuRamen.getId(), ramenPriceA.getId(),
+            List.of(new CartAddItemCommand.Option(sourceGroup.getId(), sourceOptionA.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), alcoholOptionA.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), alcoholOptionB.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), alcoholOptionC.getId()),
+                new CartAddItemCommand.Option(alcoholGroup.getId(), alcoholOptionD.getId())
+            ), 1
         );
 
         // When & Then
@@ -481,22 +578,48 @@ public class CartServiceTest {
     }
 
     @Test
+    @DisplayName("장바구니 상품 추가 실패 - 추가 상품 수량이 1개 미만인 경우")
+    void addItem_Fail_IllegalQuantity() {
+        when(orderableShopRepository.getById(orderableShop.getId())).thenReturn(orderableShop);
+        when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
+        when(userRepository.getById(user.getId())).thenReturn(user);
+
+        OrderableShopMenus orderableShopMenus = new OrderableShopMenus(orderableShop.getId(), List.of(menuGimbap));
+        when(orderableShopMenuRepository.getAllByOrderableShopId(orderableShop.getId())).thenReturn(orderableShopMenus);
+
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
+
+        CartAddItemCommand command = new CartAddItemCommand(
+            user.getId(), orderableShop.getId(), menuGimbap.getId(), gimbapPriceA.getId(), List.of(), 0
+        );
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            cartService.addItem(command);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.ILLEGAL_STATE);
+        assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
+    }
+
+    @Test
     @DisplayName("장바구니 상품 수정 성공 - 장바구니에 동일 구성 상품이 없어 기존 아이템이 직접 수정되는 경우")
     void updateItem_Success_UpdateCartItemDirectly() {
         // Given
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(itemToUpdate, "id", 7);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         // 장바구니에 담긴 상품의 가격 옵션과 선택 옵션을 모두 변경 - 모두 유효한 값으로 변경
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceB.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option2.getId()))
+            gimbapPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), toppingOptionB.getId()))
         );
 
         // When
@@ -507,34 +630,34 @@ public class CartServiceTest {
 
         CartMenuItem updatedItem = cart.getCartMenuItems().get(0);
 
-        assertThat(updatedItem.getOrderableShopMenuPrice().getId()).isEqualTo(menuPriceB.getId());
+        assertThat(updatedItem.getOrderableShopMenuPrice().getId()).isEqualTo(gimbapPriceB.getId());
         assertThat(updatedItem.getIsModified()).isTrue();
         assertThat(updatedItem.getCartMenuItemOptions()).hasSize(1);
-        assertThat(updatedItem.getCartMenuItemOptions().get(0).getOrderableShopMenuOption().getId()).isEqualTo(option2.getId());
+        assertThat(updatedItem.getCartMenuItemOptions().get(0).getOrderableShopMenuOption().getId()).isEqualTo(toppingOptionB.getId());
     }
 
     @Test
     @DisplayName("장바구니 상품 수정 성공 - 장바구니에 동일 구성 상품이 있어 해당 상품의 수량이 증가되고 기존 상품은 삭제되는 경우")
     void updateItem_Success_UpdateCartItemMerged() {
         // Given
-        // 장바구니에 상품 2개 미리 담기. menuA - 수정 대상, menuB - 병합 대상
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        // 장바구니에 상품 2개 미리 담기. menuGimbap - 수정 대상, menuRamen - 병합 대상
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(itemToUpdate, "id", 777);
 
-        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceB, List.of(toppingOptionB), 3);
         ReflectionTestUtils.setField(existingItem, "id", 888);
 
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate, existingItem)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         // 장바구니에 담긴 상품(itemToUpdate)의 가격 옵션과 선택 옵션을 existingItem 과 동일하게 변경
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceB.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option2.getId()))
+            gimbapPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), toppingOptionB.getId()))
         );
 
         // When
@@ -554,7 +677,7 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 수정 시도한 가격 옵션이 해당 메뉴에 속해 있지 않은 경우")
     void updateItem_Fail_InvalidMenuPriceOption() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
@@ -562,8 +685,8 @@ public class CartServiceTest {
 
         // 장바구니에 담긴 상품의 가격 옵션을 유효하지 않은 ID로 변경 시도
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceC.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+            ramenPriceA.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), sourceOptionA.getId()))
         );
 
         // When & Then
@@ -579,18 +702,18 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 필수적으로 선택되어야 하는 옵션 그룹이 선택되지 않은 경우")
     void updateItem_Fail_RequiredOptionGroupSelectedMissing() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuRamen, ramenPriceA, List.of(sourceOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         // 필수 옵션 그룹 선택을 누락한 요청 생성
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceC.getId(),
+            ramenPriceA.getId(),
             List.of()
         );
 
@@ -607,19 +730,19 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 메뉴에 존재하지 않는 옵션 ID인 경우")
     void updateItem_Fail_InvalidOption() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option1, option2));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuA.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(toppingOptionA, toppingOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuGimbap.getId())).thenReturn(menuOptions);
 
         // 메뉴에 속하지 않는 옵션 으로 변경 하는 요청 생성
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceB.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), option3.getId()))
+            gimbapPriceB.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), sourceOptionA.getId()))
         );
 
         // When & Then
@@ -635,19 +758,19 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 요청한 옵션 그룹 ID가 실제 해당 옵션의 옵션 그룹 ID와 일치 하지 않는 경우")
     void updateItem_Fail_InvalidOptionInGroup() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuRamen, ramenPriceA, List.of(sourceOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         // 옵션 그룹과 옵션 ID가 일치하지 않는 요청 생성
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceC.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option4.getId()))
+            ramenPriceA.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), sourceOptionB.getId()))
         );
 
         // When & Then
@@ -663,24 +786,24 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 옵션 그룹의 최소 선택 개수를 만족하지 못한 경우")
     void updateItem_Fail_MaxSelectionNotMet() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuRamen, ramenPriceA, List.of(sourceOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
         OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(
-            List.of(option3, option4, option5, option6, option7, option8)
+            List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB, alcoholOptionC, alcoholOptionD)
         );
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceC.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option5.getId()),
-                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option6.getId()),
-                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option7.getId()),
-                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option8.getId()),
-                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+            ramenPriceA.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionA.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionB.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionC.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionD.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), sourceOptionA.getId()))
         );
 
         // When & Then
@@ -696,19 +819,19 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수정 실패 - 옵션 그룹의 최대 선택 개수를 만족하지 못한 경우")
     void updateItem_Fail_MinSelectionNotMet() {
         // Given
-        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuB, menuPriceC, List.of(option3), 1);
+        CartMenuItem itemA = CartFixture.cartMenuItem(cart, menuRamen, ramenPriceA, List.of(sourceOptionA), 1);
         ReflectionTestUtils.setField(itemA, "id", 777);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemA)));
 
         when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
-        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(option3, option4, option5, option6));
-        when(orderableShopMenuOptionRepository.getAllByMenuId(menuB.getId())).thenReturn(menuOptions);
+        OrderableShopMenuOptions menuOptions = new OrderableShopMenuOptions(List.of(sourceOptionA, sourceOptionB, alcoholOptionA, alcoholOptionB));
+        when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
         CartUpdateItemRequest request = new CartUpdateItemRequest(
-            menuPriceC.getId(),
-            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), option5.getId()),
-                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), option3.getId()))
+            ramenPriceA.getId(),
+            List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionA.getId()),
+                new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), sourceOptionA.getId()))
         );
 
         // When & Then
@@ -724,7 +847,7 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수량 변경 성공 - 정상적인 수량으로 변경하는 경우")
     void updateItemQuantity_Success() {
         // Given
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 7);
         ReflectionTestUtils.setField(itemToUpdate, "id", 7);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
 
@@ -746,7 +869,7 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 Null인 경우")
     void updateItemQuantity_Fail_QuantityValueInvalid_Null() {
         // Given
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 7);
         ReflectionTestUtils.setField(itemToUpdate, "id", 7);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
 
@@ -765,7 +888,7 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 0인 경우")
     void updateItemQuantity_Fail_QuantityValueInvalid_Zero() {
         // Given
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 7);
         ReflectionTestUtils.setField(itemToUpdate, "id", 7);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
 
@@ -784,7 +907,7 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 수량 변경 실패 - 수량이 음수인 경우")
     void updateItemQuantity_Fail_QuantityValueInvalid_Negative () {
         // Given
-        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 7);
+        CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 7);
         ReflectionTestUtils.setField(itemToUpdate, "id", 7);
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
 
@@ -804,10 +927,10 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 삭제 성공 - 유효한 상품 ID인 경우")
     void deleteItem_Success_ValidCartItemId() {
         // Given
-        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(existingItem, "id", 777);
 
-        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceB, List.of(toppingOptionB), 3);
         ReflectionTestUtils.setField(deletedItem, "id", 888);
 
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(existingItem, deletedItem)));
@@ -829,10 +952,10 @@ public class CartServiceTest {
     @DisplayName("장바구니 상품 삭제 실패 - 유효하지 않은 상품 ID인 경우")
     void deleteItem_Fail_InvalidCartItemId() {
         // Given
-        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuA, menuPriceA, List.of(option1), 1);
+        CartMenuItem existingItem = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA, List.of(toppingOptionA), 1);
         ReflectionTestUtils.setField(existingItem, "id", 777);
 
-        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuA, menuPriceB, List.of(option2), 3);
+        CartMenuItem deletedItem = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceB, List.of(toppingOptionB), 3);
         ReflectionTestUtils.setField(deletedItem, "id", 888);
 
         ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(existingItem, deletedItem)));

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
@@ -298,12 +298,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.SHOP_CLOSED);
-            assertThat(exception.getMessage()).isEqualTo("상점의 영업시간이 아닙니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.SHOP_CLOSED
+            );
         }
 
         @Test
@@ -322,12 +320,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.DIFFERENT_SHOP_ITEM_IN_CART);
-            assertThat(exception.getMessage()).isEqualTo("장바구니에는 동일한 상점의 상품만 담을 수 있습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.DIFFERENT_SHOP_ITEM_IN_CART
+            );
         }
 
         @Test
@@ -349,12 +345,11 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU);
-            assertThat(exception.getDetail()).contains("메뉴가 존재하지 않습니다 : 1");
+            assertCustomExceptionThrownAndDetail(
+                () -> cartService.addItem(command),
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU,
+                "해당 상점에 메뉴가 존재하지 않습니다 : 1"
+            );
         }
 
         @Test
@@ -372,12 +367,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_MENU_IN_SHOP);
-            assertThat(exception.getMessage()).isEqualTo("선택한 메뉴는 해당 상점에 속해있지 않습니다");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.INVALID_MENU_IN_SHOP
+            );
         }
 
         @Test
@@ -395,12 +388,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MENU_SOLD_OUT);
-            assertThat(exception.getMessage()).isEqualTo("상품이 매진되었습니다");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.MENU_SOLD_OUT
+            );
         }
 
         @Test
@@ -418,12 +409,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE);
-            assertThat(exception.getMessage()).isEqualTo("유효하지 않은 가격 ID 입니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE
+            );
         }
 
         @Test
@@ -445,12 +434,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING);
-            assertThat(exception.getMessage()).isEqualTo("필수 옵션 그룹을 선택하지 않았습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING
+            );
         }
 
         @Test
@@ -473,12 +460,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION);
-            assertThat(exception.getMessage()).isEqualTo("유효하지 않은 옵션 ID 입니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION
+            );
         }
 
         @Test
@@ -501,12 +486,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_OPTION_IN_GROUP);
-            assertThat(exception.getMessage()).isEqualTo("선택한 옵션이 해당 옵션 그룹에 속해있지 않습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.INVALID_OPTION_IN_GROUP
+            );
         }
 
         @Test
@@ -532,12 +515,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MIN_SELECTION_NOT_MET);
-            assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최소 선택 개수를 만족하지 못했습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.MIN_SELECTION_NOT_MET
+            );
         }
 
         @Test
@@ -565,12 +546,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.MAX_SELECTION_EXCEEDED);
-            assertThat(exception.getMessage()).isEqualTo("옵션 그룹의 최대 선택 개수를 초과했습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.addItem(command),
+                ApiResponseCode.MAX_SELECTION_EXCEEDED
+            );
         }
 
         @Test
@@ -591,12 +570,11 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.addItem(command);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.ILLEGAL_STATE);
-            assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
+            assertCustomExceptionThrownAndDetail(
+                () -> cartService.addItem(command),
+                ApiResponseCode.ILLEGAL_STATE,
+                "수량은 1 이상이어야 합니다."
+            );
         }
     }
 
@@ -702,12 +680,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItem(request, itemA.getId(), user.getId());
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE);
-            assertThat(exception.getMessage()).isEqualTo("유효하지 않은 가격 ID 입니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.updateItem(request, itemA.getId(), user.getId()),
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE
+            );
         }
 
         @Test
@@ -730,12 +706,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItem(request, itemA.getId(), user.getId());
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING);
-            assertThat(exception.getMessage()).isEqualTo("필수 옵션 그룹을 선택하지 않았습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.updateItem(request, itemA.getId(), user.getId()),
+                ApiResponseCode.REQUIRED_OPTION_GROUP_MISSING
+            );
         }
 
         @Test
@@ -759,12 +733,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItem(request, itemA.getId(), user.getId());
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION);
-            assertThat(exception.getMessage()).isEqualTo("유효하지 않은 옵션 ID 입니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.updateItem(request, itemA.getId(), user.getId()),
+                ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION
+            );
         }
 
         @Test
@@ -788,12 +760,10 @@ public class CartServiceTest {
             );
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItem(request, itemA.getId(), user.getId());
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_OPTION_IN_GROUP);
-            assertThat(exception.getMessage()).isEqualTo("선택한 옵션이 해당 옵션 그룹에 속해있지 않습니다.");
+            assertCustomExceptionThrown(
+                () -> cartService.updateItem(request, itemA.getId(), user.getId()),
+                ApiResponseCode.INVALID_OPTION_IN_GROUP
+            );
         }
 
         @Test
@@ -903,16 +873,15 @@ public class CartServiceTest {
             when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), null);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
-            assertThat(exception.getDetail()).isEqualTo("수량은 null일 수 없습니다.");
+            assertCustomExceptionThrownAndDetail(
+                () -> cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), null),
+                ApiResponseCode.INVALID_CART_ITEM_QUANTITY,
+                "수량은 null일 수 없습니다."
+            );
         }
 
         @Test
-        @DisplayName("수량이 0인 경우")
+        @DisplayName("수량이 0 이하인 경우")
         void updateItemQuantity_Fail_QuantityValueInvalid_Zero() {
             // Given
             CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA,
@@ -923,32 +892,11 @@ public class CartServiceTest {
             when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), 0);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
-            assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
-        }
-
-        @Test
-        @DisplayName("수량이 음수인 경우")
-        void updateItemQuantity_Fail_QuantityValueInvalid_Negative() {
-            // Given
-            CartMenuItem itemToUpdate = CartFixture.cartMenuItem(cart, menuGimbap, gimbapPriceA,
-                List.of(toppingOptionA), 7);
-            ReflectionTestUtils.setField(itemToUpdate, "id", 7);
-            ReflectionTestUtils.setField(cart, "cartMenuItems", new ArrayList<>(List.of(itemToUpdate)));
-
-            when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
-
-            // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), -999);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.INVALID_CART_ITEM_QUANTITY);
-            assertThat(exception.getDetail()).isEqualTo("수량은 1 이상이어야 합니다.");
+            assertCustomExceptionThrownAndDetail(
+                () -> cartService.updateItemQuantity(user.getId(), itemToUpdate.getId(), 0),
+                ApiResponseCode.INVALID_CART_ITEM_QUANTITY,
+                "수량은 1 이상이어야 합니다."
+            );
         }
     }
 
@@ -1005,12 +953,21 @@ public class CartServiceTest {
             when(cartRepository.findCartByUserId(user.getId())).thenReturn(Optional.of(cart));
 
             // When & Then
-            CustomException exception = assertThrows(CustomException.class, () -> {
-                cartService.deleteItem(user.getId(), 9999);
-            });
-
-            assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.NOT_FOUND_CART_ITEM);
-            assertThat(exception.getMessage()).isEqualTo("장바구니에 담긴 상품이 존재하지 않습니다");
+            assertCustomExceptionThrown(
+                () -> cartService.deleteItem(user.getId(), 9999),
+                ApiResponseCode.NOT_FOUND_CART_ITEM
+            );
         }
+    }
+
+    private void assertCustomExceptionThrown(Runnable runnable, ApiResponseCode expectedCode) {
+        CustomException exception = assertThrows(CustomException.class, runnable::run);
+        assertThat(exception.getErrorCode()).isEqualTo(expectedCode);
+    }
+
+    private void assertCustomExceptionThrownAndDetail(Runnable runnable, ApiResponseCode expectedCode, String detail) {
+        CustomException exception = assertThrows(CustomException.class, runnable::run);
+        assertThat(exception.getErrorCode()).isEqualTo(expectedCode);
+        assertThat(exception.getDetail()).isEqualTo(detail);
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
@@ -41,7 +41,7 @@ public class CartTest {
     @BeforeEach
     void setUp() {
         user = UserFixture.코인_유저();
-        orderableShop = OrderableShopFixture.김밥천국();
+        orderableShop = OrderableShopFixture.김밥천국(101);
 
         menuGimbap = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 15);
         menuGimbapPrice = OrderableShopMenuFixture.createMenuPrice(menuGimbap, "소고기 김밥", 6000, 30);

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
@@ -58,7 +58,7 @@ public class CartTest {
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
 
             // when
-            cart.addItem(menu, menuPrice, menuOptions);
+            cart.addItem(menu, menuPrice, menuOptions, 1);
 
             // then
             List<CartMenuItem> cartMenuItems = cart.getCartMenuItems();
@@ -77,10 +77,10 @@ public class CartTest {
         void 장바구니에_동일한_상품이_존재하면_수량이_1_증가한다() {
             // given
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
-            cart.addItem(menu, menuPrice, menuOptions);
+            cart.addItem(menu, menuPrice, menuOptions, 1);
 
             // when
-            cart.addItem(menu, menuPrice, menuOptions);
+            cart.addItem(menu, menuPrice, menuOptions, 1);
 
             // then
             List<CartMenuItem> cartMenuItems = cart.getCartMenuItems();
@@ -94,13 +94,13 @@ public class CartTest {
         void 기존과_다른_상품을_추가하면_새로운_상품으로_담긴다() {
             // given
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
-            cart.addItem(menu, menuPrice, menuOptions);
+            cart.addItem(menu, menuPrice, menuOptions, 1);
 
             OrderableShopMenu newMenu = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 16);
             OrderableShopMenuPrice newMenuPrice = OrderableShopMenuFixture.createMenuPrice(newMenu, "매운맛", 7000, 31);
 
             // when
-            cart.addItem(newMenu, newMenuPrice, Collections.emptyList());
+            cart.addItem(newMenu, newMenuPrice, Collections.emptyList(), 1);
 
             // then
             List<CartMenuItem> cartMenuItems = cart.getCartMenuItems();

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartTest.java
@@ -31,22 +31,32 @@ public class CartTest {
 
     private User user;
     private OrderableShop orderableShop;
-    private OrderableShopMenu menu;
-    private OrderableShopMenuPrice menuPrice;
-    private List<OrderableShopMenuOption> menuOptions;
+    private OrderableShopMenu menuGimbap;
+    private OrderableShopMenu menuRamen;
+    private OrderableShopMenuPrice menuGimbapPrice;
+    private OrderableShopMenuPrice menuRamenPrice;
+    private List<OrderableShopMenuOption> menuGimbapOptions;
+    private List<OrderableShopMenuOption> menuRamenOptions;
 
     @BeforeEach
     void setUp() {
         user = UserFixture.코인_유저();
         orderableShop = OrderableShopFixture.김밥천국();
 
-        menu = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 15);
-        menuPrice = OrderableShopMenuFixture.createMenuPrice(menu, "소고기 김밥", 6000, 30);
-        menuOptions = List.of(
+        menuGimbap = OrderableShopMenuFixture.createMenu(orderableShop, "김밥", 15);
+        menuGimbapPrice = OrderableShopMenuFixture.createMenuPrice(menuGimbap, "소고기 김밥", 6000, 30);
+        menuGimbapOptions = List.of(
             OrderableShopMenuFixture.createMenuOption("단무지", 1000, 45)
         );
 
-        ReflectionTestUtils.setField(menu, "menuPrices", List.of(menuPrice));
+        menuRamen = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 16);
+        menuRamenPrice = OrderableShopMenuFixture.createMenuPrice(menuRamen, "신라면", 5500, 303);
+        menuRamenOptions = List.of(
+            OrderableShopMenuFixture.createMenuOption("단무지", 1000, 45)
+        );
+
+        ReflectionTestUtils.setField(menuGimbap, "menuPrices", List.of(menuGimbapPrice));
+        ReflectionTestUtils.setField(menuRamen, "menuPrices", List.of(menuRamenPrice));
     }
 
     @Nested
@@ -58,7 +68,7 @@ public class CartTest {
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
 
             // when
-            cart.addItem(menu, menuPrice, menuOptions, 1);
+            cart.addItem(menuGimbap, menuGimbapPrice, menuGimbapOptions, 1);
 
             // then
             List<CartMenuItem> cartMenuItems = cart.getCartMenuItems();
@@ -66,8 +76,8 @@ public class CartTest {
 
             CartMenuItem addedItem = cartMenuItems.get(0);
             assertEquals(1, addedItem.getQuantity());
-            assertEquals(menu.getId(), addedItem.getOrderableShopMenu().getId());
-            assertEquals(menuPrice.getId(), addedItem.getOrderableShopMenuPrice().getId());
+            assertEquals(menuGimbap.getId(), addedItem.getOrderableShopMenu().getId());
+            assertEquals(menuGimbapPrice.getId(), addedItem.getOrderableShopMenuPrice().getId());
             assertThat(addedItem.getCartMenuItemOptions())
                 .extracting(option -> option.getOrderableShopMenuOption().getId())
                 .containsExactlyInAnyOrder(45);
@@ -77,10 +87,10 @@ public class CartTest {
         void 장바구니에_동일한_상품이_존재하면_수량이_1_증가한다() {
             // given
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
-            cart.addItem(menu, menuPrice, menuOptions, 1);
+            cart.addItem(menuGimbap, menuGimbapPrice, menuGimbapOptions, 1);
 
             // when
-            cart.addItem(menu, menuPrice, menuOptions, 1);
+            cart.addItem(menuGimbap, menuGimbapPrice, menuGimbapOptions, 1);
 
             // then
             List<CartMenuItem> cartMenuItems = cart.getCartMenuItems();
@@ -94,7 +104,7 @@ public class CartTest {
         void 기존과_다른_상품을_추가하면_새로운_상품으로_담긴다() {
             // given
             Cart cart = spy(CartFixture.createCart(user, orderableShop));
-            cart.addItem(menu, menuPrice, menuOptions, 1);
+            cart.addItem(menuGimbap, menuGimbapPrice, menuGimbapOptions, 1);
 
             OrderableShopMenu newMenu = OrderableShopMenuFixture.createMenu(orderableShop, "라면", 16);
             OrderableShopMenuPrice newMenuPrice = OrderableShopMenuFixture.createMenuPrice(newMenu, "매운맛", 7000, 31);
@@ -122,4 +132,19 @@ public class CartTest {
         }
     }
 
+    @Test
+    void 장바구니에_담긴_상품의_종류와_총_수량을_확인한다() {
+        // Given
+        Cart cart = spy(CartFixture.createCart(user, orderableShop));
+        cart.addItem(menuGimbap, menuGimbapPrice, menuGimbapOptions, 3);
+        cart.addItem(menuRamen, menuRamenPrice, menuRamenOptions, 4);
+
+        // When
+        Integer itemTypeCount = cart.getItemTypeCount();
+        Integer totalQuantity = cart.getTotalQuantity();
+
+        // Then
+        assertEquals(2, itemTypeCount);
+        assertEquals(7, totalQuantity);
+    }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/order/ShopOpenScheduleServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/order/ShopOpenScheduleServiceTest.java
@@ -1,0 +1,76 @@
+package in.koreatech.koin.unit.domain.order;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopOpenInfo;
+import in.koreatech.koin.domain.order.shop.model.domain.OrderableShopOpenStatus;
+import in.koreatech.koin.domain.order.shop.service.ShopOpenScheduleService;
+import in.koreatech.koin.unit.fixutre.OrderableShopOpenInfoFixture;
+
+@ExtendWith(MockitoExtension.class)
+public class ShopOpenScheduleServiceTest {
+
+    @InjectMocks
+    private ShopOpenScheduleService shopOpenScheduleService;
+
+    private OrderableShopOpenInfo 수요일;
+
+    @BeforeEach
+    void setUp() {
+        수요일 = OrderableShopOpenInfoFixture.영업_정보(1, "WEDNESDAY", false, LocalTime.of(8, 30), LocalTime.of(22, 0));
+    }
+
+    @Test
+    @DisplayName("사장님이 영업 중 상태로 설정한 상점은 요일별 영업 정보와 현재 요일, 시간과 관련 없이 항상 OPERATING 상태여야 한다")
+    void determineOpenStatus_ShopOpenAlwaysOperating() {
+        // Given
+        Boolean shopIsOpen = true; // 영업 중 상태 = shopIsOpen 이 true
+
+        // When
+        OrderableShopOpenStatus orderableShopOpenStatus = shopOpenScheduleService.determineOpenStatus(수요일,
+            DayOfWeek.TUESDAY, LocalTime.now(), shopIsOpen);
+
+        //Then
+        assertThat(orderableShopOpenStatus).isEqualTo(OrderableShopOpenStatus.OPERATING);
+    }
+
+    @Test
+    @DisplayName("가게의 영업 시간이지만, 사장님이 영업 중 상태로 설정 하지 않는 가게는 PREPARING 상태여야 한다")
+    void determineOpenStatus_ShopWithinHoursNotOpenPreparing() {
+        // Given
+        Boolean shopIsOpen = false;
+        LocalTime now = LocalTime.of(12, 0);
+
+        // When
+        OrderableShopOpenStatus orderableShopOpenStatus = shopOpenScheduleService.determineOpenStatus(수요일,
+            DayOfWeek.WEDNESDAY, now, shopIsOpen);
+
+        //Then
+        assertThat(orderableShopOpenStatus).isEqualTo(OrderableShopOpenStatus.PREPARING);
+    }
+
+    @Test
+    @DisplayName("가게의 영업 시간이 아니고, 사장님이 영업 중 상태로 설정 하지 않는 가게는 CLOSED 상태여야 한다")
+    void determineOpenStatus_ShopOutsideHoursNotOpenClosed() {
+        // Given
+        Boolean shopIsOpen = false;
+        LocalTime now = LocalTime.of(23, 0);
+
+        // When
+        OrderableShopOpenStatus orderableShopOpenStatus = shopOpenScheduleService.determineOpenStatus(수요일,
+            DayOfWeek.WEDNESDAY, now, shopIsOpen);
+
+        //Then
+        assertThat(orderableShopOpenStatus).isEqualTo(OrderableShopOpenStatus.CLOSED);
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/fixutre/CartFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/CartFixture.java
@@ -1,6 +1,13 @@
 package in.koreatech.koin.unit.fixutre;
 
+import java.util.List;
+
 import in.koreatech.koin.domain.order.cart.model.Cart;
+import in.koreatech.koin.domain.order.cart.model.CartMenuItem;
+import in.koreatech.koin.domain.order.cart.model.CartMenuItemOption;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOption;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
 import in.koreatech.koin.domain.user.model.User;
 
@@ -9,6 +16,29 @@ public class CartFixture {
     private CartFixture() {}
 
     public static Cart createCart(User user, OrderableShop orderableShop) {
-        return Cart.from(user, orderableShop);
+        return Cart.builder()
+            .user(user)
+            .orderableShop(orderableShop)
+            .build();
+    }
+
+    public static CartMenuItem cartMenuItem(
+        Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice price,
+        List<OrderableShopMenuOption> options, Integer quantity
+    ) {
+        CartMenuItem cartMenuItem = CartMenuItem.builder()
+            .cart(cart)
+            .orderableShopMenu(menu)
+            .orderableShopMenuPrice(price)
+            .quantity(quantity)
+            .isModified(false)
+            .build();
+
+        if (options != null) {
+            options.forEach(option ->
+                cartMenuItem.getCartMenuItemOptions().add(CartMenuItemOption.create(cartMenuItem, option))
+            );
+        }
+        return cartMenuItem;
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/fixutre/CartMenuItemFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/CartMenuItemFixture.java
@@ -12,8 +12,8 @@ public class CartMenuItemFixture {
     private CartMenuItemFixture() {}
 
     public static CartMenuItem createCartMenuItemWithoutOption(
-        Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice menuPrice
+        Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice menuPrice, Integer quantity
     ) {
-        return CartMenuItem.create(cart, menu, menuPrice, List.of());
+        return CartMenuItem.create(cart, menu, menuPrice, List.of(), quantity);
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/fixutre/CartMenuItemFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/CartMenuItemFixture.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.unit.fixutre;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.order.cart.model.Cart;
+import in.koreatech.koin.domain.order.cart.model.CartMenuItem;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
+
+public class CartMenuItemFixture {
+
+    private CartMenuItemFixture() {}
+
+    public static CartMenuItem createCartMenuItemWithoutOption(
+        Cart cart, OrderableShopMenu menu, OrderableShopMenuPrice menuPrice
+    ) {
+        return CartMenuItem.create(cart, menu, menuPrice, List.of());
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopFixture.java
@@ -10,7 +10,7 @@ public class OrderableShopFixture {
 
     private OrderableShopFixture() {}
 
-    public static OrderableShop 김밥천국() {
+    public static OrderableShop 김밥천국(Integer id) {
         ShopOperation shopOperation = ShopOperation.builder()
             .isOpen(true)
             .isDeleted(false)
@@ -36,7 +36,7 @@ public class OrderableShopFixture {
             .shopOperation(shopOperation)
             .build();
 
-        ReflectionTestUtils.setField(shop, "id", 1);
+        ReflectionTestUtils.setField(shop, "id", id);
         ReflectionTestUtils.setField(shopOperation, "shop", shop);
 
         OrderableShop orderableShop = OrderableShop.builder()
@@ -96,7 +96,7 @@ public class OrderableShopFixture {
         return orderableShop;
     }
 
-    public static OrderableShop 김밥천국_영업_안함() {
+    public static OrderableShop 영업시간이_아닌_김밥천국() {
         ShopOperation shopOperation = ShopOperation.builder()
             .isOpen(false)
             .isDeleted(false)

--- a/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopFixture.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.unit.fixutre;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.koin.domain.order.shop.model.entity.shop.ShopOperation;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 
 public class OrderableShopFixture {
@@ -10,6 +11,11 @@ public class OrderableShopFixture {
     private OrderableShopFixture() {}
 
     public static OrderableShop 김밥천국() {
+        ShopOperation shopOperation = ShopOperation.builder()
+            .isOpen(true)
+            .isDeleted(false)
+            .build();
+
         Shop shop = Shop.builder()
             .name("김밥천국")
             .internalName("김천")
@@ -27,9 +33,97 @@ public class OrderableShopFixture {
             .hit(0)
             .bank("국민")
             .accountNumber("01022595923")
+            .shopOperation(shopOperation)
             .build();
 
         ReflectionTestUtils.setField(shop, "id", 1);
+        ReflectionTestUtils.setField(shopOperation, "shop", shop);
+
+        OrderableShop orderableShop = OrderableShop.builder()
+            .shop(shop)
+            .minimumOrderAmount(15000)
+            .takeout(true)
+            .delivery(true)
+            .serviceEvent(false)
+            .isDeleted(false)
+            .build();
+
+        ReflectionTestUtils.setField(orderableShop, "id", 1);
+
+        return orderableShop;
+    }
+
+    public static OrderableShop 마슬랜() {
+        ShopOperation shopOperation = ShopOperation.builder()
+            .isOpen(true)
+            .isDeleted(false)
+            .build();
+
+        Shop shop = Shop.builder()
+            .name("마슬랜")
+            .internalName("마슬랜")
+            .chosung("마")
+            .phone("010-7574-1212")
+            .address("천안시 동남구 병천면 1700")
+            .description("마슬랜입니다.")
+            .delivery(true)
+            .deliveryPrice(3000)
+            .payCard(true)
+            .payBank(true)
+            .isDeleted(false)
+            .isEvent(false)
+            .remarks("비고")
+            .hit(0)
+            .bank("국민")
+            .accountNumber("01022595923")
+            .shopOperation(shopOperation)
+            .build();
+
+        ReflectionTestUtils.setField(shop, "id", 2);
+        ReflectionTestUtils.setField(shopOperation, "shop", shop);
+
+        OrderableShop orderableShop = OrderableShop.builder()
+            .shop(shop)
+            .minimumOrderAmount(15000)
+            .takeout(true)
+            .delivery(true)
+            .serviceEvent(false)
+            .isDeleted(false)
+            .build();
+
+        ReflectionTestUtils.setField(orderableShop, "id", 2);
+
+        return orderableShop;
+    }
+
+    public static OrderableShop 김밥천국_영업_안함() {
+        ShopOperation shopOperation = ShopOperation.builder()
+            .isOpen(false)
+            .isDeleted(false)
+            .build();
+
+        Shop shop = Shop.builder()
+            .name("김밥천국")
+            .internalName("김천")
+            .chosung("김")
+            .phone("010-7574-1212")
+            .address("천안시 동남구 병천면 1600")
+            .description("김밥천국입니다.")
+            .delivery(true)
+            .deliveryPrice(3000)
+            .payCard(true)
+            .payBank(true)
+            .isDeleted(false)
+            .isEvent(false)
+            .remarks("비고")
+            .hit(0)
+            .bank("국민")
+            .accountNumber("01022595923")
+            .shopOperation(shopOperation)
+            .build();
+
+        ReflectionTestUtils.setField(shop, "id", 1);
+        ReflectionTestUtils.setField(shopOperation, "shop", shop);
 
         OrderableShop orderableShop = OrderableShop.builder()
             .shop(shop)

--- a/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopMenuFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopMenuFixture.java
@@ -1,9 +1,13 @@
 package in.koreatech.koin.unit.fixutre;
 
+import java.util.List;
+
 import org.springframework.test.util.ReflectionTestUtils;
 
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOption;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOptionGroup;
+import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOptionGroupMap;
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
 
@@ -17,6 +21,20 @@ public class OrderableShopMenuFixture {
             .name(name)
             .description("메뉴")
             .isSoldOut(false)
+            .isDeleted(false)
+            .build();
+
+        ReflectionTestUtils.setField(menu, "id", menuId);
+
+        return menu;
+    }
+
+    public static OrderableShopMenu createSoldOutMenu(OrderableShop shop, String name, Integer menuId) {
+        OrderableShopMenu menu = OrderableShopMenu.builder()
+            .orderableShop(shop)
+            .name(name)
+            .description("메뉴")
+            .isSoldOut(true)
             .isDeleted(false)
             .build();
 
@@ -47,5 +65,47 @@ public class OrderableShopMenuFixture {
         ReflectionTestUtils.setField(menuOption, "id", optionId);
 
         return menuOption;
+    }
+
+    public static OrderableShopMenuOptionGroup createMenuOptionGroupWithEmptyMenuOption(
+        OrderableShop shop, String name, Integer minSelect, Integer maxSelect, Boolean isRequired, Integer groupId
+    ) {
+        OrderableShopMenuOptionGroup optionGroup =  OrderableShopMenuOptionGroup.builder()
+            .orderableShop(shop)
+            .name(name)
+            .maxSelect(maxSelect)
+            .minSelect(minSelect)
+            .description("옵션 그룹")
+            .isDeleted(false)
+            .isRequired(isRequired)
+            .menuOptions(List.of())
+            .build();
+
+        ReflectionTestUtils.setField(optionGroup, "id", groupId);
+
+        return optionGroup;
+    }
+
+    public static OrderableShopMenuOption createMenuOption(OrderableShopMenuOptionGroup group, String name, Integer price, Integer optionId) {
+        OrderableShopMenuOption menuOption = OrderableShopMenuOption.builder()
+            .optionGroup(group)
+            .price(price)
+            .name(name)
+            .isDeleted(false)
+            .build();
+        ReflectionTestUtils.setField(menuOption, "id", optionId);
+
+        return menuOption;
+    }
+
+    public static OrderableShopMenuOptionGroupMap createMenuOptionGroupMap(OrderableShopMenuOptionGroup group, OrderableShopMenu orderableShopMenu, Integer id) {
+        OrderableShopMenuOptionGroupMap orderableShopMenuOptionGroupMap = OrderableShopMenuOptionGroupMap.builder()
+            .optionGroup(group)
+            .menu(orderableShopMenu)
+            .isDeleted(false)
+            .build();
+
+        ReflectionTestUtils.setField(orderableShopMenuOptionGroupMap, "id", id);
+        return orderableShopMenuOptionGroupMap;
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopOpenInfoFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/OrderableShopOpenInfoFixture.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.unit.fixutre;
+
+import java.time.LocalTime;
+
+import in.koreatech.koin.domain.order.shop.dto.shoplist.OrderableShopOpenInfo;
+
+public class OrderableShopOpenInfoFixture {
+
+    private OrderableShopOpenInfoFixture() {}
+
+    public static OrderableShopOpenInfo 영업_정보(
+        Integer shopId,
+        String dayOfWeek,
+        Boolean closed,
+        LocalTime openTime,
+        LocalTime closeTime
+    ) {
+        return new OrderableShopOpenInfo(shopId, dayOfWeek, closed, openTime, closeTime);
+    }
+
+}


### PR DESCRIPTION
# 🔥 연관 이슈

- #1842 

# 🚀 작업 내용
## 장바구니 도메인 CartService 테스트 30개 작성
<img width="2268" height="1344" alt="image" src="https://github.com/user-attachments/assets/5381e4a3-3c5b-4c75-9634-5fcbbfabd9ed" />

## 담긴 상품 수량 정보 조회 API `/cart/items/count`
```json
{
  "itemTypeCount": 0,
  "totalQuantity": 0
}
```
- 상점의 배달/포장 가능 여부와 관계 없이 장바구니에 담긴 상품의 종류와 총 수량 정보를 반환합니다.
- EX) 담긴 상품의 종류가 2개고 각각 3개, 4개의 수량 이라면
  - **itemTypeCount** : 2
  - **totalQuantity** : 7

## 장바구니 상품 추가 API `/cart/add` 수량 파라미터 추가
```java
@Schema(description = "메뉴 개수", example = "1", requiredMode = REQUIRED)
@NotNull(message = "quantity는 필수값입니다.")
@Min(value = 1, message = "수량은 최소 1 입니다.")
@Max(value = 10, message = "수량은 최대 10 입니다.")
Integer quantity
```

# 💬 리뷰 중점사항
