### PR TITLE
fix: 에러 메시지 중복 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopReviewService.java
@@ -204,7 +204,7 @@ public class ShopReviewService {
     private void checkUserLatestReviewWithin24Hours(Integer studentId, Integer shopId) {
         shopReviewRepository.findLatestReviewByStudentIdAndShopIdWithin24Hours(studentId, shopId, LocalDateTime.now(clock))
             .ifPresent(review -> {
-                throw OneReviewPerDayException.withDetail("한 상점에 하루에 한번만 리뷰를 남길 수 있습니다.");
+                throw OneReviewPerDayException.withDetail("studentId : " + studentId + "shopId : " + shopId);
             });
     }
 }


### PR DESCRIPTION
### 🔍 개요

- close #2105 

---

### 🚀 주요 변경 내용

#### 에러 메시지 중복 수정
- 24시간 내에 동일 가계에 리뷰를 남길 경우 발생하는 예외 메시지에서 동일한 내용이 두 번 나오고 있어, 이를 수정했습니다. 

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
