### PR TITLE
feat: 주문 조회 이력 API 응답값 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/OrdersResponse.java
@@ -45,6 +45,12 @@ public record OrdersResponse(
         @Schema(description = "주문 가게 이름", example = "김밥 천국", requiredMode = REQUIRED)
         String orderableShopName,
 
+        @Schema(description = "상점 오픈 여부", example = "false", requiredMode = REQUIRED)
+        Boolean openStatus,
+
+        @Schema(description = "주문 가게 썸네일 주소", example = "https://static.koreatech.in/test.png", requiredMode = REQUIRED)
+        String orderableShopThumbnail,
+
         @Schema(description = "주문 일시", example = "2025.09.07", requiredMode = REQUIRED)
         @JsonFormat(pattern = "yyyy.MM.dd")
         LocalDate orderDate,
@@ -53,7 +59,10 @@ public record OrdersResponse(
         String orderStatus,
 
         @Schema(description = "주문 내용", example = "김밥 외 1건", requiredMode = REQUIRED)
-        String orderTitle
+        String orderTitle,
+
+        @Schema(description = "주문 금액", example = "12300", requiredMode = REQUIRED)
+        Integer totalAmount
     ) {
         public static InnerOrderResponse from(OrderInfo orderInfo) {
             return new InnerOrderResponse(
@@ -61,9 +70,12 @@ public record OrdersResponse(
                 orderInfo.paymentId(),
                 orderInfo.orderShopId(),
                 orderInfo.orderableShopName(),
+                orderInfo.openStatus(),
+                orderInfo.orderableShopThumbnail(),
                 orderInfo.orderDate().toLocalDate(),
                 orderInfo.orderStatus().name(),
-                orderInfo.orderTitle()
+                orderInfo.orderTitle(),
+                orderInfo.totalAmount()
             );
         }
     }

--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderInfo.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderInfo.java
@@ -7,9 +7,12 @@ public record OrderInfo(
     Integer paymentId,
     Integer orderShopId,
     String orderableShopName,
+    Boolean openStatus,
+    String orderableShopThumbnail,
     LocalDateTime orderDate,
     OrderStatus orderStatus,
-    String orderTitle
+    String orderTitle,
+    Integer totalAmount
 ) {
     
 }

--- a/src/main/java/in/koreatech/koin/domain/order/order/repository/OrderSearchQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/repository/OrderSearchQueryRepository.java
@@ -5,6 +5,9 @@ import static com.querydsl.core.types.dsl.Expressions.anyOf;
 import static in.koreatech.koin.domain.order.order.model.QOrder.order;
 import static in.koreatech.koin.domain.order.order.model.QOrderMenu.orderMenu;
 import static in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShop.orderableShop;
+import static in.koreatech.koin.domain.order.shop.model.entity.shop.QOrderableShopImage.orderableShopImage;
+import static in.koreatech.koin.domain.order.shop.model.entity.shop.QShopOperation.shopOperation;
+
 import static in.koreatech.koin.domain.payment.model.entity.QPayment.payment;
 
 import java.util.List;
@@ -16,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import in.koreatech.koin.domain.order.order.model.OrderInfo;
@@ -30,14 +35,22 @@ public class OrderSearchQueryRepository {
 
     public Page<OrderInfo> findOrdersByCondition(Integer userId, OrderSearchCriteria criteria) {
         Pageable pageable = PageRequest.of(criteria.page() - 1, criteria.limit());
+        var normalized = normalize(criteria.query());
+
         var predicate = allOf(
             order.user.id.eq(userId),
             criteria.period() != null ? criteria.period().getPredicate() : null,
             criteria.status() != null ? criteria.status().getPredicate() : null,
             criteria.type() != null ? criteria.type().getPredicate() : null,
             anyOf(
-                orderableShop.shop.internalName.contains(normalize(criteria.query())),
-                orderMenu.menuName.contains(normalize(criteria.query()))
+                orderableShop.shop.internalName.contains(normalized),
+                JPAExpressions.selectOne()
+                    .from(orderMenu)
+                    .where(
+                        orderMenu.order.id.eq(order.id)
+                            .and(orderMenu.menuName.contains(normalized))
+                    )
+                    .exists()
             )
         );
 
@@ -47,13 +60,16 @@ public class OrderSearchQueryRepository {
                 payment.id,
                 order.orderableShop.id,
                 order.orderableShopName,
+                shopOperation.isOpen,
+                getOrderableShopThumbnailSubquery(),
                 order.createdAt,
                 order.status,
-                payment.description))
+                payment.description,
+                order.totalPrice))
             .from(order)
             .innerJoin(payment).on(payment.order.id.eq(order.id))
             .innerJoin(orderableShop).on(orderableShop.id.eq(order.orderableShop.id))
-            .innerJoin(orderMenu).on(orderMenu.order.id.eq(order.id))
+            .innerJoin(shopOperation).on(shopOperation.shop.id.eq(orderableShop.shop.id))
             .where(predicate)
             .orderBy(order.id.asc())
             .offset(pageable.getOffset())
@@ -69,6 +85,14 @@ public class OrderSearchQueryRepository {
             .fetchCount();
 
         return new PageImpl<>(results, pageable, total);
+    }
+
+    private JPQLQuery<String> getOrderableShopThumbnailSubquery() {
+        return JPAExpressions
+            .select(orderableShopImage.imageUrl)
+            .from(orderableShopImage)
+            .where(orderableShopImage.orderableShop.id.eq(orderableShop.id)
+                .and(orderableShopImage.isThumbnail.eq(true)));
     }
 
     private String normalize(String s) {


### PR DESCRIPTION
### 🔍 개요

<img width="229" height="202" alt="image" src="https://github.com/user-attachments/assets/f7518db1-a1bc-4513-ace0-84a7408b5967" />

- 주문 이력 조회 API 응답값으로 빠진 필드 추가

- close #1969 

---

### 🚀 주요 변경 내용

* 주문 금액, 상점 썸네일, 상점 상태 응답값을 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
