### PR TITLE
Refactor/article content s3 upload

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleResponse.java
@@ -54,12 +54,12 @@ public record ArticleResponse(
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt
 ) {
 
-    public static ArticleResponse of(Article article) {
+    public static ArticleResponse from(Article article, String content) {
         return new ArticleResponse(
             article.getId(),
             article.getBoard().getId(),
             article.getTitle(),
-            article.getContent(),
+            content,
             article.getAuthor(),
             article.getTotalHit(),
             article.getUrl(),

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -74,7 +74,10 @@ public class ArticleService {
     @Transactional
     public ArticleResponse getArticle(Integer boardId, Integer articleId, String publicIp) {
         Article article = articleRepository.getById(articleId);
-        String content = s3Client.getContentFromUrl(article.getContent());
+        String content = article.getContent();
+        if (content.startsWith("https")) {
+            content = s3Client.getContentFromUrl(article.getContent());
+        }
         if (articleHitUserRepository.findByArticleIdAndPublicIp(articleId, publicIp).isEmpty()) {
             article.increaseKoinHit();
             articleHitUserRepository.save(ArticleHitUser.of(articleId, publicIp));

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleService.java
@@ -29,8 +29,6 @@ import in.koreatech.koin.domain.community.article.model.redis.ArticleHitUser;
 import in.koreatech.koin.domain.community.article.model.redis.PopularKeywordTracker;
 import in.koreatech.koin.domain.community.article.model.KeywordRankingManager;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
-import in.koreatech.koin.domain.community.article.repository.ArticleSearchKeywordIpMapRepository;
-import in.koreatech.koin.domain.community.article.repository.ArticleSearchKeywordRepository;
 import in.koreatech.koin.domain.community.article.repository.BoardRepository;
 import in.koreatech.koin.domain.community.article.repository.redis.ArticleHitUserRepository;
 import in.koreatech.koin.domain.community.article.repository.redis.HotArticleRepository;
@@ -41,6 +39,7 @@ import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.global.auth.exception.AuthorizationException;
 import in.koreatech.koin.global.exception.custom.KoinIllegalArgumentException;
 import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.infrastructure.s3.client.S3Client;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -67,6 +66,7 @@ public class ArticleService {
     private final ArticleHitUserRepository articleHitUserRepository;
     private final UserRepository userRepository;
     private final Clock clock;
+    private final S3Client s3Client;
     private final KeywordExtractor keywordExtractor;
     private final PopularKeywordTracker popularKeywordTracker;
     private final KeywordRankingManager keywordRankingManager;
@@ -74,12 +74,13 @@ public class ArticleService {
     @Transactional
     public ArticleResponse getArticle(Integer boardId, Integer articleId, String publicIp) {
         Article article = articleRepository.getById(articleId);
+        String content = s3Client.getContentFromUrl(article.getContent());
         if (articleHitUserRepository.findByArticleIdAndPublicIp(articleId, publicIp).isEmpty()) {
             article.increaseKoinHit();
             articleHitUserRepository.save(ArticleHitUser.of(articleId, publicIp));
         }
         setPrevNextArticle(boardId, article);
-        return ArticleResponse.of(article);
+        return ArticleResponse.from(article, content);
     }
 
     public ArticlesResponse getArticles(Integer boardId, Integer page, Integer limit, Integer userId) {

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/client/S3Client.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/client/S3Client.java
@@ -86,7 +86,7 @@ public class S3Client {
                 .bodyToMono(String.class)
                 .block();
         } catch (Exception e) {
-            throw new KoinIllegalStateException("S3 텍스트를 불러오던 중 문제가 발생했습니다. " + e.getMessage());
+            throw new KoinIllegalStateException("URL로 부터 데이터를 불러오던 중 문제가 발생했습니다. " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
### 🔍 개요

* articles 테이블의 용량 문제로 DB 덤프가 실패하는 문제가 있습니다.

- close #1961 

---

### 🚀 주요 변경 내용

* articles 테이블의 content(본문) 컬럼 저장 방식을 변경하였습니다.
    * 기존: 크롤링 된 본문을 DB에 그대로 저장
    * 수정: 크롤링 된 본문을 s3에 업로드 후 접근 url을 DB에 저장

---

### 💬 참고 사항
* 다음 순서로 진행할 예정입니다.
    * 1. 게시글 조회 API에 본문 그대로/url 통해서 조회 둘다 가능하게 적용
    * 2. 기존 content들 s3업로드, 본문 -> url로 변경
    * 3. 배치 크롤링에서 본문 저장 -> s3 업로드&url로 저장 으로 수정
* 분실물 게시판(14번)은 본문이 html 형식이 아니라서 제외했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
