### PR TITLE
feat: 주문 가능 상점 전환 Admin 승인/거부 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestApi.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestApi.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import in.koreatech.koin.admin.ownershop.dto.AdminShopOrderServiceResponse;
 import in.koreatech.koin.admin.ownershop.dto.AdminShopOrderServicesResponse;
@@ -42,6 +43,32 @@ public interface AdminShopOrderServiceRequestApi {
     @SecurityRequirement(name = "Jwt Authentication")
     @GetMapping("/admin/owner/shops/order-service-requests/{orderServiceRequestId}")
     ResponseEntity<AdminShopOrderServiceResponse> getOrderServiceRequest(
+        @PathVariable("orderServiceRequestId") Integer orderServiceRequestId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        NOT_FOUND_SHOP_ORDER_SERVICE_REQUEST,
+        NOT_PENDING_REQUEST
+    })
+    @Operation(summary = "주문 서비스 요청 승인")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/admin/owner/shops/order-service-requests/{orderServiceRequestId}/approve")
+    ResponseEntity<Void> approveOrderServiceRequest(
+        @PathVariable("orderServiceRequestId") Integer orderServiceRequestId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        NOT_FOUND_SHOP_ORDER_SERVICE_REQUEST,
+        NOT_PENDING_REQUEST
+    })
+    @Operation(summary = "주문 서비스 요청 거절")
+    @SecurityRequirement(name = "Jwt Authentication")
+    @PostMapping("/admin/owner/shops/order-service-requests/{orderServiceRequestId}/reject")
+    ResponseEntity<Void> rejectOrderServiceRequest(
         @PathVariable("orderServiceRequestId") Integer orderServiceRequestId,
         @Auth(permit = {ADMIN}) Integer adminId
     );

--- a/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestController.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.admin.ownershop.dto.AdminShopOrderServiceResponse;
@@ -18,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class AdminShopOrderServiceRequestController implements AdminShopOrderServiceRequestApi {
+public class AdminShopOrderServiceRequestController {//implements AdminShopOrderServiceRequestApi {
 
     private final AdminShopOrderServiceRequestService adminShopOrderServiceRequestService;
 
@@ -39,5 +40,23 @@ public class AdminShopOrderServiceRequestController implements AdminShopOrderSer
     ) {
         AdminShopOrderServiceResponse response = adminShopOrderServiceRequestService.getOrderServiceRequest(id);
         return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/admin/owner/shops/order-service-requests/{id}/approve")
+    public ResponseEntity<Void> approveOrderServiceRequest(
+        @PathVariable("id") Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminShopOrderServiceRequestService.approveOrderServiceRequest(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/admin/owner/shops/order-service-requests/{id}/reject")
+    public ResponseEntity<Void> rejectOrderServiceRequest(
+        @PathVariable("id") Integer id,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        adminShopOrderServiceRequestService.rejectOrderServiceRequest(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestController.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/controller/AdminShopOrderServiceRequestController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class AdminShopOrderServiceRequestController {//implements AdminShopOrderServiceRequestApi {
+public class AdminShopOrderServiceRequestController implements AdminShopOrderServiceRequestApi {
 
     private final AdminShopOrderServiceRequestService adminShopOrderServiceRequestService;
 

--- a/src/main/java/in/koreatech/koin/admin/ownershop/repository/AdminShopOrderServiceRequestRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/repository/AdminShopOrderServiceRequestRepository.java
@@ -81,4 +81,6 @@ public interface AdminShopOrderServiceRequestRepository extends Repository<ShopO
         @Param("shopName") String shopName,
         Pageable pageable
     );
+
+    ShopOrderServiceRequest save(ShopOrderServiceRequest shopOrderServiceRequest);
 }

--- a/src/main/java/in/koreatech/koin/admin/ownershop/repository/AdminShopOrderServiceRequestRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/repository/AdminShopOrderServiceRequestRepository.java
@@ -17,8 +17,21 @@ public interface AdminShopOrderServiceRequestRepository extends Repository<ShopO
 
     Optional<ShopOrderServiceRequest> findById(Integer id);
 
+    @Query("""
+        SELECT r FROM ShopOrderServiceRequest r
+        JOIN FETCH r.shop s
+        LEFT JOIN FETCH s.owner o
+        WHERE r.id = :id
+        """)
+    Optional<ShopOrderServiceRequest> findByIdWithShopAndOwner(@Param("id") Integer id);
+
     default ShopOrderServiceRequest getById(Integer id) {
         return findById(id)
+            .orElseThrow(() -> CustomException.of(ApiResponseCode.NOT_FOUND_SHOP_ORDER_SERVICE_REQUEST));
+    }
+
+    default ShopOrderServiceRequest getByIdWithShopAndOwner(Integer id) {
+        return findByIdWithShopAndOwner(id)
             .orElseThrow(() -> CustomException.of(ApiResponseCode.NOT_FOUND_SHOP_ORDER_SERVICE_REQUEST));
     }
 

--- a/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
@@ -14,6 +14,7 @@ import in.koreatech.koin.admin.ownershop.dto.ShopOrderServiceRequestCondition;
 import in.koreatech.koin.admin.ownershop.repository.AdminShopOrderServiceRequestRepository;
 import in.koreatech.koin.common.model.Criteria;
 import in.koreatech.koin.domain.order.shop.model.entity.delivery.OrderableShopDeliveryOption;
+import in.koreatech.koin.domain.order.shop.model.entity.delivery.OrderableShopDeliveryTip;
 import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
 import in.koreatech.koin.domain.order.shop.repository.OrderableShopRepository;
 import in.koreatech.koin.domain.ownershop.model.ShopOrderServiceRequest;
@@ -69,7 +70,6 @@ public class AdminShopOrderServiceRequestService {
         createOrderableShopFromRequest(shopOrderServiceRequest);
     }
 
-    // TODO: 미완성 메서드
     private void createOrderableShopFromRequest(ShopOrderServiceRequest shopOrderServiceRequest) {
         // Shop의 계좌 정보 업데이트
         Shop shop = shopOrderServiceRequest.getShop();
@@ -77,12 +77,9 @@ public class AdminShopOrderServiceRequestService {
 
         // OrderableShop 생성 또는 업데이트
         OrderableShop orderableShop = createOrderableShop(shop, shopOrderServiceRequest);
-        // OrderableShopDeliveryOption 생성 또는 업데이트
         createOrderableShopDeliveryOption(shopOrderServiceRequest, orderableShop);
-
-        createDeliveryTips(shop, shopOrderServiceRequest);
+        createDeliveryTips(orderableShop, shopOrderServiceRequest);
         orderableShopRepository.save(orderableShop);
-
         createOwnerAttachments(shop, shopOrderServiceRequest);
     }
 
@@ -124,10 +121,20 @@ public class AdminShopOrderServiceRequestService {
         }
     }
 
-    //TODO: 미완성 메서드
-    //TODO: 아직 CampusDeliveryTip을 전체 DeliveryPrice로 설정함 -> 추후 offCampusDeliveryTip는 요구사항맞게 처리
-    private void createDeliveryTips(Shop shop, ShopOrderServiceRequest shopOrderServiceRequest) {
-        shop.updateDeliveryPrice(shopOrderServiceRequest.getCampusDeliveryTip());
+    private void createDeliveryTips(OrderableShop orderableShop, ShopOrderServiceRequest shopOrderServiceRequest) {
+        if (orderableShop.getDeliveryTip() != null) {
+            orderableShop.getDeliveryTip().updateDeliveryTip(
+                shopOrderServiceRequest.getCampusDeliveryTip(),
+                shopOrderServiceRequest.getOffCampusDeliveryTip()
+            );
+        } else {
+            OrderableShopDeliveryTip deliveryTip = OrderableShopDeliveryTip.builder()
+                .campusDeliveryTip(shopOrderServiceRequest.getCampusDeliveryTip())
+                .offCampusDeliveryTip(shopOrderServiceRequest.getOffCampusDeliveryTip())
+                .orderableShop(orderableShop)
+                .build();
+            orderableShop.updateDeliveryTip(deliveryTip);
+        }
     }
 
     private void createOwnerAttachments(Shop shop, ShopOrderServiceRequest shopOrderServiceRequest) {

--- a/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
@@ -17,6 +17,9 @@ import in.koreatech.koin.domain.ownershop.model.ShopOrderServiceRequest;
 import in.koreatech.koin.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 
+import static in.koreatech.koin.domain.ownershop.model.ShopOrderServiceRequestStatus.PENDING;
+import static in.koreatech.koin.global.code.ApiResponseCode.NOT_PENDING_REQUEST;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -41,6 +44,26 @@ public class AdminShopOrderServiceRequestService {
     public AdminShopOrderServiceResponse getOrderServiceRequest(Integer id) {
         ShopOrderServiceRequest shopOrderServiceRequest = adminShopOrderServiceRequestRepository.getById(id);
         return AdminShopOrderServiceResponse.from(shopOrderServiceRequest);
+    }
+
+    public void approveOrderServiceRequest(Integer id) {
+        ShopOrderServiceRequest shopOrderServiceRequest = adminShopOrderServiceRequestRepository.getById(id);
+        if (shopOrderServiceRequest.getRequestStatus() != PENDING) {
+            throw CustomException.of(NOT_PENDING_REQUEST);
+        }
+        shopOrderServiceRequest.approve();
+        adminShopOrderServiceRequestRepository.save(shopOrderServiceRequest);
+        
+        //여기부터 이제 Shop 관련 엔티티 생성해야징
+    }
+
+    public void rejectOrderServiceRequest(Integer id) {
+        ShopOrderServiceRequest shopOrderServiceRequest = adminShopOrderServiceRequestRepository.getById(id);
+        if (shopOrderServiceRequest.getRequestStatus() != PENDING) {
+            throw CustomException.of(NOT_PENDING_REQUEST);
+        }
+        shopOrderServiceRequest.reject();
+        adminShopOrderServiceRequestRepository.save(shopOrderServiceRequest);
     }
 
     private Long getTotalRequestsCount(ShopOrderServiceRequestCondition condition) {

--- a/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
+++ b/src/main/java/in/koreatech/koin/admin/ownershop/service/AdminShopOrderServiceRequestService.java
@@ -125,11 +125,9 @@ public class AdminShopOrderServiceRequestService {
     }
 
     //TODO: 미완성 메서드
-    //아직 CampusDeliveryTip을 전체 DeliveryPrice로 설정함 -> 추후 offCampusDeliveryTip도 생성
+    //TODO: 아직 CampusDeliveryTip을 전체 DeliveryPrice로 설정함 -> 추후 offCampusDeliveryTip는 요구사항맞게 처리
     private void createDeliveryTips(Shop shop, ShopOrderServiceRequest shopOrderServiceRequest) {
         shop.updateDeliveryPrice(shopOrderServiceRequest.getCampusDeliveryTip());
-        //TODO:  offCampusDeliveryTip 는 아직 별도로 처리안했음
-        
     }
 
     private void createOwnerAttachments(Shop shop, ShopOrderServiceRequest shopOrderServiceRequest) {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryOption.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryOption.java
@@ -44,4 +44,9 @@ public class OrderableShopDeliveryOption extends BaseEntity {
         this.offCampusDelivery = offCampusDelivery;
         this.orderableShop = orderableShop;
     }
+
+    public void updateDeliveryOption(Boolean campusDelivery, Boolean offCampusDelivery) {
+        this.campusDelivery = campusDelivery;
+        this.offCampusDelivery = offCampusDelivery;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryOption.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryOption.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +38,10 @@ public class OrderableShopDeliveryOption extends BaseEntity {
     @JoinColumn(name = "orderable_shop_id", nullable = false)
     private OrderableShop orderableShop;
 
+    @Builder
+    public OrderableShopDeliveryOption(Boolean campusDelivery, Boolean offCampusDelivery, OrderableShop orderableShop) {
+        this.campusDelivery = campusDelivery;
+        this.offCampusDelivery = offCampusDelivery;
+        this.orderableShop = orderableShop;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryTip.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/delivery/OrderableShopDeliveryTip.java
@@ -1,0 +1,50 @@
+package in.koreatech.koin.domain.order.shop.model.entity.delivery;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.domain.order.shop.model.entity.shop.OrderableShop;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "orderable_shop_delivery_tip")
+@NoArgsConstructor(access = PROTECTED)
+public class OrderableShopDeliveryTip {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name ="campus_delivery_tip", nullable = false)
+    private Integer campusDeliveryTip;
+
+    @Column(name ="off_campus_delivery_tip", nullable = false)
+    private Integer offCampusDeliveryTip;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "orderable_shop_id", nullable = false)
+    private OrderableShop orderableShop;
+
+    @Builder
+    public OrderableShopDeliveryTip(Integer campusDeliveryTip, Integer offCampusDeliveryTip, OrderableShop orderableShop) {
+        this.campusDeliveryTip = campusDeliveryTip;
+        this.offCampusDeliveryTip = offCampusDeliveryTip;
+        this.orderableShop = orderableShop;
+    }
+
+    public void updateDeliveryTip(Integer campusDeliveryTip, Integer offCampusDeliveryTip) {
+        this.campusDeliveryTip = campusDeliveryTip;
+        this.offCampusDeliveryTip = offCampusDeliveryTip;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -121,4 +121,12 @@ public class OrderableShop extends BaseEntity {
     public void updateDeliveryOption(OrderableShopDeliveryOption deliveryOption) {
         this.deliveryOption = deliveryOption;
     }
+
+    public void updateOrderableShop(Integer minimumOrderAmount, boolean takeout) {
+        if (minimumOrderAmount == null || minimumOrderAmount < 0) {
+            throw CustomException.of(ApiResponseCode.INVAILID_MINIMUM_ORDER_AMOUNT);
+        }
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.takeout = takeout;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.order.shop.model.entity.shop;
 
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -71,7 +72,7 @@ public class OrderableShop extends BaseEntity {
     @OneToMany(mappedBy = "orderableShop", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderableShopImage> shopImages = new ArrayList<>();
 
-    @OneToOne(mappedBy = "orderableShop", fetch = FetchType.LAZY)
+    @OneToOne(cascade = {PERSIST, MERGE, REMOVE}, mappedBy = "orderableShop", fetch = FetchType.LAZY)
     private OrderableShopDeliveryOption deliveryOption;
 
     @Builder
@@ -115,5 +116,9 @@ public class OrderableShop extends BaseEntity {
         return this.shop.getEventArticles().stream()
             .filter(eventArticle -> eventArticle.isOngoing(clock))
             .collect(Collectors.toList());
+    }
+
+    public void updateDeliveryOption(OrderableShopDeliveryOption deliveryOption) {
+        this.deliveryOption = deliveryOption;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/model/entity/shop/OrderableShop.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Where;
 
+import in.koreatech.koin.domain.order.shop.model.entity.delivery.OrderableShopDeliveryTip;
 import in.koreatech.koin.global.code.ApiResponseCode;
 import in.koreatech.koin.global.exception.CustomException;
 import in.koreatech.koin.global.exception.custom.KoinIllegalArgumentException;
@@ -75,6 +76,9 @@ public class OrderableShop extends BaseEntity {
     @OneToOne(cascade = {PERSIST, MERGE, REMOVE}, mappedBy = "orderableShop", fetch = FetchType.LAZY)
     private OrderableShopDeliveryOption deliveryOption;
 
+    @OneToOne(cascade = {PERSIST, MERGE, REMOVE}, mappedBy = "orderableShop", fetch = FetchType.LAZY)
+    private OrderableShopDeliveryTip deliveryTip;
+
     @Builder
     public OrderableShop(Integer id, Shop shop, boolean delivery, boolean takeout, boolean serviceEvent,
         Integer minimumOrderAmount, boolean isDeleted, List<OrderableShopMenuGroup> menuGroups) {
@@ -120,6 +124,10 @@ public class OrderableShop extends BaseEntity {
 
     public void updateDeliveryOption(OrderableShopDeliveryOption deliveryOption) {
         this.deliveryOption = deliveryOption;
+    }
+
+    public void updateDeliveryTip(OrderableShopDeliveryTip deliveryTip) {
+        this.deliveryTip = deliveryTip;
     }
 
     public void updateOrderableShop(Integer minimumOrderAmount, boolean takeout) {

--- a/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/order/shop/repository/OrderableShopRepository.java
@@ -70,6 +70,16 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
         """)
     Optional<OrderableShop> findByIdWithMenus(@Param("orderableShopId") Integer orderableShopId);
 
+    @Query("""
+                SELECT os
+                FROM OrderableShop os
+                WHERE os.shop.id = :shopId
+        """)
+    Optional<OrderableShop> findByShopId(Integer shopId);
+
+
+    boolean existsByShopId(Integer shopId);
+
     default OrderableShop getByIdWithMenus(Integer orderableShopId) {
         return findByIdWithMenus(orderableShopId).orElseThrow(
             () -> CustomException.of(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP, "해당 상점이 존재하지 않습니다 : " + orderableShopId)
@@ -79,6 +89,12 @@ public interface OrderableShopRepository extends JpaRepository<OrderableShop, In
     default OrderableShop getById(Integer orderableShopId) {
         return findById(orderableShopId).orElseThrow(
             () -> CustomException.of(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP, "해당 상점이 존재하지 않습니다 : " + orderableShopId)
+        );
+    }
+
+    default OrderableShop getByShopId(Integer shopId) {
+        return findByShopId(shopId).orElseThrow(
+            () -> CustomException.of(ApiResponseCode.NOT_FOUND_ORDERABLE_SHOP, "해당 상점이 존재하지 않습니다 : " + shopId)
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -286,9 +286,9 @@ public class Shop extends BaseEntity {
         List<String> categoryNames = List.of("추천 메뉴", "메인 메뉴", "세트 메뉴", "사이드 메뉴");
         for (String categoryName : categoryNames) {
             MenuCategory menuCategory = MenuCategory.builder()
-                    .shop(this)
-                    .name(categoryName)
-                    .build();
+                .shop(this)
+                .name(categoryName)
+                .build();
             this.menuCategories.add(menuCategory);
         }
         this.getMenuCategories().addAll(menuCategories);
@@ -297,9 +297,9 @@ public class Shop extends BaseEntity {
     public void addShopImages(List<String> imageUrls) {
         for (String imageUrl : imageUrls) {
             ShopImage shopImage = ShopImage.builder()
-                    .shop(this)
-                    .imageUrl(imageUrl)
-                    .build();
+                .shop(this)
+                .imageUrl(imageUrl)
+                .build();
             this.shopImages.add(shopImage);
         }
     }
@@ -311,9 +311,9 @@ public class Shop extends BaseEntity {
     public void addShopCategories(List<ShopCategory> shopCategories) {
         for (ShopCategory shopCategory : shopCategories) {
             ShopCategoryMap shopCategoryMap = ShopCategoryMap.builder()
-                    .shopCategory(shopCategory)
-                    .shop(this)
-                    .build();
+                .shopCategory(shopCategory)
+                .shop(this)
+                .build();
             this.shopCategories.add(shopCategoryMap);
         }
     }
@@ -338,5 +338,10 @@ public class Shop extends BaseEntity {
 
     public boolean isOwner(Integer ownerId) {
         return this.owner != null && this.owner.getId().equals(ownerId);
+    }
+
+    public void updateBankAndAccount(String bank, String accountNumber) {
+        this.bank = bank;
+        this.accountNumber = accountNumber;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/model/shop/Shop.java
@@ -344,4 +344,8 @@ public class Shop extends BaseEntity {
         this.bank = bank;
         this.accountNumber = accountNumber;
     }
+
+    public void updateDeliveryPrice(Integer deliveryPrice) {
+        this.deliveryPrice = deliveryPrice;
+    }
 }

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -36,6 +36,7 @@ public enum ApiResponseCode {
     NOT_MATCHED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 번호가 일치하지 않습니다."),
     NOT_MATCHED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 일치하지 않습니다."),
     NOT_READABLE_HTTP_MESSAGE(HttpStatus.BAD_REQUEST, "잘못된 입력 형식이거나, 값이 허용된 범위를 초과했습니다."),
+    NOT_PENDING_REQUEST(HttpStatus.BAD_REQUEST, "대기 중인 요청이 아닙니다."),
     UNSUPPORTED_OPERATION(HttpStatus.BAD_REQUEST, "지원하지 않는 API 입니다."),
     INVALID_RECRUITMENT_PERIOD(HttpStatus.BAD_REQUEST, "모집 마감일은 모집 시작일 이후여야 합니다."),
     MUST_BE_NULL_RECRUITMENT_PERIOD(HttpStatus.BAD_REQUEST, "상시 모집일 경우, 모집 시작일과 종료일은 입력하면 안 됩니다."),

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -83,6 +83,7 @@ public enum ApiResponseCode {
     INVALID_NODE_INFO_START_POINT(HttpStatus.BAD_REQUEST, "올바른 정거장 시작 위치가 아닙니다."),
     INVALID_NODE_INFO_END_POINT(HttpStatus.BAD_REQUEST, "올바른 정거장 끝 위치가 아닙니다."),
     INVALID_SEMESTER_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 학기 형식입니다."),
+    INVAILID_MINIMUM_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "최소 주문 금액은 0원 이상이어야 합니다."),
 
     /**
      * 401 Unauthorized (인증 필요)

--- a/src/main/resources/db/migration/V227__add_orderable_shop_delivery_tip_table.sql
+++ b/src/main/resources/db/migration/V227__add_orderable_shop_delivery_tip_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `koin`.`orderable_shop_delivery_tip`
+(
+    `id`                       INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    `orderable_shop_id`        INT UNSIGNED NOT NULL COMMENT '주문 가능 상점 ID',
+    `campus_delivery_tip`      INT UNSIGNED NOT NULL COMMENT '교내 배달팁',
+    `off_campus_delivery_tip`  INT UNSIGNED NOT NULL COMMENT '교외 배달팁',
+    `created_at`               TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일자',
+    `updated_at`               TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일자',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_orderable_shop_id` (`orderable_shop_id`),
+    CONSTRAINT `fk_orderable_shop_delivery_tip_orderable_shop`
+        FOREIGN KEY (`orderable_shop_id`) REFERENCES `orderable_shop` (`id`)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+)


### PR DESCRIPTION
### 🔍 개요

* 주문 가능 상점 전환 Admin 승인/거부 API 추가입니다.

- close #2081 

---

### 🚀 주요 변경 내용
- 배달 팁 교내/외 별도로 구분 지을 컬럼이 존재하지않아 `OrderableShopDeliveryTip` 테이블 추가
- 데이터 매핑시 기존 데이터 존재시 업데이트 하도록함
-----

### 테이블 매핑


ShopOrderServiceRequest 컬럼 | 매핑 위치 | 매핑되는 컬럼/속성 | 비고
-- | -- | -- | --
id | - | - | 매핑 필요없음
shop | - | - | 매핑 필요없음
minimumOrderAmount | OrderableShop | minimum_order_amount | 직접 매핑 가능
isTakeout | OrderableShop | takeout | 직접 매핑 가능
deliveryOption | OrderableShopDeliveryOption | campusDelivery, offCampusDelivery | "Both"이면 두 값 모두 true 처리
campusDeliveryTip | OrderableShopDeliveryTip(신규)| campusDeliveryTip | 신규 매핑
offCampusDeliveryTip | OrderableShopDeliveryTip(신규)| offCampusDeliveryTip |  신규 매핑
businessLicenseUrl | OwnerAttachment | url | Owner 첨부파일로 관리
businessCertificateUrl | OwnerAttachment | url | Owner 첨부파일로 관리
bankCopyUrl | OwnerAttachment | url | Owner 첨부파일로 관리
bank | Shop | bank | 직접 매핑 가능
accountNumber | Shop | account_number | 직접 매핑 가능
requestStatus | - | - | 매핑 필요없음
approvedAt | - | - | 매핑 필요없음




---

### 💬 참고 사항
* 현재 작성된 부분은 API 사용시 DB저장 및 업데이트를 확인했습니다. 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
