### PR TITLE
refactor: KeywordExtractor 클래스 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordUserMap.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordUserMap.java
@@ -56,4 +56,12 @@ public class ArticleKeywordUserMap extends BaseEntity {
     public void restore() {
         this.isDeleted = false;
     }
+
+    public String getKeyword() {
+        return articleKeyword.getKeyword();
+    }
+
+    public Integer getUserId() {
+        return user.getId();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/KeywordMatchResult.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/KeywordMatchResult.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.domain.community.keyword.model;
+
+import java.util.Objects;
+
+public class KeywordMatchResult {
+
+    private final Integer articleId;
+    private final Integer userId;
+    private String keyword;
+
+    private KeywordMatchResult(Integer articleId, Integer userId, String keyword) {
+        this.articleId = articleId;
+        this.userId = userId;
+        this.keyword = keyword;
+    }
+
+    public static KeywordMatchResult of(Integer articleId, Integer userId, String keyword) {
+        return new KeywordMatchResult(articleId, userId, keyword);
+    }
+
+    public void updateKeywordIfLonger(String candidate) {
+        if (candidate.trim().length() > this.keyword.trim().length()) {
+            this.keyword = candidate;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof KeywordMatchResult that)) return false;
+        return Objects.equals(articleId, that.articleId) && Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(articleId, userId);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
@@ -29,13 +29,6 @@ public interface ArticleKeywordUserMapRepository extends Repository<ArticleKeywo
 
     List<ArticleKeywordUserMap> findAllByUserId(Integer userId);
 
-    @Query("""
-        SELECT akw.keyword FROM ArticleKeywordUserMap akum
-        JOIN akum.articleKeyword akw
-        WHERE akum.user.id = :userId
-        """)
-    List<String> findAllKeywordByUserId(@Param("userId") Integer userId);
-
     @Query(value = """
     SELECT * FROM article_keyword_user_map akum
     WHERE akum.keyword_id = :articleKeywordId
@@ -47,11 +40,4 @@ public interface ArticleKeywordUserMapRepository extends Repository<ArticleKeywo
     );
 
     List<ArticleKeywordUserMap> findAllByArticleKeywordIdIn(List<Integer> articleKeywordIds);
-
-    @Query("""                                                                              
-      SELECT akum FROM ArticleKeywordUserMap akum
-      JOIN FETCH akum.articleKeyword
-      JOIN FETCH akum.user
-      """)
-    List<ArticleKeywordUserMap> findAll();
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
@@ -47,4 +47,11 @@ public interface ArticleKeywordUserMapRepository extends Repository<ArticleKeywo
     );
 
     List<ArticleKeywordUserMap> findAllByArticleKeywordIdIn(List<Integer> articleKeywordIds);
+
+    @Query("""                                                                              
+      SELECT akum FROM ArticleKeywordUserMap akum
+      JOIN FETCH akum.articleKeyword
+      JOIN FETCH akum.user
+      """)
+    List<ArticleKeywordUserMap> findAll();
 }

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -20,32 +20,34 @@ public class KeywordExtractor {
         Set<KeywordMatchResult> keywordMatchResults = new HashSet<>();
 
         for (Article article : articles) {
-            String title = article.getTitle();
-
             for (ArticleKeywordUserMap articleKeywordUserMap : articleKeywordUserMaps) {
-                if (Objects.equals(articleKeywordUserMap.getUserId(), authorId)) {
-                    continue;
+                if (isMatchable(article, articleKeywordUserMap, authorId)) {
+                    addOrUpdateResult(keywordMatchResults, article, articleKeywordUserMap);
                 }
-
-                String keyword = articleKeywordUserMap.getKeyword();
-                if (!title.contains(keyword)) {
-                    continue;
-                }
-
-                KeywordMatchResult keywordMatchResult = KeywordMatchResult.of(
-                    article.getId(), articleKeywordUserMap.getUserId(), keyword
-                );
-
-                keywordMatchResults.stream()
-                    .filter(result -> result.equals(keywordMatchResult))
-                    .findFirst()
-                    .ifPresentOrElse(
-                        existing -> existing.updateKeywordIfLonger(keyword),
-                        () -> keywordMatchResults.add(keywordMatchResult)
-                    );
             }
         }
 
         return keywordMatchResults.stream().toList();
+    }
+
+    private boolean isMatchable(Article article, ArticleKeywordUserMap articleKeywordUserMap, Integer authorId) {
+        return !Objects.equals(articleKeywordUserMap.getUserId(), authorId)
+            && article.getTitle().contains(articleKeywordUserMap.getKeyword());
+    }
+
+    private void addOrUpdateResult(
+        Set<KeywordMatchResult> results, Article article, ArticleKeywordUserMap userMap
+    ) {
+        KeywordMatchResult keywordMatchResult = KeywordMatchResult.of(
+            article.getId(), userMap.getUserId(), userMap.getKeyword()
+        );
+
+        results.stream()
+            .filter(result -> result.equals(keywordMatchResult))
+            .findFirst()
+            .ifPresentOrElse(
+                existing -> existing.updateKeywordIfLonger(userMap.getKeyword()),
+                () -> results.add(keywordMatchResult)
+            );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -1,20 +1,13 @@
 package in.koreatech.koin.domain.community.util;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.domain.community.article.model.Article;
-import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
-import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
+import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +25,8 @@ public class KeywordExtractor {
     public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
         List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAll();
 
+
+        /*
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();
         int offset = 0;
 
@@ -85,8 +80,9 @@ public class KeywordExtractor {
                 keywordEvents.add(new ArticleKeywordEvent(article.getId(), authorId, matchedKeywordByUserId));
             }
         }
+         */
 
-        return keywordEvents;
+        return null;
     }
 
     private String pickHigherPriorityKeyword(String previousKeyword, String candidateKeyword) {

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -36,18 +36,18 @@ public class KeywordExtractor {
     }
 
     private void addOrUpdateResult(
-        Set<KeywordMatchResult> results, Article article, ArticleKeywordUserMap userMap
+        Set<KeywordMatchResult> keywordMatchResults, Article article, ArticleKeywordUserMap articleKeywordUserMap
     ) {
         KeywordMatchResult keywordMatchResult = KeywordMatchResult.of(
-            article.getId(), userMap.getUserId(), userMap.getKeyword()
+            article.getId(), articleKeywordUserMap.getUserId(), articleKeywordUserMap.getKeyword()
         );
 
-        results.stream()
+        keywordMatchResults.stream()
             .filter(result -> result.equals(keywordMatchResult))
             .findFirst()
             .ifPresentOrElse(
-                existing -> existing.updateKeywordIfLonger(userMap.getKeyword()),
-                () -> results.add(keywordMatchResult)
+                existing -> existing.updateKeywordIfLonger(articleKeywordUserMap.getKeyword()),
+                () -> keywordMatchResults.add(keywordMatchResult)
             );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
@@ -16,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class KeywordExtractor {
 
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
-import lombok.RequiredArgsConstructor;
 
 @Component
 public class KeywordExtractor {

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.article.model.Article;
@@ -13,7 +13,7 @@ import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;
 
-@Service
+@Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class KeywordExtractor {

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -31,7 +31,7 @@ public class KeywordExtractor {
     private final ArticleKeywordRepository articleKeywordRepository;
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
 
-    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
+    public List<KeywordMatchResult> matchKeyword(List<Article> articles, Integer authorId) {
         List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAll();
         Set<KeywordMatchResult> keywordMatchResults = new HashSet<>();
 
@@ -57,6 +57,8 @@ public class KeywordExtractor {
                     );
             }
         }
+
+        return keywordMatchResults.stream().toList();
 
         /*
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -7,11 +7,9 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
-import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -20,15 +18,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class KeywordExtractor {
 
-    /**
-     * - 하나의 게시글에서 여러 키워드가 매칭 될 경우
-     * - 하나의 게시글에서 동일한 키워드가 매칭 될 경우
-     * - 여러개의 게시글에서 동일한 키워드가 매칭 될 경우
-     */
-
-    private static final int KEYWORD_BATCH_SIZE = 100;
-
-    private final ArticleKeywordRepository articleKeywordRepository;
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
 
     public List<KeywordMatchResult> matchKeyword(List<Article> articles, Integer authorId) {
@@ -59,70 +48,5 @@ public class KeywordExtractor {
         }
 
         return keywordMatchResults.stream().toList();
-
-        /*
-        Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();
-        int offset = 0;
-
-        while (true) {
-            Pageable pageable = PageRequest.of(offset / KEYWORD_BATCH_SIZE, KEYWORD_BATCH_SIZE);
-            List<ArticleKeyword> keywords = articleKeywordRepository.findAll(pageable);
-
-            if (keywords.isEmpty()) {
-                break;
-            }
-            List<Integer> keywordIds = keywords.stream()
-                .map(ArticleKeyword::getId)
-                .toList();
-            Map<Integer, List<ArticleKeywordUserMap>> userMapsByKeywordId = articleKeywordUserMapRepository
-                .findAllByArticleKeywordIdIn(keywordIds)
-                .stream()
-                .filter(keywordUserMap -> !keywordUserMap.getIsDeleted())
-                .collect(Collectors.groupingBy(
-                    keywordUserMap -> keywordUserMap.getArticleKeyword().getId(),
-                    LinkedHashMap::new,
-                    Collectors.toList()
-                ));
-
-            for (Article article : articles) {
-                String title = article.getTitle();
-                for (ArticleKeyword keyword : keywords) {
-                    if (!title.contains(keyword.getKeyword())) {
-                        continue;
-                    }
-                    Map<Integer, String> matchedKeywordByUserId = matchedKeywordByUserIdByArticleId
-                        .computeIfAbsent(article.getId(), ignored -> new LinkedHashMap<>());
-
-                    for (ArticleKeywordUserMap keywordUserMap :
-                        userMapsByKeywordId.getOrDefault(keyword.getId(), List.of())) {
-                        Integer userId = keywordUserMap.getUser().getId();
-                        matchedKeywordByUserId.merge(
-                            userId,
-                            keyword.getKeyword(),
-                            this::pickHigherPriorityKeyword
-                        );
-                    }
-                }
-            }
-            offset += KEYWORD_BATCH_SIZE;
-        }
-
-        List<ArticleKeywordEvent> keywordEvents = new ArrayList<>();
-        for (Article article : articles) {
-            Map<Integer, String> matchedKeywordByUserId = matchedKeywordByUserIdByArticleId.get(article.getId());
-            if (matchedKeywordByUserId != null && !matchedKeywordByUserId.isEmpty()) {
-                keywordEvents.add(new ArticleKeywordEvent(article.getId(), authorId, matchedKeywordByUserId));
-            }
-        }
-         */
-
-        return null;
-    }
-
-    private String pickHigherPriorityKeyword(String previousKeyword, String candidateKeyword) {
-        if (candidateKeyword.length() > previousKeyword.length()) {
-            return candidateKeyword;
-        }
-        return previousKeyword;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -30,6 +30,8 @@ public class KeywordExtractor {
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
 
     public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
+        List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAll();
+
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();
         int offset = 0;
 

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -10,17 +10,14 @@ import org.springframework.stereotype.Component;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
-import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
 public class KeywordExtractor {
 
-    private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
-
-    public List<KeywordMatchResult> matchKeyword(List<Article> articles, Integer authorId) {
-        List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAll();
+    public List<KeywordMatchResult> matchKeyword(
+        List<Article> articles, List<ArticleKeywordUserMap> articleKeywordUserMaps, Integer authorId
+    ) {
         Set<KeywordMatchResult> keywordMatchResults = new HashSet<>();
 
         for (Article article : articles) {

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.community.util;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
@@ -28,6 +29,10 @@ public class KeywordExtractor {
             String title = article.getTitle();
 
             for (ArticleKeywordUserMap articleKeywordUserMap : articleKeywordUserMaps) {
+                if (Objects.equals(articleKeywordUserMap.getUserId(), authorId)) {
+                    continue;
+                }
+
                 String keyword = articleKeywordUserMap.getKeyword();
                 if (!title.contains(keyword)) {
                     continue;

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -1,6 +1,8 @@
 package in.koreatech.koin.domain.community.util;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
+import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class KeywordExtractor {
 
+    /**
+     * - 하나의 게시글에서 여러 키워드가 매칭 될 경우
+     * - 하나의 게시글에서 동일한 키워드가 매칭 될 경우
+     * - 여러개의 게시글에서 동일한 키워드가 매칭 될 경우
+     */
+
     private static final int KEYWORD_BATCH_SIZE = 100;
 
     private final ArticleKeywordRepository articleKeywordRepository;
@@ -24,7 +33,30 @@ public class KeywordExtractor {
 
     public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
         List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAll();
+        Set<KeywordMatchResult> keywordMatchResults = new HashSet<>();
 
+        for (Article article : articles) {
+            String title = article.getTitle();
+
+            for (ArticleKeywordUserMap articleKeywordUserMap : articleKeywordUserMaps) {
+                String keyword = articleKeywordUserMap.getKeyword();
+                if (!title.contains(keyword)) {
+                    continue;
+                }
+
+                KeywordMatchResult keywordMatchResult = KeywordMatchResult.of(
+                    article.getId(), articleKeywordUserMap.getUserId(), keyword
+                );
+
+                keywordMatchResults.stream()
+                    .filter(result -> result.equals(keywordMatchResult))
+                    .findFirst()
+                    .ifPresentOrElse(
+                        existing -> existing.updateKeywordIfLonger(keyword),
+                        () -> keywordMatchResults.add(keywordMatchResult)
+                    );
+            }
+        }
 
         /*
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();


### PR DESCRIPTION
### 🔍 개요

- close #2202 

---

### 🚀 주요 변경 내용

#### 배치 조회 삭제
<img width="397" height="157" alt="image" src="https://github.com/user-attachments/assets/e1c113c9-2280-45f1-b0db-5f541238da50" />

- ArticleKeyword를 100개 단위로 페이징 조회 (총 N개, 쿼리 N / 100 + 1번 발생)
- 이로 인해 ArticleKeywordUserMap 쿼리도 N / 100 + 1번 발생
- 기능이 출시된지 1년 6개월이 지난 시점에서 ArticleKeywords의 데이터는 158개, ArticleKeywordUserMap의 데이터는 432개 
- 데이터가 소규모이며 배치 조회가 아닌 한 번에 모두 조회하는 것이 DB I/O를 줄이면서 코드도 개선할 수 있다고 판단

#### KeywordMatchResult 클래스 추가
- Map 자료구조, Stream 라이브러리 사용으로 인해 로직을 파악하기 어렵다고 판단
- 도메인 객체 KeywordMatchResult를 추가하여 개선
  - (articleId, userId)가 같은 경우 동일 인스턴스로 판단
  - 집합에 데이터가 없다면 추가, 있다면 기존 로직(단어의 길이에 따라 키워드 업데이트)를 통해 인스턴스 수정


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
