### PR TITLE
refactor: 동아리 검색&연관검색 기능 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/club/dto/request/AdminClubCreateRequest.java
@@ -83,6 +83,7 @@ public record AdminClubCreateRequest(
     public Club toEntity(ClubCategory clubCategory) {
         return Club.builder()
             .name(name)
+            .normalizedName(normalize(name))
             .lastWeekHits(0)
             .isActive(true)
             .likes(0)
@@ -94,5 +95,9 @@ public record AdminClubCreateRequest(
             .location(location)
             .isLikeHidden(false)
             .build();
+    }
+
+    private String normalize(String name) {
+        return name.replaceAll("\\s+", "").toLowerCase();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -91,7 +91,6 @@ public record ClubCreateRequest(
     public Club toEntity(ClubCategory clubCategory) {
         return Club.builder()
             .name(name)
-            .normalizedName(normalize(name))
             .lastWeekHits(0)
             .isActive(false)
             .likes(0)
@@ -103,9 +102,5 @@ public record ClubCreateRequest(
             .location(location)
             .isLikeHidden(isLikeHidden)
             .build();
-    }
-
-    private String normalize(String name) {
-        return name.replaceAll("\\s+", "").toLowerCase();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/club/dto/request/ClubCreateRequest.java
@@ -91,6 +91,7 @@ public record ClubCreateRequest(
     public Club toEntity(ClubCategory clubCategory) {
         return Club.builder()
             .name(name)
+            .normalizedName(normalize(name))
             .lastWeekHits(0)
             .isActive(false)
             .likes(0)
@@ -102,5 +103,9 @@ public record ClubCreateRequest(
             .location(location)
             .isLikeHidden(isLikeHidden)
             .build();
+    }
+
+    private String normalize(String name) {
+        return name.replaceAll("\\s+", "").toLowerCase();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/model/Club.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/Club.java
@@ -41,6 +41,11 @@ public class Club extends BaseEntity {
     private String name;
 
     @NotNull
+    @Size(max = 50)
+    @Column(name = "normalized_name", length = 50, nullable = false)
+    private String normalizedName;
+
+    @NotNull
     @Column(name = "hits", nullable = false, columnDefinition = "INT UNSIGNED DEFAULT 0")
     private Integer hits = 0;
 
@@ -106,6 +111,7 @@ public class Club extends BaseEntity {
     private Club(
         Integer id,
         String name,
+        String normalizedName,
         Integer hits,
         Integer lastWeekHits,
         String description,
@@ -119,6 +125,7 @@ public class Club extends BaseEntity {
     ) {
         this.id = id;
         this.name = name;
+        this.normalizedName = normalizedName;
         this.hits = hits;
         this.lastWeekHits = lastWeekHits;
         this.description = description;
@@ -152,11 +159,33 @@ public class Club extends BaseEntity {
         Boolean isActive
     ) {
         this.name = name;
+        this.normalizedName = normalized(name);
         this.imageUrl = imageUrl;
         this.clubCategory = clubCategory;
         this.location = location;
         this.description = description;
         this.isActive = isActive;
+    }
+
+    public void update(
+        String name,
+        String imageUrl,
+        ClubCategory category,
+        String location,
+        String description,
+        Boolean isLikeHidden
+    ) {
+        this.name = name;
+        this.normalizedName = normalized(name);
+        this.imageUrl = imageUrl;
+        this.clubCategory = category;
+        this.location = location;
+        this.description = description;
+        this.isLikeHidden = isLikeHidden;
+    }
+
+    private String normalized(String name) {
+        return name.replaceAll("\\s+", "").toLowerCase();
     }
 
     public void updateActive(Boolean active) {
@@ -169,22 +198,6 @@ public class Club extends BaseEntity {
 
     public void cancelLikes() {
         this.likes--;
-    }
-
-    public void update(
-        String name,
-        String imageUrl,
-        ClubCategory category,
-        String location,
-        String description,
-        Boolean isLikeHidden
-    ) {
-        this.name = name;
-        this.imageUrl = imageUrl;
-        this.clubCategory = category;
-        this.location = location;
-        this.description = description;
-        this.isLikeHidden = isLikeHidden;
     }
 
     public void updateIntroduction(String introduction) {

--- a/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
+++ b/src/main/java/in/koreatech/koin/domain/club/model/redis/ClubCreateRedis.java
@@ -117,6 +117,7 @@ public class ClubCreateRedis {
     public Club toClub(ClubCategory category) {
         return Club.builder()
             .name(this.name)
+            .normalizedName(normalize(name))
             .imageUrl(this.imageUrl)
             .clubCategory(category)
             .location(this.location)
@@ -135,5 +136,9 @@ public class ClubCreateRedis {
             .club(club)
             .user(requester)
             .build();
+    }
+
+    private String normalize(String name) {
+        return name.replaceAll("\\s+", "").toLowerCase();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubListQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubListQueryRepository.java
@@ -72,7 +72,10 @@ public class ClubListQueryRepository {
             builder.and(clubRecruitment.endDate.goe(LocalDate.now()).or(clubRecruitment.isAlwaysRecruiting.isTrue()));
         }
 
-        builder.and(Expressions.stringTemplate("LOWER(REPLACE({0}, ' ', ''))", club.name).contains(normalizedQuery));
+        if (!normalizedQuery.isBlank()) {
+            builder.and(club.normalizedName.contains(normalizedQuery));
+        }
+
         builder.and(club.isActive.isTrue());
 
         return builder;

--- a/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/club/repository/ClubRepository.java
@@ -44,13 +44,11 @@ public interface ClubRepository extends Repository<Club, Integer> {
         return club;
     }
 
-    @Query(value = """
-        SELECT * FROM club c 
-        WHERE c.is_active = true 
-          AND LOWER(REPLACE(c.name, ' ', '')) LIKE CONCAT(:query, '%') 
-        ORDER BY c.name
-        """, nativeQuery = true)
-    List<Club> findByNamePrefix(@Param("query") String normalizedQuery, Pageable pageable);
+    @Query("""
+        SELECT c FROM Club c
+        WHERE c.isActive = true AND c.normalizedName LIKE CONCAT(:query, '%') ORDER BY c.normalizedName
+        """)
+    List<Club> findByNamePrefix(String query, Pageable pageable);
 
     @Modifying
     @Query("UPDATE Club c SET c.hits = c.hits + :value WHERE c.id = :id")


### PR DESCRIPTION
# 🔥 연관 이슈

- close #1848 

# 🚀 작업 내용

#### 요구사항
- 검색할 때 대소문자, 띄어쓰기 구분 없이 검색되어야함
- 해당 조건을 만족하면서 충분한 성능

#### 기존로직
- 검색에서 공백 삭제, 소문자로 변환하여 DB의 동아리명과 비교
  - 동아리명은 공백이 포함될 수 있음
  - 동아리명은 대소문자가 섞여있을 수 있음
  
  → 기존 로직은 올바르게 동작하지 않음

#### 1차개선
- DB에서 name을 비교할 때 쿼리로 REPLACE로 공백제거 및 LOWER로 소문자화해서 비교
  - 이는 쿼리에 로직처리를 위임한 것이므로 바람직하지 못함
  - 또한 기존의 의도인 index RangeScan을 타지못해서 매우 비효율적임

#### 2차개선
- 쿼리에 위임하지 않으면서 성능까지 챙길 방안
  - 동아리 생성, 수정 시 동아리명이 정규화된 형태(공백제거, 소문자화)를 진행한 컬럼을 추가로 관리
  - 동아리 검색, 연관검색시 이 컬럼(normalizedName)을 이용하여 검색
  - normalizedName에 대한 index추가 (index RangeScan을 위한)
  - 검색 결과는 기존 동아리명으로 제공할 수 있음
  
   → index RangeScan을 활용할 수 있고 query의 정규화 처리를 하지 않아도 됨

# 💬 리뷰 중점사항
- 
