### PR TITLE
hotfix: AdminLandRequest internalName 유효성 검증 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/land/dto/AdminLandRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/land/dto/AdminLandRequest.java
@@ -1,17 +1,15 @@
 package in.koreatech.koin.admin.land.dto;
 
-import java.util.List;
-
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.land.model.Land;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -24,7 +22,6 @@ public record AdminLandRequest(
     String name,
 
     @Schema(description = "이름", example = "금실타운")
-    @NotBlank(message = "방이름은 필수입니다.")
     @Size(max = 50, message = "방이름의 최대 길이는 50자입니다.")
     String internalName,
 
@@ -127,7 +124,7 @@ public record AdminLandRequest(
     public Land toLand() {
         return Land.builder()
             .name(name)
-            .internalName(internalName)
+            .internalName(name.trim().replace(" ", "").toLowerCase())
             .size(String.valueOf(size))
             .roomType(roomType)
             .latitude(String.valueOf(latitude))


### PR DESCRIPTION
### 🔍 개요

* 

---

### 🚀 주요 변경 내용

* 클라이언트에서 어드민 복덕방 생성 과정에서 internalName을 요청값으로 던지지 않는 문제 발생
* 클라이언트가 해당 네임을 던지는 것이 아닌, 서버에서 처리하는 것이 적절하다고 판단하여 로직 수정

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
