### PR TITLE
feat: 임시 결제 저장 정보 저장 API 위,경도 요청값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
@@ -45,6 +45,12 @@ public record OrdersResponse(
         @Schema(description = "주문 가게 이름", example = "김밥 천국", requiredMode = REQUIRED)
         String orderableShopName,
 
+        @Schema(description = "상점 오픈 여부", example = "false", requiredMode = REQUIRED)
+        Boolean openStatus,
+
+        @Schema(description = "주문 가게 썸네일 주소", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
+        String orderableShopThumbnail,
+
         @Schema(description = "주문 일시", example = "2025.09.07", requiredMode = REQUIRED)
         @JsonFormat(pattern = "yyyy.MM.dd")
         LocalDate orderDate,
@@ -53,7 +59,10 @@ public record OrdersResponse(
         String orderStatus,
 
         @Schema(description = "주문 내용", example = "김밥 외 1건", requiredMode = REQUIRED)
-        String orderTitle
+        String orderTitle,
+
+        @Schema(description = "주문 금액", example = "12300", requiredMode = REQUIRED)
+        Integer totalAmount
     ) {
         public static InnerOrderResponse from(OrderInfo orderInfo) {
             return new InnerOrderResponse(
@@ -61,9 +70,12 @@ public record OrdersResponse(
                 orderInfo.paymentId(),
                 orderInfo.orderShopId(),
                 orderInfo.orderableShopName(),
+                orderInfo.openStatus(),
+                orderInfo.orderableShopThumbnail(),
                 orderInfo.orderDate().toLocalDate(),
                 orderInfo.orderStatus().name(),
-                orderInfo.orderTitle()
+                orderInfo.orderTitle(),
+                orderInfo.totalAmount()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.order.order.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import in.koreatech.koin.common.model.BaseEntity;
@@ -41,6 +42,14 @@ public class OrderDelivery extends BaseEntity {
     @Column(name = "address_detail", columnDefinition = "TEXT")
     private String addressDetail;
 
+    @NotNull
+    @Column(name = "latitude", nullable = false, precision = 10, scale = 8)
+    private BigDecimal latitude;
+
+    @NotNull
+    @Column(name = "longitude", nullable = false, precision = 11, scale = 8)
+    private BigDecimal longitude;
+
     @Size(max = 50)
     @Column(name = "to_owner", length = 50, updatable = false)
     private String toOwner;
@@ -71,6 +80,8 @@ public class OrderDelivery extends BaseEntity {
         Order order,
         String address,
         String addressDetail,
+        BigDecimal latitude,
+        BigDecimal longitude,
         String toOwner,
         String toRider,
         Integer deliveryTip,
@@ -82,6 +93,8 @@ public class OrderDelivery extends BaseEntity {
         this.order = order;
         this.address = address;
         this.addressDetail = addressDetail;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.toOwner = toOwner;
         this.toRider = toRider;
         this.deliveryTip = deliveryTip;

--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderInfo.java
@@ -7,9 +7,12 @@ public record OrderInfo(
     Integer paymentId,
     Integer orderShopId,
     String orderableShopName,
+    Boolean openStatus,
+    String orderableShopThumbnail,
     LocalDateTime orderDate,
     OrderStatus orderStatus,
-    String orderTitle
+    String orderTitle,
+    Integer totalAmount
 ) {
     
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/repository/OrderSearchQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/repository/OrderSearchQueryRepository.java
@@ -5,6 +5,9 @@ import static com.querydsl.core.types.dsl.Expressions.anyOf;
 import static in.koreatech.koin.domain.order.order.model.QOrder.order;
 import static in.koreatech.koin.domain.order.order.model.QOrderMenu.orderMenu;
 import static in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShop.orderableShop;
+import static in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShopImage.orderableShopImage;
+import static in.koreatech.koin.domain.order.shop.model.entity.shop.QShopOperation.shopOperation;
+
 import static in.koreatech.koin.domain.payment.model.entity.QPayment.payment;
 
 import java.util.List;
@@ -16,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import in.koreatech.koin.domain.order.order.model.OrderInfo;
@@ -30,14 +35,22 @@ public class OrderSearchQueryRepository {
 
     public Page<OrderInfo> findOrdersByCondition(Integer userId, OrderSearchCriteria criteria) {
         Pageable pageable = PageRequest.of(criteria.page() - 1, criteria.limit());
+        var normalized = normalize(criteria.query());
+
         var predicate = allOf(
             order.user.id.eq(userId),
             criteria.period() != null ? criteria.period().getPredicate() : null,
             criteria.status() != null ? criteria.status().getPredicate() : null,
             criteria.type() != null ? criteria.type().getPredicate() : null,
             anyOf(
-                orderableShop.shop.internalName.contains(normalize(criteria.query())),
-                orderMenu.menuName.contains(normalize(criteria.query()))
+                orderableShop.shop.internalName.contains(normalized),
+                JPAExpressions.selectOne()
+                    .from(orderMenu)
+                    .where(
+                        orderMenu.order.id.eq(order.id)
+                            .and(orderMenu.menuName.contains(normalized))
+                    )
+                    .exists()
             )
         );
 
@@ -47,13 +60,16 @@ public class OrderSearchQueryRepository {
                 payment.id,
                 order.orderableShop.id,
                 order.orderableShopName,
+                shopOperation.isOpen,
+                getOrderableShopThumbnailSubquery(),
                 order.createdAt,
                 order.status,
-                payment.description))
+                payment.description,
+                order.totalPrice))
             .from(order)
             .innerJoin(payment).on(payment.order.id.eq(order.id))
             .innerJoin(orderableShop).on(orderableShop.id.eq(order.orderableShop.id))
-            .innerJoin(orderMenu).on(orderMenu.order.id.eq(order.id))
+            .innerJoin(shopOperation).on(shopOperation.shop.id.eq(orderableShop.shop.id))
             .where(predicate)
             .orderBy(order.id.asc())
             .offset(pageable.getOffset())
@@ -69,6 +85,14 @@ public class OrderSearchQueryRepository {
             .fetchCount();
 
         return new PageImpl<>(results, pageable, total);
+    }
+
+    private JPQLQuery<String> getOrderableShopThumbnailSubquery() {
+        return JPAExpressions
+            .select(orderableShopImage.imageUrl)
+            .from(orderableShopImage)
+            .where(orderableShopImage.orderableShop.id.eq(orderableShop.id)
+                .and(orderableShopImage.isThumbnail.eq(true)));
     }
 
     private String normalize(String s) {

--- a/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
@@ -39,9 +39,10 @@ public interface PaymentApi {
             ## 요청 Body 필드 설명
             - `address`: 배달 받을 주소 (필수)
             - `phone_number`: 수신자 연락처 (필수)
-            - `to_owner`: 사장님께 전달할 메시지 (선택)
+            - `to_owner`: 사장님에게 전달할 메시지 (선택)
             - `to_rider`: 라이더에게 전달할 메시지 (선택)
             - `total_menu_price`: 메뉴 총 금액 (필수)
+            - `delivery_type`: 배달 타입(필수, `CAMPUS`(교내 배달) & `OFF_CAMPUS`(교외 배달))
             - `delivery_tip`: 배달 팁 (필수)
             - `total_amount`: 총 결제 금액 (필수)
             """

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,6 +21,14 @@ public record TemporaryDeliveryPaymentSaveRequest(
 
     @Schema(description = "배달 상세 주소", example = "은솔관 422호", requiredMode = NOT_REQUIRED)
     String addressDetail,
+
+    @Schema(description = "배달 주소 위도", example = "36.76125794", requiredMode = REQUIRED)
+    @NotNull(message = "배달 주소 위도는 필수 입력사항입니다.")
+    BigDecimal longitude,
+
+    @Schema(description = "배달 주소 경도", example = "127.28372942", requiredMode = REQUIRED)
+    @NotNull(message = "배달 주소 경도는 필수 입력사항입니다.")
+    BigDecimal latitude,
 
     @Schema(description = "연락처", example = "01012345678", requiredMode = REQUIRED)
     @NotBlank(message = "연락처는 필수 입력사항입니다.")

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
@@ -47,7 +47,7 @@ public record TemporaryDeliveryPaymentSaveRequest(
     Integer totalMenuPrice,
 
     @Schema(description = "배달 타입", example = "OFF_CAMPUS", requiredMode = REQUIRED)
-    @NotBlank(message = "배달 타입은 필수 입력사항입니다.")
+    @NotNull(message = "배달 타입은 필수 입력사항입니다.")
     AddressType deliveryType,
 
     @Schema(description = "배달 팁", example = "1234", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.order.delivery.model.AddressType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -44,6 +45,10 @@ public record TemporaryDeliveryPaymentSaveRequest(
     @Schema(description = "메뉴 총 금액", example = "1234", requiredMode = REQUIRED)
     @NotNull(message = "메뉴 총 금액은 필수 입력사항입니다.")
     Integer totalMenuPrice,
+
+    @Schema(description = "배달 타입", example = "OFF_CAMPUS", requiredMode = REQUIRED)
+    @NotBlank(message = "배달 타입은 필수 입력사항입니다.")
+    AddressType deliveryType,
 
     @Schema(description = "배달 팁", example = "1234", requiredMode = REQUIRED)
     @NotNull(message = "배달 팁은 필수 입력사항입니다.")

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -6,6 +6,7 @@ import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,8 +19,8 @@ import in.koreatech.koin.domain.order.order.model.OrderDelivery;
 import in.koreatech.koin.domain.order.order.model.OrderMenu;
 import in.koreatech.koin.domain.order.order.model.OrderMenuOption;
 import in.koreatech.koin.domain.order.order.model.OrderTakeout;
-import in.koreatech.koin.domain.payment.model.entity.Payment;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import in.koreatech.koin.domain.payment.model.entity.Payment;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -33,6 +34,12 @@ public record PaymentConfirmResponse(
 
     @Schema(description = "배달상세 주소", example = "은솔관 422호", requiredMode = NOT_REQUIRED)
     String deliveryAddressDetails,
+
+    @Schema(description = "배달 주소 위도", example = "36.76125794", requiredMode = NOT_REQUIRED)
+    BigDecimal longitude,
+
+    @Schema(description = "배달 주소 경도", example = "127.28372942", requiredMode = NOT_REQUIRED)
+    BigDecimal latitude,
 
     @Schema(description = "가게 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600 은솔관 422호", requiredMode = NOT_REQUIRED)
     String shopAddress,
@@ -134,6 +141,8 @@ public record PaymentConfirmResponse(
 
         String deliveryAddress = null;
         String deliveryAddressDetails = null;
+        BigDecimal longitude = null;
+        BigDecimal latitude = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -142,6 +151,8 @@ public record PaymentConfirmResponse(
             OrderDelivery delivery = order.getOrderDelivery();
             deliveryAddress = delivery.getAddress();
             deliveryAddressDetails = delivery.getAddressDetail();
+            longitude = delivery.getLongitude();
+            latitude = delivery.getLatitude();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -155,6 +166,8 @@ public record PaymentConfirmResponse(
             payment.getId(),
             deliveryAddress,
             deliveryAddressDetails,
+            longitude,
+            latitude,
             shop.getAddress(),
             toOwner,
             toRider,

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -29,6 +29,9 @@ public record PaymentConfirmResponse(
     @Schema(description = "결제 고유 id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
+    @Schema(description = "주문 상점 고유 id", example = "1", requiredMode = REQUIRED)
+    Integer orderableShopId,
+
     @Schema(description = "배달 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = NOT_REQUIRED)
     String deliveryAddress,
 
@@ -52,6 +55,12 @@ public record PaymentConfirmResponse(
 
     @Schema(description = "수저, 포크 수령 여부", example = "true", requiredMode = REQUIRED)
     Boolean provideCutlery,
+
+    @Schema(description = "메뉴 총 금액", example = "500", requiredMode = REQUIRED)
+    Integer totalMenuPrice,
+
+    @Schema(description = "배달비", example = "500", requiredMode = NOT_REQUIRED)
+    Integer deliveryTip,
 
     @Schema(description = "결제 금액", example = "1000", requiredMode = REQUIRED)
     Integer amount,
@@ -143,6 +152,7 @@ public record PaymentConfirmResponse(
         String deliveryAddressDetails = null;
         BigDecimal longitude = null;
         BigDecimal latitude = null;
+        Integer deliveryTip = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -153,6 +163,7 @@ public record PaymentConfirmResponse(
             deliveryAddressDetails = delivery.getAddressDetail();
             longitude = delivery.getLongitude();
             latitude = delivery.getLatitude();
+            deliveryTip = delivery.getDeliveryTip();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -164,6 +175,7 @@ public record PaymentConfirmResponse(
 
         return new PaymentConfirmResponse(
             payment.getId(),
+            orderableShop.getId(),
             deliveryAddress,
             deliveryAddressDetails,
             longitude,
@@ -172,7 +184,9 @@ public record PaymentConfirmResponse(
             toOwner,
             toRider,
             provideCutlery,
-            payment.getAmount(),
+            order.getTotalProductPrice(),
+            deliveryTip,
+            order.getTotalPrice(),
             shop.getName(),
             order.getOrderMenus().stream()
                 .map(InnerCartItemResponse::from)

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
@@ -6,6 +6,7 @@ import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,12 @@ public record PaymentResponse(
 
     @Schema(description = "가게 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600 은솔관 422호", requiredMode = NOT_REQUIRED)
     String shopAddress,
+
+    @Schema(description = "배달 주소 위도", example = "36.76125794", requiredMode = NOT_REQUIRED)
+    BigDecimal longitude,
+
+    @Schema(description = "배달 주소 경도", example = "127.28372942", requiredMode = NOT_REQUIRED)
+    BigDecimal latitude,
 
     @Schema(description = "사장님에게", example = "리뷰 이벤트 감사합니다.", requiredMode = NOT_REQUIRED)
     String toOwner,
@@ -134,6 +141,8 @@ public record PaymentResponse(
 
         String deliveryAddress = null;
         String deliveryAddressDetails = null;
+        BigDecimal longitude = null;
+        BigDecimal latitude = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -142,6 +151,8 @@ public record PaymentResponse(
             OrderDelivery delivery = order.getOrderDelivery();
             deliveryAddress = delivery.getAddress();
             deliveryAddressDetails = delivery.getAddressDetail();
+            longitude = delivery.getLongitude();
+            latitude = delivery.getLatitude();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -156,6 +167,8 @@ public record PaymentResponse(
             deliveryAddress,
             deliveryAddressDetails,
             shop.getAddress(),
+            longitude,
+            latitude,
             toOwner,
             toRider,
             provideCutlery,

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
@@ -29,6 +29,9 @@ public record PaymentResponse(
     @Schema(description = "결제 고유 id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
+    @Schema(description = "주문 상점 고유 id", example = "1", requiredMode = REQUIRED)
+    Integer orderableShopId,
+
     @Schema(description = "배달 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = NOT_REQUIRED)
     String deliveryAddress,
 
@@ -52,6 +55,12 @@ public record PaymentResponse(
 
     @Schema(description = "수저, 포크 수령 여부", example = "true", requiredMode = REQUIRED)
     Boolean provideCutlery,
+
+    @Schema(description = "메뉴 총 금액", example = "500", requiredMode = REQUIRED)
+    Integer totalMenuPrice,
+
+    @Schema(description = "배달비", example = "500", requiredMode = NOT_REQUIRED)
+    Integer deliveryTip,
 
     @Schema(description = "결제 금액", example = "1000", requiredMode = REQUIRED)
     Integer amount,
@@ -143,6 +152,7 @@ public record PaymentResponse(
         String deliveryAddressDetails = null;
         BigDecimal longitude = null;
         BigDecimal latitude = null;
+        Integer deliveryTip = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -153,6 +163,7 @@ public record PaymentResponse(
             deliveryAddressDetails = delivery.getAddressDetail();
             longitude = delivery.getLongitude();
             latitude = delivery.getLatitude();
+            deliveryTip = delivery.getDeliveryTip();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -164,6 +175,7 @@ public record PaymentResponse(
 
         return new PaymentResponse(
             payment.getId(),
+            orderableShop.getId(),
             deliveryAddress,
             deliveryAddressDetails,
             shop.getAddress(),
@@ -172,7 +184,9 @@ public record PaymentResponse(
             toOwner,
             toRider,
             provideCutlery,
-            payment.getAmount(),
+            order.getTotalProductPrice(),
+            deliveryTip,
+            order.getTotalPrice(),
             shop.getName(),
             order.getOrderMenus().stream()
                 .map(InnerCartItemResponse::from)

--- a/src/main/java/in/koreatech/koin/domain/payment/model/domain/DeliveryPaymentInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/domain/DeliveryPaymentInfo.java
@@ -2,12 +2,16 @@ package in.koreatech.koin.domain.payment.model.domain;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.ORDER_PRICE_MISMATCH;
 
+import java.math.BigDecimal;
+
 import in.koreatech.koin.global.exception.CustomException;
 
 public record DeliveryPaymentInfo(
     String phoneNumber,
     String address,
     String addressDetail,
+    BigDecimal longitude,
+    BigDecimal latitude,
     String toOwner,
     String toRider,
     Boolean provideCutlery,
@@ -19,6 +23,8 @@ public record DeliveryPaymentInfo(
         String phoneNumber,
         String address,
         String addressDetail,
+        BigDecimal longitude,
+        BigDecimal latitude,
         String toOwner,
         String toRider,
         Boolean provideCutlery,
@@ -30,6 +36,8 @@ public record DeliveryPaymentInfo(
             phoneNumber,
             address,
             addressDetail,
+            longitude,
+            latitude,
             toOwner,
             toRider,
             provideCutlery,

--- a/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
@@ -185,6 +185,8 @@ public class TemporaryPayment {
                 .order(order)
                 .address(address)
                 .addressDetail(addressDetail)
+                .latitude(latitude)
+                .longitude(longitude)
                 .toOwner(toOwner)
                 .toRider(toRider)
                 .provideCutlery(provideCutlery)

--- a/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/model/redis/TemporaryPayment.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.domain.order.order.model.OrderType.DELIVERY;
 import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
 import static in.koreatech.koin.global.code.ApiResponseCode.MISMATCH_TEMPORARY_PAYMENT;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.Id;
@@ -41,6 +42,10 @@ public class TemporaryPayment {
 
     private String addressDetail;
 
+    private BigDecimal longitude;
+
+    private BigDecimal latitude;
+
     private String toOwner;
 
     private String toRider;
@@ -66,6 +71,8 @@ public class TemporaryPayment {
         OrderType orderType,
         String address,
         String addressDetail,
+        BigDecimal longitude,
+        BigDecimal latitude,
         String toOwner,
         String toRider,
         Boolean provideCutlery,
@@ -80,6 +87,8 @@ public class TemporaryPayment {
         this.orderType = orderType;
         this.address = address;
         this.addressDetail = addressDetail;
+        this.longitude = longitude;
+        this.latitude = latitude;
         this.toOwner = toOwner;
         this.toRider = toRider;
         this.provideCutlery = provideCutlery;
@@ -97,6 +106,8 @@ public class TemporaryPayment {
         String phoneNumber,
         String address,
         String addressDetail,
+        BigDecimal longitude,
+        BigDecimal latitude,
         String toOwner,
         String toRider,
         Boolean provideCutlery,
@@ -112,6 +123,8 @@ public class TemporaryPayment {
             DELIVERY,
             address,
             addressDetail,
+            longitude,
+            latitude,
             toOwner,
             toRider,
             provideCutlery,
@@ -137,6 +150,8 @@ public class TemporaryPayment {
             orderableShopId,
             phoneNumber,
             TAKE_OUT,
+            null,
+            null,
             null,
             null,
             toOwner,

--- a/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
@@ -38,6 +38,8 @@ public class PaymentService {
             request.phoneNumber(),
             request.address(),
             request.addressDetail(),
+            request.longitude(),
+            request.latitude(),
             request.toOwner(),
             request.toRider(),
             request.provideCutlery(),

--- a/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.payment.service;
 import org.springframework.stereotype.Service;
 
 import in.koreatech.koin.domain.address.service.AddressValidator;
+import in.koreatech.koin.domain.order.delivery.model.AddressType;
 import in.koreatech.koin.domain.payment.dto.request.PaymentCancelRequest;
 import in.koreatech.koin.domain.payment.dto.request.PaymentConfirmRequest;
 import in.koreatech.koin.domain.payment.dto.request.TemporaryDeliveryPaymentSaveRequest;
@@ -32,7 +33,9 @@ public class PaymentService {
     public TemporaryPaymentResponse createTemporaryDeliveryPayment(
         Integer userId, TemporaryDeliveryPaymentSaveRequest request
     ) {
-        addressValidator.validateAddress(request.address());
+        if (request.deliveryType() == AddressType.OFF_CAMPUS) {
+            addressValidator.validateAddress(request.address());
+        }
         User user = userAuthenticationService.authenticateUser(userId);
         DeliveryPaymentInfo deliveryPaymentInfo = DeliveryPaymentInfo.of(
             request.phoneNumber(),

--- a/src/main/java/in/koreatech/koin/domain/payment/service/TemporaryPaymentService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/TemporaryPaymentService.java
@@ -42,6 +42,8 @@ public class TemporaryPaymentService {
             deliveryPaymentInfo.phoneNumber(),
             deliveryPaymentInfo.address(),
             deliveryPaymentInfo.addressDetail(),
+            deliveryPaymentInfo.longitude(),
+            deliveryPaymentInfo.latitude(),
             deliveryPaymentInfo.toOwner(),
             deliveryPaymentInfo.toRider(),
             deliveryPaymentInfo.provideCutlery(),

--- a/src/main/resources/db/migration/V225__alter_order_delivery_add_column.sql
+++ b/src/main/resources/db/migration/V225__alter_order_delivery_add_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `koin`.`order_delivery_v2`
+    ADD COLUMN `latitude` DECIMAL(10, 8) NULL COMMENT '위도' AFTER `address_detail`,
+    ADD COLUMN `longitude` DECIMAL(11, 8) NULL COMMENT '경도' AFTER `latitude`;


### PR DESCRIPTION
### 🔍 개요

<img width="415" height="255" alt="image" src="https://github.com/user-attachments/assets/0c89a27b-d2d7-47be-9c31-5b723aadb4c2" />

- 클라이언트 요청으로 위,경도 요청값 추가
- close #1955

---

### 🚀 주요 변경 내용

* POST /payments/temporary/delivery 요청값에 위도, 경도 값을 추가했습니다.
* order_delivery_v2 테이블에 주문 주소의 위도, 경도 컬럼을 추가했습니다.
* 주문 조회 응답값에 주문 주소의 위도, 경도 값을 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
