### PR TITLE
refactor: sendKeywordNotification 메소드 리팩토링

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import static in.koreatech.koin.domain.community.article.service.ArticleService.
 import static in.koreatech.koin.domain.community.article.service.ArticleService.NOTICE_BOARD_ID;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,7 +29,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
 
     Optional<Article> findById(Integer articleId);
 
-    List<Article> findAllByIdIn(List<Integer> articleIds);
+    List<Article> findAllByIdIn(Collection<Integer> articleIds);
 
     Page<Article> findAll(Pageable pageable);
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/dto/KeywordNotificationRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/dto/KeywordNotificationRequest.java
@@ -1,6 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.dto;
 
-import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -9,10 +9,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(SnakeCaseStrategy.class)
-public record KeywordNotificationRequest (
+public record KeywordNotificationRequest(
     @Schema(description = "업데이트 된 공지사항 목록", example = "[1, 2, 3]")
     @NotNull
-    List<Integer> updateNotification
+    Set<Integer> updateNotification
 ) {
 
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -147,18 +147,14 @@ public class KeywordService {
     }
 
     public void sendKeywordNotification(KeywordNotificationRequest request) {
-        List<Integer> updateNotificationIds = request.updateNotification().stream()
-            .distinct()
-            .toList();
-
-        if (updateNotificationIds.isEmpty()) {
+        if (request.updateNotification().isEmpty()) {
             return;
         }
 
-        List<Article> fetchedArticles = articleRepository.findAllByIdIn(updateNotificationIds);
+        List<Article> fetchedArticles = articleRepository.findAllByIdIn(request.updateNotification());
         var articleById = fetchedArticles.stream()
             .collect(Collectors.toMap(Article::getId, article -> article));
-        List<Article> articles = updateNotificationIds.stream()
+        List<Article> articles = request.updateNotification().stream()
             .map(articleId -> {
                 Article article = articleById.get(articleId);
                 if (article == null) {

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundException;
+import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
@@ -23,7 +23,6 @@ import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest
 import in.koreatech.koin.domain.community.keyword.exception.KeywordDuplicationException;
 import in.koreatech.koin.domain.community.keyword.exception.KeywordLimitExceededException;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
-import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
@@ -151,19 +150,7 @@ public class KeywordService {
             return;
         }
 
-        List<Article> fetchedArticles = articleRepository.findAllByIdIn(request.updateNotification());
-        var articleById = fetchedArticles.stream()
-            .collect(Collectors.toMap(Article::getId, article -> article));
-        List<Article> articles = request.updateNotification().stream()
-            .map(articleId -> {
-                Article article = articleById.get(articleId);
-                if (article == null) {
-                    throw ArticleNotFoundException.withDetail("articleId: " + articleId);
-                }
-                return article;
-            })
-            .toList();
-
+        List<Article> articles = articleRepository.findAllByIdIn(request.updateNotification());
         List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, null);
         for (ArticleKeywordEvent event : keywordEvents) {
             eventPublisher.publishEvent(event);


### PR DESCRIPTION
### 🔍 개요

- close #2201 

---

### 🚀 주요 변경 내용

#### KeywordNotificationRequest updateNotification 자료형 수정
- KeywordService의 sendKeywordNotification 메소드에서 distinct 메소드를 통해 updateNotification으로 넘어오는 id 값 중복 제거
- 해당 로직 간결화를 위해 자료형을 List에서 Set으로 수정 (Jackson 역직렬화 과정에서 중복제거)

#### 유효성 검증 로직 삭제
```java
var articleById = fetchedArticles.stream()
    .collect(Collectors.toMap(Article::getId, article -> article));

List<Article> articles = updateNotificationIds.stream()
    .map(articleId -> {
        Article article = articleById.get(articleId);
        if (article == null) {
            throw ArticleNotFoundException.withDetail("articleId: " + articleId);
        }
        return article;
    })
    .toList();
```
- DB에서 조회된 Article들의 Id와 요청값으로 들어온 articlesId의 유효성 검증 로직으로 확인
- 과도한 방어 로직이라 판단하여 삭제

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
