### PR TITLE
hotfix: 레거시 GET /bus 호환을 위해 주말 direction 기본값을 등교로 처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/model/Route.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/model/Route.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import in.koreatech.koin.domain.bus.enums.BusDirection;
 import in.koreatech.koin.domain.bus.enums.BusStation;
 import in.koreatech.koin.domain.bus.enums.ShuttleBusRegion;
 import in.koreatech.koin.domain.bus.enums.ShuttleRouteType;
@@ -88,20 +89,31 @@ public class Route {
 
     public void sortArrivalNodesByDirection() {
         setDirection();
-        if (direction.equals("하교") && routeType != SHUTTLE) {
+        if (BusDirection.SOUTH.getName().equals(direction) && routeType != SHUTTLE) {
             Collections.reverse(this.arrivalNodes);
         }
     }
 
     private void setDirection() {
         if (routeType.equals(WEEKDAYS)) {
-            this.direction = routeInfo;
+            this.direction = normalizeDirection(routeInfo);
             return;
         }
+
         if (routeType.equals(WEEKEND)) {
-            this.direction = routeDetail;
+            this.direction = normalizeDirection(routeDetail);
             return;
         }
-        this.direction = arrivalNodes.get(0).getArrivalTime() == null ? "등교" : "하교";
+
+        this.direction = arrivalNodes.get(0).getArrivalTime() == null
+            ? BusDirection.NORTH.getName()
+            : BusDirection.SOUTH.getName();
+    }
+
+    private String normalizeDirection(String value) {
+        if (BusDirection.SOUTH.getName().equals(value)) {
+            return BusDirection.SOUTH.getName();
+        }
+        return BusDirection.NORTH.getName();
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 레거시 API(`GET /bus`) 호환성 이슈로 주말 노선 direction 처리 로직을 보완했습니다.
* 주말 노선 `detail` 값이 `등교/하교`가 아닐 때 기본값을 `등교`로 처리하도록 수정했습니다.

- close #2161

---

### 🚀 주요 변경 내용

* `Route.sortArrivalNodesByDirection()` 비교를 null-safe 방식으로 변경
* `WEEKEND`/`WEEKDAYS` direction 값 정규화 로직 추가
* 유효값이 `하교`일 때만 `하교`로 처리, 그 외(`null`/기타 문자열)는 `등교`로 처리

---

### 💬 참고 사항

* 정규학기 주말 노선 중 천안 셔틀은 등하교 혼합 특성으로 `detail`이 방향값 규칙을 따르지 않는 케이스가 있어 fallback이 필요했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
