### PR TITLE
fix: LostItemArticle foundAt columnDefinition 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/LostItemArticle.java
@@ -75,7 +75,7 @@ public class LostItemArticle extends BaseEntity {
     @Column(name = "is_found", nullable = false)
     private Boolean isFound = false;
 
-    @Column(name = "found_at")
+    @Column(name = "found_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime foundAt; // "찾음" 처리된 날짜
 
     @NotNull


### PR DESCRIPTION
### 🔍 개요

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: wrong column type encountered in column [found_at] in table [koin.lost_item_articles]; found [timestamp (Types#TIMESTAMP)], but expecting [varchar(255) (Types#VARCHAR)]
```

- close #2114

---

### 🚀 주요 변경 내용

* LostItemArticle foundAt 필드에 columnDefinition="TIMESTAMP" 추가

---

### 💬 참고 사항

* Hibernate가 TIMESTAMP 타입 추론을 제대로 못하는 것 같네요. 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
