### PR TITLE
fix: 위도, 경도 유효성 검증 어노테이션 삭제

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/model/OrderDelivery.java
@@ -42,11 +42,9 @@ public class OrderDelivery extends BaseEntity {
     @Column(name = "address_detail", columnDefinition = "TEXT")
     private String addressDetail;
 
-    @NotNull
     @Column(name = "latitude", nullable = false, precision = 10, scale = 8)
     private BigDecimal latitude;
 
-    @NotNull
     @Column(name = "longitude", nullable = false, precision = 11, scale = 8)
     private BigDecimal longitude;
 

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/request/TemporaryDeliveryPaymentSaveRequest.java
@@ -23,11 +23,11 @@ public record TemporaryDeliveryPaymentSaveRequest(
     @Schema(description = "배달 상세 주소", example = "은솔관 422호", requiredMode = NOT_REQUIRED)
     String addressDetail,
 
-    @Schema(description = "배달 주소 위도", example = "36.76125794", requiredMode = REQUIRED)
+    @Schema(description = "배달 주소 위도", example = "127.28372942", requiredMode = REQUIRED)
     @NotNull(message = "배달 주소 위도는 필수 입력사항입니다.")
     BigDecimal longitude,
 
-    @Schema(description = "배달 주소 경도", example = "127.28372942", requiredMode = REQUIRED)
+    @Schema(description = "배달 주소 경도", example = "36.76125794", requiredMode = REQUIRED)
     @NotNull(message = "배달 주소 경도는 필수 입력사항입니다.")
     BigDecimal latitude,
 


### PR DESCRIPTION
### 🔍 개요

* order_delivery_v2 테이블의 위도, 경도 컬럼이 nullable
* OrderDelivery의 위도, 경도 컬럼에 Notnull 어노테이션이 걸려있어서 에러 발생

- close #1973 

---

### 🚀 주요 변경 내용

* OrderDelivery 클래스 위도, 경도 컬럼에 걸려있는 NotNull 어노테이션을 삭제했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
