### PR TITLE
feat: 교외 배달 주소 검증 로직 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/delivery/dto/UserOffCampusDeliveryAddressValidateRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/dto/UserOffCampusDeliveryAddressValidateRequest.java
@@ -18,7 +18,10 @@ public record UserOffCampusDeliveryAddressValidateRequest(
     String siGunGu,
 
     @Schema(description = "읍/면/동", example = "병천면", nullable = true)
-    String eupMyeonDong
+    String eupMyeonDong,
+
+    @Schema(description = "건물 이름", example = "한국기술교육대학교", nullable = true)
+    String building
 
 ) {
 
@@ -27,6 +30,7 @@ public record UserOffCampusDeliveryAddressValidateRequest(
             .siDo(siDo)
             .siGunGu(siGunGu)
             .eupMyeonDong(eupMyeonDong)
+            .building(building)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/model/OffCampusDeliveryAddress.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/model/OffCampusDeliveryAddress.java
@@ -58,4 +58,8 @@ public class OffCampusDeliveryAddress {
             siGunGu.equals(this.siGunGu) &&
             eupMyeonDong.equals(this.eupMyeonDong);
     }
+
+    public Boolean isNotAllowedBuilding(String building) {
+        return building.equals(this.building);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryAddressValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/order/delivery/service/DeliveryAddressValidator.java
@@ -12,6 +12,7 @@ public class DeliveryAddressValidator {
     private static final String ALLOWED_SI_DO = "충청남도";
     private static final String ALLOWED_SI_GUN_GU = "천안시 동남구";
     private static final String ALLOWED_EUP_MYEON_DONG = "병천면";
+    private static final String NOT_ALLOWED_BUILDING_NAME = "한국기술교육대학교";
 
     /*
      * 추후 각 상점 별 배달 가능 지역 요구 사항이 추가 되면 검증 로직을 추가 해야 함
@@ -19,6 +20,9 @@ public class DeliveryAddressValidator {
     public void validateOffCampusAddress(OffCampusDeliveryAddress address) {
         if (!address.isValidDeliveryArea(ALLOWED_SI_DO, ALLOWED_SI_GUN_GU, ALLOWED_EUP_MYEON_DONG)) {
             throw CustomException.of(ApiResponseCode.INVALID_DELIVERY_AREA);
+        }
+        if (address.isNotAllowedBuilding(NOT_ALLOWED_BUILDING_NAME)) {
+            throw CustomException.of(ApiResponseCode.INVALID_DELIVERY_BUILDING);
         }
     }
 }

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -26,6 +26,7 @@ public enum ApiResponseCode {
     INVALID_GENDER_INDEX(HttpStatus.BAD_REQUEST, "올바르지 않은 성별 인덱스입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "올바르지 않은 인증 토큰입니다."),
     INVALID_DELIVERY_AREA(HttpStatus.BAD_REQUEST, "배달이 불가능한 지역이에요."),
+    INVALID_DELIVERY_BUILDING(HttpStatus.BAD_REQUEST, "교외 주문 주소에 교내 주문 주소를 입력하면 안 됩니다."),
     NOT_MATCHED_EMAIL(HttpStatus.BAD_REQUEST, "이메일이 일치하지 않습니다."),
     NOT_MATCHED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "전화번호가 일치하지 않습니다."),
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
### 🔍 개요

* 교외 배달 주소 검색 과정에서 `한국기술교육대학교`가 검색이 되고 선택이 되는 상황
* 이를 막기 위해 교외 배달 주소 검증 API에서 검증 로직 추가

- close #1936 

---

### 🚀 주요 변경 내용

* DeliveryAddressValidator에서 건물명을 검증하는 로직을 추가했습니다.
* POST /delivery/address/off-campus-validate 요청 바디에 건물명을 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
