### PR TITLE
fix: 주변 상점 리뷰 중복 집계 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/dto/ShopCustomRepository.java
@@ -33,35 +33,44 @@ public class ShopCustomRepository {
         QEventArticle eventArticle = QEventArticle.eventArticle;
         QShopReview shopReview = QShopReview.shopReview;
 
-        List<Tuple> results = queryFactory
-            .select(
-                shop.id,
-                ExpressionUtils.as(eventArticle.id.count().gt(0L), "isEventActive"),
-                ExpressionUtils.as(
-                    Expressions.numberTemplate(Double.class, "ROUND(COALESCE({0}, 0), 1)", shopReview.rating.avg()),
-                    "averageRate"
-                ),
-                shopReview.id.count().as("reviewCount")
-            )
+        Map<Integer, Boolean> eventMap = queryFactory
+            .select(shop.id, eventArticle.id.count().gt(0L))
             .from(shop)
             .leftJoin(shop.eventArticles, eventArticle)
             .on(eventArticle.startDate.loe(now.toLocalDate())
                 .and(eventArticle.endDate.goe(now.toLocalDate())))
+            .groupBy(shop.id)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(0, Integer.class),
+                tuple -> tuple.get(1, Boolean.class)
+            ));
+
+        List<Tuple> reviewResults = queryFactory
+            .select(
+                shop.id,
+                Expressions.numberTemplate(Double.class,
+                    "ROUND(COALESCE({0}, 0), 1)", shopReview.rating.avg()),
+                shopReview.id.count()
+            )
+            .from(shop)
             .leftJoin(shop.reviews, shopReview)
             .on(shopReview.isDeleted.eq(false))
             .groupBy(shop.id)
             .fetch();
 
-        Map<Integer, ShopInfo> map = new HashMap<>(results.size());
-
-        for (Tuple result : results) {
-            ShopInfo shopResult = new ShopInfo(
-                result.get(1, Boolean.class),
-                result.get(2, Double.class),
-                result.get(3, Long.class)
+        Map<Integer, ShopInfo> map = new HashMap<>(reviewResults.size());
+        for (Tuple result : reviewResults) {
+            Integer shopId = result.get(0, Integer.class);
+            ShopInfo shopInfo = new ShopInfo(
+                eventMap.getOrDefault(shopId, false),
+                result.get(1, Double.class),
+                result.get(2, Long.class)
             );
-            map.put(result.get(0, Integer.class), shopResult);
+            map.put(shopId, shopInfo);
         }
+
         return map;
     }
 


### PR DESCRIPTION
### 🔍 개요

- close #2084 
- `ShopCustomRepository.findAllShopInfo()` 메서드에서 리뷰 개수가 실제와는 다르게 집계되는 버그 발견. 특정 상점에서만 발생하며, 이벤트 개수와 연관성이 있음.

```java
List<Tuple> results = queryFactory
    .select(
        shop.id,
        ExpressionUtils.as(eventArticle.id.count().gt(0L), "isEventActive"),
        ExpressionUtils.as(
            Expressions.numberTemplate(Double.class, "ROUND(COALESCE({0}, 0), 1)", shopReview.rating.avg()),
            "averageRate"
        ),
        shopReview.id.count().as("reviewCount")
    )
    .from(shop)
    .leftJoin(shop.eventArticles, eventArticle)  //  JOIN
    .on(eventArticle.startDate.loe(now.toLocalDate())
        .and(eventArticle.endDate.goe(now.toLocalDate())))
    .leftJoin(shop.reviews, shopReview)  // JOIN
    .on(shopReview.isDeleted.eq(false))
    .groupBy(shop.id)
    .fetch();
```
- 활성 이벤트 11개, 삭제되지 않은 리뷰 6개 -> 66개로 집계
---

### 🚀 주요 변경 내용

* 이벤트 정보와 리뷰 정보를 별도로 조회 후 병합

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
