### PR TITLE
feat: 진행 중인 주문 조회 시 주문 가능한 상점 ID를 응답하도록 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -56,7 +56,7 @@ public interface OrderApi {
         summary = "주문 내역 중 현재 활성화된(배달완료, 취소 제외) 주문을 조회한다",
         description = """
             ## 다음과 같은 항목을 반환한다.
-            - 상점 ID ex) 14
+            - 주문 가능 상점 ID ex) 14
             - 가게 이름 ex) "코인 병천점"
             - 주문 타입 ex)
                 DELIVERY

--- a/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/dto/response/InprogressOrderResponse.java
@@ -21,8 +21,8 @@ public record InprogressOrderResponse(
     @Schema(description = "주문 ID", example = "1", requiredMode = REQUIRED)
     Integer id,
 
-    @Schema(description = "상점 ID", example = "14", requiredMode = REQUIRED)
-    Integer shopId,
+    @Schema(description = "주문 가능 상점 ID", example = "14", requiredMode = REQUIRED)
+    Integer orderableShopId,
 
     @Schema(description = "결제 ID", example = "1", requiredMode = REQUIRED)
     Integer paymentId,
@@ -62,7 +62,7 @@ public record InprogressOrderResponse(
 
         return new InprogressOrderResponse(
             order.getId(),
-            order.getOrderableShop().getShop().getId(),
+            order.getOrderableShop().getId(),
             payment.getId(),
             order.getOrderType().name(),
             order.getOrderableShopName(),


### PR DESCRIPTION
### 🔍 개요

* 기존에는 shop_id를 반환했으나, orderable_shop_id를 반환하도록 변경함.

- close #2023

---

### 🚀 주요 변경 내용

* 진행 중인 주문 정보 조회(/order/in-progress)의 응답 결과 중 shop_id를 orderable_shop_id로 변경함.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
