### PR TITLE
refactor: order swagger description LAST_6_MONTHS 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
+++ b/src/main/java/in/koreatech/koin/domain/order/order/controller/OrderApi.java
@@ -29,7 +29,7 @@ public interface OrderApi {
             - period
                 - NONE : 기본값
                 - LAST_3_MONTHS : 최근 3개월
-                - LAST_6_MONTHS : 최근 3개월
+                - LAST_6_MONTHS : 최근 6개월
                 - LAST_1_YEAR : 최근 1년
             - status
                 - NONE : 기본값


### PR DESCRIPTION
### 🔍 개요

* order swagger description LAST_6_MONTHS 수정

- close #2029

---

### 🚀 주요 변경 내용

* LAST_6_MONTHS이 3개월로 잘못표기되어있는부분 수정
<img width="269" height="268" alt="image" src="https://github.com/user-attachments/assets/efea8a40-6410-4c21-b310-5f50312f3053" />


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
