### PR TITLE
feat: 키워드 알림 스레드 분리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -42,6 +43,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
     private final KeywordService keywordService;
     private final ArticleRepository articleRepository;
 
+    @Async
     @TransactionalEventListener
     public void onKeywordRequest(ArticleKeywordEvent event) {
         Map<Integer, String> matchedKeywordByUserId = event.matchedKeywordByUserId();

--- a/src/main/java/in/koreatech/koin/global/config/AsyncConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/AsyncConfig.java
@@ -6,6 +6,7 @@ import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,7 +17,13 @@ public class AsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {
-        return null;
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.initialize();
+        return executor;
     }
 
     @Override

--- a/src/main/java/in/koreatech/koin/global/config/AsyncConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/AsyncConfig.java
@@ -1,5 +1,7 @@
 package in.koreatech.koin.global.config;
 
+import static java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+
 import java.util.concurrent.Executor;
 
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
@@ -22,6 +24,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(20);
         executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.setRejectedExecutionHandler(new CallerRunsPolicy());
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
### 🔍 개요

<img width="3416" height="1778" alt="Image" src="https://github.com/user-attachments/assets/551b00d0-6d8c-48d8-a428-a2aab3169046" />

* 키워드 알림 API(POST /articles/keyword/notification)에서 하나의 스레드를 점유하는 문제 발생
* HTTP 요청/응답을 관리하는 톰켓 스레드에서 키워드 알림 이벤트 발행 후 처리 로직까지 관할하는 건 설계 문제라고 판단
* 키워드 알림 이벤트 발행 후 처리는 별도의 스레드에서 관할하고, 톰켓 스레드는 HTTP 요청/응답만을 수행하도록 개선
- close #2191 

---

### 🚀 주요 변경 내용

#### ThreadPoolTaskExecutor 설정 추가
- 키워드 알림의 경우 평일에 발생하며, 하루에 3~4번의 API 호출이 발생합니다.
- 한 번 API가 발생할 경우 이벤트가 4~6개 내외로 발생합니다.
- 해당 상황을 반영하여 최소 2개, 최대 5개의 스레드풀을 소유하도록 설정했고 대기 큐에는 최대 20개의 작업이 대기하도록 설정했습니다.
- 대기 큐까지 꽉 찬 경우, 에러로 처리하여 손실하는 것이 아닌 톰켓 스레드가 직접 처리하도록 `CallerRunsPolicy` 설정을 했습니다.

#### 키워드 알림 이벤트 비동기 처리
- 스레드 분리를 위해 키워드 알림 이벤트 비동기 처리를 진행했습니다.

---

### 💬 참고 사항

* 작업 관련해서 잘 정리된 [블로그](https://xxeol.tistory.com/44) 하나 첨부합니다.
* 작업 간 AI와의 [대화 이력](https://docs.google.com/document/d/1XNv3MjeDdnGRCT3VTNiDte6eZBBGj-7m2Bytl27ZsQc/edit?usp=sharing) 첨부합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
