### PR TITLE
feat: 주변상점 요약 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -18,7 +18,7 @@ import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopSummaryResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
@@ -56,9 +56,9 @@ public interface ShopApi {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
         }
     )
-    @Operation(summary = "특정 상점 조회 V2")
-    @GetMapping("/v2/shops/{id}")
-    ResponseEntity<ShopResponseV2> getShopByIdV2(
+    @Operation(summary = "특정 상점 요약 정보 조회")
+    @GetMapping("/shops/{id}/summary")
+    ResponseEntity<ShopSummaryResponse> getShopSummary(
         @Parameter(in = PATH) @PathVariable Integer id
     );
 

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopApi.java
@@ -3,17 +3,26 @@ package in.koreatech.koin.domain.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 import in.koreatech.koin.domain.shop.dto.search.response.RelatedKeywordResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteriaV3;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
-import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
+import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,12 +30,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "(Normal) Shop: 상점", description = "상점 정보를 관리한다")
 public interface ShopApi {
@@ -42,6 +45,20 @@ public interface ShopApi {
     @Operation(summary = "특정 상점 조회")
     @GetMapping("/shops/{id}")
     ResponseEntity<ShopResponse> getShopById(
+        @Parameter(in = PATH) @PathVariable Integer id
+    );
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "특정 상점 조회 V2")
+    @GetMapping("/v2/shops/{id}")
+    ResponseEntity<ShopResponseV2> getShopByIdV2(
         @Parameter(in = PATH) @PathVariable Integer id
     );
 

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -49,7 +49,7 @@ public class ShopController implements ShopApi {
     public ResponseEntity<ShopSummaryResponse> getShopSummary(
         @Parameter(in = PATH) @PathVariable Integer id
     ) {
-        ShopSummaryResponse response = shopService.getShopV2(id);
+        ShopSummaryResponse response = shopService.getShopSummary(id);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -47,7 +47,7 @@ public class ShopController implements ShopApi {
 
     @GetMapping("/shops/{id}/summary")
     public ResponseEntity<ShopSummaryResponse> getShopSummary(
-        @Parameter(in = PATH) @PathVariable Integer id
+        @PathVariable Integer id
     ) {
         ShopSummaryResponse response = shopService.getShopSummary(id);
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -3,29 +3,32 @@ package in.koreatech.koin.domain.shop.controller;
 import static in.koreatech.koin.domain.user.model.UserType.*;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
 
-import in.koreatech.koin.domain.shop.dto.search.response.RelatedKeywordResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteriaV3;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
-import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
-import in.koreatech.koin.domain.shop.service.ShopSearchService;
-import in.koreatech.koin.domain.shop.service.ShopService;
-import in.koreatech.koin.global.auth.Auth;
-import io.swagger.v3.oas.annotations.Parameter;
 import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.shop.dto.search.response.RelatedKeywordResponse;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteriaV3;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
+import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
+import in.koreatech.koin.domain.shop.service.ShopSearchService;
+import in.koreatech.koin.domain.shop.service.ShopService;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,6 +43,14 @@ public class ShopController implements ShopApi {
     ) {
         ShopResponse shopResponse = shopService.getShop(id);
         return ResponseEntity.ok(shopResponse);
+    }
+
+    @GetMapping("/v2/shops/{id}")
+    public ResponseEntity<ShopResponseV2> getShopByIdV2(
+        @PathVariable Integer id
+    ) {
+        ShopResponseV2 response = shopService.getShopV2(id);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/shops")

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopController.java
@@ -20,7 +20,7 @@ import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopSummaryResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
@@ -45,11 +45,11 @@ public class ShopController implements ShopApi {
         return ResponseEntity.ok(shopResponse);
     }
 
-    @GetMapping("/v2/shops/{id}")
-    public ResponseEntity<ShopResponseV2> getShopByIdV2(
-        @PathVariable Integer id
+    @GetMapping("/shops/{id}/summary")
+    public ResponseEntity<ShopSummaryResponse> getShopSummary(
+        @Parameter(in = PATH) @PathVariable Integer id
     ) {
-        ShopResponseV2 response = shopService.getShopV2(id);
+        ShopSummaryResponse response = shopService.getShopV2(id);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopResponseV2.java
@@ -1,22 +1,21 @@
 package in.koreatech.koin.domain.shop.dto.shop.response;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.shop.model.shop.Shop;
+import in.koreatech.koin.domain.shop.model.shop.ShopImage;
+import in.koreatech.koin.domain.shop.repository.shop.dto.ShopInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record ShopResponseV2(
     @Schema(description = "상점 Id", example = "1", requiredMode = REQUIRED)
     Integer shopId,
-
-    @Schema(description = "주문 가능 상점 Id", example = "1", requiredMode = NOT_REQUIRED)
-    Integer orderableShopId,
 
     @Schema(description = "상점 이름", example = "수신반점", requiredMode = REQUIRED)
     String name,
@@ -25,10 +24,10 @@ public record ShopResponseV2(
     String introduction,
 
     @Schema(description = "리뷰 평균 평점", example = "4.5", requiredMode = REQUIRED)
-    Double ratingAverage,
+    double ratingAverage,
 
     @Schema(description = "리뷰 수", example = "15", requiredMode = REQUIRED)
-    Integer reviewCount,
+    long reviewCount,
 
     @Schema(description = "이미지 url 리스트", requiredMode = REQUIRED)
     List<InnerImageResponse> images
@@ -41,6 +40,24 @@ public record ShopResponseV2(
         @Schema(description = "이미지 Thumbnail 여부", example = "true", requiredMode = REQUIRED)
         Boolean isThumbnail
     ) {
+        public static InnerImageResponse from(ShopImage shopImage) {
+            return new InnerImageResponse(
+                shopImage.getImageUrl(),
+                false
+            );
+        }
+    }
 
+    public static ShopResponseV2 from(Shop shop, ShopInfo shopInfo) {
+        return new ShopResponseV2(
+            shop.getId(),
+            shop.getName(),
+            shop.getIntroduction(),
+            shopInfo.averageRate(),
+            shopInfo.reviewCount(),
+            shop.getShopImages().stream()
+                .map(InnerImageResponse::from)
+                .toList()
+        );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopResponseV2.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopResponseV2.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.shop.dto.shop.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record ShopResponseV2(
+    @Schema(description = "상점 Id", example = "1", requiredMode = REQUIRED)
+    Integer shopId,
+
+    @Schema(description = "주문 가능 상점 Id", example = "1", requiredMode = NOT_REQUIRED)
+    Integer orderableShopId,
+
+    @Schema(description = "상점 이름", example = "수신반점", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "상점 소개", example = "안녕하세요 수신 반점입니다.", requiredMode = REQUIRED)
+    String introduction,
+
+    @Schema(description = "리뷰 평균 평점", example = "4.5", requiredMode = REQUIRED)
+    Double ratingAverage,
+
+    @Schema(description = "리뷰 수", example = "15", requiredMode = REQUIRED)
+    Integer reviewCount,
+
+    @Schema(description = "이미지 url 리스트", requiredMode = REQUIRED)
+    List<InnerImageResponse> images
+) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerImageResponse(
+        @Schema(description = "이미지 url", example = "https://static.koreatech.in/upload/market/2022/03/26/0e650fe1-811b-411e-9a82-0dd4f43c42ca-1648289492264.jpg", requiredMode = REQUIRED)
+        String imageUrl,
+
+        @Schema(description = "이미지 Thumbnail 여부", example = "true", requiredMode = REQUIRED)
+        Boolean isThumbnail
+    ) {
+
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.shop.dto.shop.response;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public record ShopSummaryResponse(
     @Schema(description = "상점 이름", example = "수신반점", requiredMode = REQUIRED)
     String name,
 
-    @Schema(description = "상점 소개", example = "안녕하세요 수신 반점입니다.", requiredMode = REQUIRED)
+    @Schema(description = "상점 소개", example = "안녕하세요 수신 반점입니다.", requiredMode = NOT_REQUIRED)
     String introduction,
 
     @Schema(description = "리뷰 평균 평점", example = "4.5", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -40,24 +41,28 @@ public record ShopSummaryResponse(
         @Schema(description = "이미지 Thumbnail 여부", example = "true", requiredMode = REQUIRED)
         Boolean isThumbnail
     ) {
-        public static InnerImageResponse from(ShopImage shopImage) {
+        public static InnerImageResponse from(ShopImage shopImage, boolean isThumbnail) {
             return new InnerImageResponse(
                 shopImage.getImageUrl(),
-                false
+                isThumbnail
             );
         }
     }
 
     public static ShopSummaryResponse from(Shop shop, ShopInfo shopInfo) {
+        List<ShopImage> images = shop.getShopImages();
+
+        List<InnerImageResponse> imageResponses = IntStream.range(0, images.size())
+            .mapToObj(index -> InnerImageResponse.from(images.get(index), index == 0))
+            .toList();
+
         return new ShopSummaryResponse(
             shop.getId(),
             shop.getName(),
             shop.getIntroduction(),
             shopInfo.averageRate(),
             shopInfo.reviewCount(),
-            shop.getShopImages().stream()
-                .map(InnerImageResponse::from)
-                .toList()
+            imageResponses
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/shop/response/ShopSummaryResponse.java
@@ -13,7 +13,7 @@ import in.koreatech.koin.domain.shop.repository.shop.dto.ShopInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(value = SnakeCaseStrategy.class)
-public record ShopResponseV2(
+public record ShopSummaryResponse(
     @Schema(description = "상점 Id", example = "1", requiredMode = REQUIRED)
     Integer shopId,
 
@@ -48,8 +48,8 @@ public record ShopResponseV2(
         }
     }
 
-    public static ShopResponseV2 from(Shop shop, ShopInfo shopInfo) {
-        return new ShopResponseV2(
+    public static ShopSummaryResponse from(Shop shop, ShopInfo shopInfo) {
+        return new ShopSummaryResponse(
             shop.getId(),
             shop.getName(),
             shop.getIntroduction(),

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
@@ -17,7 +17,6 @@ import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShop;
 import in.koreatech.koin.domain.shop.model.event.QEventArticle;
 import in.koreatech.koin.domain.shop.model.review.QShopReview;
 import in.koreatech.koin.domain.shop.model.shop.QShop;

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -26,7 +26,7 @@ import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
-import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopSummaryResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
@@ -61,11 +61,11 @@ public class ShopService {
         return ShopResponse.from(shop, now);
     }
 
-    public ShopResponseV2 getShopV2(Integer shopId) {
+    public ShopSummaryResponse getShopV2(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
         LocalDateTime now = LocalDateTime.now(clock);
         ShopInfo shopInfo = shopCustomRepository.findAllShopInfo(now).get(shopId);
-        return ShopResponseV2.from(shop, shopInfo);
+        return ShopSummaryResponse.from(shop, shopInfo);
     }
 
     public ShopsResponse getShops() {

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -2,8 +2,22 @@ package in.koreatech.koin.domain.shop.service;
 
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.REVIEW_PROMPT;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import in.koreatech.koin.domain.benefit.model.BenefitCategoryMap;
 import in.koreatech.koin.domain.benefit.repository.BenefitCategoryMapRepository;
+import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.shop.cache.ShopsCacheService;
 import in.koreatech.koin.domain.shop.cache.dto.ShopsCache;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsFilterCriteria;
@@ -12,6 +26,7 @@ import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteria;
 import in.koreatech.koin.domain.shop.dto.shop.ShopsSortCriteriaV3;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopCategoriesResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponse;
+import in.koreatech.koin.domain.shop.dto.shop.response.ShopResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponse;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV2;
 import in.koreatech.koin.domain.shop.dto.shop.response.ShopsResponseV3;
@@ -23,20 +38,8 @@ import in.koreatech.koin.domain.shop.repository.shop.ShopRepository;
 import in.koreatech.koin.domain.shop.repository.shop.ShopReviewNotificationRedisRepository;
 import in.koreatech.koin.domain.shop.repository.shop.dto.ShopCustomRepository;
 import in.koreatech.koin.domain.shop.repository.shop.dto.ShopInfo;
-import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.global.exception.custom.KoinIllegalArgumentException;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -56,6 +59,13 @@ public class ShopService {
         Shop shop = shopRepository.getById(shopId);
         LocalDate now = LocalDate.now(clock);
         return ShopResponse.from(shop, now);
+    }
+
+    public ShopResponseV2 getShopV2(Integer shopId) {
+        Shop shop = shopRepository.getById(shopId);
+        LocalDateTime now = LocalDateTime.now(clock);
+        ShopInfo shopInfo = shopCustomRepository.findAllShopInfo(now).get(shopId);
+        return ShopResponseV2.from(shop, shopInfo);
     }
 
     public ShopsResponse getShops() {

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopService.java
@@ -61,7 +61,7 @@ public class ShopService {
         return ShopResponse.from(shop, now);
     }
 
-    public ShopSummaryResponse getShopV2(Integer shopId) {
+    public ShopSummaryResponse getShopSummary(Integer shopId) {
         Shop shop = shopRepository.getById(shopId);
         LocalDateTime now = LocalDateTime.now(clock);
         ShopInfo shopInfo = shopCustomRepository.findAllShopInfo(now).get(shopId);


### PR DESCRIPTION
### 🔍 개요

* GET /shops/{id}의 경우 주문 가능 상점 API와 응답값 형태가 달라서 클라이언트에서 처리하기가 힘들다고 요청이 들어옴
* 관련해서 주변 상점 요약 API 구현

- close #1862 

---

### 🚀 주요 변경 내용

* 이미지 썸네일 여부의 경우 컬럼을 추가할까 말까하다가 코드단에서 처리했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
