### PR TITLE
hotfix: accessHistory 조회 실패 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/abtest/repository/AccessHistoryRepository.java
@@ -19,12 +19,12 @@ public interface AccessHistoryRepository extends Repository<AccessHistory, Integ
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
-    @Query("SELECT a FROM AccessHistory a JOIN FETCH a.device WHERE a.id = :id")
+    @Query("SELECT a FROM AccessHistory a LEFT JOIN FETCH a.device WHERE a.id = :id")
     Optional<AccessHistory> findById(Integer id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
-    @Query("SELECT a FROM AccessHistory a JOIN FETCH a.device WHERE a.device.id = :deviceId")
+    @Query("SELECT a FROM AccessHistory a LEFT JOIN FETCH a.device WHERE a.device.id = :deviceId")
     Optional<AccessHistory> findByDeviceId(@Param("deviceId") Integer deviceId);
 
     default AccessHistory getById(Integer accessHistoryId) {


### PR DESCRIPTION
### 개요

* #2117 병합 이후 AccessHistory 조회 시 연관된 Device가 없는 경우, 데이터가 존재함에도 불구하고 조회되지 않는 문제를 해결합니다.

---

### 배경

AccessHistory를 조회할 때 device 정보를 함께 가져오기 위해 JOIN FETCH를 사용하고 있었습니다.

### 문제 상황

기존 쿼리: `@Query("SELECT a FROM AccessHistory a JOIN FETCH a.device ...")`
JOIN FETCH는 기본적으로 INNER JOIN으로 동작합니다.(기본 SQL 문법을 따라감)
Inner Join에 의해 AccessHistory 데이터가 DB에 존재하더라도, 연관된 Device가 없는 경우 조인 조건이 성립하지 않습니다.

결과:
Device를 가지지 않은 AccessHistory는 모두 `AccessHistoryNotFoundException`을 발생시킵니다.

### 해결

쿼리에 `LEFT`를 명시하여 Inner Join이 아니라 Left Outer Join으로 동작하도록 수정했습니다. 이제 Device가 있든 없든 AccessHistory만 존재하면 응답을 반환합니다.

### 검증
테스트 코드를 작성하여 문제 상황을 재현했습니다. 테스트 코드는 PR에 포함시켰고, LEFT 키워드 적용/제거에 따라 테스트의 성공 여부가 달라짐을 확인할 수 있습니다.

---

### 💬 참고 사항

* 대부분의 상황에서는 페치 조인 시 LEFT JOIN을 명시적으로 사용한다고 합니다. 연관 엔티티가 반드시 존재해야 하는 경우는 fk 컬럼이 NotNull인 경우 뿐이고, 그마저도 jpa에서 조회하는 기존 흐름과 달라 직관성이 떨어지기 때문입니다.
    * 기존: 연관관계 엔티티가 있든말든 데이터만 있으면 조회됨
    * JOIN FETCH: 연관관계 엔티티가 없으면 데이터가 있어도 조회안됨
    * LEFT JOIN FETCH: 연관관계 엔티티가 있든말든 데이터만 있으면 조회됨

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
