### PR TITLE
feat: 분실물 키워드 알림 구독 Enum 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationSubscribeType.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationSubscribeType.java
@@ -20,6 +20,7 @@ public enum NotificationSubscribeType {
     LOST_ITEM_CHAT(List.of()),
     CALLVAN(List.of()),
     MARKETING(List.of()),
+    LOST_ITEM_KEYWORD(List.of()),
     ;
 
     private final List<NotificationDetailSubscribeType> detailTypes;

--- a/src/test/java/in/koreatech/koin/acceptance/domain/NotificationApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/NotificationApiTest.java
@@ -139,6 +139,13 @@ class NotificationApiTest extends AcceptanceTest {
                                  "detail_subscribes": [
                                     \s
                                  ]
+                             },
+                             {
+                                 "type": "LOST_ITEM_KEYWORD",
+                                 "is_permit": false,
+                                 "detail_subscribes": [
+                                    \s
+                                 ]
                              }
                         ]
                     }
@@ -271,6 +278,13 @@ class NotificationApiTest extends AcceptanceTest {
                              "detail_subscribes": [
                                 \s
                              ]
+                         },
+                         {
+                             "type": "LOST_ITEM_KEYWORD",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
                          }
                      ]
                  }
@@ -399,6 +413,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "MARKETING",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "LOST_ITEM_KEYWORD",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s
@@ -543,6 +564,13 @@ class NotificationApiTest extends AcceptanceTest {
                              "detail_subscribes": [
                                 \s
                              ]
+                         },
+                         {
+                             "type": "LOST_ITEM_KEYWORD",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
                          }
                      ]
                  }
@@ -676,6 +704,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "MARKETING",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "LOST_ITEM_KEYWORD",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s


### PR DESCRIPTION
### 🔍 개요

- close #2231

---

### 🚀 주요 변경 내용

* 분실물 키워드 알림 구독을 위한 Enum을 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
