### PR TITLE
feat: 주문 내역 리스트 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/model/Order.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/Order.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.order.model;
 
-import static in.koreatech.koin.domain.order.model.OrderStatus.CANCELED;
+import static in.koreatech.koin.domain.order.model.OrderStatus.*;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
@@ -177,5 +177,13 @@ public class Order extends BaseEntity {
         this.status = CANCELED;
         this.canceledReason = cancelReason;
         this.canceledAt = LocalDateTime.now();
+    }
+
+    public void deliveryComplete() {
+        this.status = DELIVERED;
+    }
+
+    public void takeoutComplete() {
+        this.status = PACKAGED;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderDelivery.java
@@ -90,4 +90,11 @@ public class OrderDelivery extends BaseEntity {
         this.completedAt = completedAt;
         this.estimatedArrivalAt = estimatedArrivalAt;
     }
+
+    public void deliveryComplete() {
+        this.dispatchedAt = LocalDateTime.now();
+        this.completedAt = LocalDateTime.now();
+        this.estimatedArrivalAt = LocalDateTime.now();
+        this.order.deliveryComplete();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderInfo.java
@@ -1,14 +1,14 @@
 package in.koreatech.koin.domain.order.model;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record OrderInfo(
     Integer orderId,
     Integer paymentId,
     Integer orderShopId,
     String orderableShopName,
-    LocalDate orderDate,
-    String orderStatus,
+    LocalDateTime orderDate,
+    OrderStatus orderStatus,
     String orderTitle
 ) {
     

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderInfo.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.order.model;
+
+import java.time.LocalDate;
+
+public record OrderInfo(
+    Integer orderId,
+    Integer paymentId,
+    Integer orderShopId,
+    String orderableShopName,
+    LocalDate orderDate,
+    String orderStatus,
+    String orderTitle
+) {
+    
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderSearchCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderSearchCriteria.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.order.model;
+
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchPeriodCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderStatusCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderTypeCriteria;
+
+public record OrderSearchCriteria(
+    Integer page,
+    Integer limit,
+    OrderSearchPeriodCriteria period,
+    OrderStatusCriteria status,
+    OrderTypeCriteria type
+) {
+    public static OrderSearchCriteria from(OrderSearchCondition condition) {
+        return new OrderSearchCriteria(
+            condition.page(),
+            condition.limit(),
+            condition.period(),
+            condition.status(),
+            condition.type()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderStatus.java
@@ -9,7 +9,8 @@ public enum OrderStatus {
     PACKAGED("포장 완료"),
     DELIVERING("배달 중"),
     DELIVERED("배달 완료"),
-    CANCELED("취소");
+    CANCELED("취소"),
+    ;
 
     private final String description;
 

--- a/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
+++ b/src/main/java/in/koreatech/koin/domain/order/model/OrderTakeout.java
@@ -2,6 +2,9 @@ package in.koreatech.koin.domain.order.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.time.LocalDateTime;
+
+import in.koreatech.koin.common.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -19,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "order_takeout_v2")
 @NoArgsConstructor(access = PROTECTED)
-public class OrderTakeout {
+public class OrderTakeout extends BaseEntity {
 
     @Id
     @Column(name = "order_id", nullable = false, updatable = false)
@@ -38,14 +41,30 @@ public class OrderTakeout {
     @Column(name = "provide_cutlery", nullable = false, updatable = false, columnDefinition = "TINYINT(1)")
     private Boolean provideCutlery;
 
+    @Column(name = "packaged_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime packagedAt;
+
+    @Column(name = "estimated_packaged_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime estimatedPackagedAt;
+
     @Builder
     private OrderTakeout(
         Order order,
         String toOwner,
-        Boolean provideCutlery
+        Boolean provideCutlery,
+        LocalDateTime packagedAt,
+        LocalDateTime estimatedPackagedAt
     ) {
         this.order = order;
         this.toOwner = toOwner;
         this.provideCutlery = provideCutlery;
+        this.packagedAt = packagedAt;
+        this.estimatedPackagedAt = estimatedPackagedAt;
+    }
+
+    public void takeoutComplete() {
+        this.packagedAt = LocalDateTime.now();
+        this.estimatedPackagedAt = LocalDateTime.now();
+        this.order.takeoutComplete();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -1,0 +1,21 @@
+package in.koreatech.koin.domain.order.order.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "(Normal) Order: 주문", description = "주문을 관리한다.")
+@RequestMapping("/order")
+public interface OrderApi {
+
+    @GetMapping
+    ResponseEntity<OrdersResponse> getOrders(
+        @Auth(permit = {STUDENT}) Integer userId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -12,12 +12,32 @@ import in.koreatech.koin.domain.order.order.dto.request.OrderStatusCriteria;
 import in.koreatech.koin.domain.order.order.dto.request.OrderTypeCriteria;
 import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
 import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "(Normal) Order: 주문", description = "주문을 관리한다.")
 @RequestMapping("/order")
 public interface OrderApi {
 
+    @Operation(
+        summary = "주문 이력을 조회한다.",
+        description = """
+            ## 주문 이력 조회
+            - period
+                - NONE : 기본값
+                - LAST_3_MONTHS : 최근 3개월
+                - LAST_6_MONTHS : 최근 3개월
+                - LAST_1_YEAR : 최근 1년
+            - status
+                - NONE : 기본값
+                - COMPLETED : 주문 완료, 포장 완료
+                - CANCELED : 주문 취소
+            - type
+                - NONE : 기본값
+                - DELIVERY : 배달
+                - TAKE_OUT : 포장
+            """
+    )
     @GetMapping
     ResponseEntity<OrdersResponse> getOrders(
         @RequestParam(name = "page", required = false, defaultValue = "1") Integer page,

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -5,7 +5,11 @@ import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchPeriodCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderStatusCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderTypeCriteria;
 import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,6 +20,11 @@ public interface OrderApi {
 
     @GetMapping
     ResponseEntity<OrdersResponse> getOrders(
+        @RequestParam(name = "page", required = false, defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", required = false, defaultValue = "10") Integer limit,
+        @RequestParam(name = "period", required = false, defaultValue = "NONE") OrderSearchPeriodCriteria period,
+        @RequestParam(name = "status", required = false, defaultValue = "NONE") OrderStatusCriteria status,
+        @RequestParam(name = "type", required = false, defaultValue = "NONE") OrderTypeCriteria type,
         @Auth(permit = {STUDENT}) Integer userId
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderController.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.order.order.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchPeriodCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderStatusCriteria;
+import in.koreatech.koin.domain.order.order.dto.request.OrderTypeCriteria;
+import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
+import in.koreatech.koin.domain.order.order.service.OrderService;
+import in.koreatech.koin.global.auth.Auth;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order")
+public class OrderController implements OrderApi {
+
+    private final OrderService orderService;
+
+    @GetMapping
+    public ResponseEntity<OrdersResponse> getOrders(
+        @RequestParam(name = "page", required = false, defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", required = false, defaultValue = "10") Integer limit,
+        @RequestParam(name = "period", required = false, defaultValue = "NONE") OrderSearchPeriodCriteria period,
+        @RequestParam(name = "status", required = false, defaultValue = "NONE") OrderStatusCriteria status,
+        @RequestParam(name = "type", required = false, defaultValue = "NONE") OrderTypeCriteria type,
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        OrderSearchCondition orderSearchCondition = OrderSearchCondition.of(page, limit, period, status, type);
+        OrdersResponse response = orderService.getOrders(userId, orderSearchCondition);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderTestApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderTestApi.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.domain.order.order.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+
+import in.koreatech.koin.domain.order.model.OrderStatus;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.code.ApiResponseCode;
+import in.koreatech.koin.global.code.ApiResponseCodes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Profile("dev")
+@Tag(name = "(Normal) Order: 주문 테스트", description = "주문 테스트 API")
+public interface OrderTestApi {
+
+    @ApiResponseCodes(
+        {
+            ApiResponseCode.NOT_FOUND_ORDER,
+            ApiResponseCode.NOT_FOUND_USER,
+            ApiResponseCode.FORBIDDEN_ORDER,
+        }
+    )
+    @Operation(
+        summary = "주문 상태 변경 테스트",
+        description = """
+            - orderStatus가 DELIVERED이면서 변경할 주문이 배달인 경우에는 배달 완료로 업데이트가 됩니다.
+            - orderStatus가 PACKAGED이면서 변경할 주문이 배달인 경우에는 포장 완료로 업데이트가 됩니다.
+            - 나머지 orderStatus에 대해서는 아무런 처리가 되지 않습니다.
+            - 결제 취소의 경우 결제 취소 API를 사용해주세요.
+            """
+    )
+    @PutMapping("/order/{orderId}/status")
+    ResponseEntity<Void> updateOrderStatus(
+        @PathVariable(name = "orderId") Integer orderId,
+        @Auth(permit = {STUDENT}) Integer userId,
+        OrderStatus orderStatus
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderTestController.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderTestController.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.order.order.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.order.model.OrderStatus;
+import in.koreatech.koin.domain.order.order.service.OrderTestService;
+import in.koreatech.koin.global.auth.Auth;
+import lombok.RequiredArgsConstructor;
+
+@Profile("dev")
+@RestController
+@RequiredArgsConstructor
+public class OrderTestController implements OrderTestApi {
+
+    private final OrderTestService orderTestService;
+
+    @PutMapping("/order/{id}/status")
+    public ResponseEntity<Void> updateOrderStatus(
+        @PathVariable(name = "id") Integer orderId,
+        @Auth(permit = {STUDENT}) Integer userId,
+        OrderStatus orderStatus
+    ) {
+        orderTestService.updateOrderStatus(orderId, userId, orderStatus);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderSearchCondition.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderSearchCondition.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.domain.order.order.dto.request;
+
+public record OrderSearchCondition(
+    Integer page,
+    Integer limit,
+    OrderSearchPeriodCriteria period,
+    OrderStatusCriteria status,
+    OrderTypeCriteria type
+) {
+    public static OrderSearchCondition of(
+        Integer page,
+        Integer limit,
+        OrderSearchPeriodCriteria period,
+        OrderStatusCriteria status,
+        OrderTypeCriteria type
+    ) {
+        return new OrderSearchCondition(page, limit, period, status, type);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderSearchPeriodCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderSearchPeriodCriteria.java
@@ -1,0 +1,46 @@
+package in.koreatech.koin.domain.order.order.dto.request;
+
+import static in.koreatech.koin.domain.order.model.QOrder.order;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderSearchPeriodCriteria {
+
+    NONE("NONE") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return null;
+        }
+    },
+    LAST_3_MONTHS("LAST_3_MONTHS") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.createdAt.goe(LocalDateTime.now().minusMonths(3));
+        }
+    },
+    LAST_6_MONTHS("LAST_6_MONTHS") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.createdAt.goe(LocalDateTime.now().minusMonths(6));
+        }
+    },
+    LAST_1_YEAR("LAST_1_YEAR") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.createdAt.goe(LocalDateTime.now().minusYears(1));
+        }
+    };
+
+    private final String value;
+
+    OrderSearchPeriodCriteria(String value) {
+        this.value = value;
+    }
+
+    public abstract BooleanExpression getPredicate();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.order.order.dto.request;
 
 import static in.koreatech.koin.domain.order.model.OrderStatus.DELIVERED;
+import static in.koreatech.koin.domain.order.model.OrderStatus.PACKAGED;
 import static in.koreatech.koin.domain.order.model.QOrder.order;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -20,7 +21,7 @@ public enum OrderStatusCriteria {
     COMPLETED("COMPLETED") {
         @Override
         public BooleanExpression getPredicate() {
-            return order.status.in(DELIVERED, DELIVERED);
+            return order.status.in(DELIVERED, PACKAGED);
         }
     },
     CANCELED("CANCELED") {

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
@@ -15,7 +15,7 @@ public enum OrderStatusCriteria {
     NONE("NONE") {
         @Override
         public BooleanExpression getPredicate() {
-            return null;
+            return order.status.in(DELIVERED, PACKAGED, OrderStatus.CANCELED);
         }
     },
     COMPLETED("COMPLETED") {

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderStatusCriteria.java
@@ -1,0 +1,41 @@
+package in.koreatech.koin.domain.order.order.dto.request;
+
+import static in.koreatech.koin.domain.order.model.OrderStatus.DELIVERED;
+import static in.koreatech.koin.domain.order.model.QOrder.order;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import in.koreatech.koin.domain.order.model.OrderStatus;
+import lombok.Getter;
+
+@Getter
+public enum OrderStatusCriteria {
+
+    NONE("NONE") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return null;
+        }
+    },
+    COMPLETED("COMPLETED") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.status.in(DELIVERED, DELIVERED);
+        }
+    },
+    CANCELED("CANCELED") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.status.in(OrderStatus.CANCELED);
+        }
+    },
+    ;
+
+    private final String value;
+
+    OrderStatusCriteria(String value) {
+        this.value = value;
+    }
+
+    public abstract BooleanExpression getPredicate();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderTypeCriteria.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/request/OrderTypeCriteria.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.domain.order.order.dto.request;
+
+import static in.koreatech.koin.domain.order.model.QOrder.order;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import in.koreatech.koin.domain.order.model.OrderType;
+import lombok.Getter;
+
+@Getter
+public enum OrderTypeCriteria {
+
+    NONE("NONE") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return null;
+        }
+    },
+    DELIVERY("DELIVERY") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.orderType.eq(OrderType.DELIVERY);
+        }
+    },
+    TAKE_OUT("TAKE_OUT") {
+        @Override
+        public BooleanExpression getPredicate() {
+            return order.orderType.eq(OrderType.TAKE_OUT);
+        }
+    },
+    ;
+
+    private final String value;
+
+    OrderTypeCriteria(String value) {
+        this.value = value;
+    }
+
+    public abstract BooleanExpression getPredicate();
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
@@ -1,0 +1,82 @@
+package in.koreatech.koin.domain.order.order.dto.response;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.order.model.OrderInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record OrdersResponse(
+    @Schema(description = "주문 내역 수", example = "10", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지에서 조회된 주문 내역 수", example = "5", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "최대 페이지", example = "2", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage,
+
+    @Schema(description = "주문 내역 리스트", requiredMode = REQUIRED)
+    List<InnerOrderResponse> orders
+) {
+    @JsonNaming(value = SnakeCaseStrategy.class)
+    public record InnerOrderResponse(
+        @Schema(description = "주문 고유 Id", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "결제 고유 Id", example = "1", requiredMode = REQUIRED)
+        Integer paymentId,
+
+        @Schema(description = "주문 가능 상점 ID", example = "1", requiredMode = REQUIRED)
+        Integer orderableShopId,
+
+        @Schema(description = "주문 가게 이름", example = "김밥 천국", requiredMode = REQUIRED)
+        String orderableShopName,
+
+        @Schema(description = "주문 일시", example = "2025.09.07", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDate orderDate,
+
+        @Schema(description = "주문 상태", example = "DELIVERED", requiredMode = REQUIRED)
+        String orderStatus,
+
+        @Schema(description = "주문 내용", example = "김밥 외 1건", requiredMode = REQUIRED)
+        String orderTitle
+    ) {
+        public static InnerOrderResponse from(OrderInfo orderInfo) {
+            return new InnerOrderResponse(
+                orderInfo.orderId(),
+                orderInfo.paymentId(),
+                orderInfo.orderShopId(),
+                orderInfo.orderableShopName(),
+                orderInfo.orderDate(),
+                orderInfo.orderStatus(),
+                orderInfo.orderTitle()
+            );
+        }
+    }
+
+    public static OrdersResponse of(Page<OrderInfo> orderInfoPage) {
+        return new OrdersResponse(
+            orderInfoPage.getTotalElements(),
+            orderInfoPage.getContent().size(),
+            orderInfoPage.getTotalPages(),
+            orderInfoPage.getNumber() + 1,
+            orderInfoPage.stream()
+                .map(InnerOrderResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
@@ -61,8 +61,8 @@ public record OrdersResponse(
                 orderInfo.paymentId(),
                 orderInfo.orderShopId(),
                 orderInfo.orderableShopName(),
-                orderInfo.orderDate(),
-                orderInfo.orderStatus(),
+                orderInfo.orderDate().toLocalDate(),
+                orderInfo.orderStatus().name(),
                 orderInfo.orderTitle()
             );
         }

--- a/src/main/java/in/koreatech/koin/domain/order/order/service/OrderService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/service/OrderService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.order.model.OrderInfo;
+import in.koreatech.koin.domain.order.model.OrderSearchCriteria;
 import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
 import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
 import in.koreatech.koin.domain.order.repository.OrderSearchQueryRepository;
@@ -18,7 +19,8 @@ public class OrderService {
     private final OrderSearchQueryRepository orderSearchQueryRepository;
 
     public OrdersResponse getOrders(Integer userId, OrderSearchCondition orderSearchCondition) {
-        Page<OrderInfo> orderPage = orderSearchQueryRepository.findOrdersByCondition(userId, orderSearchCondition);
+        OrderSearchCriteria orderSearchCriteria = OrderSearchCriteria.from(orderSearchCondition);
+        Page<OrderInfo> orderPage = orderSearchQueryRepository.findOrdersByCondition(userId, orderSearchCriteria);
         return OrdersResponse.of(orderPage);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/service/OrderService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/service/OrderService.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.order.order.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.order.model.OrderInfo;
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
+import in.koreatech.koin.domain.order.order.dto.response.OrdersResponse;
+import in.koreatech.koin.domain.order.repository.OrderSearchQueryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderSearchQueryRepository orderSearchQueryRepository;
+
+    public OrdersResponse getOrders(Integer userId, OrderSearchCondition orderSearchCondition) {
+        Page<OrderInfo> orderPage = orderSearchQueryRepository.findOrdersByCondition(userId, orderSearchCondition);
+        return OrdersResponse.of(orderPage);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.domain.order.order.service;
+
+import static in.koreatech.koin.domain.order.model.OrderStatus.DELIVERED;
+import static in.koreatech.koin.domain.order.model.OrderStatus.PACKAGED;
+import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_ORDER;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import in.koreatech.koin.domain.order.model.Order;
+import in.koreatech.koin.domain.order.model.OrderDelivery;
+import in.koreatech.koin.domain.order.model.OrderStatus;
+import in.koreatech.koin.domain.order.model.OrderTakeout;
+import in.koreatech.koin.domain.order.repository.OrderRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Profile("dev")
+@Service
+@RequiredArgsConstructor
+public class OrderTestService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+
+    public void updateOrderStatus(Integer orderId, Integer userId, OrderStatus orderStatus) {
+        User user = userRepository.getById(userId);
+        Order order = orderRepository.getById(orderId);
+        if (!order.getUser().getId().equals(user.getId())) {
+            throw CustomException.of(FORBIDDEN_ORDER);
+        }
+
+        if (orderStatus.equals(DELIVERED) && order.getStatus().equals(DELIVERED)) {
+            OrderDelivery orderDelivery = order.getOrderDelivery();
+            orderDelivery.deliveryComplete();
+        } else if (orderStatus.equals(PACKAGED) && order.getStatus().equals(DELIVERED)) {
+            OrderTakeout orderTakeout = order.getOrderTakeout();
+            orderTakeout.takeoutComplete();
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/repository/OrderRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/repository/OrderRepository.java
@@ -1,10 +1,22 @@
 package in.koreatech.koin.domain.order.repository;
 
+import static in.koreatech.koin.global.code.ApiResponseCode.NOT_FOUND_ORDER;
+
+import java.util.Optional;
+
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.order.model.Order;
+import in.koreatech.koin.global.exception.CustomException;
 
-public interface OrderRepository extends Repository<Order, String> {
+public interface OrderRepository extends Repository<Order, Integer> {
 
     void save(Order order);
+
+    Optional<Order> findById(Integer orderId);
+
+    default Order getById(Integer orderId) {
+        return findById(orderId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_ORDER));
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/repository/OrderSearchQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/repository/OrderSearchQueryRepository.java
@@ -1,0 +1,65 @@
+package in.koreatech.koin.domain.order.repository;
+
+import static com.querydsl.core.types.dsl.Expressions.allOf;
+import static in.koreatech.koin.domain.order.model.QOrder.order;
+import static in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShop.orderableShop;
+import static in.koreatech.koin.domain.payment.model.entity.QPayment.payment;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import in.koreatech.koin.domain.order.model.OrderInfo;
+import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSearchQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<OrderInfo> findOrdersByCondition(Integer userId, OrderSearchCondition condition) {
+        Pageable pageable = PageRequest.of(condition.page() - 1, condition.limit());
+        var predicate = allOf(
+            order.user.id.eq(userId),
+            condition.period() != null ? condition.period().getPredicate() : null,
+            condition.status() != null ? condition.status().getPredicate() : null,
+            condition.type() != null ? condition.type().getPredicate() : null
+        );
+
+        List<OrderInfo> results = jpaQueryFactory
+            .select(Projections.constructor(OrderInfo.class,
+                order.id,
+                payment.id,
+                order.orderableShop.id,
+                order.orderableShopName,
+                order.createdAt,
+                order.status,
+                payment.description))
+            .from(order)
+            .innerJoin(payment).on(payment.order.id.eq(order.id))
+            .innerJoin(orderableShop).on(orderableShop.id.eq(order.orderableShop.id))
+            .where(predicate)
+            .orderBy(order.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = jpaQueryFactory
+            .selectFrom(order)
+            .innerJoin(payment).on(payment.order.id.eq(order.id))
+            .innerJoin(orderableShop).on(orderableShop.id.eq(order.orderableShop.id))
+            .where(predicate)
+            .fetchCount();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/repository/OrderSearchQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/repository/OrderSearchQueryRepository.java
@@ -17,7 +17,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import in.koreatech.koin.domain.order.model.OrderInfo;
-import in.koreatech.koin.domain.order.order.dto.request.OrderSearchCondition;
+import in.koreatech.koin.domain.order.model.OrderSearchCriteria;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -26,13 +26,13 @@ public class OrderSearchQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Page<OrderInfo> findOrdersByCondition(Integer userId, OrderSearchCondition condition) {
-        Pageable pageable = PageRequest.of(condition.page() - 1, condition.limit());
+    public Page<OrderInfo> findOrdersByCondition(Integer userId, OrderSearchCriteria criteria) {
+        Pageable pageable = PageRequest.of(criteria.page() - 1, criteria.limit());
         var predicate = allOf(
             order.user.id.eq(userId),
-            condition.period() != null ? condition.period().getPredicate() : null,
-            condition.status() != null ? condition.status().getPredicate() : null,
-            condition.type() != null ? condition.type().getPredicate() : null
+            criteria.period() != null ? criteria.period().getPredicate() : null,
+            criteria.status() != null ? criteria.status().getPredicate() : null,
+            criteria.type() != null ? criteria.type().getPredicate() : null
         );
 
         List<OrderInfo> results = jpaQueryFactory

--- a/src/main/java/in/koreatech/koin/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/repository/PaymentRepository.java
@@ -19,4 +19,11 @@ public interface PaymentRepository extends Repository<Payment, Integer> {
         return findById(id)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_PAYMENT));
     }
+
+    Optional<Payment> findByOrderId(Integer orderId);
+
+    default Payment getByOrderId(Integer orderId) {
+        return findById(orderId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_PAYMENT));
+    }
 }

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -83,6 +83,7 @@ public enum ApiResponseCode {
     FORBIDDEN_VERIFICATION(HttpStatus.FORBIDDEN, "이메일/휴대폰 인증 후 다시 시도해주십시오."),
     FORBIDDEN_BLOCKED_USER(HttpStatus.FORBIDDEN, "차단된 사용자입니다."),
     PAYMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "결제 정보 접근 권한이 없습니다."),
+    FORBIDDEN_ORDER(HttpStatus.FORBIDDEN, "주문 정보 접근 권한이 없습니다."),
 
     /**
      * 404 Not Found (리소스를 찾을 수 없음)
@@ -105,6 +106,7 @@ public enum ApiResponseCode {
     NOT_FOUND_LOST_ITEM_CHATROOM(HttpStatus.NOT_FOUND, "분실물 게시글 채팅방이 존재하지 않습니다."),
     NOT_FOUND_TEMPORARY_PAYMENT(HttpStatus.NOT_FOUND, "임시 결제 정보가 존재하지 않습니다."),
     NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, "결제 정보가 존재하지 않습니다."),
+    NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "주문 정보가 존재하지 않습니다."),
 
     /**
      * 409 CONFLICT (중복 혹은 충돌)


### PR DESCRIPTION
### 🔍 개요

<img width="848" height="594" alt="image" src="https://github.com/user-attachments/assets/9f6b7e62-c354-4c7b-89d1-803e09b1b081" />

- 지난 주문 페이지에서 사용할 주문 내역 리스트 조회 API 추가
- close #1940 

---

### 🚀 주요 변경 내용

* 주문 내역 리스트 조회 API를 추가했습니다.
  * 필터링 조건은 `조회 기간, 주문 상태, 주문 정보(주문 타입)` 입니다.
  * 페이지네이션 API으로 요청을 받아서 페이지네이션으로 작업했습니다.

---

### 💬 참고 사항

* 사진에 주소가 나와있는데, 해당 부분은 제외될 부분입니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
