### PR TITLE
feat: 키워드 알림 카테고리 Enum 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordApi.java
@@ -8,12 +8,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsSuggestionResponse;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,6 +41,7 @@ public interface KeywordApi {
     @PostMapping("/articles/keyword")
     ResponseEntity<ArticleKeywordResponse> createKeyword(
         @Valid @RequestBody ArticleKeywordCreateRequest request,
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId
     );
 
@@ -67,6 +70,7 @@ public interface KeywordApi {
     @Operation(summary = "자신의 알림 키워드 전체 조회")
     @GetMapping("/articles/keyword/me")
     ResponseEntity<ArticleKeywordsResponse> getMyKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId
     );
 
@@ -79,6 +83,7 @@ public interface KeywordApi {
     @Operation(summary = "알림 키워드 추천")
     @GetMapping("/articles/keyword/suggestions")
     ResponseEntity<ArticleKeywordsSuggestionResponse> suggestKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory
     );
 
     @Operation(summary = "키워드 알림 전송", hidden = true)

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
@@ -16,6 +17,7 @@ import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsSuggestionResponse;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.service.KeywordService;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
@@ -24,13 +26,14 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/articles/keyword")
-public class KeywordController implements KeywordApi{
+public class KeywordController implements KeywordApi {
 
     private final KeywordService keywordService;
 
     @PostMapping()
     public ResponseEntity<ArticleKeywordResponse> createKeyword(
         @Valid @RequestBody ArticleKeywordCreateRequest request,
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
         ArticleKeywordResponse response = keywordService.createKeyword(userId, request);
@@ -48,6 +51,7 @@ public class KeywordController implements KeywordApi{
 
     @GetMapping("/me")
     public ResponseEntity<ArticleKeywordsResponse> getMyKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId
     ) {
         ArticleKeywordsResponse response = keywordService.getMyKeywords(userId);
@@ -56,6 +60,7 @@ public class KeywordController implements KeywordApi{
 
     @GetMapping("/suggestions")
     public ResponseEntity<ArticleKeywordsSuggestionResponse> suggestKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory
     ) {
         ArticleKeywordsSuggestionResponse response = keywordService.suggestKeywords();
         return ResponseEntity.ok(response);

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/enums/KeywordCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/enums/KeywordCategory.java
@@ -1,0 +1,10 @@
+package in.koreatech.koin.domain.community.keyword.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum KeywordCategory {
+    KOREATECH,
+    LOST_ITEM,
+    ;
+}

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/enums/KeywordCategory.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/enums/KeywordCategory.java
@@ -1,8 +1,5 @@
 package in.koreatech.koin.domain.community.keyword.enums;
 
-import lombok.Getter;
-
-@Getter
 public enum KeywordCategory {
     KOREATECH,
     LOST_ITEM,


### PR DESCRIPTION
### 🔍 개요

- close #2229 

---

### 🚀 주요 변경 내용

* 분실물 키워드와 교내 게시글 키워드 알림 분리를 위해 enum을 추가했습니다.
* API 내부 로직 수정은 다음 PR에서 진행할 예정입니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyword endpoints now support optional type filtering by category (KOREATECH or LOST_ITEM)
  * Users can specify the keyword category when creating, retrieving personal keywords, or discovering keyword suggestions
  * Type parameter defaults to KOREATECH to maintain full backward compatibility with existing API clients
  * Improved filtering capabilities across Create Keyword, Get My Keywords, and Suggest Keywords endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->