### PR TITLE
fix: RedisRepository 스캔 범위 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/config/repository/RedisConfig.java
+++ b/src/main/java/in/koreatech/koin/config/repository/RedisConfig.java
@@ -28,7 +28,10 @@ import in.koreatech.koin.global.marker.RedisRepositoryMarker;
 
 @Configuration
 @EnableRedisRepositories(
-    basePackages = "in.koreatech.koin",
+    basePackages = {
+        "in.koreatech.koin.admin",
+        "in.koreatech.koin.domain"
+    },
     enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
     includeFilters = @ComponentScan.Filter(
         type = FilterType.ANNOTATION,


### PR DESCRIPTION
### 🔍 개요

<img width="1492" height="49" alt="image" src="https://github.com/user-attachments/assets/e640bb55-f0a8-4f0d-99f3-842e9a681121" />

* [Spring Data 스캔 개선 작업](https://github.com/BCSDLab/KOIN_API_V2/pull/2026) 적용 결과, RedisRepository 스캔 시간이 약 12배 늘어난 것을 확인
* RedisRepository 스캔 범위가 `in.koreatech.koin`으로, 모든 패키지를 스캔하고 있음을 확인

- close #2034 

---

### 🚀 주요 변경 내용

* RedisRepository 스캔 범위를 `in.koreatech.koin.admin`과 `in.koreatech.koin.domain`으로 좁혔습니다.

---

### 💬 참고 사항

* 로컬 환경에서는 해당 작업에 대한 개선 여부를 수치적으로 확인하기 어려워, 배포 이후에 결과를 확인할 예정입니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)