### PR TITLE
hotfix: 키워드 알림 이력 저장 트랜잭션 분리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/UserNotificationStatusRepository.java
@@ -32,9 +32,11 @@ public interface UserNotificationStatusRepository extends Repository<UserNotific
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(value = """
-        INSERT INTO user_notification_status (user_id, last_notified_article_id)
-        VALUES (:userId, :notifiedArticleId)
-        ON DUPLICATE KEY UPDATE last_notified_article_id = :notifiedArticleId
+        INSERT INTO user_notification_status (user_id, last_notified_article_id, created_at, updated_at)
+        VALUES (:userId, :notifiedArticleId, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON DUPLICATE KEY UPDATE
+            last_notified_article_id = :notifiedArticleId,
+            updated_at = CURRENT_TIMESTAMP
         """, nativeQuery = true)
     void upsertLastNotifiedArticleId(
         @Param("userId") Integer userId,

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -9,6 +9,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundException;
@@ -206,7 +207,7 @@ public class KeywordService {
         }
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createNotifiedArticleStatus(Integer userId, Integer articleId) {
         userNotificationStatusRepository.upsertLastNotifiedArticleId(userId, articleId);
     }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
@@ -1,11 +1,13 @@
 package in.koreatech.koin.unit.domain.community.keyword.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
@@ -16,6 +18,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
@@ -106,5 +110,15 @@ class KeywordServiceTest {
         keywordService.createNotifiedArticleStatus(1, 100);
 
         verify(userNotificationStatusRepository).upsertLastNotifiedArticleId(1, 100);
+    }
+
+    @Test
+    @DisplayName("발송 이력 저장은 항상 새로운 트랜잭션에서 수행한다.")
+    void createNotifiedArticleStatus_startsNewTransaction() throws NoSuchMethodException {
+        Method method = KeywordService.class.getMethod("createNotifiedArticleStatus", Integer.class, Integer.class);
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 키워드 알림 발송 후 이력 저장 과정에서 트랜잭션 종료 이후 DB write가 수행되며 `no transaction is in progress` 오류 발생하던 문제 수정함
* `user_notification_status` native upsert에서 audit 컬럼 누락으로 insert 실패 가능하던 부분 함께 보완함

- close #2187

---

### 🚀 주요 변경 내용

* 키워드 알림 이력 저장 로직을 별도 트랜잭션(`REQUIRES_NEW`)으로 분리함
* `user_notification_status` upsert 쿼리에 `created_at`, `updated_at` 반영함
* 관련 단위 테스트로 트랜잭션 전파 설정 검증함

---

### 💬 참고 사항

* 실제 원인은 커밋 이후 실행되는 리스너에서 DB write를 수행한 트랜잭션 경계 문제였음
* 추가로 native upsert가 audit 컬럼을 직접 채우지 않아 운영 환경에서 insert 실패 가능성 있었음
* 검증용 acceptance 테스트는 제외하고 실제 수정 코드만 반영함

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted internal transaction behavior for a keyword-related operation (no user-facing API changes).

* **Data**
  * Notification storage now records creation and update timestamps when inserting/updating records, improving timestamp accuracy.

* **Tests**
  * Added a unit test that verifies the transaction behavior change.

---

Note: These are internal improvements with no direct user-facing UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->