### PR TITLE
fix: 콜벤 요약 정보 단건 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanApi.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanApi.java
@@ -123,6 +123,24 @@ public interface CallvanApi {
 
     @ApiResponseCodes({
         OK,
+        NOT_FOUND_ARTICLE
+    })
+    @Operation(summary = "콜밴 게시글 요약 정보 조회", description = """
+        ### 콜밴 게시글 요약 정보 조회 API
+        목록 갱신을 위해 콜밴 게시글 목록 조회에서 출력되는 각 게시글을 단건으로 조회합니다.
+
+        #### 비즈니스 로직
+        1. 존재하지 않는 게시글(`NOT_FOUND_ARTICLE`)이면 예외가 발생합니다.
+        2. 로그인된 사용자의 경우, 해당 콜벤 게시글에 합류한 상태면 `isJoined` 필드가 true로 표시됩니다.
+        """)
+    @GetMapping("/posts/{postId}/summary")
+    ResponseEntity<CallvanPostSearchResponse.CallvanPostResponse> getCallvanPostSummary(
+        @PathVariable Integer postId,
+        @UserId Integer userId
+    );
+
+    @ApiResponseCodes({
+        OK,
         NOT_FOUND_ARTICLE,
         FORBIDDEN_PARTICIPANT
     })

--- a/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanController.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanController.java
@@ -16,6 +16,7 @@ import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateRequest;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostDetailResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostSearchResponse;
+import in.koreatech.koin.domain.callvan.dto.CallvanPostSearchResponse.CallvanPostResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanUserReportCreateRequest;
 import in.koreatech.koin.domain.callvan.model.enums.CallvanLocation;
 import in.koreatech.koin.domain.callvan.model.filter.CallvanAuthorFilter;
@@ -80,6 +81,15 @@ public class CallvanController implements CallvanApi {
             author, departures, departureKeyword, arrivals, arrivalKeyword, statuses, title, sort, page, limit,
             userId);
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/posts/{postId}/summary")
+    public ResponseEntity<CallvanPostResponse> getCallvanPostSummary(
+        @PathVariable Integer postId,
+        @UserId Integer userId
+    ) {
+        CallvanPostResponse response = callvanPostQueryService.getCallvanPostSummary(postId, userId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/posts/{postId}")

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
@@ -118,8 +118,8 @@ public class CallvanPostQueryService {
 
     public CallvanPostSearchResponse.CallvanPostResponse getCallvanPostSummary(Integer postId, Integer userId) {
         CallvanPost callvanPost = callvanPostRepository.getById(postId);
-        boolean isJoined = callvanParticipantRepository.existsByPostIdAndMemberIdAndIsDeletedFalse(postId, userId);
-
+        boolean isJoined =
+            userId != null && callvanParticipantRepository.existsByPostIdAndMemberIdAndIsDeletedFalse(postId, userId);
         return CallvanPostSearchResponse.CallvanPostResponse.from(callvanPost, isJoined, userId);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPostQueryService.java
@@ -115,4 +115,11 @@ public class CallvanPostQueryService {
 
         return CallvanPostDetailResponse.from(callvanPost, userId, reportedUserIds);
     }
+
+    public CallvanPostSearchResponse.CallvanPostResponse getCallvanPostSummary(Integer postId, Integer userId) {
+        CallvanPost callvanPost = callvanPostRepository.getById(postId);
+        boolean isJoined = callvanParticipantRepository.existsByPostIdAndMemberIdAndIsDeletedFalse(postId, userId);
+
+        return CallvanPostSearchResponse.CallvanPostResponse.from(callvanPost, isJoined, userId);
+    }
 }


### PR DESCRIPTION
### 🔍 개요

- close #2180 

---

### 🚀 주요 변경 내용

* 클라이언트 요청으로 콜벤 상태 갱신용 요약 정보 조회 API 추가

---

### 💬 참고 사항


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /posts/{postId}/summary endpoint to fetch a Callvan post summary.
  * Returns post details and indicates whether the current user has joined (when authenticated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->