### PR TITLE
fix: 버스 공지 n+1 쿼리 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
@@ -2,11 +2,27 @@ package in.koreatech.koin.domain.community.article.dto;
 
 import java.time.LocalDateTime;
 
-public interface BusArticleProjection {
+public class BusArticleProjection {
 
-    Integer getId();
+    private final Integer id;
+    private final String title;
+    private final LocalDateTime createdAt;
 
-    String getTitle();
+    public BusArticleProjection(Integer id, String title, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+    }
 
-    LocalDateTime getCreatedAt();
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.community.article.dto;
+
+import java.time.LocalDateTime;
+
+public interface BusArticleProjection {
+
+    Integer getId();
+
+    String getTitle();
+
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/BusArticleProjection.java
@@ -2,27 +2,10 @@ package in.koreatech.koin.domain.community.article.dto;
 
 import java.time.LocalDateTime;
 
-public class BusArticleProjection {
+public record BusArticleProjection(
+    Integer id,
+    String title,
+    LocalDateTime createdAt
+) {
 
-    private final Integer id;
-    private final String title;
-    private final LocalDateTime createdAt;
-
-    public BusArticleProjection(Integer id, String title, LocalDateTime createdAt) {
-        this.id = id;
-        this.title = title;
-        this.createdAt = createdAt;
-    }
-
-    public Integer getId() {
-        return id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/redis/BusNoticeArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/redis/BusNoticeArticle.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.article.model.redis;
 
+import in.koreatech.koin.domain.community.article.dto.BusArticleProjection;
 import in.koreatech.koin.domain.community.article.model.Article;
 import org.springframework.data.annotation.Id;
 import lombok.Builder;
@@ -25,6 +26,13 @@ public class BusNoticeArticle {
         return BusNoticeArticle.builder()
                 .id(article.getId())
                 .title(article.getTitle())
+                .build();
+    }
+
+    public static BusNoticeArticle from(BusArticleProjection projection) {
+        return BusNoticeArticle.builder()
+                .id(projection.getId())
+                .title(projection.getTitle())
                 .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/redis/BusNoticeArticle.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/redis/BusNoticeArticle.java
@@ -1,11 +1,10 @@
 package in.koreatech.koin.domain.community.article.model.redis;
 
-import in.koreatech.koin.domain.community.article.dto.BusArticleProjection;
-import in.koreatech.koin.domain.community.article.model.Article;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @RedisHash(value = "busNoticeArticle")
@@ -22,17 +21,10 @@ public class BusNoticeArticle {
         this.title = title;
     }
 
-    public static BusNoticeArticle from(Article article) {
+    public static BusNoticeArticle of(int id, String title) {
         return BusNoticeArticle.builder()
-                .id(article.getId())
-                .title(article.getTitle())
-                .build();
-    }
-
-    public static BusNoticeArticle from(BusArticleProjection projection) {
-        return BusNoticeArticle.builder()
-                .id(projection.getId())
-                .title(projection.getTitle())
-                .build();
+            .id(id)
+            .title(title)
+            .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.domain.community.article.dto.BusArticleProjection;
 import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.article.exception.BoardNotFoundException;
 import in.koreatech.koin.domain.community.article.model.Article;
@@ -184,8 +185,9 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     @Query("SELECT a.title FROM Article a WHERE a.id = :id")
     String getTitleById(@Param("id") Integer id);
 
-    @Query(value = "SELECT * FROM new_articles a "
+    @Query(value = "SELECT a.id AS id, a.title AS title, a.created_at AS createdAt "
+        + "FROM new_articles a "
         + "WHERE a.title REGEXP '통학버스|등교버스|셔틀버스|하교버스' AND a.is_notice = true "
         + "ORDER BY a.created_at DESC LIMIT 5", nativeQuery = true)
-    List<Article> findBusArticlesTop5OrderByCreatedAtDesc();
+    List<BusArticleProjection> findBusArticlesTop5OrderByCreatedAtDesc();
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -185,9 +185,19 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     @Query("SELECT a.title FROM Article a WHERE a.id = :id")
     String getTitleById(@Param("id") Integer id);
 
-    @Query(value = "SELECT a.id AS id, a.title AS title, a.created_at AS createdAt "
-        + "FROM new_articles a "
-        + "WHERE a.title REGEXP '통학버스|등교버스|셔틀버스|하교버스' AND a.is_notice = true "
-        + "ORDER BY a.created_at DESC LIMIT 5", nativeQuery = true)
-    List<BusArticleProjection> findBusArticlesTop5OrderByCreatedAtDesc();
+    @Query("""
+        SELECT new in.koreatech.koin.domain.community.article.dto.BusArticleProjection(
+            a.id, a.title, a.createdAt
+        )
+        FROM Article a
+        WHERE (
+            a.title LIKE '%통학버스%'
+            OR a.title LIKE '%등교버스%'
+            OR a.title LIKE '%셔틀버스%'
+            OR a.title LIKE '%하교버스%'
+        )
+        AND a.isNotice = true
+        ORDER BY a.createdAt DESC
+        """)
+    List<BusArticleProjection> findBusArticlesTop5OrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleSyncService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleSyncService.java
@@ -1,5 +1,20 @@
 package in.koreatech.koin.domain.community.article.service;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import in.koreatech.koin.domain.community.article.dto.BusArticleProjection;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.ArticleSearchKeyword;
@@ -14,20 +29,6 @@ import in.koreatech.koin.domain.community.article.repository.redis.BusArticleRep
 import in.koreatech.koin.domain.community.article.repository.redis.HotArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 @Slf4j
 @Service
@@ -76,10 +77,11 @@ public class ArticleSyncService {
 
     @Transactional
     public void updateBusNoticeArticle() {
-        List<BusArticleProjection> articles = articleRepository.findBusArticlesTop5OrderByCreatedAtDesc();
-        LocalDate latestDate = articles.get(0).getCreatedAt().toLocalDate();
+        List<BusArticleProjection> articles = articleRepository.findBusArticlesTop5OrderByCreatedAtDesc(
+            PageRequest.of(0, 5));
+        LocalDate latestDate = articles.get(0).createdAt().toLocalDate();
         List<BusArticleProjection> latestArticles = articles.stream()
-            .filter(article -> article.getCreatedAt().toLocalDate().isEqual(latestDate))
+            .filter(article -> article.createdAt().toLocalDate().isEqual(latestDate))
             .toList();
 
         if (latestArticles.size() >= 2) {
@@ -89,21 +91,23 @@ public class ArticleSyncService {
                     int secondWeight = 0;
 
                     // 제목(title)에 "사과"가 들어가면 후순위, "긴급"이 포함되면 우선순위
-                    if (first.getTitle().contains("사과"))
+                    if (first.title().contains("사과"))
                         firstWeight++;
-                    if (first.getTitle().contains("긴급"))
+                    if (first.title().contains("긴급"))
                         firstWeight--;
 
-                    if (second.getTitle().contains("사과"))
+                    if (second.title().contains("사과"))
                         secondWeight++;
-                    if (second.getTitle().contains("긴급"))
+                    if (second.title().contains("긴급"))
                         secondWeight--;
 
                     return Integer.compare(firstWeight, secondWeight);
                 })
                 .toList();
         }
-        busArticleRepository.save(BusNoticeArticle.from(latestArticles.get(0)));
+
+        BusArticleProjection latestArticle = latestArticles.get(0);
+        busArticleRepository.save(BusNoticeArticle.of(latestArticle.id(), latestArticle.title()));
     }
 
     @Transactional
@@ -131,9 +135,10 @@ public class ArticleSyncService {
             String ipAddress = ipKey.replace(IP_SEARCH_COUNT_PREFIX, "");
 
             for (Map.Entry<Object, Object> entry : keywordSearchCounts.entrySet()) {
-                String searchedKeyword = (String) entry.getKey();
+                String searchedKeyword = (String)entry.getKey();
                 int searchCount = Integer.parseInt(entry.getValue().toString());
-                if (searchCount <= 0) continue;
+                if (searchCount <= 0)
+                    continue;
 
                 articleSearchKeywordRepository.findByKeyword(searchedKeyword).ifPresent(keywordEntity -> {
                     ipMapRepository.findByArticleSearchKeywordAndIpAddress(keywordEntity, ipAddress)

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleSyncService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/ArticleSyncService.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.article.service;
 
+import in.koreatech.koin.domain.community.article.dto.BusArticleProjection;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.ArticleSearchKeyword;
 import in.koreatech.koin.domain.community.article.model.ArticleSearchKeywordIpMap;
@@ -75,9 +76,9 @@ public class ArticleSyncService {
 
     @Transactional
     public void updateBusNoticeArticle() {
-        List<Article> articles = articleRepository.findBusArticlesTop5OrderByCreatedAtDesc();
+        List<BusArticleProjection> articles = articleRepository.findBusArticlesTop5OrderByCreatedAtDesc();
         LocalDate latestDate = articles.get(0).getCreatedAt().toLocalDate();
-        List<Article> latestArticles = articles.stream()
+        List<BusArticleProjection> latestArticles = articles.stream()
             .filter(article -> article.getCreatedAt().toLocalDate().isEqual(latestDate))
             .toList();
 


### PR DESCRIPTION
### 🔍 개요

* 버스 공지 스케줄러(`updateBusNoticeArticle`)에서 `Article` 엔티티 전체를 조회하던 쿼리를 Projection으로 개선하여 N+1 문제 및 불필요한 컬럼 조회를 제거합니다.
* 최근 버스 공지 5건을 조회하는 과정에서 각 공지별로 4개씩 추가 쿼리가 실행되어, 총 21개의 쿼리가 발생하는 N+1 문제를 확인했습니다.
<img width="1954" height="771" alt="image" src="https://github.com/user-attachments/assets/d4074eea-2170-45b6-b36a-4088a1877531" />


- close #2195

---

### 🚀 주요 변경 내용

* `BusArticleProjection` 클래스 신규 추가
  * `id`, `title`, `createdAt` 필드만 포함하는 Projection DTO
* `ArticleRepository.findBusArticlesTop5OrderByCreatedAtDesc()` 쿼리 수정
  * `SELECT *` → `SELECT a.id, a.title, a.created_at` 로 필요한 컬럼만 조회
  * 반환 타입 `List<Article>` → `List<BusArticleProjection>` 변경
* `BusNoticeArticle.from(BusArticleProjection)` 팩토리 메서드 추가
* `ArticleSyncService.updateBusNoticeArticle()` 에서 `BusArticleProjection` 타입으로 처리하도록 변경

---

### 💬 참고 사항

* 기존 `Article` 엔티티 전체를 로딩할 경우 연관 엔티티에 의한 N+1 쿼리가 발생할 수 있었으나, Projection 적용으로 필요한 3개 컬럼만 단일 쿼리로 조회합니다.
* `BusArticleProjection`은 JPA Native Query 결과 매핑을 위한 일반 클래스로 구현되었습니다 (인터페이스 Projection 대신 생성자 기반 매핑 사용).

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved bus notice retrieval: now fetches and processes a compact, paginated set of recent bus-related posts (top 5) with more precise keyword matching, resulting in faster, more efficient notice updates and reduced data stored for notices.
  * Minor stability and formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->