### PR TITLE
fix: Payment 필드 유효성 검증 어노테이션 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/payment/model/entity/Payment.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/entity/Payment.java
@@ -47,13 +47,11 @@ public class Payment {
     private Integer amount;
 
     @NotNull
-    @Size(max = 30)
     @Enumerated(STRING)
     @Column(name = "status", length = 30, nullable = false)
     private PaymentStatus paymentStatus;
 
     @NotNull
-    @Size(max = 30)
     @Enumerated(STRING)
     @Column(name = "method", length = 30, nullable = false, updatable = false)
     private PaymentMethod paymentMethod;


### PR DESCRIPTION
### 🔍 개요

- close #1923 

---

### 🚀 주요 변경 내용

* Payment Enum 필드에 걸려있는 Size 어노테이션을 삭제했습니다.
  * Enum의 경우 Size 어노테이션이 작동하지 않습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
