### PR TITLE
hotfix: 사장님 회원가입 전화번호 중복 문제 해결 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/owner/dto/sms/OwnerRegisterByPhoneRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/owner/dto/sms/OwnerRegisterByPhoneRequest.java
@@ -63,7 +63,6 @@ public record OwnerRegisterByPhoneRequest(
 
     public Owner toOwner(PasswordEncoder passwordEncoder) {
         User user = User.builder()
-            .loginId(phoneNumber)
             .loginPw(passwordEncoder.encode(password))
             .name(name)
             .email(null)
@@ -80,6 +79,7 @@ public record OwnerRegisterByPhoneRequest(
             .grantEvent(false)
             .account(phoneNumber)
             .build();
+
         List<OwnerAttachment> attachments = attachmentUrls.stream()
             .map(OwnerRegisterByPhoneInnerAttachmentUrl::fileUrl)
             .map(fileUrl -> OwnerAttachment.builder()
@@ -89,6 +89,7 @@ public record OwnerRegisterByPhoneRequest(
                 .name(name)
                 .build())
             .toList();
+
         owner.getAttachments().addAll(attachments);
         return owner;
     }


### PR DESCRIPTION
### 🔍 개요

* 사장님 회원가입 전화번호 중복 문제 해결

- close #2000 

---

### 🚀 주요 변경 내용

* 사장님 회원가입시 유저 테이블의 전화번호 칼럼에 저장되어 중복 문제 발생

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
