### PR TITLE
fix: 키워드 페이징 조회를 단건 조회로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
@@ -30,6 +30,8 @@ public interface ArticleKeywordRepository extends Repository<ArticleKeyword, Int
 
     List<ArticleKeyword> findAll(Pageable pageable);
 
+    List<ArticleKeyword> findAll();
+
     @Query("""
     SELECT new in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult(k.id, k.keyword, COUNT(u))
     FROM ArticleKeywordUserMap u

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,56 +22,49 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class KeywordExtractor {
 
-    private static final int KEYWORD_BATCH_SIZE = 100;
-
     private final ArticleKeywordRepository articleKeywordRepository;
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
 
     public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
+        List<ArticleKeyword> keywords = articleKeywordRepository.findAll();
+
+        if (keywords.isEmpty()) {
+            return List.of();
+        }
+
+        List<Integer> keywordIds = keywords.stream()
+            .map(ArticleKeyword::getId)
+            .toList();
+        Map<Integer, List<ArticleKeywordUserMap>> userMapsByKeywordId = articleKeywordUserMapRepository
+            .findAllByArticleKeywordIdIn(keywordIds)
+            .stream()
+            .filter(keywordUserMap -> !keywordUserMap.getIsDeleted())
+            .collect(Collectors.groupingBy(
+                keywordUserMap -> keywordUserMap.getArticleKeyword().getId(),
+                LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();
-        int offset = 0;
+        for (Article article : articles) {
+            String title = article.getTitle();
+            for (ArticleKeyword keyword : keywords) {
+                if (!title.contains(keyword.getKeyword())) {
+                    continue;
+                }
+                Map<Integer, String> matchedKeywordByUserId = matchedKeywordByUserIdByArticleId
+                    .computeIfAbsent(article.getId(), ignored -> new LinkedHashMap<>());
 
-        while (true) {
-            Pageable pageable = PageRequest.of(offset / KEYWORD_BATCH_SIZE, KEYWORD_BATCH_SIZE);
-            List<ArticleKeyword> keywords = articleKeywordRepository.findAll(pageable);
-
-            if (keywords.isEmpty()) {
-                break;
-            }
-            List<Integer> keywordIds = keywords.stream()
-                .map(ArticleKeyword::getId)
-                .toList();
-            Map<Integer, List<ArticleKeywordUserMap>> userMapsByKeywordId = articleKeywordUserMapRepository
-                .findAllByArticleKeywordIdIn(keywordIds)
-                .stream()
-                .filter(keywordUserMap -> !keywordUserMap.getIsDeleted())
-                .collect(Collectors.groupingBy(
-                    keywordUserMap -> keywordUserMap.getArticleKeyword().getId(),
-                    LinkedHashMap::new,
-                    Collectors.toList()
-                ));
-
-            for (Article article : articles) {
-                String title = article.getTitle();
-                for (ArticleKeyword keyword : keywords) {
-                    if (!title.contains(keyword.getKeyword())) {
-                        continue;
-                    }
-                    Map<Integer, String> matchedKeywordByUserId = matchedKeywordByUserIdByArticleId
-                        .computeIfAbsent(article.getId(), ignored -> new LinkedHashMap<>());
-
-                    for (ArticleKeywordUserMap keywordUserMap :
-                        userMapsByKeywordId.getOrDefault(keyword.getId(), List.of())) {
-                        Integer userId = keywordUserMap.getUser().getId();
-                        matchedKeywordByUserId.merge(
-                            userId,
-                            keyword.getKeyword(),
-                            this::pickHigherPriorityKeyword
-                        );
-                    }
+                for (ArticleKeywordUserMap keywordUserMap :
+                    userMapsByKeywordId.getOrDefault(keyword.getId(), List.of())) {
+                    Integer userId = keywordUserMap.getUser().getId();
+                    matchedKeywordByUserId.merge(
+                        userId,
+                        keyword.getKeyword(),
+                        this::pickHigherPriorityKeyword
+                    );
                 }
             }
-            offset += KEYWORD_BATCH_SIZE;
         }
 
         List<ArticleKeywordEvent> keywordEvents = new ArrayList<>();

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -9,10 +9,10 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
-import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
@@ -51,9 +50,8 @@ class KeywordExtractorTest {
         ArticleKeyword keywordA = createKeyword(1, "근로", subscriber);
         ArticleKeyword keywordB = createKeyword(2, "근로장학", subscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
-            .thenReturn(List.of(keywordA, keywordB))
-            .thenReturn(List.of());
+        when(articleKeywordRepository.findAll())
+            .thenReturn(List.of(keywordA, keywordB));
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
             .thenReturn(List.of(
                 keywordA.getArticleKeywordUserMaps().get(0),
@@ -79,9 +77,8 @@ class KeywordExtractorTest {
         User subscriber = UserFixture.id_설정_코인_유저(1);
         ArticleKeyword keyword = createKeyword(1, "장학금", subscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
-            .thenReturn(List.of(keyword))
-            .thenReturn(List.of());
+        when(articleKeywordRepository.findAll())
+            .thenReturn(List.of(keyword));
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
             .thenReturn(List.of(keyword.getArticleKeywordUserMaps().get(0)));
 
@@ -106,9 +103,8 @@ class KeywordExtractorTest {
         ArticleKeyword firstKeyword = createKeyword(1, "근로", firstSubscriber);
         ArticleKeyword secondKeyword = createKeyword(2, "장학금", secondSubscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
-            .thenReturn(List.of(firstKeyword, secondKeyword))
-            .thenReturn(List.of());
+        when(articleKeywordRepository.findAll())
+            .thenReturn(List.of(firstKeyword, secondKeyword));
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
             .thenReturn(List.of(
                 firstKeyword.getArticleKeywordUserMaps().get(0),
@@ -128,8 +124,7 @@ class KeywordExtractorTest {
     @DisplayName("등록된 키워드가 없으면 빈 결과를 반환한다.")
     void matchKeyword_whenNoKeywordsExist_returnsEmptyResult() {
         Article article = mock(Article.class);
-        when(article.getId()).thenReturn(1);
-        when(articleKeywordRepository.findAll(any(Pageable.class))).thenReturn(List.of());
+        when(articleKeywordRepository.findAll()).thenReturn(List.of());
 
         List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null);
 


### PR DESCRIPTION
### 🔍 개요

* 

---

### 🚀 주요 변경 내용

* 키워드 알림 테스트를 위해 페이징 조회를 단건 조회로 수정했습니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified keyword extraction to load and process the full keyword set in one pass, removing batched pagination and streamlining matching across articles for more predictable performance.
* **Tests**
  * Updated unit tests to reflect the new single-pass keyword retrieval approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->