### PR TITLE
hotfix: 중복된 강의 데이터 삭제 시 발생하는 에러 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/repository/TimetableLectureRepositoryV2.java
@@ -27,12 +27,17 @@ public interface TimetableLectureRepositoryV2 extends Repository<TimetableLectur
 
     TimetableLecture save(TimetableLecture timetableLecture);
 
-    Optional<TimetableLecture> findByTimetableFrameIdAndLectureId(Integer frameId, Integer lectureId);
+    List<TimetableLecture> findAllByTimetableFrameIdAndLectureId(Integer frameId, Integer lectureId);
 
-    default TimetableLecture getByFrameIdAndLectureId(Integer frameId, Integer lectureId) {
-        return findByTimetableFrameIdAndLectureId(frameId, lectureId)
-            .orElseThrow(() -> TimetableLectureNotFoundException.withDetail(
-                "frameId: " + frameId + ", lectureId: " + lectureId));
+    default List<TimetableLecture> getAllByFrameIdAndLectureId(Integer frameId, Integer lectureId) {
+        List<TimetableLecture> timetableLectures = findAllByTimetableFrameIdAndLectureId(frameId, lectureId);
+
+        if (timetableLectures.isEmpty()) {
+            throw TimetableLectureNotFoundException.withDetail(
+                "frameId: " + frameId + ", lectureId: " + lectureId);
+        }
+
+        return timetableLectures;
     }
 
     @Query(value = "SELECT * FROM timetable_lecture WHERE id = :id", nativeQuery = true)

--- a/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
+++ b/src/main/java/in/koreatech/koin/domain/timetableV2/service/TimetableLectureService.java
@@ -95,8 +95,9 @@ public class TimetableLectureService {
     public void deleteTimetableLectureByFrameId(Integer frameId, Integer lectureId, Integer userId) {
         TimetableFrame frame = timetableFrameRepositoryV2.getById(frameId);
         validateUserOwnsFrame(frame.getUser().getId(), userId);
-        TimetableLecture timetableLecture = timetableLectureRepositoryV2.getByFrameIdAndLectureId(frameId, lectureId);
-        timetableLecture.delete();
+        List<TimetableLecture> timetableLectures = timetableLectureRepositoryV2
+            .getAllByFrameIdAndLectureId(frameId, lectureId);
+        timetableLectures.forEach(TimetableLecture::delete);
     }
 
     @Transactional


### PR DESCRIPTION
### 🔍 개요

* 

- close #2123 

---

### 🚀 주요 변경 내용

* 중복으로 삽입된 강의 데이터가 있어 리스트 타입으로 시간표의 강의 데이터를 조회하여 삭제하도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
