### PR TITLE
fix: 활성화된 주문 조회 API 응답값(변수명) 통일

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
@@ -19,16 +19,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonNaming(value = SnakeCaseStrategy.class)
 public record InprogressOrderResponse(
     @Schema(description = "주문 ID", example = "1", requiredMode = REQUIRED)
-    Integer orderId,
+    Integer id,
 
     @Schema(description = "주문 타입", example = "TAKEOUT", requiredMode = REQUIRED)
     String orderType,
 
     @Schema(description = "상점 이름", example = "코인 병천점", requiredMode = REQUIRED)
-    String shopName,
+    String orderableShopName,
 
     @Schema(description = "상점 썸네일 URL", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
-    String shopThumbnail,
+    String orderableShopThumbnail,
 
     @Schema(description = "예상 시각", example = "17:45", requiredMode = NOT_REQUIRED)
     @JsonFormat(pattern = "HH:mm")
@@ -38,7 +38,7 @@ public record InprogressOrderResponse(
     String orderStatus,
 
     @Schema(description = "주문 내용", example = "족발 외 1건", requiredMode = REQUIRED)
-    String paymentDescription,
+    String orderTitle,
 
     @Schema(description = "총 금액", example = "50000", requiredMode = REQUIRED)
     Integer totalAmount


### PR DESCRIPTION
### 🔍 개요

* 현재 sprint에 사용되는 두개의 API (/order, /order/in-progress)의 응답값(변수명)이 달라 /order/in-progress API의 변수명을 통일함.

- close #1959 

---

### 🚀 주요 변경 내용

* 응답값(변수명)을 통일하기 위해 변수명 변경하였습니다.


---

### 💬 참고 사항

*


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
