### PR TITLE
feat: ClubCategoryService, ClubService 단위 테스트 추가 (1차)

### DIFF
--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubCategoryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubCategoryServiceTest.java
@@ -1,0 +1,58 @@
+package in.koreatech.koin.unit.domain.club.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.domain.club.dto.response.ClubCategoriesResponse;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+import in.koreatech.koin.domain.club.repository.ClubCategoryRepository;
+import in.koreatech.koin.domain.club.service.ClubCategoryService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubCategoryServiceTest {
+
+    @Mock
+    private ClubCategoryRepository clubCategoryRepository;
+
+    @InjectMocks
+    private ClubCategoryService clubCategoryService;
+
+    @Test
+    void 동아리의_모든_카테고리를_조회한다() {
+        // given
+        List<ClubCategory> clubCategories = List.of(
+            ClubCategory.builder()
+                .id(1)
+                .name("학술")
+                .build(),
+            ClubCategory.builder()
+                .id(2)
+                .name("운동")
+                .build()
+        );
+        when(clubCategoryRepository.findAll()).thenReturn(clubCategories);
+
+        // when
+        ClubCategoriesResponse response = clubCategoryService.getClubCategories();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.clubCategories()).hasSize(2);
+
+        assertThat(response.clubCategories().get(0).id()).isEqualTo(1);
+        assertThat(response.clubCategories().get(0).name()).isEqualTo("학술");
+
+        assertThat(response.clubCategories().get(1).id()).isEqualTo(2);
+        assertThat(response.clubCategories().get(1).name()).isEqualTo("운동");
+
+        verify(clubCategoryRepository).findAll();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
@@ -81,7 +81,7 @@ public class ClubServiceTest {
     @Mock private ClubEventRepository clubEventRepository;
     @Mock private ClubEventImageRepository clubEventImageRepository;
     @Mock private ClubEventSubscriptionRepository clubEventSubscriptionRepository;
-    
+
     @InjectMocks private ClubService clubService;
 
     @Nested
@@ -264,6 +264,7 @@ public class ClubServiceTest {
 
         @Test
         void 활성화된_동아리를_상세_조회한다() {
+            // given
             Club club = ClubFixture.활성화_BCSD_동아리(1);
 
             List<ClubSNS> snsList = List.of(
@@ -315,9 +316,11 @@ public class ClubServiceTest {
 
         @Test
         void 비활성화된_동아리를_상세_조회_시_예외를_발생한다() {
+            // given
             Club club = ClubFixture.비활성화_BCSD_동아리(1);
             when(clubRepository.getById(clubId)).thenReturn(club);
 
+            // when / then
             assertThatThrownBy(() -> clubService.getClub(clubId, studentId))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("비활성화 동아리입니다.");
@@ -351,7 +354,8 @@ public class ClubServiceTest {
                 ClubBaseInfoFixture.동아리_기본_정보(3, "테스트3", "공연", ClubRecruitmentStatus.NONE)
             );
 
-            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId))
+                .thenReturn(clubBaseInfos);
 
             // when
             ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
@@ -373,10 +377,13 @@ public class ClubServiceTest {
             query = null;
             userId = 1;
 
-            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId))
+                .thenReturn(clubBaseInfos);
 
             // when
-            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            ClubsByCategoryResponse response = clubService.getClubByCategory(
+                categoryId, isRecruiting, sortType, query, userId
+            );
 
             // then
             assertThat(response.clubs())
@@ -390,21 +397,23 @@ public class ClubServiceTest {
             // given
             List<ClubBaseInfo> clubBaseInfos = List.of(
                 ClubBaseInfoFixture.동아리_기본_정보(1, "BCSD Lab", "학술", ClubRecruitmentStatus.RECRUITING)
-
             );
 
             query = "Lab";
 
-            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId))
+                .thenReturn(clubBaseInfos);
 
             // when
-            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            ClubsByCategoryResponse response = clubService.getClubByCategory(
+                categoryId, isRecruiting, sortType, query, userId
+            );
 
             // then
             assertThat(response.clubs())
                 .hasSize(1)
                 .extracting("name")
-                .anyMatch(name -> ((String) name).toLowerCase().contains(query.toLowerCase()));
+                .anyMatch(name -> ((String)name).toLowerCase().contains(query.toLowerCase()));
         }
 
         @Test
@@ -417,10 +426,13 @@ public class ClubServiceTest {
 
             isRecruiting = true;
 
-            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId))
+                .thenReturn(clubBaseInfos);
 
             // when
-            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            ClubsByCategoryResponse response = clubService.getClubByCategory(
+                categoryId, isRecruiting, sortType, query, userId
+            );
 
             // then
             assertThat(response.clubs())
@@ -441,7 +453,7 @@ public class ClubServiceTest {
             assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType1, query, userId))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
-                    CustomException ce = (CustomException) ex;
+                    CustomException ce = (CustomException)ex;
                     assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
                     assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
                 });
@@ -449,7 +461,7 @@ public class ClubServiceTest {
             assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType2, query, userId))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
-                    CustomException ce = (CustomException) ex;
+                    CustomException ce = (CustomException)ex;
                     assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
                     assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
                 });

--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
@@ -25,6 +25,7 @@ import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
 import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
 import in.koreatech.koin.domain.club.dto.response.ClubResponse;
 import in.koreatech.koin.domain.club.dto.response.ClubsByCategoryResponse;
+import in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus;
 import in.koreatech.koin.domain.club.enums.ClubSortType;
 import in.koreatech.koin.domain.club.enums.SNSType;
 import in.koreatech.koin.domain.club.model.Club;
@@ -55,6 +56,7 @@ import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.global.code.ApiResponseCode;
 import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.unit.fixture.ClubBaseInfoFixture;
 import in.koreatech.koin.unit.fixture.ClubFixture;
 
 @ExtendWith(MockitoExtension.class)
@@ -152,7 +154,7 @@ public class ClubServiceTest {
 
             clubId = 1;
             studentId = 1;
-            club = ClubFixture.활성화_BCSD_동아리();
+            club = ClubFixture.활성화_BCSD_동아리(1);
         }
 
         @Test
@@ -217,7 +219,7 @@ public class ClubServiceTest {
             request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
             clubId = 1;
             studentId = 1;
-            club = ClubFixture.활성화_BCSD_동아리();
+            club = ClubFixture.활성화_BCSD_동아리(1);
         }
 
         @Test
@@ -262,7 +264,7 @@ public class ClubServiceTest {
 
         @Test
         void 활성화된_동아리를_상세_조회한다() {
-            Club club = ClubFixture.활성화_BCSD_동아리();
+            Club club = ClubFixture.활성화_BCSD_동아리(1);
 
             List<ClubSNS> snsList = List.of(
                 new ClubSNS(club, SNSType.INSTAGRAM, "https://instagram.com/bcsdlab")
@@ -313,7 +315,7 @@ public class ClubServiceTest {
 
         @Test
         void 비활성화된_동아리를_상세_조회_시_예외를_발생한다() {
-            Club club = ClubFixture.비활성화_BCSD_동아리();
+            Club club = ClubFixture.비활성화_BCSD_동아리(1);
             when(clubRepository.getById(clubId)).thenReturn(club);
 
             assertThatThrownBy(() -> clubService.getClub(clubId, studentId))
@@ -344,30 +346,9 @@ public class ClubServiceTest {
         void 모든_동아리를_조회한다() {
             // given
             List<ClubBaseInfo> clubBaseInfos = List.of(
-                new ClubBaseInfo(
-                    1,
-                    "BCSD Lab",
-                    "학술",
-                    100,
-                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                    true,
-                    false,
-                    LocalDate.now().minusDays(1),
-                    LocalDate.now(),
-                    false
-                ),
-                new ClubBaseInfo(
-                    2,
-                    "테스트",
-                    "테스트",
-                    100,
-                    "https://example.com/static/img/logo.png",
-                    true,
-                    false,
-                    LocalDate.now().minusDays(1),
-                    LocalDate.now(),
-                    false
-                )
+                ClubBaseInfoFixture.동아리_기본_정보(1, "테스트1", "학술", ClubRecruitmentStatus.RECRUITING),
+                ClubBaseInfoFixture.동아리_기본_정보(2, "테스트2", "운동", ClubRecruitmentStatus.ALWAYS),
+                ClubBaseInfoFixture.동아리_기본_정보(3, "테스트3", "공연", ClubRecruitmentStatus.NONE)
             );
 
             when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
@@ -376,25 +357,14 @@ public class ClubServiceTest {
             ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
 
             // then
-            assertThat(response.clubs()).hasSize(2);
+            assertThat(response.clubs()).hasSize(3);
         }
 
         @Test
         void 특정_카테고리를_지닌_모든_동아리를_조회한다() {
             // given
             List<ClubBaseInfo> clubBaseInfos = List.of(
-                new ClubBaseInfo(
-                    1,
-                    "BCSD Lab",
-                    "학술",
-                    100,
-                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                    true,
-                    false,
-                    LocalDate.now().minusDays(1),
-                    LocalDate.now(),
-                    false
-                )
+                ClubBaseInfoFixture.동아리_기본_정보(1, "테스트1", "학술", ClubRecruitmentStatus.RECRUITING)
             );
 
             categoryId = 1;
@@ -419,18 +389,8 @@ public class ClubServiceTest {
         void query_내용을_지닌_모든_동아리를_조회한다() {
             // given
             List<ClubBaseInfo> clubBaseInfos = List.of(
-                new ClubBaseInfo(
-                    1,
-                    "BCSD Lab",
-                    "학술",
-                    100,
-                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                    true,
-                    false,
-                    LocalDate.now().minusDays(1),
-                    LocalDate.now(),
-                    false
-                )
+                ClubBaseInfoFixture.동아리_기본_정보(1, "BCSD Lab", "학술", ClubRecruitmentStatus.RECRUITING)
+
             );
 
             query = "Lab";
@@ -451,30 +411,8 @@ public class ClubServiceTest {
         void 인원_모집중인_모든_동아리를_조회한다() {
             // given
             List<ClubBaseInfo> clubBaseInfos = List.of(
-                new ClubBaseInfo(
-                    1,
-                    "BCSD Lab",
-                    "학술",
-                    100,
-                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                    true,
-                    false,
-                    null,
-                    null,
-                    true
-                ),
-                new ClubBaseInfo(
-                    2,
-                    "테스트",
-                    "테스트",
-                    100,
-                    "https://example.com/static/img/logo.png",
-                    true,
-                    false,
-                    LocalDate.now().minusDays(1),
-                    LocalDate.now(),
-                    false
-                )
+                ClubBaseInfoFixture.동아리_기본_정보(1, "테스트1", "학술", ClubRecruitmentStatus.RECRUITING),
+                ClubBaseInfoFixture.동아리_기본_정보(2, "테스트2", "학술", ClubRecruitmentStatus.ALWAYS)
             );
 
             isRecruiting = true;

--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
@@ -9,6 +9,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -80,424 +82,439 @@ public class ClubServiceTest {
     
     @InjectMocks private ClubService clubService;
 
-    @Test
-    void 동아리_생성_요청을_처리한다() {
-        // given
-        ClubCreateRequest request = new ClubCreateRequest(
-            "BCSD",
-            "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-            List.of(new ClubCreateRequest.InnerClubManagerRequest("bcsdlab")),
-            1,
-            "학생회관",
-            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
-            "https://www.instagram.com/bcsdlab/",
-            "https://forms.gle/example",
-            "https://open.kakao.com/example",
-            "01012345678",
-            "회장",
-            false
-        );
+    @Nested
+    class createClubRequest {
 
-        Integer studentId = 1;
+        ClubCreateRequest request;
+        Integer studentId;
 
-        // when
-        clubService.createClubRequest(request, studentId);
-
-        // then
-        ArgumentCaptor<ClubCreateRedis> redisCaptor = ArgumentCaptor.forClass(ClubCreateRedis.class);
-        verify(clubCreateRedisRepository).save(redisCaptor.capture());
-
-        ArgumentCaptor<ClubCreateEvent> eventCaptor = ArgumentCaptor.forClass(ClubCreateEvent.class);
-        verify(eventPublisher).publishEvent(eventCaptor.capture());
-    }
-
-    @Test
-    void 동아리_관리자가_정보_수정_요청을_보낸_경우_정상적으로_처리한다() {
-        // given
-        ClubUpdateRequest request = new ClubUpdateRequest(
-            "Updated BCSD",
-            "https://bcsdlab.com/static/img/new_logo.png",
-            2,
-            "2공학관",
-            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
-            "https://www.instagram.com/bcsdlab/",
-            "https://forms.gle/example",
-            "https://open.kakao.com/example",
-            "01012345678",
-            false
-        );
-
-        ClubCategory newCategory = ClubCategory.builder()
-            .id(2)
-            .name("문화")
-            .build();
-
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.활성화_BCSD_동아리();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubCategoryRepository.getById(request.clubCategoryId())).thenReturn(newCategory);
-        when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-
-        // when
-        ClubResponse response = clubService.updateClub(clubId, request, studentId);
-
-        // then (club 객체 상태 검증)
-        assertThat(club.getName()).isEqualTo(request.name());
-        assertThat(club.getImageUrl()).isEqualTo(request.imageUrl());
-        assertThat(club.getClubCategory()).isEqualTo(newCategory);
-        assertThat(club.getLocation()).isEqualTo(request.location());
-        assertThat(club.getDescription()).isEqualTo(request.description());
-        assertThat(club.getIsLikeHidden()).isEqualTo(request.isLikeHidden());
-
-        // then (response 상태 검증)
-        assertThat(response.name()).isEqualTo(request.name());
-        assertThat(response.imageUrl()).isEqualTo(request.imageUrl());
-        assertThat(response.category()).isEqualTo(newCategory.getName());
-        assertThat(response.location()).isEqualTo(request.location());
-        assertThat(response.description()).isEqualTo(request.description());
-        assertThat(response.isLikeHidden()).isEqualTo(request.isLikeHidden());
-        assertThat(response.isLiked()).isTrue();
-        assertThat(response.isRecruitSubscribed()).isTrue();
-        assertThat(response.manager()).isTrue();
-        assertThat(response.instagram()).contains(request.instagram());
-        assertThat(response.googleForm()).contains(request.googleForm());
-        assertThat(response.openChat()).contains(request.openChat());
-        assertThat(response.phoneNumber()).contains(request.phoneNumber());
-    }
-
-    @Test
-    void 동아리_관리자가_아닌_유저가_정보_수정_요청을_보낸_경우_예외를_발생한다() {
-        // given
-        ClubUpdateRequest request = new ClubUpdateRequest(
-            "Updated BCSD",
-            "https://bcsdlab.com/static/img/new_logo.png",
-            2,
-            "2공학관",
-            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
-            "https://www.instagram.com/bcsdlab/",
-            "https://forms.gle/example",
-            "https://open.kakao.com/example",
-            "01012345678",
-            false
-        );
-
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.활성화_BCSD_동아리();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
-
-        // when / then
-        assertThatThrownBy(() -> clubService.updateClub(clubId, request, studentId))
-            .isInstanceOf(AuthorizationException.class)
-            .hasMessageContaining("권한이 없습니다.");
-    }
-
-    @Test
-    void 동아리_관리자가_동아리_소개_수정_요청을_보낸_경우_정상적으로_처리한다() {
-        // given
-        ClubIntroductionUpdateRequest request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
-
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.활성화_BCSD_동아리();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-
-        // when
-        ClubResponse response = clubService.updateClubIntroduction(clubId, request, studentId);
-
-        // then
-        assertThat(response.introduction()).isEqualTo(request.introduction());
-    }
-
-    @Test
-    void 동아리_관리자가_아닌_유저가_동아리_소개_수정_요청을_보낸_경우_예외를_발생한다() {
-        // given
-        ClubIntroductionUpdateRequest request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
-
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.활성화_BCSD_동아리();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
-
-        // when / then
-        assertThatThrownBy(() -> clubService.updateClubIntroduction(clubId, request, studentId))
-            .isInstanceOf(AuthorizationException.class)
-            .hasMessageContaining("권한이 없습니다.");
-    }
-
-    @Test
-    void 활성화된_동아리를_상세_조회한다() {
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.활성화_BCSD_동아리();
-
-        List<ClubSNS> snsList = List.of(
-            new ClubSNS(club, SNSType.INSTAGRAM, "https://instagram.com/bcsdlab")
-        );
-
-        ClubHot clubHot1 = ClubHot.builder()
-            .id(1)
-            .club(club)
-            .ranking(1)
-            .periodHits(100)
-            .startDate(LocalDate.of(2025, 8, 21))
-            .endDate(LocalDate.of(2025, 8, 21))
-            .build();
-
-        ClubHot clubHot2 = ClubHot.builder()
-            .id(2)
-            .club(club)
-            .ranking(1)
-            .periodHits(150)
-            .startDate(LocalDate.of(2025, 8, 28))
-            .endDate(LocalDate.of(2025, 8, 28))
-            .build();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-        when(clubSNSRepository.findAllByClub(club)).thenReturn(snsList);
-        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
-        when(clubHotRepository.findTopByClubIdOrderByIdDesc(clubId)).thenReturn(Optional.of(clubHot2));
-        when(clubHotRepository.findAllByOrderByIdDesc()).thenReturn(List.of(clubHot2, clubHot1));
-
-        // when
-        ClubResponse response = clubService.getClub(clubId, studentId);
-
-        // then
-        assertThat(response.name()).isEqualTo(club.getName());
-        assertThat(response.manager()).isTrue();
-        assertThat(response.isLiked()).isTrue();
-        assertThat(response.isRecruitSubscribed()).isTrue();
-
-        assertThat(response.hotStatus()).isNotNull();
-        assertThat(response.hotStatus().month()).isEqualTo(8);
-        assertThat(response.hotStatus().weekOfMonth()).isEqualTo(4);
-        assertThat(response.hotStatus().streakCount()).isEqualTo(2);
-
-        verify(clubHitsRedisRepository).incrementHits(clubId);
-    }
-
-    @Test
-    void 비활성화된_동아리를_상세_조회_시_예외를_발생한다() {
-        // given
-        Integer clubId = 1;
-        Integer studentId = 1;
-        Club club = ClubFixture.비활성화_BCSD_동아리();
-
-        when(clubRepository.getById(clubId)).thenReturn(club);
-
-        // when / then
-        assertThatThrownBy(() -> clubService.getClub(clubId, studentId))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("비활성화 동아리입니다.");
-    }
-
-    @Test
-    void 모든_동아리를_조회한다() {
-        // given
-        List<ClubBaseInfo> clubBaseInfos = List.of(
-            new ClubBaseInfo(
-                1,
-                "BCSD Lab",
-                "학술",
-                100,
+        @BeforeEach
+        void init() {
+            request = new ClubCreateRequest(
+                "BCSD",
                 "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                true,
-                false,
-                LocalDate.now().minusDays(1),
-                LocalDate.now(),
+                List.of(new ClubCreateRequest.InnerClubManagerRequest("bcsdlab")),
+                1,
+                "학생회관",
+                "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
+                "https://www.instagram.com/bcsdlab/",
+                "https://forms.gle/example",
+                "https://open.kakao.com/example",
+                "01012345678",
+                "회장",
                 false
+            );
+            studentId = 1;
+        }
+
+        @Test
+        void 동아리_생성_요청을_처리한다() {
+            // when
+            clubService.createClubRequest(request, studentId);
+
+            // then
+            ArgumentCaptor<ClubCreateRedis> redisCaptor = ArgumentCaptor.forClass(ClubCreateRedis.class);
+            verify(clubCreateRedisRepository).save(redisCaptor.capture());
+
+            ArgumentCaptor<ClubCreateEvent> eventCaptor = ArgumentCaptor.forClass(ClubCreateEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+        }
+    }
+
+    @Nested
+    class updateClub {
+
+        ClubUpdateRequest request;
+        ClubCategory newCategory;
+        Integer clubId;
+        Integer studentId;
+        Club club;
+
+        @BeforeEach
+        void init() {
+            request = new ClubUpdateRequest(
+                "Updated BCSD",
+                "https://bcsdlab.com/static/img/new_logo.png",
+                2,
+                "2공학관",
+                "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
+                "https://www.instagram.com/bcsdlab/",
+                "https://forms.gle/example",
+                "https://open.kakao.com/example",
+                "01012345678",
+                false
+            );
+
+            newCategory = ClubCategory.builder()
+                .id(2)
+                .name("문화")
+                .build();
+
+            clubId = 1;
+            studentId = 1;
+            club = ClubFixture.활성화_BCSD_동아리();
+        }
+
+        @Test
+        void 동아리_관리자가_정보_수정_요청을_보낸_경우_정상적으로_처리한다() {
+            // given
+            when(clubRepository.getById(clubId)).thenReturn(club);
+            when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubCategoryRepository.getById(request.clubCategoryId())).thenReturn(newCategory);
+            when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+
+            // when
+            ClubResponse response = clubService.updateClub(clubId, request, studentId);
+
+            // then (club 객체 상태 검증)
+            assertThat(club.getName()).isEqualTo(request.name());
+            assertThat(club.getImageUrl()).isEqualTo(request.imageUrl());
+            assertThat(club.getClubCategory()).isEqualTo(newCategory);
+            assertThat(club.getLocation()).isEqualTo(request.location());
+            assertThat(club.getDescription()).isEqualTo(request.description());
+            assertThat(club.getIsLikeHidden()).isEqualTo(request.isLikeHidden());
+
+            // then (response 상태 검증)
+            assertThat(response.name()).isEqualTo(request.name());
+            assertThat(response.imageUrl()).isEqualTo(request.imageUrl());
+            assertThat(response.category()).isEqualTo(newCategory.getName());
+            assertThat(response.location()).isEqualTo(request.location());
+            assertThat(response.description()).isEqualTo(request.description());
+            assertThat(response.isLikeHidden()).isEqualTo(request.isLikeHidden());
+            assertThat(response.isLiked()).isTrue();
+            assertThat(response.isRecruitSubscribed()).isTrue();
+            assertThat(response.manager()).isTrue();
+            assertThat(response.instagram()).contains(request.instagram());
+            assertThat(response.googleForm()).contains(request.googleForm());
+            assertThat(response.openChat()).contains(request.openChat());
+            assertThat(response.phoneNumber()).contains(request.phoneNumber());
+        }
+
+        @Test
+        void 동아리_관리자가_아닌_유저가_정보_수정_요청을_보낸_경우_예외를_발생한다() {
+            // given
+            when(clubRepository.getById(clubId)).thenReturn(club);
+            when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
+
+            // when / then
+            assertThatThrownBy(() -> clubService.updateClub(clubId, request, studentId))
+                .isInstanceOf(AuthorizationException.class)
+                .hasMessageContaining("권한이 없습니다.");
+        }
+    }
+
+    @Nested
+    class updateClubIntroduction {
+
+        ClubIntroductionUpdateRequest request;
+        Integer clubId;
+        Integer studentId;
+        Club club;
+
+        @BeforeEach
+        void init() {
+            request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
+            clubId = 1;
+            studentId = 1;
+            club = ClubFixture.활성화_BCSD_동아리();
+        }
+
+        @Test
+        void 동아리_관리자가_동아리_소개_수정_요청을_보낸_경우_정상적으로_처리한다() {
+            // given
+            when(clubRepository.getById(clubId)).thenReturn(club);
+            when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+
+            // when
+            ClubResponse response = clubService.updateClubIntroduction(clubId, request, studentId);
+
+            // then
+            assertThat(response.introduction()).isEqualTo(request.introduction());
+        }
+
+        @Test
+        void 동아리_관리자가_아닌_유저가_동아리_소개_수정_요청을_보낸_경우_예외를_발생한다() {
+            // given
+            when(clubRepository.getById(clubId)).thenReturn(club);
+            when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
+
+            // when / then
+            assertThatThrownBy(() -> clubService.updateClubIntroduction(clubId, request, studentId))
+                .isInstanceOf(AuthorizationException.class)
+                .hasMessageContaining("권한이 없습니다.");
+        }
+    }
+
+    @Nested
+    class getClub {
+
+        Integer clubId;
+        Integer studentId;
+
+        @BeforeEach
+        void init() {
+            clubId = 1;
+            studentId = 1;
+        }
+
+        @Test
+        void 활성화된_동아리를_상세_조회한다() {
+            Club club = ClubFixture.활성화_BCSD_동아리();
+
+            List<ClubSNS> snsList = List.of(
+                new ClubSNS(club, SNSType.INSTAGRAM, "https://instagram.com/bcsdlab")
+            );
+
+            ClubHot clubHot1 = ClubHot.builder()
+                .id(1)
+                .club(club)
+                .ranking(1)
+                .periodHits(100)
+                .startDate(LocalDate.of(2025, 8, 21))
+                .endDate(LocalDate.of(2025, 8, 21))
+                .build();
+
+            ClubHot clubHot2 = ClubHot.builder()
+                .id(2)
+                .club(club)
+                .ranking(1)
+                .periodHits(150)
+                .startDate(LocalDate.of(2025, 8, 28))
+                .endDate(LocalDate.of(2025, 8, 28))
+                .build();
+
+            when(clubRepository.getById(clubId)).thenReturn(club);
+            when(clubSNSRepository.findAllByClub(club)).thenReturn(snsList);
+            when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+            when(clubHotRepository.findTopByClubIdOrderByIdDesc(clubId)).thenReturn(Optional.of(clubHot2));
+            when(clubHotRepository.findAllByOrderByIdDesc()).thenReturn(List.of(clubHot2, clubHot1));
+
+            // when
+            ClubResponse response = clubService.getClub(clubId, studentId);
+
+            // then
+            assertThat(response.name()).isEqualTo(club.getName());
+            assertThat(response.manager()).isTrue();
+            assertThat(response.isLiked()).isTrue();
+            assertThat(response.isRecruitSubscribed()).isTrue();
+
+            assertThat(response.hotStatus()).isNotNull();
+            assertThat(response.hotStatus().month()).isEqualTo(8);
+            assertThat(response.hotStatus().weekOfMonth()).isEqualTo(4);
+            assertThat(response.hotStatus().streakCount()).isEqualTo(2);
+
+            verify(clubHitsRedisRepository).incrementHits(clubId);
+        }
+
+        @Test
+        void 비활성화된_동아리를_상세_조회_시_예외를_발생한다() {
+            Club club = ClubFixture.비활성화_BCSD_동아리();
+            when(clubRepository.getById(clubId)).thenReturn(club);
+
+            assertThatThrownBy(() -> clubService.getClub(clubId, studentId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("비활성화 동아리입니다.");
+        }
+    }
+
+    @Nested
+    class getClubByCategory {
+
+        Integer categoryId;
+        Boolean isRecruiting;
+        ClubSortType sortType;
+        String query;
+        Integer userId;
+
+        @BeforeEach
+        void init() {
+            categoryId = null;
+            isRecruiting = false;
+            sortType = ClubSortType.CREATED_AT_ASC;
+            query = null;
+            userId = 1;
+        }
+
+        @Test
+        void 모든_동아리를_조회한다() {
+            // given
+            List<ClubBaseInfo> clubBaseInfos = List.of(
+                new ClubBaseInfo(
+                    1,
+                    "BCSD Lab",
+                    "학술",
+                    100,
+                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+                    true,
+                    false,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now(),
+                    false
                 ),
-            new ClubBaseInfo(
-                2,
-                "테스트",
-                "테스트",
-                100,
-                "https://example.com/static/img/logo.png",
-                true,
-                false,
-                LocalDate.now().minusDays(1),
-                LocalDate.now(),
-                false
-            )
-        );
+                new ClubBaseInfo(
+                    2,
+                    "테스트",
+                    "테스트",
+                    100,
+                    "https://example.com/static/img/logo.png",
+                    true,
+                    false,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now(),
+                    false
+                )
+            );
 
-        Integer categoryId = null;
-        Boolean isRecruiting = false;
-        ClubSortType sortType = ClubSortType.CREATED_AT_ASC;
-        String query = null;
-        Integer userId = 1;
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
 
-        when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            // when
+            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
 
-        // when
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            // then
+            assertThat(response.clubs()).hasSize(2);
+        }
 
-        // then
-        assertThat(response.clubs()).hasSize(2);
-    }
+        @Test
+        void 특정_카테고리를_지닌_모든_동아리를_조회한다() {
+            // given
+            List<ClubBaseInfo> clubBaseInfos = List.of(
+                new ClubBaseInfo(
+                    1,
+                    "BCSD Lab",
+                    "학술",
+                    100,
+                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+                    true,
+                    false,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now(),
+                    false
+                )
+            );
 
-    @Test
-    void 특정_카테고리를_지닌_모든_동아리를_조회한다() {
-        // given
-        List<ClubBaseInfo> clubBaseInfos = List.of(
-            new ClubBaseInfo(
-                1,
-                "BCSD Lab",
-                "학술",
-                100,
-                "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                true,
-                false,
-                LocalDate.now().minusDays(1),
-                LocalDate.now(),
-                false
-            )
-        );
+            categoryId = 1;
+            isRecruiting = false;
+            sortType = ClubSortType.CREATED_AT_ASC;
+            query = null;
+            userId = 1;
 
-        Integer categoryId = 1;
-        Boolean isRecruiting = false;
-        ClubSortType sortType = ClubSortType.CREATED_AT_ASC;
-        String query = null;
-        Integer userId = 1;
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
 
-        when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            // when
+            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
 
-        // when
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            // then
+            assertThat(response.clubs())
+                .hasSize(1)
+                .extracting("category")
+                .containsExactly("학술");
+        }
 
-        // then
-        assertThat(response.clubs())
-            .hasSize(1)
-            .extracting("category")
-            .containsExactly("학술");
-    }
+        @Test
+        void query_내용을_지닌_모든_동아리를_조회한다() {
+            // given
+            List<ClubBaseInfo> clubBaseInfos = List.of(
+                new ClubBaseInfo(
+                    1,
+                    "BCSD Lab",
+                    "학술",
+                    100,
+                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+                    true,
+                    false,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now(),
+                    false
+                )
+            );
 
-    @Test
-    void query_내용을_지닌_모든_동아리를_조회한다() {
-        // given
-        List<ClubBaseInfo> clubBaseInfos = List.of(
-            new ClubBaseInfo(
-                1,
-                "BCSD Lab",
-                "학술",
-                100,
-                "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                true,
-                false,
-                LocalDate.now().minusDays(1),
-                LocalDate.now(),
-                false
-            )
-        );
+            query = "Lab";
 
-        Integer categoryId = null;
-        Boolean isRecruiting = false;
-        ClubSortType sortType = ClubSortType.CREATED_AT_ASC;
-        String query = "Lab";
-        Integer userId = 1;
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
 
-        when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            // when
+            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
 
-        // when
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            // then
+            assertThat(response.clubs())
+                .hasSize(1)
+                .extracting("name")
+                .anyMatch(name -> ((String) name).toLowerCase().contains(query.toLowerCase()));
+        }
 
-        // then
-        assertThat(response.clubs())
-            .hasSize(1)
-            .extracting("name")
-            .anyMatch(name -> ((String) name).toLowerCase().contains(query.toLowerCase()));
-    }
+        @Test
+        void 인원_모집중인_모든_동아리를_조회한다() {
+            // given
+            List<ClubBaseInfo> clubBaseInfos = List.of(
+                new ClubBaseInfo(
+                    1,
+                    "BCSD Lab",
+                    "학술",
+                    100,
+                    "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+                    true,
+                    false,
+                    null,
+                    null,
+                    true
+                ),
+                new ClubBaseInfo(
+                    2,
+                    "테스트",
+                    "테스트",
+                    100,
+                    "https://example.com/static/img/logo.png",
+                    true,
+                    false,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now(),
+                    false
+                )
+            );
 
-    @Test
-    void 인원_모집중인_모든_동아리를_조회한다() {
-        // given
-        List<ClubBaseInfo> clubBaseInfos = List.of(
-            new ClubBaseInfo(
-                1,
-                "BCSD Lab",
-                "학술",
-                100,
-                "https://bcsdlab.com/static/img/logo.d89d9cc.png",
-                true,
-                false,
-                null,
-                null,
-                true
-            ),
-            new ClubBaseInfo(
-                2,
-                "테스트",
-                "테스트",
-                100,
-                "https://example.com/static/img/logo.png",
-                true,
-                false,
-                LocalDate.now().minusDays(1),
-                LocalDate.now(),
-                false
-            )
-        );
+            isRecruiting = true;
 
-        Integer categoryId = null;
-        Boolean isRecruiting = true;
-        ClubSortType sortType = ClubSortType.CREATED_AT_ASC;
-        String query = null;
-        Integer userId = 1;
+            when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
 
-        when(clubListQueryRepository.findAllClubInfo(categoryId, sortType, isRecruiting, query, userId)).thenReturn(clubBaseInfos);
+            // when
+            ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
 
-        // when
-        ClubsByCategoryResponse response = clubService.getClubByCategory(categoryId, isRecruiting, sortType, query, userId);
+            // then
+            assertThat(response.clubs())
+                .hasSize(2)
+                .extracting("recruitmentInfo")
+                .extracting("status")
+                .containsAnyOf("ALWAYS", "RECRUITING");
+        }
 
-        // then
-        assertThat(response.clubs())
-            .hasSize(2)
-            .extracting("recruitmentInfo")
-            .extracting("status")
-            .containsAnyOf("ALWAYS", "RECRUITING");
-    }
+        @Test
+        void 동아리_모집_관련_정렬이지만_모집중이_아닌_옵션을_선택_시_예외를_발생한다() {
+            // given
+            isRecruiting = false;
+            ClubSortType sortType1 = ClubSortType.RECRUITING_DEADLINE_ASC;
+            ClubSortType sortType2 = ClubSortType.RECRUITMENT_UPDATED_DESC;
 
-    @Test
-    void 동아리_모집_관련_정렬이지만_모집중이_아닌_옵션을_선택_시_예외를_발생한다() {
-        // given
-        Integer categoryId = null;
-        Boolean isRecruiting = false;
-        ClubSortType sortType1 = ClubSortType.RECRUITING_DEADLINE_ASC;
-        ClubSortType sortType2 = ClubSortType.RECRUITMENT_UPDATED_DESC;
-        String query = null;
-        Integer userId = 1;
+            // when / then
+            assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType1, query, userId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException ce = (CustomException) ex;
+                    assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
+                    assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
+                });
 
-        // when / then
-        assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType1, query, userId))
-            .isInstanceOf(CustomException.class)
-            .satisfies(ex -> {
-                CustomException ce = (CustomException) ex;
-                assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
-                assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
-            });
-
-        assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType2, query, userId))
-            .isInstanceOf(CustomException.class)
-            .satisfies(ex -> {
-                CustomException ce = (CustomException) ex;
-                assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
-                assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
-            });
+            assertThatThrownBy(() -> clubService.getClubByCategory(categoryId, isRecruiting, sortType2, query, userId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException ce = (CustomException) ex;
+                    assertThat(ce.getErrorCode()).isEqualTo(ApiResponseCode.NOT_ALLOWED_RECRUITING_SORT_TYPE);
+                    assertThat(ce.getMessage()).contains("해당 정렬 방식은 모집 중일 때만 사용할 수 있습니다.");
+                });
+        }
     }
 }
-
-

--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
@@ -1,0 +1,95 @@
+package in.koreatech.koin.unit.domain.club.service;
+
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import in.koreatech.koin.common.event.ClubCreateEvent;
+import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
+import in.koreatech.koin.domain.club.model.redis.ClubCreateRedis;
+import in.koreatech.koin.domain.club.repository.ClubCategoryRepository;
+import in.koreatech.koin.domain.club.repository.ClubEventImageRepository;
+import in.koreatech.koin.domain.club.repository.ClubEventRepository;
+import in.koreatech.koin.domain.club.repository.ClubEventSubscriptionRepository;
+import in.koreatech.koin.domain.club.repository.ClubHotRepository;
+import in.koreatech.koin.domain.club.repository.ClubLikeRepository;
+import in.koreatech.koin.domain.club.repository.ClubListQueryRepository;
+import in.koreatech.koin.domain.club.repository.ClubManagerRepository;
+import in.koreatech.koin.domain.club.repository.ClubQnaRepository;
+import in.koreatech.koin.domain.club.repository.ClubRecruitmentRepository;
+import in.koreatech.koin.domain.club.repository.ClubRecruitmentSubscriptionRepository;
+import in.koreatech.koin.domain.club.repository.ClubRepository;
+import in.koreatech.koin.domain.club.repository.ClubSNSRepository;
+import in.koreatech.koin.domain.club.repository.redis.ClubCreateRedisRepository;
+import in.koreatech.koin.domain.club.repository.redis.ClubHitsRedisRepository;
+import in.koreatech.koin.domain.club.repository.redis.ClubHotRedisRepository;
+import in.koreatech.koin.domain.club.service.ClubService;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ClubServiceTest {
+
+    @Mock private ClubHotRedisRepository hotClubRedisRepository;
+    @Mock private ClubHotRepository clubHotRepository;
+    @Mock private ClubQnaRepository clubQnaRepository;
+    @Mock private ClubRepository clubRepository;
+    @Mock private StudentRepository studentRepository;
+    @Mock private ClubManagerRepository clubManagerRepository;
+    @Mock private ClubCategoryRepository clubCategoryRepository;
+    @Mock private ClubSNSRepository clubSNSRepository;
+    @Mock private ClubLikeRepository clubLikeRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ClubCreateRedisRepository clubCreateRedisRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private ClubHitsRedisRepository clubHitsRedisRepository;
+    @Mock private ClubRecruitmentRepository clubRecruitmentRepository;
+    @Mock private ClubListQueryRepository clubListQueryRepository;
+    @Mock private ClubRecruitmentSubscriptionRepository clubRecruitmentSubscriptionRepository;
+    @Mock private ClubEventRepository clubEventRepository;
+    @Mock private ClubEventImageRepository clubEventImageRepository;
+    @Mock private ClubEventSubscriptionRepository clubEventSubscriptionRepository;
+    
+    @InjectMocks private ClubService clubService;
+
+    @Test
+    void 동아리_생성_요청을_처리한다() {
+        // given
+        ClubCreateRequest request = new ClubCreateRequest(
+            "BCSD",
+            "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+            List.of(new ClubCreateRequest.InnerClubManagerRequest("bcsdlab")),
+            1,
+            "학생회관",
+            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
+            "https://www.instagram.com/bcsdlab/",
+            "https://forms.gle/example",
+            "https://open.kakao.com/example",
+            "01012345678",
+            "회장",
+            false
+        );
+
+        Integer studentId = 1;
+
+        // when
+        clubService.createClubRequest(request, studentId);
+
+        // then
+        ArgumentCaptor<ClubCreateRedis> redisCaptor = ArgumentCaptor.forClass(ClubCreateRedis.class);
+        verify(clubCreateRedisRepository).save(redisCaptor.capture());
+
+        ArgumentCaptor<ClubCreateEvent> eventCaptor = ArgumentCaptor.forClass(ClubCreateEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+    }
+}
+
+

--- a/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/club/service/ClubServiceTest.java
@@ -1,6 +1,9 @@
 package in.koreatech.koin.unit.domain.club.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -14,6 +17,11 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import in.koreatech.koin.common.event.ClubCreateEvent;
 import in.koreatech.koin.domain.club.dto.request.ClubCreateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubIntroductionUpdateRequest;
+import in.koreatech.koin.domain.club.dto.request.ClubUpdateRequest;
+import in.koreatech.koin.domain.club.dto.response.ClubResponse;
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubCategory;
 import in.koreatech.koin.domain.club.model.redis.ClubCreateRedis;
 import in.koreatech.koin.domain.club.repository.ClubCategoryRepository;
 import in.koreatech.koin.domain.club.repository.ClubEventImageRepository;
@@ -34,6 +42,8 @@ import in.koreatech.koin.domain.club.repository.redis.ClubHotRedisRepository;
 import in.koreatech.koin.domain.club.service.ClubService;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.auth.exception.AuthorizationException;
+import in.koreatech.koin.unit.fixture.ClubFixture;
 
 @ExtendWith(MockitoExtension.class)
 public class ClubServiceTest {
@@ -89,6 +99,132 @@ public class ClubServiceTest {
 
         ArgumentCaptor<ClubCreateEvent> eventCaptor = ArgumentCaptor.forClass(ClubCreateEvent.class);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
+    }
+
+    @Test
+    void 동아리_관리자가_정보_수정_요청을_보낸_경우_정상적으로_처리한다() {
+        // given
+        ClubUpdateRequest request = new ClubUpdateRequest(
+            "Updated BCSD",
+            "https://bcsdlab.com/static/img/new_logo.png",
+            2,
+            "2공학관",
+            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
+            "https://www.instagram.com/bcsdlab/",
+            "https://forms.gle/example",
+            "https://open.kakao.com/example",
+            "01012345678",
+            false
+        );
+
+        ClubCategory newCategory = ClubCategory.builder()
+            .id(2)
+            .name("문화")
+            .build();
+
+        Integer clubId = 1;
+        Integer studentId = 1;
+        Club club = ClubFixture.활성화_BCSD_동아리();
+
+        when(clubRepository.getById(clubId)).thenReturn(club);
+        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+        when(clubCategoryRepository.getById(request.clubCategoryId())).thenReturn(newCategory);
+        when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+        when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+
+        // when
+        ClubResponse response = clubService.updateClub(clubId, request, studentId);
+
+        // then (club 객체 상태 검증)
+        assertThat(club.getName()).isEqualTo(request.name());
+        assertThat(club.getImageUrl()).isEqualTo(request.imageUrl());
+        assertThat(club.getClubCategory()).isEqualTo(newCategory);
+        assertThat(club.getLocation()).isEqualTo(request.location());
+        assertThat(club.getDescription()).isEqualTo(request.description());
+        assertThat(club.getIsLikeHidden()).isEqualTo(request.isLikeHidden());
+
+        // then (response 상태 검증)
+        assertThat(response.name()).isEqualTo(request.name());
+        assertThat(response.imageUrl()).isEqualTo(request.imageUrl());
+        assertThat(response.category()).isEqualTo(newCategory.getName());
+        assertThat(response.location()).isEqualTo(request.location());
+        assertThat(response.description()).isEqualTo(request.description());
+        assertThat(response.isLikeHidden()).isEqualTo(request.isLikeHidden());
+        assertThat(response.isLiked()).isTrue();
+        assertThat(response.isRecruitSubscribed()).isTrue();
+        assertThat(response.manager()).isTrue();
+        assertThat(response.instagram()).contains(request.instagram());
+        assertThat(response.googleForm()).contains(request.googleForm());
+        assertThat(response.openChat()).contains(request.openChat());
+        assertThat(response.phoneNumber()).contains(request.phoneNumber());
+    }
+
+    @Test
+    void 동아리_관리자가_아닌_유저가_정보_수정_요청을_보낸_경우_예외를_발생한다() {
+        // given
+        ClubUpdateRequest request = new ClubUpdateRequest(
+            "Updated BCSD",
+            "https://bcsdlab.com/static/img/new_logo.png",
+            2,
+            "2공학관",
+            "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
+            "https://www.instagram.com/bcsdlab/",
+            "https://forms.gle/example",
+            "https://open.kakao.com/example",
+            "01012345678",
+            false
+        );
+
+        Integer clubId = 1;
+        Integer studentId = 1;
+        Club club = ClubFixture.활성화_BCSD_동아리();
+
+        when(clubRepository.getById(clubId)).thenReturn(club);
+        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
+
+        // when / then
+        assertThatThrownBy(() -> clubService.updateClub(clubId, request, studentId))
+            .isInstanceOf(AuthorizationException.class)
+            .hasMessageContaining("권한이 없습니다.");
+    }
+
+    @Test
+    void 동아리_관리자가_동아리_소개_수정_요청을_보낸_경우_정상적으로_처리한다() {
+        // given
+        ClubIntroductionUpdateRequest request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
+
+        Integer clubId = 1;
+        Integer studentId = 1;
+        Club club = ClubFixture.활성화_BCSD_동아리();
+
+        when(clubRepository.getById(clubId)).thenReturn(club);
+        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+        when(clubLikeRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+        when(clubRecruitmentSubscriptionRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(true);
+
+        // when
+        ClubResponse response = clubService.updateClubIntroduction(clubId, request, studentId);
+
+        // then
+        assertThat(response.introduction()).isEqualTo(request.introduction());
+    }
+
+    @Test
+    void 동아리_관리자가_아닌_유저가_동아리_소개_수정_요청을_보낸_경우_예외를_발생한다() {
+        // given
+        ClubIntroductionUpdateRequest request = new ClubIntroductionUpdateRequest("수정된 동아리 소개 문자열");
+
+        Integer clubId = 1;
+        Integer studentId = 1;
+        Club club = ClubFixture.활성화_BCSD_동아리();
+
+        when(clubRepository.getById(clubId)).thenReturn(club);
+        when(clubManagerRepository.existsByClubIdAndUserId(clubId, studentId)).thenReturn(false);
+
+        // when / then
+        assertThatThrownBy(() -> clubService.updateClubIntroduction(clubId, request, studentId))
+            .isInstanceOf(AuthorizationException.class)
+            .hasMessageContaining("권한이 없습니다.");
     }
 }
 

--- a/src/test/java/in/koreatech/koin/unit/fixture/ClubBaseInfoFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixture/ClubBaseInfoFixture.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.unit.fixture;
+
+import java.time.LocalDate;
+
+import in.koreatech.koin.domain.club.enums.ClubRecruitmentStatus;
+import in.koreatech.koin.domain.club.model.ClubBaseInfo;
+
+public class ClubBaseInfoFixture {
+
+    public static ClubBaseInfo 동아리_기본_정보(
+        Integer id,
+        String name,
+        String category,
+        ClubRecruitmentStatus status
+    ) {
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+        Boolean isAlwaysRecruiting = null;
+
+        switch (status) {
+            case NONE -> {}
+            case RECRUITING -> {
+                startDate = LocalDate.now().minusDays(1);
+                endDate = LocalDate.now();
+                isAlwaysRecruiting = false;
+            }
+            case ALWAYS -> isAlwaysRecruiting = true;
+        }
+
+        return new ClubBaseInfo(
+            id,
+            name,
+            category,
+            100,
+            "https://bcsdlab.com/static/img/logo.d89d9cc.png",
+            true,
+            false,
+            startDate,
+            endDate,
+            isAlwaysRecruiting
+        );
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/fixture/ClubFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixture/ClubFixture.java
@@ -1,0 +1,67 @@
+package in.koreatech.koin.unit.fixture;
+
+import java.time.LocalDateTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.club.model.Club;
+import in.koreatech.koin.domain.club.model.ClubCategory;
+
+public class ClubFixture {
+
+    private ClubFixture() {}
+
+    public static Club 활성화_BCSD_동아리() {
+        ClubCategory category = ClubCategory.builder()
+            .id(1)
+            .name("학술")
+            .build();
+
+        Club club = Club.builder()
+            .id(1)
+            .name("BCSD Lab")
+            .normalizedName("BCSDLab")
+            .hits(1234)
+            .lastWeekHits(1000)
+            .description("즐겁게 일하고 열심히 노는 IT 특성화 동아리")
+            .isActive(true)
+            .imageUrl("https://bcsdlab.com/static/img/logo.d89d9cc.png")
+            .likes(100)
+            .location("학생회관")
+            .introduction("안녕하세요 BCSD Lab입니다")
+            .isLikeHidden(false)
+            .clubCategory(category)
+            .build();
+
+        ReflectionTestUtils.setField(club, "updatedAt", LocalDateTime.now());
+
+        return club;
+    }
+
+    public static Club 비활성화_BCSD_동아리() {
+        ClubCategory category = ClubCategory.builder()
+            .id(1)
+            .name("학술")
+            .build();
+
+        Club club = Club.builder()
+            .id(1)
+            .name("BCSD Lab")
+            .normalizedName("BCSDLab")
+            .hits(1234)
+            .lastWeekHits(1000)
+            .description("즐겁게 일하고 열심히 노는 IT 특성화 동아리")
+            .isActive(false)
+            .imageUrl("https://bcsdlab.com/static/img/logo.d89d9cc.png")
+            .likes(100)
+            .location("학생회관")
+            .introduction("안녕하세요 BCSD Lab입니다")
+            .isLikeHidden(false)
+            .clubCategory(category)
+            .build();
+
+        ReflectionTestUtils.setField(club, "updatedAt", LocalDateTime.now());
+
+        return club;
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/fixture/ClubFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixture/ClubFixture.java
@@ -11,14 +11,14 @@ public class ClubFixture {
 
     private ClubFixture() {}
 
-    public static Club 활성화_BCSD_동아리() {
+    public static Club 활성화_BCSD_동아리(Integer id) {
         ClubCategory category = ClubCategory.builder()
             .id(1)
             .name("학술")
             .build();
 
         Club club = Club.builder()
-            .id(1)
+            .id(id)
             .name("BCSD Lab")
             .normalizedName("BCSDLab")
             .hits(1234)
@@ -38,14 +38,14 @@ public class ClubFixture {
         return club;
     }
 
-    public static Club 비활성화_BCSD_동아리() {
+    public static Club 비활성화_BCSD_동아리(Integer id) {
         ClubCategory category = ClubCategory.builder()
             .id(1)
             .name("학술")
             .build();
 
         Club club = Club.builder()
-            .id(1)
+            .id(id)
             .name("BCSD Lab")
             .normalizedName("BCSDLab")
             .hits(1234)
@@ -64,4 +64,6 @@ public class ClubFixture {
 
         return club;
     }
+
+
 }


### PR DESCRIPTION
### 🔍 개요

* 동아리 관련 서비스인 ClubCategoryService, ClubService의 단위 테스트를 위한 코드를 작성한다.

- close #1893 

---

### 🚀 주요 변경 내용

* ClubCategoryService의 단위 테스트를 추가했습니다.
* ClubService의 경우 크기가 커서 일부만 작성했고, 추가 작업할 예정입니다.

---

### 💬 참고 사항

* 테스트 코드 작성 중 조회 메소드의 경우 Repository에서 반환해주는 데이터의 의존도가 높은데, Mock을 통해 Repository에서 직접 반환해주는 데이터를 결정 한다면 테스트의 큰 의미가 있을까 하는 고민을 했습니다.
* 서비스 레벨의 테스트 코드는 Repository가 정상 작동한다는 가정이 있어야 하므로 괜찮겠지만 그래도 아직 고민 거리가 찜찜하게 남아있는 듯한 느낌입니다....

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
