### PR TITLE
refactor: 비즈니스 2차 QA (장바구니 상품 수정 API)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoService.java
@@ -100,7 +100,7 @@ public class LostItemChatRoomInfoService {
         validateAuthor(lostItemArticle.getAuthor());
         validateSelfChat(messageSendUserId, lostItemArticle.getAuthor().getId());
 
-        Integer nextChatRoomId = getNextChatRoomId(lostItemArticle.getId());
+        Integer nextChatRoomId = getNextChatRoomId(articleId);
         chatRoomInfoRepository.save(
             LostItemChatRoomInfoEntity.toEntity(
                 articleId, nextChatRoomId, messageSendUserId, lostItemArticle.getAuthor().getId()

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -675,6 +675,7 @@ public interface CartApi {
             - **동일 구성 상품이 없으면**: 현재 상품의 가격과 옵션을 요청된 내용으로 수정합니다.
             
         ### 요청 Body 필드 설명
+        - **quantity**: 새롭게 변경할 메뉴 개수 (필수)
         - **orderableShopMenuPriceId**: 새롭게 선택한 메뉴 가격 ID (필수)
         - **options**: 새롭게 선택한 옵션 목록 (선택 사항)
           - **optionGroupId**: 옵션 그룹 ID

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -477,6 +477,7 @@ public interface CartApi {
                 @ExampleObject(name = "성공", value = """
                         {
                           "id": 101,
+                          "quantity": 2,
                           "name": "후라이드 치킨",
                           "description": "바삭하고 고소한 오리지널 후라이드",
                           "images": [

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartMenuItemEditResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartMenuItemEditResponse.java
@@ -22,14 +22,19 @@ public record CartMenuItemEditResponse(
 
     @Schema(description = "메뉴 수량", example = "2")
     Integer quantity,
+
     @Schema(description = "메뉴 이름", example = "후라이드 치킨")
     String name,
+
     @Schema(description = "메뉴 설명", example = "바삭하고 고소한 오리지널 후라이드", nullable = true)
     String description,
+
     @Schema(description = "메뉴 이미지 URL 목록", nullable = true)
     List<String> images,
+
     @Schema(description = "메뉴 가격 정보 목록")
     List<InnerPriceResponse> prices,
+
     @Schema(description = "메뉴 옵션 그룹 목록")
     List<InnerOptionGroupResponse> optionGroups
 ) {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartMenuItemEditResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartMenuItemEditResponse.java
@@ -19,6 +19,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CartMenuItemEditResponse(
     @Schema(description = "메뉴 고유 식별자", example = "1")
     Integer id,
+
+    @Schema(description = "메뉴 수량", example = "2")
+    Integer quantity,
     @Schema(description = "메뉴 이름", example = "후라이드 치킨")
     String name,
     @Schema(description = "메뉴 설명", example = "바삭하고 고소한 오리지널 후라이드", nullable = true)
@@ -50,7 +53,7 @@ public record CartMenuItemEditResponse(
             .map(groupMap -> InnerOptionGroupResponse.from(groupMap.getOptionGroup(), selectedOptionIds))
             .toList();
 
-        return new CartMenuItemEditResponse(menu.getId(), menu.getName(), menu.getDescription(), images,
+        return new CartMenuItemEditResponse(menu.getId(), cartMenuItem.getQuantity(), menu.getName(), menu.getDescription(), images,
             priceResponses, optionGroupResponses);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartUpdateItemRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/dto/CartUpdateItemRequest.java
@@ -13,6 +13,9 @@ import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record CartUpdateItemRequest(
+
+    @Schema(description = "메뉴 수량", example = "2")
+    Integer quantity,
     @Schema(description = "새롭게 선택한 메뉴 가격 ID", example = "2", requiredMode = REQUIRED)
     @NotNull
     Integer orderableShopMenuPriceId,

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/CartMenuItem.java
@@ -145,12 +145,13 @@ public class CartMenuItem extends BaseEntity {
         return existingOptionIds.equals(newOptionIds);
     }
 
-    public void updatePriceAndOptions(OrderableShopMenuPrice newPrice, List<OrderableShopMenuOption> newOptions) {
+    public void update(OrderableShopMenuPrice newPrice, List<OrderableShopMenuOption> newOptions, Integer newQuantity) {
         this.orderableShopMenuPrice = newPrice;
         this.cartMenuItemOptions.clear();
         if (newOptions != null) {
             newOptions.forEach(option -> this.cartMenuItemOptions.add(CartMenuItemOption.create(this, option)));
         }
+        updateQuantity(newQuantity);
         this.isModified = true;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/order/cart/service/CartService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/service/CartService.java
@@ -67,11 +67,10 @@ public class CartService {
     @Transactional
     public void updateItem(CartUpdateItemRequest request, Integer cartMenuItemId, Integer userId) {
         Cart cart = getCartOrThrow(userId);
-        CartMenuItem itemToUpdate = cart.getCartMenuItem(cartMenuItemId);
+        CartMenuItem cartItem = cart.getCartMenuItem(cartMenuItemId);
 
         // 새로운 가격 및 옵션 구성의 유효성 검증
-        OrderableShopMenu menu = itemToUpdate.getOrderableShopMenu();
-        Integer originalQuantity = itemToUpdate.getQuantity();
+        OrderableShopMenu menu = cartItem.getOrderableShopMenu();
 
         menu.requiredMenuPriceById(request.orderableShopMenuPriceId());
         OrderableShopMenuPrice newPrice = menu.getMenuPriceById(request.orderableShopMenuPriceId());
@@ -80,15 +79,15 @@ public class CartService {
         List<OrderableShopMenuOption> newSelectedOptions = shopMenuOptions.resolveSelectedOptions(request.toOptions());
 
         // 변경 후의 구성이 장바구니에 이미 존재 하는지 확인
-        Optional<CartMenuItem> existingSameItem = cart.findSameItem(menu, newPrice, newSelectedOptions, itemToUpdate.getId());
+        Optional<CartMenuItem> existingSameItem = cart.findSameItem(menu, newPrice, newSelectedOptions, cartItem.getId());
 
         if (existingSameItem.isPresent()) {
             // 장바구니에 동일한 구성한 상품 존재시 수량을 합치고 기존 상품 삭제
-            existingSameItem.get().increaseQuantity(originalQuantity);
-            cart.removeItem(itemToUpdate.getId());
+            existingSameItem.get().increaseQuantity(request.quantity());
+            cart.removeItem(cartItem.getId());
         } else {
             // 동일 구성 상품 없으면 현재 상품의 구성을 직접 변경
-            itemToUpdate.updatePriceAndOptions(newPrice, newSelectedOptions);
+            cartItem.update(newPrice, newSelectedOptions, request.quantity());
         }
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/cart/CartServiceTest.java
@@ -599,6 +599,7 @@ public class CartServiceTest {
 
             // 장바구니에 담긴 상품의 가격 옵션과 선택 옵션을 모두 변경 - 모두 유효한 값으로 변경
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 gimbapPriceB.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), toppingOptionB.getId()))
             );
@@ -641,6 +642,7 @@ public class CartServiceTest {
 
             // 장바구니에 담긴 상품(itemToUpdate)의 가격 옵션과 선택 옵션을 existingItem 과 동일하게 변경
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 gimbapPriceB.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), toppingOptionB.getId()))
             );
@@ -675,6 +677,7 @@ public class CartServiceTest {
 
             // 장바구니에 담긴 상품의 가격 옵션을 유효하지 않은 ID로 변경 시도
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 ramenPriceA.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), sourceOptionA.getId()))
             );
@@ -701,6 +704,7 @@ public class CartServiceTest {
 
             // 필수 옵션 그룹 선택을 누락한 요청 생성
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 ramenPriceA.getId(),
                 List.of()
             );
@@ -728,6 +732,7 @@ public class CartServiceTest {
 
             // 메뉴에 속하지 않는 옵션 으로 변경 하는 요청 생성
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 gimbapPriceB.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(toppingGroup.getId(), sourceOptionA.getId()))
             );
@@ -755,6 +760,7 @@ public class CartServiceTest {
 
             // 옵션 그룹과 옵션 ID가 일치하지 않는 요청 생성
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 ramenPriceA.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), sourceOptionB.getId()))
             );
@@ -782,6 +788,7 @@ public class CartServiceTest {
             when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 ramenPriceA.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionA.getId()),
                     new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionB.getId()),
@@ -814,6 +821,7 @@ public class CartServiceTest {
             when(orderableShopMenuOptionRepository.getAllByMenuId(menuRamen.getId())).thenReturn(menuOptions);
 
             CartUpdateItemRequest request = new CartUpdateItemRequest(
+                1,
                 ramenPriceA.getId(),
                 List.of(new CartUpdateItemRequest.InnerOptionRequest(alcoholGroup.getId(), alcoholOptionA.getId()),
                     new CartUpdateItemRequest.InnerOptionRequest(sourceGroup.getId(), sourceOptionA.getId()))


### PR DESCRIPTION
### 🔍 개요
- #1859 

---

### 🚀 주요 변경 내용
#### 장바구니 상품 수정 API
  * 옵션 변경 페이지에서 수량까지 변경할 수 있어야 함
  * 장바구니 옵션 변경용 메뉴 조회 API `quantity` 응답 필드 추가
  * 장바구니 상품의 가격 및 옵션 구성 변경 API `quantity` 요청 필드 추가

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
