### PR TITLE
hotfix: 키워드 알림 중복 발송 문제 해결 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -63,8 +63,6 @@ public class ArticleService {
     private final ApplicationEventPublisher eventPublisher;
     private final ArticleRepository articleRepository;
     private final BoardRepository boardRepository;
-    private final ArticleSearchKeywordIpMapRepository articleSearchKeywordIpMapRepository;
-    private final ArticleSearchKeywordRepository articleSearchKeywordRepository;
     private final HotArticleRepository hotArticleRepository;
     private final ArticleHitUserRepository articleHitUserRepository;
     private final UserRepository userRepository;

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/UserNotificationStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/UserNotificationStatus.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,15 +28,10 @@ public class UserNotificationStatus extends BaseEntity {
     private Integer userId;
 
     @Column(name = "last_notified_article_id", nullable = false)
-    private Integer lastNotifiedArticleId;
+    private Integer notifiedArticleId;
 
-    @Builder
-    public UserNotificationStatus(Integer userId, Integer lastNotifiedArticleId) {
+    public UserNotificationStatus(Integer userId, Integer notifiedArticleId) {
         this.userId = userId;
-        this.lastNotifiedArticleId = lastNotifiedArticleId;
-    }
-
-    public void updateLastNotifiedArticleId(Integer articleId) {
-        this.lastNotifiedArticleId = articleId;
+        this.notifiedArticleId = notifiedArticleId;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
@@ -9,10 +9,9 @@ import in.koreatech.koin.domain.community.keyword.model.UserNotificationStatus;
 
 public interface UserNotificationStatusRepository extends Repository<UserNotificationStatus, Integer> {
 
-    @Query("SELECT u.lastNotifiedArticleId FROM UserNotificationStatus u WHERE u.userId = :userId")
-    Optional<Integer> findLastNotifiedArticleIdByUserId(Integer userId);
+    void save(UserNotificationStatus status);
 
     Optional<UserNotificationStatus> findByUserId(Integer userId);
 
-    void save(UserNotificationStatus status);
+    boolean existsByLastNotifiedArticleIdAndUserId(Integer lastNotificationArticleId, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
@@ -13,5 +13,5 @@ public interface UserNotificationStatusRepository extends Repository<UserNotific
 
     Optional<UserNotificationStatus> findByUserId(Integer userId);
 
-    boolean existsByLastNotifiedArticleIdAndUserId(Integer lastNotificationArticleId, Integer userId);
+    boolean existsByNotifiedArticleIdAndUserId(Integer notifiedArticleId, Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -200,12 +200,7 @@ public class KeywordService {
     }
 
     @Transactional
-    public void updateLastNotifiedArticle(Integer userId, Integer articleId) {
-        UserNotificationStatus status = userNotificationStatusRepository.findByUserId(userId)
-            .orElseGet(() -> new UserNotificationStatus(userId, articleId));
-
-        status.updateLastNotifiedArticleId(articleId);
-
-        userNotificationStatusRepository.save(status);
+    public void createNotifiedArticleStatus(Integer userId, Integer articleId) {
+        userNotificationStatusRepository.save(new UserNotificationStatus(userId, articleId));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -94,7 +94,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             subscribe.getUser()
         );
 
-        keywordService.updateLastNotifiedArticle(userId, article.getId());
+        keywordService.createNotifiedArticleStatus(userId, article.getId());
         return notification;
     }
 

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -46,7 +46,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             .stream()
             .filter(this::hasDeviceToken)
             .filter(subscribe -> isKeywordRegistered(event, subscribe))
-            .filter(subscribe -> isNewArticle(event, subscribe))
+            .filter(subscribe -> isNewNotifiedArticleId(event.articleId(), subscribe))
             .filter(subscribe -> !isMyArticle(event, subscribe))
             .map(subscribe -> createAndRecordNotification(article, board, event.keyword(), subscribe))
             .toList();
@@ -64,12 +64,9 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             .anyMatch(map -> map.getUser().getId().equals(subscribe.getUser().getId()));
     }
 
-    private boolean isNewArticle(ArticleKeywordEvent event, NotificationSubscribe subscribe) {
+    private boolean isNewNotifiedArticleId(Integer articleId, NotificationSubscribe subscribe) {
         Integer userId = subscribe.getUser().getId();
-        Integer lastNotifiedId = userNotificationStatusRepository
-            .findLastNotifiedArticleIdByUserId(userId)
-            .orElse(0);
-        return !lastNotifiedId.equals(event.articleId());
+        return !userNotificationStatusRepository.existsByLastNotifiedArticleIdAndUserId(articleId, userId);
     }
 
     private boolean isMyArticle(ArticleKeywordEvent event, NotificationSubscribe subscribe) {

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -66,7 +66,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
 
     private boolean isNewNotifiedArticleId(Integer articleId, NotificationSubscribe subscribe) {
         Integer userId = subscribe.getUser().getId();
-        return !userNotificationStatusRepository.existsByLastNotifiedArticleIdAndUserId(articleId, userId);
+        return !userNotificationStatusRepository.existsByNotifiedArticleIdAndUserId(articleId, userId);
     }
 
     private boolean isMyArticle(ArticleKeywordEvent event, NotificationSubscribe subscribe) {


### PR DESCRIPTION
### 🔍 개요

* 키워드 알림 중복 발송 문제 발생
<img width="200" height="2796" alt="image" src="https://github.com/user-attachments/assets/8ecb26db-c3d4-491e-9018-d5aaa5b5fd83" />


- close #1875 

---

### 🚀 주요 변경 내용

* 아직 알림을 보내지 않은 게시글에 대해서만 알림을 보내도록 수정
  * 게시글 키워드 알림을 보낸 것을 모두 저장하도록 수정
  * 그렇기에 최신 게시글이 DB에 저장되었는지만 필터링하면 중복 방지 가능


---

### 💬 참고 사항

* 추후 eventListener의 비즈니스로직을 정리해야함


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
