### PR TITLE
fix: sendKeywordNotification 메소드 1+4N 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleSummary.java
@@ -1,0 +1,8 @@
+package in.koreatech.koin.domain.community.article.dto;
+
+public record ArticleSummary(
+    Integer id,
+    String title
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/dto/ArticleSummary.java
@@ -4,5 +4,7 @@ public record ArticleSummary(
     Integer id,
     String title
 ) {
-
+    public static ArticleSummary of(Integer id, String title) {
+        return new ArticleSummary(id, title);
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.domain.community.article.dto.ArticleSummary;
 import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundException;
 import in.koreatech.koin.domain.community.article.exception.BoardNotFoundException;
 import in.koreatech.koin.domain.community.article.model.Article;
@@ -30,6 +31,13 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     Optional<Article> findById(Integer articleId);
 
     List<Article> findAllByIdIn(Collection<Integer> articleIds);
+
+    @Query(value = """
+        SELECT new in.koreatech.koin.domain.community.article.dto.ArticleSummary(a.id, a.title)
+        FROM Article a
+        WHERE a.id IN :articleIds
+        """)
+    List<ArticleSummary> findAllSummaryByIdIn(@Param("articleIds") Collection<Integer> articleIds);
 
     Page<Article> findAll(Pageable pageable);
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
+import in.koreatech.koin.domain.community.article.dto.ArticleSummary;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
@@ -150,8 +151,8 @@ public class KeywordService {
             return;
         }
 
-        List<Article> articles = articleRepository.findAllByIdIn(request.updateNotification());
-        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, null);
+        List<ArticleSummary> articleSummaries = articleRepository.findAllSummaryByIdIn(request.updateNotification());
+        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articleSummaries, null);
         for (ArticleKeywordEvent event : keywordEvents) {
             eventPublisher.publishEvent(event);
         }

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
-import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.article.dto.ArticleSummary;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
 
@@ -15,14 +15,14 @@ import in.koreatech.koin.domain.community.keyword.model.KeywordMatchResult;
 public class KeywordExtractor {
 
     public List<KeywordMatchResult> matchKeyword(
-        List<Article> articles, List<ArticleKeywordUserMap> articleKeywordUserMaps, Integer authorId
+        List<ArticleSummary> articleSummaries, List<ArticleKeywordUserMap> articleKeywordUserMaps, Integer authorId
     ) {
         Set<KeywordMatchResult> keywordMatchResults = new HashSet<>();
 
-        for (Article article : articles) {
+        for (ArticleSummary articleSummary : articleSummaries) {
             for (ArticleKeywordUserMap articleKeywordUserMap : articleKeywordUserMaps) {
-                if (isMatchable(article, articleKeywordUserMap, authorId)) {
-                    addOrUpdateResult(keywordMatchResults, article, articleKeywordUserMap);
+                if (isMatchable(articleSummary, articleKeywordUserMap, authorId)) {
+                    addOrUpdateResult(keywordMatchResults, articleSummary, articleKeywordUserMap);
                 }
             }
         }
@@ -30,16 +30,19 @@ public class KeywordExtractor {
         return keywordMatchResults.stream().toList();
     }
 
-    private boolean isMatchable(Article article, ArticleKeywordUserMap articleKeywordUserMap, Integer authorId) {
+    private boolean isMatchable(
+        ArticleSummary articleSummaries, ArticleKeywordUserMap articleKeywordUserMap, Integer authorId
+    ) {
         return !Objects.equals(articleKeywordUserMap.getUserId(), authorId)
-            && article.getTitle().contains(articleKeywordUserMap.getKeyword());
+            && articleSummaries.title().contains(articleKeywordUserMap.getKeyword());
     }
 
     private void addOrUpdateResult(
-        Set<KeywordMatchResult> keywordMatchResults, Article article, ArticleKeywordUserMap articleKeywordUserMap
+        Set<KeywordMatchResult> keywordMatchResults, ArticleSummary ArticleSummary,
+        ArticleKeywordUserMap articleKeywordUserMap
     ) {
         KeywordMatchResult keywordMatchResult = KeywordMatchResult.of(
-            article.getId(), articleKeywordUserMap.getUserId(), articleKeywordUserMap.getKeyword()
+            ArticleSummary.id(), articleKeywordUserMap.getUserId(), articleKeywordUserMap.getKeyword()
         );
 
         keywordMatchResults.stream()


### PR DESCRIPTION
### 🔍 개요

- close #2206 

---

### 🚀 주요 변경 내용

#### 1 + 4N 문제 개선
<img width="660" height="157" alt="image" src="https://github.com/user-attachments/assets/9af86819-9e32-4c18-8f53-43a5f06ef6d3" />

- Article은 총 4개의 엔티티와 OneToOne 관계를 가지고 있으며, 연관관계의 주인
- Article가 조회되는 시점에서 OneToOne 관계로 인해 연관 엔티티들도 조회하는 쿼리 발생
- Fetch Join으로 모두 가져오는 방법과 DTO Projection 사용 방법 고민
- 키워드 알림에서는 Article의 id와 title만 사용하기 때문에 Fetch Join을 통해 4개의 엔티티를 가져오는 건 불필요하다고 판단
- DTO Projection을 적용하여 개선

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
