### PR TITLE
fix: 비즈니스 3차 QA - 장바구니 검증 API 주문 타입 조건 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -852,13 +852,17 @@ public interface CartApi {
         summary = "장바구니 검증",
         description = """
             ## 장바구니 검증
-            - 장바구니의 상품 주문 금액이 상점의 최소 주문 금액을 충족하는지 검증합니다.
-            - 상점이 현재 주문 가능 상태(영업 중) 인지 검증합니다.
+            - 주문 타입이 배달(OrderType.DELIVERY) 일 경우
+              - 상점이 현재 주문 가능 상태(영업 중) 인지 검증합니다.
+              - 장바구니에 담긴 상품의 총 금액이 상점의 최소 주문 금액을 충족하는지 검증합니다.
+            - 주문 타입이 포장(OrderType.TAKE_OUT) 일 경우
+              - 상점이 현재 주문 가능 상태(영업 중) 인지 검증합니다.
             """
     )
     @GetMapping("/cart/validate")
     ResponseEntity<Void> getCartValidateResult(
-        @Parameter(hidden = true) @Auth(permit = {GENERAL, STUDENT}) Integer userId
+        @Parameter(hidden = true) @Auth(permit = {GENERAL, STUDENT}) Integer userId,
+        @RequestParam(name = "type") OrderType orderType
     );
 
     @ApiResponses(value = {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartApi.java
@@ -852,17 +852,17 @@ public interface CartApi {
         summary = "장바구니 검증",
         description = """
             ## 장바구니 검증
-            - 주문 타입이 배달(OrderType.DELIVERY) 일 경우
+            - 주문 타입이 배달(order_type=DELIVERY) 일 경우
               - 상점이 현재 주문 가능 상태(영업 중) 인지 검증합니다.
               - 장바구니에 담긴 상품의 총 금액이 상점의 최소 주문 금액을 충족하는지 검증합니다.
-            - 주문 타입이 포장(OrderType.TAKE_OUT) 일 경우
+            - 주문 타입이 포장(order_type=TAKE_OUT) 일 경우
               - 상점이 현재 주문 가능 상태(영업 중) 인지 검증합니다.
             """
     )
     @GetMapping("/cart/validate")
     ResponseEntity<Void> getCartValidateResult(
         @Parameter(hidden = true) @Auth(permit = {GENERAL, STUDENT}) Integer userId,
-        @RequestParam(name = "type") OrderType orderType
+        @RequestParam(name = "order_type") OrderType orderType
     );
 
     @ApiResponses(value = {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
@@ -120,9 +120,10 @@ public class CartController implements CartApi {
 
     @GetMapping("/cart/validate")
     public ResponseEntity<Void> getCartValidateResult(
-        @Auth(permit = {GENERAL, STUDENT}) Integer userId
+        @Auth(permit = {GENERAL, STUDENT}) Integer userId,
+        @RequestParam(name = "type") OrderType orderType
     ) {
-        cartQueryService.validateCart(userId);
+        cartQueryService.validateCart(userId, orderType);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/controller/CartController.java
@@ -121,7 +121,7 @@ public class CartController implements CartApi {
     @GetMapping("/cart/validate")
     public ResponseEntity<Void> getCartValidateResult(
         @Auth(permit = {GENERAL, STUDENT}) Integer userId,
-        @RequestParam(name = "type") OrderType orderType
+        @RequestParam(name = "order_type") OrderType orderType
     ) {
         cartQueryService.validateCart(userId, orderType);
         return ResponseEntity.ok().build();

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import in.koreatech.koin.global.code.ApiResponseCode;
-import in.koreatech.koin.global.exception.CustomException;
 import in.koreatech.koin.common.model.BaseEntity;
 import in.koreatech.koin.domain.order.model.OrderType;
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenu;
@@ -16,6 +14,8 @@ import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuOp
 import in.koreatech.koin.domain.order.shop.model.entity.menu.OrderableShopMenuPrice;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
 import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.global.code.ApiResponseCode;
+import in.koreatech.koin.global.exception.CustomException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -59,7 +59,8 @@ public class Cart extends BaseEntity {
         }
     }
 
-    public void addItem(OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options, Integer quantity) {
+    public void addItem(OrderableShopMenu menu, OrderableShopMenuPrice price, List<OrderableShopMenuOption> options,
+        Integer quantity) {
         // 장바구니에 옵션 까지 전부 동일한 메뉴가 이미 존재 하는 경우, 담긴 상품 수량 증가
         Optional<CartMenuItem> existingItem = findSameItem(menu, price, options);
 
@@ -104,10 +105,9 @@ public class Cart extends BaseEntity {
     }
 
     public Integer calculateItemsAmount() {
-        int sum = this.cartMenuItems.stream()
+        return Math.max(0, this.cartMenuItems.stream()
             .mapToInt(CartMenuItem::calculateTotalAmount)
-            .sum();
-        return Math.max(0, sum);
+            .sum());
     }
 
     public Integer calculateDeliveryFee(OrderType orderType) {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/model/Cart.java
@@ -104,9 +104,10 @@ public class Cart extends BaseEntity {
     }
 
     public Integer calculateItemsAmount() {
-        return this.cartMenuItems.stream()
+        int sum = this.cartMenuItems.stream()
             .mapToInt(CartMenuItem::calculateTotalAmount)
             .sum();
+        return Math.max(0, sum);
     }
 
     public Integer calculateDeliveryFee(OrderType orderType) {

--- a/src/main/java/in/koreatech/koin/domain/order/cart/service/CartQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/cart/service/CartQueryService.java
@@ -78,11 +78,14 @@ public class CartQueryService {
         return CartPaymentSummaryResponse.from(cart, orderType);
     }
 
-    public void validateCart(Integer userId) {
+    public void validateCart(Integer userId, OrderType orderType) {
         Cart cart = getCartOrThrow(userId);
         OrderableShop orderableShop = cart.getOrderableShop();
         orderableShop.requireShopOpen();
-        orderableShop.requireMinimumOrderAmount(cart.calculateItemsAmount());
+
+        if (orderType == OrderType.DELIVERY) {
+            orderableShop.requireMinimumOrderAmount(cart.calculateItemsAmount());
+        }
     }
 
     public CartItemsCountSummaryResponse getCartItemsCountSummary(Integer userId) {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -98,9 +98,6 @@ public class OrderableShop extends BaseEntity {
     }
 
     public void requireMinimumOrderAmount(Integer totalOrderAmount) {
-        if (totalOrderAmount == null || totalOrderAmount < 0) {
-            throw new KoinIllegalArgumentException("주문 금액은 null이거나 음수일 수 없습니다.");
-        }
         if (totalOrderAmount < minimumOrderAmount) {
             throw CustomException.of(ApiResponseCode.ORDER_AMOUNT_BELOW_MINIMUM);
         }


### PR DESCRIPTION
### 🔍 개요

- #1866 

---

### 🚀 주요 변경 내용

* 장바구니 검증 API OrderType 조건 추가
- 주문 타입이 배달(OrderType.DELIVERY) 일 경우
  - 상점이 현재 주문 가능 상태(영업 중) 인지 검증
  - 장바구니에 담긴 상품의 총 금액이 상점의 최소 주문 금액을 충족하는지 검증

- 주문 타입이 포장(OrderType.TAKE_OUT) 일 경우
  - 상점이 현재 주문 가능 상태(영업 중) 인지 검증
---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
