### PR TITLE
refactor: 인수 테스트 과정에서 불필요한 DB 초기화 쿼리 실행 개선

### DIFF
--- a/src/test/java/in/koreatech/koin/acceptance/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/AcceptanceTest.java
@@ -142,8 +142,8 @@ public abstract class AcceptanceTest {
     }
 
     protected void clear() {
-        dataInitializer.initIncrement();
         dataInitializer.clear();
+        dataInitializer.initIncrement();
     }
 
     protected void forceVerify(Runnable runnable) {

--- a/src/test/java/in/koreatech/koin/acceptance/AcceptanceTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/AcceptanceTest.java
@@ -142,6 +142,7 @@ public abstract class AcceptanceTest {
     }
 
     protected void clear() {
+        dataInitializer.initIncrement();
         dataInitializer.clear();
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/domain/BusApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/BusApiTest.java
@@ -258,8 +258,6 @@ class BusApiTest extends AcceptanceTest {
         verify(publicExpressBusClient, times(1)).storeRemainTime();
         verify(tmoneyExpressBusClient, never()).storeRemainTime();
         verify(staticExpressBusClient, never()).storeRemainTime();
-        clear();
-        setUp();
     }
 
     @Test
@@ -273,7 +271,5 @@ class BusApiTest extends AcceptanceTest {
         verify(publicExpressBusClient, times(1)).storeRemainTime();
         verify(tmoneyExpressBusClient, times(1)).storeRemainTime();
         verify(staticExpressBusClient, never()).storeRemainTime();
-        clear();
-        setUp();
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/DiningApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/DiningApiTest.java
@@ -281,7 +281,6 @@ class DiningApiTest extends AcceptanceTest {
             .andReturn();
 
         forceVerify(() -> verify(coopEventListener).onDiningSoldOutRequest(any()));
-        clear();
         setUp();
     }
 
@@ -302,7 +301,6 @@ class DiningApiTest extends AcceptanceTest {
             .andExpect(status().isOk())
             .andReturn();
         forceVerify(() -> verify(coopEventListener, never()).onDiningSoldOutRequest(any()));
-        clear();
         setUp();
     }
 
@@ -323,7 +321,6 @@ class DiningApiTest extends AcceptanceTest {
             .andExpect(status().isOk())
             .andReturn();
         forceVerify(() -> verify(coopEventListener, never()).onDiningSoldOutRequest(any()));
-        clear();
         setUp();
     }
 
@@ -485,7 +482,6 @@ class DiningApiTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk());
-        clear();
         setUp();
     }
 
@@ -495,7 +491,6 @@ class DiningApiTest extends AcceptanceTest {
         coopService.sendDiningNotify();
 
         forceVerify(() -> verify(coopEventListener, never()).onDiningImageUploadRequest(any()));
-        clear();
         setUp();
     }
 
@@ -506,7 +501,6 @@ class DiningApiTest extends AcceptanceTest {
         coopService.sendDiningNotify();
 
         forceVerify(() -> verify(coopEventListener, never()).onDiningImageUploadRequest(any()));
-        clear();
         setUp();
     }
 
@@ -517,7 +511,6 @@ class DiningApiTest extends AcceptanceTest {
         coopService.sendDiningNotify();
 
         forceVerify(() -> verify(coopEventListener).onDiningImageUploadRequest(any()));
-        clear();
         setUp();
     }*/
 

--- a/src/test/java/in/koreatech/koin/acceptance/domain/KeywordApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/KeywordApiTest.java
@@ -244,7 +244,6 @@ public class KeywordApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk());
         forceVerify(() -> verify(articleKeywordEventListener).onKeywordRequest(any()));
-        clear();
         setup();
     }
 
@@ -275,7 +274,6 @@ public class KeywordApiTest extends AcceptanceTest {
             )
             .andExpect(status().isOk());
         forceVerify(() -> verify(articleKeywordEventListener, never()).onKeywordRequest(any()));
-        clear();
         setup();
     }
 
@@ -357,7 +355,6 @@ public class KeywordApiTest extends AcceptanceTest {
             )
             .andExpect(status().isForbidden());
         forceVerify(() -> verify(articleKeywordEventListener, never()).onKeywordRequest(any()));
-        clear();
         setup();
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/OwnerShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/OwnerShopApiTest.java
@@ -234,7 +234,6 @@ class OwnerShopApiTest extends AcceptanceTest {
                 softly.assertThat(result.getShopImages()).hasSize(3);
                 softly.assertThat(result.getShopOpens()).hasSize(7);
                 softly.assertThat(result.getShopCategories()).hasSize(1);
-                System.out.println("dsa");
             }
         );
     }
@@ -828,7 +827,6 @@ class OwnerShopApiTest extends AcceptanceTest {
             }
         );
         forceVerify(() -> verify(shopEventListener, times(1)).onShopEventCreate(any()));
-        clear();
         setUp();
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/domain/ShopReviewApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/ShopReviewApiTest.java
@@ -509,7 +509,6 @@ class ShopReviewApiTest extends AcceptanceTest {
                 softly.assertThat(shopReviewReport2.get().getContent()).isEqualTo("광고가 포함된 리뷰입니다.");
                 softly.assertThat(shopReviewReport2.get().getReportStatus()).isEqualTo(UNHANDLED);
                 forceVerify(() -> verify(reviewEventListener).onReviewReportRegister(any()));
-                clear();
                 setUp();
             }
         );

--- a/src/test/java/in/koreatech/koin/acceptance/domain/StudentApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/StudentApiTest.java
@@ -361,7 +361,6 @@ public class StudentApiTest extends AcceptanceTest {
                 softly.assertThat(student.get().getStudentNumber()).isEqualTo("2021136012");
                 softly.assertThat(student.get().getDepartment()).isEqualTo(Dept.COMPUTER_SCIENCE.getName());
                 forceVerify(() -> verify(studentEventListener).onStudentRegisterRequestEvent(any()));
-                clear();
                 setup();
             }
         );
@@ -402,7 +401,6 @@ public class StudentApiTest extends AcceptanceTest {
 
         assertThat(user.isAuthed()).isTrue();
         forceVerify(() -> verify(studentEventListener).onStudentRegisterEvent(any()));
-        clear();
         setup();
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
+++ b/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
@@ -36,10 +36,6 @@ public class DBInitializer {
     }
 
     private void truncateDirtyTables() {
-        if (tableNames.isEmpty()) {
-            findDatabaseTableNames();
-        }
-
         setForeignKeyCheck(OFF);
         for (String tableName : tableNames) {
             long count = ((Number) entityManager
@@ -69,6 +65,9 @@ public class DBInitializer {
 
     @Transactional
     public void clear() {
+        if (tableNames.isEmpty()) {
+            findDatabaseTableNames();
+        }
         entityManager.clear();
         truncateDirtyTables();
         clearRedis();

--- a/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
+++ b/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
@@ -1,9 +1,6 @@
 package in.koreatech.koin.acceptance.support;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestComponent;
@@ -20,12 +17,6 @@ public class DBInitializer {
 
     private static final int OFF = 0;
     private static final int ON = 1;
-    private static final int COLUMN_INDEX = 1;
-
-    private List<String> tableNames = new ArrayList<>();
-
-    @Autowired
-    private DataSource dataSource;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -56,8 +47,9 @@ public class DBInitializer {
     public void initIncrement() {
         String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND AUTO_INCREMENT > 1";
         List<String> dirtyTables = entityManager.createNativeQuery(sql).getResultList();
-        for (String tableName: dirtyTables) {
-            entityManager.createNativeQuery(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", tableName)).executeUpdate();
+        for (String tableName : dirtyTables) {
+            entityManager.createNativeQuery(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", tableName))
+                .executeUpdate();
         }
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
+++ b/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.acceptance.support;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,18 +28,27 @@ public class DBInitializer {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    private List<String> tableNames = new ArrayList<>();
+
+    private void findDatabaseTableNames() {
+        String sql = "SHOW TABLES";
+        tableNames = entityManager.createNativeQuery(sql).getResultList();
+    }
+
     private void truncateDirtyTables() {
-        String sql = """
-            SELECT TABLE_NAME
-            FROM INFORMATION_SCHEMA.TABLES
-            WHERE TABLE_SCHEMA = 'test'
-              AND TABLE_TYPE = 'BASE TABLE'
-              AND (AUTO_INCREMENT > 1 OR AUTO_INCREMENT IS NULL)
-            """;
-        List<String> dirtyTables = entityManager.createNativeQuery(sql).getResultList();
+        if (tableNames.isEmpty()) {
+            findDatabaseTableNames();
+        }
+
         setForeignKeyCheck(OFF);
-        for (String dirtyTable : dirtyTables) {
-            entityManager.createNativeQuery(String.format("TRUNCATE TABLE `%s`", dirtyTable)).executeUpdate();
+        for (String tableName : tableNames) {
+            long count = ((Number) entityManager
+                .createNativeQuery(String.format("SELECT COUNT(*) FROM `%s`", tableName))
+                .getSingleResult()).longValue();
+
+            if (count > 0) {
+                entityManager.createNativeQuery(String.format("TRUNCATE TABLE `%s`", tableName)).executeUpdate();
+            }
         }
         setForeignKeyCheck(ON);
     }

--- a/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
+++ b/src/test/java/in/koreatech/koin/acceptance/support/DBInitializer.java
@@ -51,7 +51,7 @@ public class DBInitializer {
 
     @Transactional
     public void initIncrement() {
-        String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND AUTO_INCREMENT >= 1";
+        String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND AUTO_INCREMENT > 1";
         List<String> dirtyTables = entityManager.createNativeQuery(sql).getResultList();
         for (String tableName: dirtyTables) {
             entityManager.createNativeQuery(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", tableName)).executeUpdate();


### PR DESCRIPTION
### 🔍 개요

- DBInitializer 클래스의 initIncrement 메소드에서 AUTO_INCREMENT 초기화를 수행
    - 현재 조건이 `AUTO_INCREMENT >= 1` 로 설정되어 있어, 실제로 데이터가 삽입되지 않은 테이블까지 불필요하게 롤백
    - 이로 인해 각 테스트 메소드 종료 시마다 모든 테이블에 `ALTER TABLE %s AUTO_INCREMENT = 1` 쿼리가 실행되어 테스트 속도 저하
    - AUTO_INCREMENT 값이 1보다 큰 테이블만 대상으로 롤백하도록 로직 개선
- DBInitializer 클래스의 truncateAllTable 메소드에서 테이블 TRUNCATE 수행
    - 현재 조건이 모든 테이블에 대해 TRUNCATE를 수행
    - 이로 인해 각 테스트 클래스 종료 시 마다 모든 테이블에 `TRUNCATE TABLE` 쿼리가 실행되어 테스트 속도 저하
    - 데이터가 들어간 테이블에 대해서만 TRUNCATE 쿼리가 실행되게 하여 로직 개선
- close #1874

---

### 🚀 주요 변경 내용

### AUTO_INCREMENT >= 1 -> AUTO_INCREMENT > 1

```sql
Hibernate:
    SELECT
        TABLE_NAME
    FROM
        INFORMATION_SCHEMA.TABLES
    WHERE
        TABLE_SCHEMA = 'test'
        AND AUTO_INCREMENT >= 1
Hibernate:
    ALTER TABLE abtest AUTO_INCREMENT = 1
Hibernate:
    ALTER TABLE abtest_variable AUTO_INCREMENT = 1
Hibernate:
    ALTER TABLE access_history AUTO_INCREMENT = 1
...

```

- 각 테스트 메소드가 끝날 때 마다 다음과 같은 쿼리가 날라감
- 2025년 8월 17일 스테이지 기준으로 테이블은 총 118개, 테스트 메소드가 끝날 때 마다 `ALTER TABLE *s AUTO_INCREMENT = 1` 쿼리가 118개 날라감
- 실제 데이터가 들어간 테이블에만 쿼리가 날라가도록 쿼리 조건을 변경

```java
@Transactional
public void initIncrement() {
    String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND AUTO_INCREMENT >= 1";
    List<String> dirtyTables = entityManager.createNativeQuery(sql).getResultList();
    for (String tableName : dirtyTables) {
        entityManager.createNativeQuery(String.format("ALTER TABLE %s AUTO_INCREMENT = 1", tableName))
            .executeUpdate();
    }
}
```

### TRUNCATE 쿼리 개선

```sql
Hibernate: 
    
SET
    FOREIGN_KEY_CHECKS = 0
Hibernate: 
    TRUNCATE TABLE `abtest`
Hibernate: 
    TRUNCATE TABLE `abtest_variable`
Hibernate: 
    TRUNCATE TABLE `access_history`
Hibernate: 
    TRUNCATE TABLE `access_history_abtest_variable`
```

- 각 테스트 메소드가 끝날 때 마다 다음과 같은 쿼리가 날라감
- 2025년 8월 17일 스테이지 기준으로 테이블은 총 118개, 테스트 메소드가 끝날 때 마다 `TRUNCATE TABLE %s` 쿼리가 118개 날라감
- 실제 데이터가 들어간 테이블에만 TRUNCATE 쿼리가 날라가도록 쿼리 조건을 변경

```java
private void truncateDirtyTables() {
    if (tableNames.isEmpty()) {
        findDatabaseTableNames();
    }

    setForeignKeyCheck(OFF);
    for (String tableName : tableNames) {
        long count = ((Number) entityManager
            .createNativeQuery(String.format("SELECT COUNT(*) FROM `%s`", tableName))
            .getSingleResult()).longValue();

        if (count > 0) {
            entityManager.createNativeQuery(String.format("TRUNCATE TABLE `%s`", tableName)).executeUpdate();
        }
    }
    setForeignKeyCheck(ON);
}
```

### 중복 초기화 로직 삭제

- 일부 테스트에서 clear 메소드와 setup 메소드를 동시에 호출하는 경우가 존재
- 이로 인해 불필요한 쿼리가 중복 실행
    - setup 내부에 이미 clear 메소드가 포함되어 있음에도, 별도로 한 번 더 호출
- 중복 초기화 로직을 제거

### 결과

> 인수 테스트 + 단위 테스트를 통합해서 실행한 시간 측정

- 실행 환경
  - MacBook Air 15 (M3, 16GB, macOS Sonoma)
  - Galaxy Book3 Pro (Intel i5, 16GB, Windows 11)

- 맥 환경
  - Overall time 62% 감소, Sum time 56% 감소
<img width="665" height="105" alt="스크린샷 2025-08-17 오전 12 14 11" src="https://github.com/user-attachments/assets/de5b73f0-733f-4ae6-a845-447b0eaaa762" />
<img width="539" height="84" alt="스크린샷 2025-08-17 오전 11 47 56" src="https://github.com/user-attachments/assets/4a3e920b-bd55-42b8-a9a3-35bbd05b8cb4" />

- 윈도우 환경
  - 89% 감소
<img width="891" height="544" alt="image" src="https://github.com/user-attachments/assets/a7acdd7f-8618-44cb-af10-8078689c0a5b" />
<img width="927" height="838" alt="image (1)" src="https://github.com/user-attachments/assets/9c9ae7c4-2083-431f-bcad-a52e6fa56c35" />

- CI
  - 30% 감소
<img width="1276" height="71" alt="스크린샷 2025-08-17 오후 12 27 43" src="https://github.com/user-attachments/assets/82a4b655-7a2d-4d15-b913-0f4df9f3d4bc" />
<img width="1275" height="76" alt="스크린샷 2025-08-17 오후 12 26 52" src="https://github.com/user-attachments/assets/d62a410c-d027-4472-8e1b-e2841cd125a4" />


---

### 💬 참고 사항

---

### ✅ Checklist (완료 조건)

- [x]  코드 스타일 가이드 준수
- [x]  테스트 코드 포함됨
- [x]  Reviewers / Assignees / Labels 지정 완료
- [x]  보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)