### PR TITLE
feat: logback 롤링 도입

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,6 +28,12 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/app.log</file>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/app.%d{yyyy-MM}.log.gz</fileNamePattern>
+
+            <maxHistory>12</maxHistory>
+        </rollingPolicy>
     </appender>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -25,9 +25,9 @@
     <conversionRule conversionWord="clr"
       converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-      <file>logs/app.log</file>
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/app.log</file>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -21,7 +21,50 @@
     </root>
   </springProfile>
 
-  <springProfile name="default, dev, prod">
+  <springProfile name="default, dev">
+      <conversionRule conversionWord="clr"
+                      converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+      <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+          <file>logs/app.log</file>
+          <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+
+          <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+              <fileNamePattern>logs/app.%d{yyyy-MM}.log.gz</fileNamePattern>
+
+              <maxHistory>12</maxHistory>
+          </rollingPolicy>
+      </appender>
+
+      <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+          <encoder>
+              <pattern>${consoleLogPattern}</pattern>
+          </encoder>
+      </appender>
+
+      <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+          <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+          <layout class="ch.qos.logback.classic.PatternLayout">
+              <pattern>${slackLogPattern}</pattern>
+          </layout>
+          <colorCoding>true</colorCoding>
+      </appender>
+
+      <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+          <appender-ref ref="SLACK"/>
+          <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+              <level>ERROR</level>
+          </filter>
+      </appender>
+
+      <root level="info">
+          <appender-ref ref="console"/>
+          <appender-ref ref="FILE"/>
+          <appender-ref ref="ASYNC_SLACK"/>
+      </root>
+  </springProfile>
+
+  <springProfile name="prod">
     <conversionRule conversionWord="clr"
       converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
@@ -57,7 +100,7 @@
       </filter>
     </appender>
 
-    <root level="info">
+    <root level="error">
       <appender-ref ref="console"/>
       <appender-ref ref="FILE"/>
       <appender-ref ref="ASYNC_SLACK"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -100,7 +100,7 @@
       </filter>
     </appender>
 
-    <root level="error">
+    <root level="warn">
       <appender-ref ref="console"/>
       <appender-ref ref="FILE"/>
       <appender-ref ref="ASYNC_SLACK"/>


### PR DESCRIPTION
### 🔍 개요

<img width="271" height="58" alt="Image" src="https://github.com/user-attachments/assets/73283f48-6f32-4470-8cea-70ab942275c6" />
<img width="276" height="55" alt="image" src="https://github.com/user-attachments/assets/cf987193-acb4-4d0d-9bb3-79b9ea5208b1" />


* 코인 프로젝트는 `logs/app.log`에 INFO 레벨 이상의 로그를 찍고 있음
* 하나의 파일에 지속적으로 로그를 찍고 있다보니, 파일의 용량이 커지고 있는 상황
  * 2025년 9월 30일 기준 : 스테이지 (약 235MB), 프로덕션 (약 12.37GB)
* 최근 발생하고 있는 EC2 용량 부족 문제 해결과 향후 로그를 확인하는 과정에서 발생할 수 있는 불편함을 해소하기 위해 logback 파일 롤링 도입

- close #2019 

---

### 🚀 주요 변경 내용

### Appender 수정
* Appender를 `FileAppender`에서 `RollingFileAppender`으로 수정했습니다.
* RollingPolicy의 경우 한 달을 주기로 롤링, 최대 12개까지 보관할 수 있도록 설정했습니다. 
* 롤링된 파일은 `.gz`으로 압축해서 관리됩니다.

---

### 💬 참고 사항

* Appender : log의 출력 대상과 형식을 설정
  * ConsoleAppender : 콘솔에 로그를 출력
  * FileAppender : 파일에 로그를 저장
  * RollingFileAppender : 여러개의 파일로 순환 저장 (FileAppender 상속)
  * SMTPAppender : 로그를 메일로 보낸다.
  * DBAppender : DB에 로그를 쌓는다.

* RollingPolicy : 로그 보관 정책
  * TimeBasedRollingPolicy : 시간을 기준으로 롤링
  * SizeAndTimeBasedRollingPolicy : 시간을 기준으로 롤링하면서 용량 제한 가능
  * FixedWindowRollingPolicy : 파일 번호를 붙여 롤링
  * 속성 : maxHistory(보관 기간/개수), totalSizeCap(전체 보관 용량 제한)

* TriggeringPolicy : 롤링 트리거
  * SizeBasedTriggeringPolicy : 로그 파일 크기가 임계치를 넘기면 트리거 발생
  * TimeBasedRollingPolicy와 SizeAndTimeBasedRollingPolicy의 경우 TriggeringPolicy를 내장하고 있음

* 용량 제한을 걸지 않은 이유는 달마다 롤링을 했을 때 로그 파일의 용량이 그렇게 크지 않을것으로 예상했기 때문입니다. 
* 후속작업으로 `aws s3 sync`으로 s3 적재해볼 생각입니다. 

- 참고
  - [참고 1](https://ckddn9496.tistory.com/82)
  - [참고 2](https://agileryuhaeul.tistory.com/entry/Logback-%EC%9D%B4%EB%9E%80)
  - [참고 3](https://lovethefeel.tistory.com/89#google_vignette)
---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
