### PR TITLE
refactor: 상점 조회 쿼리 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
@@ -28,6 +28,12 @@ public interface ShopRepository extends Repository<Shop, Integer> {
             .orElseThrow(() -> ShopNotFoundException.withDetail("shopId: " + shopId));
     }
 
+    @Query("""
+        select s
+        from Shop s
+        left join fetch s.shopOperation op
+        where s.isDeleted = false
+    """)
     List<Shop> findAll();
 
     @Query("""

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
@@ -23,21 +23,20 @@ public interface ShopRepository extends Repository<Shop, Integer> {
 
     Optional<Shop> findById(Integer shopId);
 
-    Optional<Shop> findByOwnerId(Integer ownerId);
-
     default Shop getById(Integer shopId) {
         return findById(shopId)
             .orElseThrow(() -> ShopNotFoundException.withDetail("shopId: " + shopId));
     }
 
-    default Shop getByOwnerId(Integer ownerId) {
-        return findByOwnerId(ownerId)
-            .orElseThrow(() -> ShopNotFoundException.withDetail("ownerId: " + ownerId));
-    }
-
     List<Shop> findAll();
 
-    @Query("SELECT s FROM Shop s JOIN FETCH s.eventArticles e WHERE s.isDeleted = false AND e.isDeleted = false")
+    @Query("""
+        SELECT s FROM Shop s
+        JOIN FETCH s.eventArticles e
+        LEFT JOIN FETCH s.shopOperation op
+        LEFT JOIN FETCH s.shopMainCategory mc
+        WHERE s.isDeleted = false AND e.isDeleted = false
+    """)
     List<Shop> findAllWithEventArticles();
 
     @Query("""


### PR DESCRIPTION
### 🔍 개요

* Shop을 조회할 떄 ShopOperation 쿼리가 중복으로 발생 (이벤트 조회시 평균72번, 전체 상점 조회시 평균 15번)

<img width="1742" height="352" alt="Image" src="https://github.com/user-attachments/assets/40cad302-cf7d-4902-9604-51dd048d2cba" />

<img width="1331" height="885" alt="Image" src="https://github.com/user-attachments/assets/7379ac1a-36d0-4d0f-bf49-cb83a0498617" />

- close #1889 

---

### 🚀 주요 변경 내용

* 전체 상점 조회와 이벤트 조회시 ShopOperation 을 fetch join하여 n+1문제 방지


---

### 💬 참고 사항

* OrderableShop 클래스와의 의존성으로 임시대응함.
* 1:1 매핑의 소유측이 부모(Shop) 쪽에 치우쳐 있어(= mappedBy 기반 접근),읽기 경로에서 to-one 존재 확인/추가 SELECT 또는 과도한 조인 의존이 생김. 즉, 소유 객체의 위치가 잘못됨.
* `1:1 소유측을 자식(ShopOperation)으로 이동 + @MapsId 공유 PK` 로 수정하면서 OrderableShop 에도 영향없게 수정하는 방향 @DHkimgit @ImTotem 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
