### PR TITLE
feat: 임시 배달 결제 정보 저장 API 배달 타입 요청값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
@@ -39,9 +39,10 @@ public interface PaymentApi {
             ## 요청 Body 필드 설명
             - `address`: 배달 받을 주소 (필수)
             - `phone_number`: 수신자 연락처 (필수)
-            - `to_owner`: 사장님께 전달할 메시지 (선택)
+            - `to_owner`: 사장님에게 전달할 메시지 (선택)
             - `to_rider`: 라이더에게 전달할 메시지 (선택)
             - `total_menu_price`: 메뉴 총 금액 (필수)
+            - `delivery_type`: 배달 타입(필수, `CAMPUS`(교내 배달) & `OFF_CAMPUS`(교외 배달))
             - `delivery_tip`: 배달 팁 (필수)
             - `total_amount`: 총 결제 금액 (필수)
             """

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import in.koreatech.koin.domain.order.delivery.model.AddressType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -44,6 +45,10 @@ public record TemporaryDeliveryPaymentSaveRequest(
     @Schema(description = "메뉴 총 금액", example = "1234", requiredMode = REQUIRED)
     @NotNull(message = "메뉴 총 금액은 필수 입력사항입니다.")
     Integer totalMenuPrice,
+
+    @Schema(description = "배달 타입", example = "OFF_CAMPUS", requiredMode = REQUIRED)
+    @NotBlank(message = "배달 타입은 필수 입력사항입니다.")
+    AddressType deliveryType,
 
     @Schema(description = "배달 팁", example = "1234", requiredMode = REQUIRED)
     @NotNull(message = "배달 팁은 필수 입력사항입니다.")

--- a/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.payment.service;
 import org.springframework.stereotype.Service;
 
 import in.koreatech.koin.domain.address.service.AddressValidator;
+import in.koreatech.koin.domain.order.delivery.model.AddressType;
 import in.koreatech.koin.domain.payment.dto.request.PaymentCancelRequest;
 import in.koreatech.koin.domain.payment.dto.request.PaymentConfirmRequest;
 import in.koreatech.koin.domain.payment.dto.request.TemporaryDeliveryPaymentSaveRequest;
@@ -32,7 +33,9 @@ public class PaymentService {
     public TemporaryPaymentResponse createTemporaryDeliveryPayment(
         Integer userId, TemporaryDeliveryPaymentSaveRequest request
     ) {
-        addressValidator.validateAddress(request.address());
+        if (request.deliveryType() == AddressType.OFF_CAMPUS) {
+            addressValidator.validateAddress(request.address());
+        }
         User user = userAuthenticationService.authenticateUser(userId);
         DeliveryPaymentInfo deliveryPaymentInfo = DeliveryPaymentInfo.of(
             request.phoneNumber(),


### PR DESCRIPTION
### 🔍 개요
#### 문제 상황
- 임시 배달 결제 정보 저장 API의 교내 배달 주소 검증 과정에서 클라이언트에서 인자로 넘기는 address 를 그대로 사용하면 검증 오류가 발생
```java
@JsonNaming(value = SnakeCaseStrategy.class)
public record TemporaryDeliveryPaymentSaveRequest(
    @Schema(description = "배달 주소", example = "충청남도 천안시 동남구 병천면 충절로 1600", requiredMode = REQUIRED)
    @NotBlank(message = "배달 주소는 필수 입력사항입니다.")
    String address
```

#### 발생 원인
- `address` 값에 `충청남도 천안시 동남구 병천면 충절로 1600 한국기술교육대학교 제1캠퍼스 생활관 104동` 이나 `충청남도 천안시 동남구 병천면 충절로 1600 한국기술교육대학교 제1캠퍼스 생활관` 을 넘겨주고 있는 상황. 
- 검증에 사용하는 외부 API에서 해당 주소를 정상적인 주소로 판단하지 못하는 문제 발생

#### 해결 방안
1. 임시 결제 정보 저장 API Request에 교내배달, 교외배달 타입 필드 추가해서 교내 배달인 경우 검증 생략하기
2. 검증 외부 API에서 정상적인 주소로 판단하는 `충청남도 천안시 동남구 병천면 충절로 1600 한국기술교육대학교` 값을 넘길 수 있는 필드 추가하기

- 2번 의 경우 DB에 불필요한 데이터를 추가해야 하는 작업 필요. 배달 타입 필드를 클라이언트 내부에서 관리하고 있으므로 1번 방법을 사용하기로 결정함.

- close #1967

---

### 🚀 주요 변경 내용

* 임시 결제 정보 저장 API Request에 교내배달, 교외배달 타입 필드 추가

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
