### PR TITLE
fix: 콜밴 게시글 조회 시 소프트 딜리트 여부 고려하여 참여 여부 상태 결정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanParticipantRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanParticipantRepository.java
@@ -19,5 +19,5 @@ public interface CallvanParticipantRepository extends Repository<CallvanParticip
 
     void delete(CallvanParticipant callvanParticipant);
 
-    List<CallvanParticipant> findAllByMemberIdAndPostIdIn(Integer memberId, List<Integer> postIds);
+    List<CallvanParticipant> findAllByMemberIdAndPostIdInAndIsDeletedFalse(Integer memberId, List<Integer> postIds);
 }

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
@@ -78,8 +78,8 @@ public class CallvanPostQueryService {
             List<Integer> postIds = posts.stream()
                 .map(CallvanPost::getId)
                 .toList();
-            List<CallvanParticipant> participants = callvanParticipantRepository.findAllByMemberIdAndPostIdIn(userId,
-                postIds);
+            List<CallvanParticipant> participants = callvanParticipantRepository.findAllByMemberIdAndPostIdInAndIsDeletedFalse(
+                userId, postIds);
             joinedPostIds = participants.stream()
                 .map(participant -> participant.getPost().getId())
                 .collect(Collectors.toSet());


### PR DESCRIPTION
### 🔍 개요

* 콜밴 게시글 목록 조회에서 soft-delete된 참여 이력이 참여 여부 계산에 포함되어, 탈퇴한 사용자가 계속 참여 중으로 보이던 문제를 수정한다.

- close #2178

---

### 🚀 주요 변경 내용

* `CallvanParticipantRepository`의 목록 참여 조회 메서드를 `findAllByMemberIdAndPostIdInAndIsDeletedFalse(...)`로 변경했습니다.

* `CallvanPostQueryService`에서 게시글 목록의 `joinedPostIds` 계산 시 soft-delete되지 않은 참여 이력만 반영하도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data accuracy by ensuring logically deleted participant records are consistently excluded from queries, improving the reliability of participant information across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->