### PR TITLE
fix: 결제 취소 로직 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/model/Order.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/Order.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.order.model;
 
+import static in.koreatech.koin.domain.order.model.OrderStatus.CANCELED;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
@@ -170,5 +171,11 @@ public class Order extends BaseEntity {
             orderMenus = new ArrayList<>();
         }
         this.orderMenus.add(orderMenu);
+    }
+
+    public void cancel(String cancelReason) {
+        this.status = CANCELED;
+        this.canceledReason = cancelReason;
+        this.canceledAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/payment/model/entity/Payment.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/entity/Payment.java
@@ -118,7 +118,8 @@ public class Payment extends BaseEntity {
         }
     }
 
-    public void cancel() {
+    public void cancel(String reason) {
         this.paymentStatus = CANCELED;
+        this.order.cancel(reason);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
@@ -158,6 +158,7 @@ public class TemporaryPayment {
             .orderableShopName(orderableShop.getShop().getName())
             .phoneNumber(phoneNumber)
             .totalProductPrice(totalProductPrice)
+            .discountAmount(0) // 현재 할인 정책이 없기 때문에 0원 처리
             .totalPrice(totalPrice)
             .orderableShop(orderableShop)
             .user(user)

--- a/src/main/java/in/koreatech/koin/domain/payment/service/PaymentCancelService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/PaymentCancelService.java
@@ -8,14 +8,14 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.payment.model.entity.Payment;
-import in.koreatech.koin.domain.payment.model.entity.PaymentCancel;
-import in.koreatech.koin.domain.payment.model.entity.PaymentStatus;
 import in.koreatech.koin.domain.payment.dto.response.PaymentCancelResponse;
 import in.koreatech.koin.domain.payment.gateway.pg.PaymentGatewayService;
 import in.koreatech.koin.domain.payment.gateway.pg.dto.PaymentGatewayCancelResponse;
 import in.koreatech.koin.domain.payment.mapper.PaymentCancelMapper;
 import in.koreatech.koin.domain.payment.model.domain.PaymentCancelInfo;
+import in.koreatech.koin.domain.payment.model.entity.Payment;
+import in.koreatech.koin.domain.payment.model.entity.PaymentCancel;
+import in.koreatech.koin.domain.payment.model.entity.PaymentStatus;
 import in.koreatech.koin.domain.payment.repository.PaymentCancelRepository;
 import in.koreatech.koin.domain.payment.repository.PaymentRepository;
 import in.koreatech.koin.domain.user.model.User;
@@ -43,7 +43,7 @@ public class PaymentCancelService {
             paymentCancelInfo.cancelReason(), paymentIdempotencyKey);
         validatePaymentIsCanceled(pgResponse.status());
 
-        payment.cancel();
+        payment.cancel(paymentCancelInfo.cancelReason());
         List<PaymentCancel> paymentCancels = paymentCancelMapper.toEntity(payment, pgResponse);
         paymentCancelRepository.saveAll(paymentCancels);
 


### PR DESCRIPTION
### 🔍 개요

* 결제 취소 과정에서 order 테이블의 결제 취소 관련 컬럼을 업데이트 수행하지 않고 있음
- close #1938 

---

### 🚀 주요 변경 내용

* order 테이블의 status(주문상태), canceled_at(취소 일시), canceled_reason(취소 사유)를 업데이트 하도록 수정


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
