### PR TITLE
hotfix: 코인 어드민 로그인 오류 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
+++ b/src/main/java/in/koreatech/koin/admin/history/aop/AdminActivityHistoryAspect.java
@@ -48,11 +48,11 @@ public class AdminActivityHistoryAspect {
     private void excludeGetMapping() {
     }
 
-    @Pointcut("!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.adminLogin(..)) && "
-        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.logout(..)) && "
-        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.refresh(..)) && "
-        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.createAdmin(..)) && "
-        + "!execution(* in.koreatech.koin.admin.user.controller.AdminUserController.adminPasswordChange(..)) && "
+    @Pointcut("!execution(* in.koreatech.koin.admin.manager.controller.AdminController.adminLogin(..)) && "
+        + "!execution(* in.koreatech.koin.admin.manager.controller.AdminController.logout(..)) && "
+        + "!execution(* in.koreatech.koin.admin.manager.controller.AdminController.refresh(..)) && "
+        + "!execution(* in.koreatech.koin.admin.manager.controller.AdminController.createAdmin(..)) && "
+        + "!execution(* in.koreatech.koin.admin.manager.controller.AdminController.adminPasswordChange(..)) && "
         + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.assignOrGetAbtestVariable(..)) &&"
         + "!execution(* in.koreatech.koin.admin.abtest.controller.AbtestController.issueAccessHistoryId(..))")
     private void excludeSpecificMethods() {


### PR DESCRIPTION
### 🔍 개요

* [프로덕션 배포](https://github.com/BCSDLab/KOIN_API_V2/pull/1905) 이후 코인 어드민이 로그인 안 되는 상황 발생

---

### 🚀 주요 변경 내용

* 코인 어드민 히스토리 AOP 포인트 컷 수정
  * [코인 어드민 패키지 분리 작업](https://github.com/BCSDLab/KOIN_API_V2/pull/1882)을 진행했음
  * 코인 어드민 히스토리의 경우 개인 정보(비밀번호)가 포함된 요청, GET 요청을 제외한 모든 API에 대해 기록
  * 패키지 경로 & GetMapping 어노테이션을 통해서 해당 케이스를 제외 시켰음
  * 코인 어드민 패키지가 변경됨에 따라 AOP 경로에서 제외되고, 코인 어드민 로그인 API가 히스토리 AOP를 타게 됨
  * 로그인 과정에서는 AuthContext의 userId가 null이기 때문에 조회 오류 발생
  -> 변경된 패키지 경로로 코인 어드민 히스토리 AOP 포인트 컷을 수정


---

### 💬 참고 사항

* 향후 진행 사항
  * 현재 API Path, 패키지 경로를 통해서 로직이 분기되어 있음
  * 이를 해결하기 위해 코인 어드민 히스토리 로깅 전용 어노테이션을 구현하여, 해당 문제 해결

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
