### PR TITLE
feat: 주문 진행 상황 조회 시 상점 id 반환, 결제 단건 조회 시 예상시간 및 주문 상태 반환

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -56,6 +56,7 @@ public interface OrderApi {
         summary = "주문 내역 중 현재 활성화된(배달완료, 취소 제외) 주문을 조회한다",
         description = """
             ## 다음과 같은 항목을 반환한다.
+            - 상점 ID ex) 14
             - 가게 이름 ex) "코인 병천점"
             - 주문 타입 ex)
                 DELIVERY

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
@@ -21,6 +21,9 @@ public record InprogressOrderResponse(
     @Schema(description = "주문 ID", example = "1", requiredMode = REQUIRED)
     Integer id,
 
+    @Schema(description = "상점 ID", example = "14", requiredMode = REQUIRED)
+    Integer shopId,
+
     @Schema(description = "결제 ID", example = "1", requiredMode = REQUIRED)
     Integer paymentId,
 
@@ -59,6 +62,7 @@ public record InprogressOrderResponse(
 
         return new InprogressOrderResponse(
             order.getId(),
+            order.getOrderableShop().getShop().getId(),
             payment.getId(),
             order.getOrderType().name(),
             order.getOrderableShopName(),

--- a/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/controller/PaymentApi.java
@@ -114,7 +114,44 @@ public interface PaymentApi {
         @Auth(permit = {STUDENT}) Integer userId
     );
 
-    @Operation(summary = "결제 단건 조회를 한다.")
+    @Operation(
+        summary = "결제 단건 조회를 한다.",
+        description = """
+            ## Path Variable
+            - `paymentId`: 결제 고유 ID
+
+            ## 응답 Body 필드 설명
+            - `id`: 결제 고유 ID
+            - `orderable_shop_id`: 주문 상점 고유 ID
+            - `delivery_address`: 배달 주소
+            - `delivery_address_details`: 배달상세 주소
+            - `shop_address`: 가게 주소
+            - `longitude`: 배달 주소 위도
+            - `latitude`: 배달 주소 경도
+            - `to_owner`: 사장님에게
+            - `to_rider`: 라이더에게
+            - `provide_cutlery`: 수저, 포크 수령 여부
+            - `total_menu_price`: 메뉴 총 금액
+            - `delivery_tip`: 배달비
+            - `amount`: 결제 금액
+            - `shop_name`: 상점 이름
+            - `menus`: 주문 메뉴 목록
+              - `name`: 메뉴 이름
+              - `quantity`: 수량
+              - `price`: 메뉴 가격
+              - `options`: 선택한 옵션 목록
+                - `option_group_name`: 옵션 그룹 이름
+                - `option_name`: 옵션 이름
+                - `option_price`: 옵션 가격
+            - `order_type`: 주문 방법 (DELIVERY | TAKE_OUT)
+            - `easy_pay_company`: 간편결제사
+            - `requested_at`: 결제 요청 일시 (yyyy.MM.dd HH:mm)
+            - `approved_at`: 결제 승인 일시 (yyyy.MM.dd HH:mm)
+            - `payment_method`: 결제 수단
+            - `estimated_at`: 예상 시각 (HH:mm)
+            - `order_status`: 주문 상태
+            """
+    )
     @GetMapping("/{paymentId}")
     ResponseEntity<PaymentResponse> getPayment(
         @Parameter(description = "결제 고유 ID", example = "1")

--- a/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/dto/response/PaymentResponse.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.domain.payment.dto.response;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static in.koreatech.koin.domain.order.order.model.OrderType.DELIVERY;
 import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
-import static in.koreatech.koin.domain.order.order.model.OrderStatus.CONFIRMING;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
@@ -12,7 +11,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -151,29 +149,10 @@ public record PaymentResponse(
         }
     }
 
-    private static Optional<LocalTime> computeEstimatedTime(Order order) {
-        if (order.getStatus() == CONFIRMING) {
-            return Optional.empty();
-        }
-
-        if (order.getOrderType() == DELIVERY) {
-            OrderDelivery delivery = order.getOrderDelivery();
-            if (delivery != null && delivery.getEstimatedArrivalAt() != null) {
-                return Optional.of(LocalTime.from(delivery.getEstimatedArrivalAt()));
-            }
-        } else if (order.getOrderType() == TAKE_OUT) {
-            OrderTakeout takeout = order.getOrderTakeout();
-            if (takeout != null && takeout.getEstimatedPackagedAt() != null) {
-                return Optional.of(LocalTime.from(takeout.getEstimatedPackagedAt()));
-            }
-        }
-
-        return Optional.empty();
-    }
-
     public static PaymentResponse of(
         Payment payment,
-        Order order
+        Order order,
+        LocalTime estimatedAt
     ) {
         OrderableShop orderableShop = order.getOrderableShop();
         Shop shop = orderableShop.getShop();
@@ -203,7 +182,7 @@ public record PaymentResponse(
             provideCutlery = takeout.getProvideCutlery();
         }
 
-        LocalTime estimatedTime = computeEstimatedTime(order).orElse(null);
+        LocalTime estimatedTime = estimatedAt;
 
         return new PaymentResponse(
             payment.getId(),

--- a/src/main/java/in/koreatech/koin/domain/payment/service/PaymentQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/payment/service/PaymentQueryService.java
@@ -4,11 +4,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.order.order.model.Order;
+import in.koreatech.koin.domain.order.order.model.OrderDelivery;
+import in.koreatech.koin.domain.order.order.model.OrderTakeout;
 import in.koreatech.koin.domain.payment.dto.response.PaymentResponse;
 import in.koreatech.koin.domain.payment.model.entity.Payment;
 import in.koreatech.koin.domain.payment.repository.PaymentRepository;
 import in.koreatech.koin.domain.user.model.User;
+import java.time.LocalTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+
+import static in.koreatech.koin.domain.order.order.model.OrderType.DELIVERY;
+import static in.koreatech.koin.domain.order.order.model.OrderType.TAKE_OUT;
+import static in.koreatech.koin.domain.order.order.model.OrderStatus.CONFIRMING;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +30,26 @@ public class PaymentQueryService {
         payment.validateUserIdMatches(user.getId());
         Order order = payment.getOrder();
 
-        return PaymentResponse.of(payment, order);
+        LocalTime estimatedAt = computeEstimatedTime(order).orElse(null);
+
+        return PaymentResponse.of(payment, order, estimatedAt);
+    }
+
+    private Optional<LocalTime> computeEstimatedTime(Order order) {
+        if (order.getStatus() == CONFIRMING) {
+            return Optional.empty();
+        }
+        if (order.getOrderType() == DELIVERY) {
+            OrderDelivery delivery = order.getOrderDelivery();
+            if (delivery != null && delivery.getEstimatedArrivalAt() != null) {
+                return Optional.of(LocalTime.from(delivery.getEstimatedArrivalAt()));
+            }
+        } else if (order.getOrderType() == TAKE_OUT) {
+            OrderTakeout takeout = order.getOrderTakeout();
+            if (takeout != null && takeout.getEstimatedPackagedAt() != null) {
+                return Optional.of(LocalTime.from(takeout.getEstimatedPackagedAt()));
+            }
+        }
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 주문 조회(/order/in-progress) 시 상점 id를 반환하도록 한다.
* 결제 단건 조회(/payments/{paymentId}) 시 예상 시간과 주문 상태를 반환하도록 한다.

- close #2011 

---

### 🚀 주요 변경 내용

* 주문 조회 시 상점 id도 반환하도록 추가하였습니다.
* 결제 단건 조회 시 예상 시간(estimated_at)과 주문 상태(order_status)를 반환하도록 추가하였습니다.


---

### 💬 참고 사항

* 결제 단건 조회의 응답 body 필드 설명을 추가하였습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
