### PR TITLE
refactor: 모든 상점 이벤트 조회 쿼리 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
@@ -37,6 +37,9 @@ public interface ShopRepository extends Repository<Shop, Integer> {
 
     List<Shop> findAll();
 
+    @Query("SELECT s FROM Shop s JOIN FETCH s.eventArticles e WHERE s.isDeleted = false AND e.isDeleted = false")
+    List<Shop> findAllWithEventArticles();
+
     @Query("""
         SELECT new in.koreatech.koin.domain.shop.dto.shop.ShopNotificationQueryResponse(
             s.id,

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopEventService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopEventService.java
@@ -24,7 +24,7 @@ public class ShopEventService {
     }
 
     public ShopEventsWithBannerUrlResponse getAllEvents() {
-        List<Shop> shops = shopRepository.findAll();
+        List<Shop> shops = shopRepository.findAllWithEventArticles();
         return ShopEventsWithBannerUrlResponse.of(shops, clock);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 요청이 많지 않음에도 P95 LATENCY가 높음
* 확인해보니 한번의 요청당 동일한 쿼리가 72번 발생함 

<img width="952" height="260" alt="Image" src="https://github.com/user-attachments/assets/fdc8b280-9fb5-4d80-827a-7d822ca93416" />

<img width="1299" height="309" alt="Image" src="https://github.com/user-attachments/assets/ac6d5855-0e57-412b-b058-3b6cd118e651" />

- close #1887 

---

### 🚀 주요 변경 내용

* Shop과 EventArticle이 OneToMany 관계로 Lazy로딩 되어 n+1 문제가 발생하였습니다.
* 상점 조회시 이벤트도 함꼐 조회 (fetch join)하도록 수정하였습니다.


---

### 💬 참고 사항

* Stage에서 성능 체크하여 여기에 기록하겠습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
