### PR TITLE
refactor: @Controller -> @RestController 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerEventController.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerEventController.java
@@ -9,17 +9,18 @@ import in.koreatech.koin.domain.ownershop.service.OwnerEventService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class OwnerEventController implements OwnerEventApi {
 

--- a/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerMenuController.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerMenuController.java
@@ -13,9 +13,9 @@ import in.koreatech.koin.domain.shop.dto.menu.response.ShopMenuResponse;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,8 +23,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class OwnerMenuController implements OwnerMenuApi {
 

--- a/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopController.java
+++ b/src/main/java/in/koreatech/koin/domain/ownershop/controller/OwnerShopController.java
@@ -4,12 +4,12 @@ import static in.koreatech.koin.domain.user.model.UserType.OWNER;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsRequest;
 import in.koreatech.koin.domain.ownershop.dto.OwnerShopsResponse;
@@ -20,7 +20,7 @@ import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class OwnerShopController implements OwnerShopApi {
 


### PR DESCRIPTION
### 🔍 개요

* 불필요한 @Controller를 @RestController로 변경한다.

- close #2066 

---

### 🚀 주요 변경 내용

*` @Controller`가 사용된 4개중 `MessageSocket`을 제외한 부분을 `@RestController`로 바꾼다.
<img width="1341" height="346" alt="image" src="https://github.com/user-attachments/assets/6f79bf93-f236-4cc8-9247-32ee9d3d8dfc" />



---

### 💬 참고 사항

* 기존 `@Controller` 로 사용했을때 오류가 없던 이유는 `ResponseEntity` 때문인거같습니다


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
