### PR TITLE
feat: 분실물 채팅방 생성 및 조회 서비스 테스트 코드 작성

### DIFF
--- a/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
@@ -102,8 +102,8 @@ public class LostItemChatRoomInfoServiceTest {
             when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, messageSenderId)).thenReturn(
                 Optional.empty());
             when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(lostItemArticle);
-            LostItemChatRoomInfoEntity lostItemChatRoomInfoA = LostItemChatFixture.분실물_게시글_채팅방(articleId, 1, authorId, 3);
-            LostItemChatRoomInfoEntity lostItemChatRoomInfoB = LostItemChatFixture.분실물_게시글_채팅방(articleId, 2, authorId, 4);
+            LostItemChatRoomInfoEntity lostItemChatRoomInfoA = LostItemChatFixture.분실물_게시글_채팅방(articleId, 1, authorId, 888);
+            LostItemChatRoomInfoEntity lostItemChatRoomInfoB = LostItemChatFixture.분실물_게시글_채팅방(articleId, 2, authorId, 999);
             when(chatRoomInfoRepository.findByArticleId(articleId)).thenReturn(List.of(lostItemChatRoomInfoA, lostItemChatRoomInfoB));
 
             // when

--- a/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
@@ -1,0 +1,163 @@
+package in.koreatech.koin.unit.domain.community.lostitem.chatroom.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.community.article.model.LostItemArticle;
+import in.koreatech.koin.domain.community.article.repository.LostItemArticleRepository;
+import in.koreatech.koin.domain.community.lostitem.chatroom.model.LostItemChatRoomInfoEntity;
+import in.koreatech.koin.domain.community.lostitem.chatroom.repository.LostItemChatRoomInfoRepository;
+import in.koreatech.koin.domain.community.lostitem.chatroom.service.LostItemChatRoomInfoService;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.global.code.ApiResponseCode;
+import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.unit.fixutre.LostItemArticleFixture;
+import in.koreatech.koin.unit.fixutre.LostItemChatFixture;
+import in.koreatech.koin.unit.fixutre.UserFixture;
+
+@ExtendWith(MockitoExtension.class)
+public class LostItemChatRoomInfoServiceTest {
+
+    @InjectMocks
+    private LostItemChatRoomInfoService lostItemChatRoomInfoService;
+    @Mock
+    private LostItemArticleRepository lostItemArticleRepository;
+    @Mock
+    private LostItemChatRoomInfoRepository chatRoomInfoRepository;
+    private User author;
+    private User messageSender;
+    private LostItemArticle lostItemArticle;
+    private final Integer authorId = 1;
+    private final Integer messageSenderId = 2;
+    private final Integer articleId = 1001;
+    private final Integer lostItemArticleId = 101;
+
+    @BeforeEach
+    void setUp() {
+        author = UserFixture.코인_유저();
+        ReflectionTestUtils.setField(author, "id", authorId);
+
+        messageSender = UserFixture.코인_유저();
+        ReflectionTestUtils.setField(messageSender, "id", messageSenderId);
+
+        lostItemArticle = LostItemArticleFixture.분실물_게시글_학생등록(articleId, lostItemArticleId, author);
+    }
+
+    @Nested
+    @DisplayName("채팅방 생성 및 조회 - 성공")
+    class GetOrCreateChatRoomSuccess {
+
+        @Test
+        void 기존에_생성된_채팅방이_있으면_해당_채팅방_ID를_반환한다() {
+            LostItemChatRoomInfoEntity lostItemChatRoomInfo = LostItemChatFixture.분실물_게시글_채팅방(articleId, 77, authorId, messageSenderId);
+            when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, messageSenderId)).thenReturn(
+                Optional.of(lostItemChatRoomInfo));
+
+            // when
+            Integer chatRoomId = lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, messageSenderId);
+
+            // then
+            assertThat(chatRoomId).isEqualTo(77);
+            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
+        }
+
+        @Test
+        void 첫_번째_채팅방_생성시_채팅방_ID가_1로_생성된다() {
+            // given
+            when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, messageSenderId)).thenReturn(
+                Optional.empty());
+            when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(lostItemArticle);
+            when(chatRoomInfoRepository.findByArticleId(articleId)).thenReturn(List.of());
+
+            // when
+            Integer chatRoomId = lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, messageSenderId);
+
+            // then
+            assertThat(chatRoomId).isEqualTo(1);
+            verify(chatRoomInfoRepository).save(argThat(entity ->
+                entity.getArticleId().equals(articleId) &&
+                    entity.getChatRoomId().equals(1) &&
+                    entity.getOwnerId().equals(messageSenderId) &&
+                    entity.getAuthorId().equals(authorId)
+            ));
+        }
+
+        @Test
+        void 기존_채팅방들이_있으면_최대_ID에_1_더한_값으로_새_채팅방을_생성한다() {
+            when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, messageSenderId)).thenReturn(
+                Optional.empty());
+            when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(lostItemArticle);
+            LostItemChatRoomInfoEntity lostItemChatRoomInfoA = LostItemChatFixture.분실물_게시글_채팅방(articleId, 1, authorId, 3);
+            LostItemChatRoomInfoEntity lostItemChatRoomInfoB = LostItemChatFixture.분실물_게시글_채팅방(articleId, 2, authorId, 3);
+            when(chatRoomInfoRepository.findByArticleId(articleId)).thenReturn(List.of(lostItemChatRoomInfoA, lostItemChatRoomInfoB));
+
+            // when
+            Integer chatRoomId = lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, messageSenderId);
+
+            // then
+            assertThat(chatRoomId).isEqualTo(3);
+            verify(chatRoomInfoRepository).save(argThat(entity ->
+                entity.getChatRoomId().equals(3)
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 생성 - 실패")
+    class GetOrCreateChatRoomFailure {
+
+        @Test
+        void 게시글_작성자가_자신의_게시글에_채팅방을_생성하려_하면_예외가_발생한다() {
+            // given
+            when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, authorId)).thenReturn(
+                Optional.empty());
+            when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(lostItemArticle);
+
+            // when & then
+            assertCustomExceptionThrown(
+                () -> lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, authorId),
+                ApiResponseCode.INVALID_SELF_CHAT
+            );
+
+            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
+        }
+
+        @Test
+        void 탈퇴한_사용자의_게시글에_채팅방을_생성하려_하면_예외가_발생한다() {
+            // given
+            LostItemArticle articleWithNullAuthor = LostItemArticleFixture.분실물_게시글_학생등록(articleId, lostItemArticleId, null);
+            when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, authorId)).thenReturn(
+                Optional.empty());
+            when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(articleWithNullAuthor);
+
+
+            // when & then
+            assertCustomExceptionThrown(
+                () -> lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, authorId),
+                ApiResponseCode.NOT_FOUND_USER
+            );
+
+            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
+        }
+    }
+
+    private void assertCustomExceptionThrown(Runnable runnable, ApiResponseCode expectedCode) {
+        CustomException exception = assertThrows(CustomException.class, runnable::run);
+        assertThat(exception.getErrorCode()).isEqualTo(expectedCode);
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
@@ -73,7 +73,6 @@ public class LostItemChatRoomInfoServiceTest {
 
             // then
             assertThat(chatRoomId).isEqualTo(77);
-            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
         }
 
         @Test
@@ -88,7 +87,6 @@ public class LostItemChatRoomInfoServiceTest {
             Integer chatRoomId = lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, messageSenderId);
 
             // then
-            verify(chatRoomInfoRepository, times(1)).save(any(LostItemChatRoomInfoEntity.class));
             assertThat(chatRoomId).isEqualTo(1);
         }
 
@@ -106,9 +104,6 @@ public class LostItemChatRoomInfoServiceTest {
 
             // then
             assertThat(chatRoomId).isEqualTo(3);
-            verify(chatRoomInfoRepository).save(argThat(entity ->
-                entity.getChatRoomId().equals(3)
-            ));
         }
     }
 
@@ -128,8 +123,6 @@ public class LostItemChatRoomInfoServiceTest {
                 () -> lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, authorId),
                 ApiResponseCode.INVALID_SELF_CHAT
             );
-
-            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
         }
 
         @Test
@@ -145,8 +138,6 @@ public class LostItemChatRoomInfoServiceTest {
                 () -> lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, authorId),
                 ApiResponseCode.NOT_FOUND_USER
             );
-
-            verify(chatRoomInfoRepository, never()).save(any(LostItemChatRoomInfoEntity.class));
         }
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
@@ -103,7 +103,7 @@ public class LostItemChatRoomInfoServiceTest {
                 Optional.empty());
             when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(lostItemArticle);
             LostItemChatRoomInfoEntity lostItemChatRoomInfoA = LostItemChatFixture.분실물_게시글_채팅방(articleId, 1, authorId, 3);
-            LostItemChatRoomInfoEntity lostItemChatRoomInfoB = LostItemChatFixture.분실물_게시글_채팅방(articleId, 2, authorId, 3);
+            LostItemChatRoomInfoEntity lostItemChatRoomInfoB = LostItemChatFixture.분실물_게시글_채팅방(articleId, 2, authorId, 4);
             when(chatRoomInfoRepository.findByArticleId(articleId)).thenReturn(List.of(lostItemChatRoomInfoA, lostItemChatRoomInfoB));
 
             // when

--- a/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/lostitem/chatroom/service/LostItemChatRoomInfoServiceTest.java
@@ -88,13 +88,8 @@ public class LostItemChatRoomInfoServiceTest {
             Integer chatRoomId = lostItemChatRoomInfoService.getOrCreateChatRoomId(articleId, messageSenderId);
 
             // then
+            verify(chatRoomInfoRepository, times(1)).save(any(LostItemChatRoomInfoEntity.class));
             assertThat(chatRoomId).isEqualTo(1);
-            verify(chatRoomInfoRepository).save(argThat(entity ->
-                entity.getArticleId().equals(articleId) &&
-                    entity.getChatRoomId().equals(1) &&
-                    entity.getOwnerId().equals(messageSenderId) &&
-                    entity.getAuthorId().equals(authorId)
-            ));
         }
 
         @Test
@@ -144,7 +139,6 @@ public class LostItemChatRoomInfoServiceTest {
             when(chatRoomInfoRepository.findByArticleIdAndMessageSenderId(articleId, authorId)).thenReturn(
                 Optional.empty());
             when(lostItemArticleRepository.getByArticleId(articleId)).thenReturn(articleWithNullAuthor);
-
 
             // when & then
             assertCustomExceptionThrown(

--- a/src/test/java/in/koreatech/koin/unit/fixutre/LostItemArticleFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/LostItemArticleFixture.java
@@ -1,0 +1,53 @@
+package in.koreatech.koin.unit.fixutre;
+
+import java.time.LocalDate;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.article.model.Board;
+import in.koreatech.koin.domain.community.article.model.LostItemArticle;
+import in.koreatech.koin.domain.user.model.User;
+
+public class LostItemArticleFixture {
+
+    private LostItemArticleFixture() {}
+
+    public static LostItemArticle 분실물_게시글_학생등록(Integer articleId, Integer lostItemArticleId, User author) {
+        Board lostItemArticleBoard = Board.builder()
+            .name("분실물게시판")
+            .isAnonymous(false)
+            .articleCount(0)
+            .isDeleted(false)
+            .isNotice(false)
+            .parentId(null)
+            .build();
+        ReflectionTestUtils.setField(lostItemArticleBoard, "id", 14);
+
+        Article article = Article.builder()
+            .id(articleId)
+            .board(lostItemArticleBoard)
+            .title("신분증 | 학교 | 24.12.17")
+            .content("학생회관 앞 계단에 …")
+            .hit(0)
+            .isNotice(false)
+            .isDeleted(false)
+            .build();
+
+        LostItemArticle lostItemArticle = LostItemArticle.builder()
+            .article(article)
+            .author(author)
+            .category("신분증")
+            .foundDate(LocalDate.of(2024, 12, 17))
+            .foundPlace("학교")
+            .isDeleted(false)
+            .type("LOST")
+            .isCouncil(false)
+            .build();
+
+        ReflectionTestUtils.setField(lostItemArticle, "id", lostItemArticleId);
+        ReflectionTestUtils.setField(article, "lostItemArticle", lostItemArticle);
+
+        return lostItemArticle;
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/fixutre/LostItemChatFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixutre/LostItemChatFixture.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.unit.fixutre;
+
+import in.koreatech.koin.domain.community.lostitem.chatroom.model.LostItemChatRoomInfoEntity;
+
+public class LostItemChatFixture {
+
+    private LostItemChatFixture() {}
+
+    public static LostItemChatRoomInfoEntity 분실물_게시글_채팅방(
+        Integer articleId, Integer chatRoomId, Integer authorId, Integer messageSenderId) {
+
+        return LostItemChatRoomInfoEntity.builder()
+            .articleId(articleId)
+            .chatRoomId(chatRoomId)
+            .authorId(authorId)
+            .ownerId(messageSenderId)
+            .build();
+    }
+}


### PR DESCRIPTION
### 🔍 개요

- #1798 리팩터링 과정에서 코드가 잘못 수정되었으나, 테스트 코드 누락으로 인해 오류를 사전에 발견하지 못하여 스테이지 환경에서 장애가 발생함 (25/08/02)
- 동일한 문제의 재발 방지를 위해 LostItemChatRoomInfoService에 대한 테스트 코드를 추가함
- 관련 이슈: #1861

---

### 🚀 주요 변경 내용

- LostItemChatRoomInfoService의 getOrCreateChatRoomId 메서드에 대한 단위 테스트 추가
  - ✅ 기존 채팅방 조회 시나리오
  - ✅ 새 채팅방 생성 시나리오 (첫 번째 채팅방, N번째 채팅방)
  - ✅ 예외 상황 처리 (자기 자신과의 채팅, 탈퇴 사용자 게시글)

### 📋 테스트 커버리지
- 정상 케이스 3개, 예외 케이스 2개로 주요 비즈니스 로직 검증
- Mock을 활용한 의존성 격리 및 행위 검증(verify) 포함

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
