### PR TITLE
refactor: 식단 품절 알림 구독자 조회 로직 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -38,12 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 
-import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
-import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.admin.abtest.useragent.UserAgentInfo;
 import in.koreatech.koin.common.event.DiningImageUploadEvent;
 import in.koreatech.koin.common.event.DiningSoldOutEvent;
-import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
-import in.koreatech.koin.admin.abtest.useragent.UserAgentInfo;
 import in.koreatech.koin.domain.coop.dto.CoopLoginRequest;
 import in.koreatech.koin.domain.coop.dto.CoopLoginResponse;
 import in.koreatech.koin.domain.coop.dto.CoopResponse;
@@ -54,6 +51,7 @@ import in.koreatech.koin.domain.coop.exception.DiningNowDateException;
 import in.koreatech.koin.domain.coop.exception.DuplicateExcelRequestException;
 import in.koreatech.koin.domain.coop.exception.StartDateAfterEndDateException;
 import in.koreatech.koin.domain.coop.model.Coop;
+import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
 import in.koreatech.koin.domain.coop.model.ExcelDownloadCache;
 import in.koreatech.koin.domain.coop.repository.CoopRepository;
 import in.koreatech.koin.domain.coop.repository.DiningNotifyCacheRepository;
@@ -67,6 +65,8 @@ import in.koreatech.koin.domain.dining.repository.DiningRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.domain.user.service.RefreshTokenService;
+import in.koreatech.koin.global.auth.JwtProvider;
+import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
 import in.koreatech.koin.infrastructure.s3.client.S3Client;
 import lombok.RequiredArgsConstructor;
 
@@ -512,7 +512,7 @@ public class CoopService {
         LocalDate date = dining.getDate();
         // ex) 2024-12-17-점심-B코너.png
         return date.getYear() + "-" + date.getMonthValue() + "-" + date.getDayOfMonth() + "-"
-               + dining.getType().getDiningName() + "-" + dining.getPlace() + extension;
+            + dining.getType().getDiningName() + "-" + dining.getPlace() + extension;
     }
 
     private String extractS3KeyFrom(String imageUrl) {

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 
+import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
 import in.koreatech.koin.global.auth.JwtProvider;
 import in.koreatech.koin.common.event.DiningImageUploadEvent;
 import in.koreatech.koin.common.event.DiningSoldOutEvent;
@@ -105,6 +106,7 @@ public class CoopService {
             dining.setSoldOut(now);
             boolean isOpened = coopShopService.getIsOpened(now, CoopShopType.CAFETERIA, dining.getType(), false);
             if (isOpened && diningSoldOutCacheRepository.findById(dining.getPlace()).isEmpty()) {
+                diningSoldOutCacheRepository.save(DiningSoldOutCache.from(dining.getPlace()));
                 eventPublisher.publishEvent(
                     new DiningSoldOutEvent(dining.getId(), dining.getPlace(), dining.getType()));
             }

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -25,7 +25,7 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
 
     @TransactionalEventListener
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
-        notificationService.sendDiningSoldOutNotifications(event);
+        notificationService.sendDiningSoldOutNotifications(event.id(), event.place(), event.diningType());
     }
 
     @TransactionalEventListener

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -28,20 +28,15 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
     @TransactionalEventListener
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
-        var notifications = notificationSubscribeRepository
-            .findAllBySubscribeTypeAndDetailTypeIsNull(DINING_SOLD_OUT).stream()
-            .filter(subscribe -> notificationSubscribeRepository.existsByUserIdAndSubscribeTypeAndDetailType(
-                subscribe.getUser().getId(),
-                DINING_SOLD_OUT,
-                detailType
-            ))
-            .filter(subscribe -> subscribe.getUser().getDeviceToken() != null)
+        var notifications = notificationSubscribeRepository.findAllSoldOutSubscribers(DINING_SOLD_OUT, detailType)
+            .stream()
             .map(subscribe -> notificationFactory.generateSoldOutNotification(
                 DINING,
                 event.id(),
                 event.place(),
                 subscribe.getUser()
-            )).toList();
+            ))
+            .toList();
         notificationService.pushNotifications(notifications);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -10,8 +10,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin.common.event.DiningImageUploadEvent;
 import in.koreatech.koin.common.event.DiningSoldOutEvent;
-import in.koreatech.koin.domain.coop.model.DiningSoldOutCache;
-import in.koreatech.koin.domain.coop.repository.DiningSoldOutCacheRepository;
 import in.koreatech.koin.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
@@ -26,11 +24,9 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
     private final NotificationService notificationService;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
     private final NotificationFactory notificationFactory;
-    private final DiningSoldOutCacheRepository diningSoldOutCacheRepository;
 
     @TransactionalEventListener
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
-        diningSoldOutCacheRepository.save(DiningSoldOutCache.from(event.place()));
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
         var notifications = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailTypeIsNull(DINING_SOLD_OUT).stream()

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/CoopEventListener.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.notification.eventlistener;
 
 import static in.koreatech.koin.common.model.MobileAppPath.DINING;
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.DINING_IMAGE_UPLOAD;
-import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.DINING_SOLD_OUT;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -10,7 +9,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin.common.event.DiningImageUploadEvent;
 import in.koreatech.koin.common.event.DiningSoldOutEvent;
-import in.koreatech.koin.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.notification.service.NotificationService;
@@ -27,17 +25,7 @@ public class CoopEventListener { // TODO : 리팩터링 필요 (비즈니스로�
 
     @TransactionalEventListener
     public void onDiningSoldOutRequest(DiningSoldOutEvent event) {
-        NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
-        var notifications = notificationSubscribeRepository.findAllSoldOutSubscribers(DINING_SOLD_OUT, detailType)
-            .stream()
-            .map(subscribe -> notificationFactory.generateSoldOutNotification(
-                DINING,
-                event.id(),
-                event.place(),
-                subscribe.getUser()
-            ))
-            .toList();
-        notificationService.pushNotifications(notifications);
+        notificationService.sendDiningSoldOutNotifications(event);
     }
 
     @TransactionalEventListener

--- a/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationSubscribeRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationSubscribeRepository.java
@@ -51,7 +51,7 @@ public interface NotificationSubscribeRepository extends Repository<Notification
         )
         AND u.deviceToken IS NOT NULL
         """)
-    List<NotificationSubscribe> findAllSoldOutSubscribers(
+    List<NotificationSubscribe> findAllBySubscribeTypeAndDetailType(
         @Param("subscribeType") NotificationSubscribeType subscribeType,
         @Param("detailType") NotificationDetailSubscribeType detailType
     );

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
@@ -9,7 +9,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.common.event.DiningSoldOutEvent;
+import in.koreatech.koin.domain.dining.model.DiningType;
 import in.koreatech.koin.domain.notification.dto.NotificationStatusResponse;
 import in.koreatech.koin.domain.notification.exception.NotificationNotPermitException;
 import in.koreatech.koin.domain.notification.model.Notification;
@@ -122,14 +122,14 @@ public class NotificationService {
         notificationSubscribeRepository.deleteByUserIdAndDetailType(userId, detailType);
     }
 
-    public void sendDiningSoldOutNotifications(DiningSoldOutEvent event) {
-        NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(event.diningType());
+    public void sendDiningSoldOutNotifications(Integer dinningId, String place, DiningType diningType) {
+        NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(diningType);
         var notifications = notificationSubscribeRepository.findAllSoldOutSubscribers(DINING_SOLD_OUT, detailType)
             .stream()
             .map(subscribe -> notificationFactory.generateSoldOutNotification(
                 DINING,
-                event.id(),
-                event.place(),
+                dinningId,
+                place,
                 subscribe.getUser()
             ))
             .toList();

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
@@ -124,7 +124,7 @@ public class NotificationService {
 
     public void sendDiningSoldOutNotifications(Integer dinningId, String place, DiningType diningType) {
         NotificationDetailSubscribeType detailType = NotificationDetailSubscribeType.from(diningType);
-        var notifications = notificationSubscribeRepository.findAllSoldOutSubscribers(DINING_SOLD_OUT, detailType)
+        var notifications = notificationSubscribeRepository.findAllBySubscribeTypeAndDetailType(DINING_SOLD_OUT, detailType)
             .stream()
             .map(subscribe -> notificationFactory.generateSoldOutNotification(
                 DINING,


### PR DESCRIPTION
### 🔍 개요

<img width="1194" height="589" alt="Image" src="https://github.com/user-attachments/assets/64c008cf-0385-4e4e-bd29-5a7f0ebdcfa3" />

* 식단 품절 API (PATCH /coop/dining/soldout)에서 알림 구독자를 조회하는 과정에서 알림 구독자 수만큼 쿼리가 발생
* 확인 결과, 모든 식단 알림 구독자를 조회 이후 품절 식단(아침, 점심, 저녁) 알림을 구독했는 지 추가 조회함으로써 추가 쿼리 발생

- close #2010 

---

### 🚀 주요 변경 내용

### 알림 구독자 조회 로직 개선 
```java
var notifications = notificationSubscribeRepository
    .findAllBySubscribeTypeAndDetailTypeIsNull(DINING_SOLD_OUT).stream()
    .filter(subscribe -> notificationSubscribeRepository.existsByUserIdAndSubscribeTypeAndDetailType(
        subscribe.getUser().getId(),
        DINING_SOLD_OUT,
       detailType
    ))
```

* `findAllBySubscribeTypeAndDetailTypeIsNull` 메소드로 식단 알림 구독 리스트 1차 조회
* 알림 구독 리스트에서 (user_id, subscrib_type, detail_type)를 통해 품절 식단 알림 구독자 리스트를 2차 조회
  * subscrib_type : DINING_SOLD_OUT
  * detail_type : 아침, 점심, 저녁
* 이 과정에서 알림 구독자 수만큼 쿼리 발생

``` java
@Query("""
        SELECT DISTINCT ns
        FROM NotificationSubscribe ns
        JOIN FETCH ns.user u
        WHERE ns.subscribeType = :subscribeType
        AND ns.detailType IS NULL
        AND EXISTS (
            SELECT 1 FROM NotificationSubscribe ns2
            WHERE ns2.user.id = ns.user.id
            AND ns2.subscribeType = :subscribeType
            AND ns2.detailType = :detailType
        )
        AND u.deviceToken IS NOT NULL
        """)
    List<NotificationSubscribe> findAllBySubscribeTypeAndDetailType(
        @Param("subscribeType") NotificationSubscribeType subscribeType,
        @Param("detailType") NotificationDetailSubscribeType detailType
    );
```
* `subscribeType`와 `detailType`를 통해 한 번에 가져오도록 리파지토리 메소드 추가

### onDiningSoldOutRequest 메소드 리펙토링
* CoopEventListener 내부에 있는 onDiningSoldOutRequest 메소드의 비즈니스 로직 제거 및 알림 책임만 갖도록 리펙토링
  * 캐싱 저장 로직은 `CoopService`로 이동
  * 알림 타입 변환 & 알림 구독자 조회 로직은 `NotificationService`로 이동

---

### 💬 참고 사항

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
