### PR TITLE
fix: 사장님 회원가입 전화번호 검증 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/dto/sms/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/sms/OwnerRegisterByPhoneRequest.java
@@ -67,7 +67,6 @@ public record OwnerRegisterByPhoneRequest(
             .loginPw(passwordEncoder.encode(password))
             .name(name)
             .email(null)
-            .phoneNumber(phoneNumber)
             .userType(OWNER)
             .isAuthed(false)
             .isDeleted(false)

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerSmsService.java
@@ -73,7 +73,7 @@ public class OwnerSmsService {
             .shopNumber(request.shopNumber())
             .build();
         ownerShopRedisRepository.save(ownerShop);
-        ownerInVerificationRedisRepository.deleteByVerify(newOwner.getUser().getPhoneNumber());
+        ownerInVerificationRedisRepository.deleteByVerify(newOwner.getAccount());
         ownerUtilService.sendSlackNotification(newOwner);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/owner/service/OwnerValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/service/OwnerValidator.java
@@ -1,22 +1,18 @@
 package in.koreatech.koin.domain.owner.service;
 
-import static in.koreatech.koin.domain.user.model.UserType.OWNER;
+import org.springframework.stereotype.Component;
 
 import in.koreatech.koin.domain.owner.exception.DuplicationCompanyNumberException;
 import in.koreatech.koin.domain.owner.exception.DuplicationPhoneNumberException;
 import in.koreatech.koin.domain.owner.repository.OwnerRepository;
 import in.koreatech.koin.domain.user.model.User;
-import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class OwnerValidator {
 
-    private final UserRepository userRepository;
     private final OwnerRepository ownerRepository;
 
     public void validateAuth(User user) {
@@ -26,7 +22,7 @@ public class OwnerValidator {
     }
 
     public void validateExistPhoneNumber(String phoneNumber) {
-        if (userRepository.findByPhoneNumberAndUserType(phoneNumber, OWNER).isPresent()) {
+        if (ownerRepository.findByAccount(phoneNumber).isPresent()) {
             throw DuplicationPhoneNumberException.withDetail("account: " + phoneNumber);
         }
     }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/OwnerApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/OwnerApiTest.java
@@ -167,7 +167,7 @@ class OwnerApiTest extends AcceptanceTest {
                             softly.assertThat(owner).isNotNull();
                             softly.assertThat(owner.getUser().getName()).isEqualTo("최준호");
                             softly.assertThat(owner.getUser().getEmail()).isEqualTo(null);
-                            softly.assertThat(owner.getUser().getPhoneNumber()).isEqualTo("01012341234");
+                            softly.assertThat(owner.getAccount()).isEqualTo("01012341234");
                             softly.assertThat(owner.getCompanyRegistrationNumber()).isEqualTo("012-34-56789");
                             softly.assertThat(owner.getAccount()).isEqualTo("01012341234");
                             softly.assertThat(owner.getAttachments().size()).isEqualTo(1);


### PR DESCRIPTION
### 🔍 개요

* 유저테이블 부분적 분리 작업 과정에서 사장님의 전화번호는 owner 테이블의 account 컬럼에 저장하도록 변경
* 기존 회원 가입 로직에서 owner 테이블의 account가 아닌 users 테이블의 phone_number을 통해 유니크 검사 & users 테이블에 전화번호가 저장되고 있었음
* users 테이블에 insert 과정에서 유니크 에러 발생

- close #1919

---

### 🚀 주요 변경 내용

* 사장님 전화번호 유효성 검증 로직을 수정했습니다.
* 엔티티 변환 과정에서 user 테이블에 전화번호가 저장되지 않도록 수정했습니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
