### PR TITLE
fix: confirming이 아닐 때 예상 시각이 null이면 localTime을 넣도록 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
@@ -105,4 +105,8 @@ public class OrderDelivery extends BaseEntity {
         this.dispatchedAt = LocalDateTime.now();
         this.order.delivering();
     }
+
+    public void updateEstimatedArrivalAt() {
+        this.estimatedArrivalAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderTakeout.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderTakeout.java
@@ -75,4 +75,8 @@ public class OrderTakeout extends BaseEntity {
     public void pickedUp() {
         this.order.pickedUp();
     }
+
+    public void updateEstimatedPackagedAt() {
+        this.estimatedPackagedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
@@ -44,8 +44,7 @@ public class OrderTestService {
                     OrderTakeout orderTakeout = order.getOrderTakeout();
                     orderTakeout.updateEstimatedPackagedAt();
                 }
-            }
-            else if (order.getOrderType().equals(DELIVERY)) {
+            } else if (order.getOrderType().equals(DELIVERY)) {
                 if (order.getOrderDelivery().getEstimatedArrivalAt() == null) {
                     OrderDelivery orderDelivery = order.getOrderDelivery();
                     orderDelivery.updateEstimatedArrivalAt();

--- a/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/service/OrderTestService.java
@@ -5,6 +5,9 @@ import static in.koreatech.koin.domain.order.order.model.OrderType.DELIVERY;
 import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
 import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_ORDER;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +36,21 @@ public class OrderTestService {
         Order order = orderRepository.getById(orderId);
         if (!order.getUser().getId().equals(user.getId())) {
             throw CustomException.of(FORBIDDEN_ORDER);
+        }
+
+        if (orderStatus != CONFIRMING) {
+            if (order.getOrderType().equals(TAKE_OUT)) {
+                if (order.getOrderTakeout().getEstimatedPackagedAt() == null) {
+                    OrderTakeout orderTakeout = order.getOrderTakeout();
+                    orderTakeout.updateEstimatedPackagedAt();
+                }
+            }
+            else if (order.getOrderType().equals(DELIVERY)) {
+                if (order.getOrderDelivery().getEstimatedArrivalAt() == null) {
+                    OrderDelivery orderDelivery = order.getOrderDelivery();
+                    orderDelivery.updateEstimatedArrivalAt();
+                }
+            }
         }
 
         if (orderStatus.equals(COOKING)) {


### PR DESCRIPTION
### 🔍 개요

* 현재 confirming이 아닐 경우 null을 허용하지 않으나, status를 바꾸는 API에서 고려가 되지 않았기 때문에 confirming이 아닐 떄 예상 시각이 null이면 localTime을 넣도록 변경함

- close #1966 

### 🚀 주요 변경 내용

* OrderDelivery, OrderTakeout 쪽에 예상 시각(estimated_packaged_at, estimated_arrival_at)을 변경하는 로직 추가


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
