### PR TITLE
feat: 결제 조회 API 응답값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -53,6 +53,12 @@ public record PaymentConfirmResponse(
     @Schema(description = "수저, 포크 수령 여부", example = "true", requiredMode = REQUIRED)
     Boolean provideCutlery,
 
+    @Schema(description = "메뉴 총 금액", example = "500", requiredMode = REQUIRED)
+    Integer totalMenuPrice,
+
+    @Schema(description = "배달비", example = "500", requiredMode = NOT_REQUIRED)
+    Integer deliveryTip,
+
     @Schema(description = "결제 금액", example = "1000", requiredMode = REQUIRED)
     Integer amount,
 
@@ -143,6 +149,7 @@ public record PaymentConfirmResponse(
         String deliveryAddressDetails = null;
         BigDecimal longitude = null;
         BigDecimal latitude = null;
+        Integer deliveryTip = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -153,6 +160,7 @@ public record PaymentConfirmResponse(
             deliveryAddressDetails = delivery.getAddressDetail();
             longitude = delivery.getLongitude();
             latitude = delivery.getLatitude();
+            deliveryTip = delivery.getDeliveryTip();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -172,7 +180,9 @@ public record PaymentConfirmResponse(
             toOwner,
             toRider,
             provideCutlery,
-            payment.getAmount(),
+            order.getTotalProductPrice(),
+            deliveryTip,
+            order.getTotalPrice(),
             shop.getName(),
             order.getOrderMenus().stream()
                 .map(InnerCartItemResponse::from)

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentConfirmResponse.java
@@ -29,6 +29,9 @@ public record PaymentConfirmResponse(
     @Schema(description = "결제 고유 id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
+    @Schema(description = "주문 상점 고유 id", example = "1", requiredMode = REQUIRED)
+    Integer orderableShopId,
+
     @Schema(description = "배달 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = NOT_REQUIRED)
     String deliveryAddress,
 
@@ -172,6 +175,7 @@ public record PaymentConfirmResponse(
 
         return new PaymentConfirmResponse(
             payment.getId(),
+            orderableShop.getId(),
             deliveryAddress,
             deliveryAddressDetails,
             longitude,

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
@@ -53,6 +53,12 @@ public record PaymentResponse(
     @Schema(description = "수저, 포크 수령 여부", example = "true", requiredMode = REQUIRED)
     Boolean provideCutlery,
 
+    @Schema(description = "메뉴 총 금액", example = "500", requiredMode = REQUIRED)
+    Integer totalMenuPrice,
+
+    @Schema(description = "배달비", example = "500", requiredMode = NOT_REQUIRED)
+    Integer deliveryTip,
+
     @Schema(description = "결제 금액", example = "1000", requiredMode = REQUIRED)
     Integer amount,
 
@@ -143,6 +149,7 @@ public record PaymentResponse(
         String deliveryAddressDetails = null;
         BigDecimal longitude = null;
         BigDecimal latitude = null;
+        Integer deliveryTip = null;
         String toOwner = null;
         String toRider = null;
         Boolean provideCutlery = null;
@@ -153,6 +160,7 @@ public record PaymentResponse(
             deliveryAddressDetails = delivery.getAddressDetail();
             longitude = delivery.getLongitude();
             latitude = delivery.getLatitude();
+            deliveryTip = delivery.getDeliveryTip();
             toOwner = delivery.getToOwner();
             toRider = delivery.getToRider();
             provideCutlery = delivery.getProvideCutlery();
@@ -172,7 +180,9 @@ public record PaymentResponse(
             toOwner,
             toRider,
             provideCutlery,
-            payment.getAmount(),
+            order.getTotalProductPrice(),
+            deliveryTip,
+            order.getTotalPrice(),
             shop.getName(),
             order.getOrderMenus().stream()
                 .map(InnerCartItemResponse::from)

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
@@ -29,6 +29,9 @@ public record PaymentResponse(
     @Schema(description = "결제 고유 id", example = "1", requiredMode = REQUIRED)
     Integer id,
 
+    @Schema(description = "주문 상점 고유 id", example = "1", requiredMode = REQUIRED)
+    Integer orderableShopId,
+
     @Schema(description = "배달 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = NOT_REQUIRED)
     String deliveryAddress,
 
@@ -172,6 +175,7 @@ public record PaymentResponse(
 
         return new PaymentResponse(
             payment.getId(),
+            orderableShop.getId(),
             deliveryAddress,
             deliveryAddressDetails,
             shop.getAddress(),


### PR DESCRIPTION
### 🔍 개요

<img width="392" height="220" alt="image" src="https://github.com/user-attachments/assets/94ff25dd-7707-4254-9328-96ae5c9bf475" />

- 클라이이언트 요청으로 결제 조회 API 응답값을 추가했습니다.
- close #1957 

---

### 🚀 주요 변경 내용

* `POST /payments/confirm, GET /payments/{paymentId}` 응답값에 `배달비, 메뉴 총 금액, 주문 가능 상점 ID`를 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
