### PR TITLE
feat: 분실물 키워드 알림 로직 분리

### DIFF
--- a/.github/workflows/flyway-dangerous-sql-validator.yml
+++ b/.github/workflows/flyway-dangerous-sql-validator.yml
@@ -32,7 +32,7 @@ jobs:
 
           for file in $(git diff --name-only "$BASE" "$HEAD" -- src/main/resources/db/migration/*.sql); do
             ADDED_SQL=$(git diff "$BASE" "$HEAD" -- "$file" \
-              | grep -i -wE "^\+.*\b(DROP|TRUNCATE|RENAME|CHANGE)\b" || true)
+              | grep -i -wE "^\+.*\b(DROP COLUMN|TRUNCATE|RENAME|CHANGE)\b" || true)
 
             if [[ -n "$ADDED_SQL" ]]; then
               echo "::error::⚠️ 위험 SQL 감지됨"

--- a/src/main/java/in/koreatech/koin/admin/keyword/controller/AdminKeywordApi.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/controller/AdminKeywordApi.java
@@ -7,10 +7,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.admin.history.aop.AdminActivityLogging;
 import in.koreatech.koin.admin.keyword.dto.AdminFilteredKeywordsResponse;
 import in.koreatech.koin.admin.keyword.dto.AdminKeywordFilterRequest;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,6 +38,7 @@ public interface AdminKeywordApi {
     @AdminActivityLogging(domain = KEYWORDS)
     ResponseEntity<Void> toggleKeywordFilter(
         @Valid @RequestBody AdminKeywordFilterRequest request,
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 
@@ -50,6 +53,7 @@ public interface AdminKeywordApi {
     @Operation(summary = "필터링 된 키워드 조회")
     @GetMapping("/admin/articles/keyword/filtered")
     ResponseEntity<AdminFilteredKeywordsResponse> getFilteredKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 }

--- a/src/main/java/in/koreatech/koin/admin/keyword/controller/AdminKeywordController.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/controller/AdminKeywordController.java
@@ -8,12 +8,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.admin.history.aop.AdminActivityLogging;
 import in.koreatech.koin.admin.keyword.dto.AdminFilteredKeywordsResponse;
 import in.koreatech.koin.admin.keyword.dto.AdminKeywordFilterRequest;
 import in.koreatech.koin.admin.keyword.service.AdminKeywordService;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.global.auth.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,17 +31,19 @@ public class AdminKeywordController implements AdminKeywordApi {
     @AdminActivityLogging(domain = KEYWORDS)
     public ResponseEntity<Void> toggleKeywordFilter(
         @Valid @RequestBody AdminKeywordFilterRequest request,
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
-        adminKeywordService.filterKeyword(request.keyword(), request.isFiltered());
+        adminKeywordService.filterKeyword(request.keyword(), request.isFiltered(), keywordCategory);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/filtered")
     public ResponseEntity<AdminFilteredKeywordsResponse> getFilteredKeywords(
+        @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
-        AdminFilteredKeywordsResponse response = adminKeywordService.getFilteredKeywords();
+        AdminFilteredKeywordsResponse response = adminKeywordService.getFilteredKeywords(keywordCategory);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/admin/keyword/repository/AdminArticleKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/repository/AdminArticleKeywordRepository.java
@@ -13,9 +13,11 @@ public interface AdminArticleKeywordRepository extends Repository<ArticleKeyword
 
     Optional<ArticleKeyword> findByKeywordAndCategory(String keyword, KeywordCategory category);
 
-    default ArticleKeyword getByKeyword(String keyword) {
-        return findByKeywordAndCategory(keyword, KeywordCategory.KOREATECH)
-            .orElseThrow(() -> ArticleKeywordNotFoundException.withDetail("keyword : " + keyword));
+    default ArticleKeyword getByKeywordAndCategory(String keyword, KeywordCategory category) {
+        return findByKeywordAndCategory(keyword, category)
+            .orElseThrow(() -> ArticleKeywordNotFoundException.withDetail(
+                "keyword : " + keyword + ", category : " + category
+            ));
     }
 
     List<ArticleKeyword> findByIsFilteredAndCategory(boolean isFiltered, KeywordCategory category);

--- a/src/main/java/in/koreatech/koin/admin/keyword/repository/AdminArticleKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/repository/AdminArticleKeywordRepository.java
@@ -6,16 +6,17 @@ import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 import in.koreatech.koin.domain.community.keyword.exception.ArticleKeywordNotFoundException;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
 
 public interface AdminArticleKeywordRepository extends Repository<ArticleKeyword, Integer> {
 
-    Optional<ArticleKeyword> findByKeyword(String keyword);
+    Optional<ArticleKeyword> findByKeywordAndCategory(String keyword, KeywordCategory category);
 
     default ArticleKeyword getByKeyword(String keyword) {
-        return findByKeyword(keyword)
+        return findByKeywordAndCategory(keyword, KeywordCategory.KOREATECH)
             .orElseThrow(() -> ArticleKeywordNotFoundException.withDetail("keyword : " + keyword));
     }
 
-    List<ArticleKeyword> findByIsFiltered(boolean isFiltered);
+    List<ArticleKeyword> findByIsFilteredAndCategory(boolean isFiltered, KeywordCategory category);
 }

--- a/src/main/java/in/koreatech/koin/admin/keyword/service/AdminKeywordService.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/service/AdminKeywordService.java
@@ -21,21 +21,21 @@ public class AdminKeywordService {
     private final AdminArticleKeywordRepository adminArticleKeywordRepository;
 
     @Transactional
-    public void filterKeyword(String keyword, Boolean isFiltered) {
-        ArticleKeyword articleKeyword = adminArticleKeywordRepository.getByKeyword(keyword);
+    public void filterKeyword(String keyword, Boolean isFiltered, KeywordCategory category) {
+        ArticleKeyword articleKeyword = adminArticleKeywordRepository.getByKeywordAndCategory(keyword, category);
 
         if (Objects.equals(articleKeyword.getIsFiltered(), isFiltered)) {
             String action = isFiltered ? "필터링 된" : "필터링이 취소된";
-            throw new KoinIllegalArgumentException("이미 " + action + " 키워드입니다: " + keyword);
+            throw new KoinIllegalArgumentException("이미 " + action + " 키워드입니다: " + keyword + ", category: " + category);
         }
 
         articleKeyword.applyFiltered(isFiltered);
     }
 
-    public AdminFilteredKeywordsResponse getFilteredKeywords() {
+    public AdminFilteredKeywordsResponse getFilteredKeywords(KeywordCategory category) {
         List<ArticleKeyword> filteredKeywords = adminArticleKeywordRepository.findByIsFilteredAndCategory(
             true,
-            KeywordCategory.KOREATECH
+            category
         );
         return AdminFilteredKeywordsResponse.from(filteredKeywords);
     }

--- a/src/main/java/in/koreatech/koin/admin/keyword/service/AdminKeywordService.java
+++ b/src/main/java/in/koreatech/koin/admin/keyword/service/AdminKeywordService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.admin.keyword.repository.AdminArticleKeywordRepository;
 import in.koreatech.koin.admin.keyword.dto.AdminFilteredKeywordsResponse;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
 import in.koreatech.koin.global.exception.custom.KoinIllegalArgumentException;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,10 @@ public class AdminKeywordService {
     }
 
     public AdminFilteredKeywordsResponse getFilteredKeywords() {
-        List<ArticleKeyword> filteredKeywords = adminArticleKeywordRepository.findByIsFiltered(true);
+        List<ArticleKeyword> filteredKeywords = adminArticleKeywordRepository.findByIsFilteredAndCategory(
+            true,
+            KeywordCategory.KOREATECH
+        );
         return AdminFilteredKeywordsResponse.from(filteredKeywords);
     }
 }

--- a/src/main/java/in/koreatech/koin/common/event/ArticleKeywordEvent.java
+++ b/src/main/java/in/koreatech/koin/common/event/ArticleKeywordEvent.java
@@ -4,9 +4,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
+
 public record ArticleKeywordEvent(
     Integer articleId,
     Integer authorId,
+    KeywordCategory category,
     Map<Integer, String> matchedKeywordByUserId
 ) {
 

--- a/src/main/java/in/koreatech/koin/common/model/MobileAppPath.java
+++ b/src/main/java/in/koreatech/koin/common/model/MobileAppPath.java
@@ -9,6 +9,7 @@ public enum MobileAppPath {
     SHOP("shop"),
     DINING("dining"),
     KEYWORD("keyword"),
+    LOST_ITEM("lost-item"),
     CHAT("chat"),
     CALLVAN("callvan"),
     CALLVAN_CHAT("callvan-chat"),

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/LostItemArticleService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/LostItemArticleService.java
@@ -34,6 +34,7 @@ import in.koreatech.koin.domain.community.article.model.redis.PopularKeywordTrac
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.article.repository.BoardRepository;
 import in.koreatech.koin.domain.community.article.repository.LostItemArticleRepository;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.util.KeywordExtractor;
 import in.koreatech.koin.domain.organization.model.Organization;
 import in.koreatech.koin.domain.organization.repository.OrganizationRepository;
@@ -252,7 +253,7 @@ public class LostItemArticleService {
     }
 
     private void sendKeywordNotification(List<Article> articles, Integer authorId) {
-        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, authorId);
+        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, authorId, KeywordCategory.LOST_ITEM);
         if (!keywordEvents.isEmpty()) {
             for (ArticleKeywordEvent event : keywordEvents) {
                 eventPublisher.publishEvent(event);

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/controller/KeywordController.java
@@ -36,7 +36,7 @@ public class KeywordController implements KeywordApi {
         @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {STUDENT, COUNCIL}) Integer userId
     ) {
-        ArticleKeywordResponse response = keywordService.createKeyword(userId, request);
+        ArticleKeywordResponse response = keywordService.createKeyword(userId, request, keywordCategory);
         return ResponseEntity.ok(response);
     }
 
@@ -54,7 +54,7 @@ public class KeywordController implements KeywordApi {
         @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory,
         @Auth(permit = {GENERAL, STUDENT, COUNCIL}) Integer userId
     ) {
-        ArticleKeywordsResponse response = keywordService.getMyKeywords(userId);
+        ArticleKeywordsResponse response = keywordService.getMyKeywords(userId, keywordCategory);
         return ResponseEntity.ok(response);
     }
 
@@ -62,7 +62,7 @@ public class KeywordController implements KeywordApi {
     public ResponseEntity<ArticleKeywordsSuggestionResponse> suggestKeywords(
         @RequestParam(value = "type", required = false, defaultValue = "KOREATECH") KeywordCategory keywordCategory
     ) {
-        ArticleKeywordsSuggestionResponse response = keywordService.suggestKeywords();
+        ArticleKeywordsSuggestionResponse response = keywordService.suggestKeywords(keywordCategory);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeyword.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeyword.java
@@ -10,13 +10,17 @@ import java.util.List;
 import org.hibernate.annotations.Where;
 
 import in.koreatech.koin.common.model.BaseEntity;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +28,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Where(clause = "is_deleted = 0")
-@Table(name = "article_keywords")
+@Table(name = "article_keywords", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"keyword", "category"})
+})
 @NoArgsConstructor(access = PROTECTED)
 public class ArticleKeyword extends BaseEntity {
 
@@ -32,8 +38,12 @@ public class ArticleKeyword extends BaseEntity {
     @GeneratedValue(strategy = IDENTITY)
     private Integer id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, length = 50)
     private String keyword;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private KeywordCategory category;
 
     @Column(name = "last_used_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime lastUsedAt;
@@ -48,8 +58,9 @@ public class ArticleKeyword extends BaseEntity {
     private List<ArticleKeywordUserMap> articleKeywordUserMaps = new ArrayList<>();
 
     @Builder
-    private ArticleKeyword(String keyword, LocalDateTime lastUsedAt, Boolean isFiltered) {
+    private ArticleKeyword(String keyword, KeywordCategory category, LocalDateTime lastUsedAt, Boolean isFiltered) {
         this.keyword = keyword;
+        this.category = category != null ? category : KeywordCategory.KOREATECH;
         this.lastUsedAt = lastUsedAt;
         this.isFiltered = isFiltered != null ? isFiltered : false;
     }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordSuggestCache.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordSuggestCache.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.community.keyword.model;
 
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
@@ -13,12 +14,19 @@ public class ArticleKeywordSuggestCache {
     @Id
     private Integer hotKeywordId;
     private String keyword;
+    private KeywordCategory category;
     private Integer count;
 
     @Builder
-    private ArticleKeywordSuggestCache(Integer hotKeywordId, String keyword, Integer count) {
+    private ArticleKeywordSuggestCache(
+        Integer hotKeywordId,
+        String keyword,
+        KeywordCategory category,
+        Integer count
+    ) {
         this.hotKeywordId = hotKeywordId;
         this.keyword = keyword;
+        this.category = category != null ? category : KeywordCategory.KOREATECH;
         this.count = count;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordSuggestCache.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/model/ArticleKeywordSuggestCache.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.community.keyword.model;
 import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class ArticleKeywordSuggestCache {
     @Id
     private Integer hotKeywordId;
     private String keyword;
+    @Indexed
     private KeywordCategory category;
     private Integer count;
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
@@ -10,17 +10,22 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
 
 public interface ArticleKeywordRepository extends Repository<ArticleKeyword, Integer> {
 
-    Optional<ArticleKeyword> findByKeyword(String keyword);
+    Optional<ArticleKeyword> findByKeywordAndCategory(String keyword, KeywordCategory category);
 
     @Query(value = """
     SELECT * FROM article_keywords ak
     WHERE ak.keyword = :keyword
+      AND ak.category = :category
     """, nativeQuery = true)
-    Optional<ArticleKeyword> findByKeywordIncludingDeleted(@Param("keyword") String keyword);
+    Optional<ArticleKeyword> findByKeywordAndCategoryIncludingDeleted(
+        @Param("keyword") String keyword,
+        @Param("category") String category
+    );
 
     ArticleKeyword save(ArticleKeyword articleKeyword);
 
@@ -28,25 +33,32 @@ public interface ArticleKeywordRepository extends Repository<ArticleKeyword, Int
 
     Optional<ArticleKeyword> findById(Integer id);
 
-    List<ArticleKeyword> findAll(Pageable pageable);
+    List<ArticleKeyword> findAllByCategory(KeywordCategory category, Pageable pageable);
 
     @Query("""
     SELECT new in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult(k.id, k.keyword, COUNT(u))
     FROM ArticleKeywordUserMap u
     JOIN u.articleKeyword k
-    WHERE k.lastUsedAt >= :oneWeekAgo AND k.isFiltered = false
+    WHERE k.lastUsedAt >= :oneWeekAgo
+      AND k.isFiltered = false
+      AND k.category = :category
     GROUP BY k.id, k.keyword
     ORDER BY COUNT(u) DESC
     """)
-    List<ArticleKeywordResult> findTopKeywordsInLastWeekExcludingFiltered(LocalDateTime oneWeekAgo, Pageable top15);
+    List<ArticleKeywordResult> findTopKeywordsInLastWeekExcludingFiltered(
+        LocalDateTime oneWeekAgo,
+        KeywordCategory category,
+        Pageable top15
+    );
 
     @Query("""
     SELECT new in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult(k.id, k.keyword, COUNT(u))
     FROM ArticleKeyword k
     LEFT JOIN k.articleKeywordUserMaps u
     WHERE k.isFiltered = false
+      AND k.category = :category
     GROUP BY k.id, k.keyword
     ORDER BY k.createdAt DESC
     """)
-    List<ArticleKeywordResult> findTop15KeywordsExcludingFiltered(Pageable top15);
+    List<ArticleKeywordResult> findTop15KeywordsExcludingFiltered(KeywordCategory category, Pageable top15);
 }

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordSuggestRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordSuggestRepository.java
@@ -4,11 +4,14 @@ import java.util.List;
 
 import org.springframework.data.repository.Repository;
 
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
 
 public interface ArticleKeywordSuggestRepository extends Repository<ArticleKeywordSuggestCache, String> {
 
     List<ArticleKeywordSuggestCache> findTop15ByOrderByCountDesc();
+
+    List<ArticleKeywordSuggestCache> findTop15ByCategoryOrderByCountDesc(KeywordCategory category);
 
     void deleteAll();
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordUserMapRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.exception.ArticleKeywordUserMapNotFoundException;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 
@@ -14,7 +15,7 @@ public interface ArticleKeywordUserMapRepository extends Repository<ArticleKeywo
 
     ArticleKeywordUserMap save(ArticleKeywordUserMap articleKeywordUserMap);
 
-    Long countByUserId(Integer userId);
+    Long countByUserIdAndArticleKeywordCategory(Integer userId, KeywordCategory category);
 
     void deleteById(Integer keywordId);
 
@@ -27,14 +28,18 @@ public interface ArticleKeywordUserMapRepository extends Repository<ArticleKeywo
             () -> ArticleKeywordUserMapNotFoundException.withDetail("keywordUserMapId: " + keywordUserMapId));
     }
 
-    List<ArticleKeywordUserMap> findAllByUserId(Integer userId);
+    List<ArticleKeywordUserMap> findAllByUserIdAndArticleKeywordCategory(Integer userId, KeywordCategory category);
 
     @Query("""
         SELECT akw.keyword FROM ArticleKeywordUserMap akum
         JOIN akum.articleKeyword akw
         WHERE akum.user.id = :userId
+          AND akw.category = :category
         """)
-    List<String> findAllKeywordByUserId(@Param("userId") Integer userId);
+    List<String> findAllKeywordByUserIdAndCategory(
+        @Param("userId") Integer userId,
+        @Param("category") KeywordCategory category
+    );
 
     @Query(value = """
     SELECT * FROM article_keyword_user_map akum

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -193,28 +193,30 @@ public class KeywordService {
         Pageable top15 = PageRequest.of(0, 15);
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
 
-        List<ArticleKeywordResult> topKeywords = articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(
-            oneWeekAgo,
-            KeywordCategory.KOREATECH,
-            top15
-        );
-
-        if (topKeywords.size() < 15) {
-            topKeywords = articleKeywordRepository.findTop15KeywordsExcludingFiltered(KeywordCategory.KOREATECH, top15);
-        }
-
-        List<ArticleKeywordSuggestCache> hotKeywords = topKeywords.stream()
-            .map(result -> ArticleKeywordSuggestCache.builder()
-                .hotKeywordId(result.hotKeywordId())
-                .keyword(result.keyword())
-                .category(KeywordCategory.KOREATECH)
-                .count(result.count().intValue())
-                .build())
-            .toList();
-
         articleKeywordSuggestRepository.deleteAll();
-        for (ArticleKeywordSuggestCache hotKeyword : hotKeywords) {
-            articleKeywordSuggestRepository.save(hotKeyword);
+        for (KeywordCategory category : KeywordCategory.values()) {
+            List<ArticleKeywordResult> topKeywords = articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(
+                oneWeekAgo,
+                category,
+                top15
+            );
+
+            if (topKeywords.size() < 15) {
+                topKeywords = articleKeywordRepository.findTop15KeywordsExcludingFiltered(category, top15);
+            }
+
+            List<ArticleKeywordSuggestCache> hotKeywords = topKeywords.stream()
+                .map(result -> ArticleKeywordSuggestCache.builder()
+                    .hotKeywordId(result.hotKeywordId())
+                    .keyword(result.keyword())
+                    .category(category)
+                    .count(result.count().intValue())
+                    .build())
+                .toList();
+
+            for (ArticleKeywordSuggestCache hotKeyword : hotKeywords) {
+                articleKeywordSuggestRepository.save(hotKeyword);
+            }
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -21,6 +21,7 @@ import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsResponse;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordsSuggestionResponse;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.exception.KeywordDuplicationException;
 import in.koreatech.koin.domain.community.keyword.exception.KeywordLimitExceededException;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
@@ -56,40 +57,45 @@ public class KeywordService {
     private final KeywordExtractor keywordExtractor;
 
     @Transactional
-    public ArticleKeywordResponse createKeyword(Integer userId, ArticleKeywordCreateRequest request) {
+    public ArticleKeywordResponse createKeyword(
+        Integer userId,
+        ArticleKeywordCreateRequest request,
+        KeywordCategory category
+    ) {
         String keyword = validateAndGetKeyword(request.keyword());
 
-        validateKeywordLimit(userId);
+        validateKeywordLimit(userId, category);
 
-        ArticleKeyword existingKeyword = findOrRestoreKeyword(keyword);
+        ArticleKeyword existingKeyword = findOrRestoreKeyword(keyword, category);
 
         ArticleKeywordUserMap userMap = findOrCreateKeywordMapping(existingKeyword, userId);
 
         return new ArticleKeywordResponse(userMap.getId(), existingKeyword.getKeyword());
     }
 
-    private void validateKeywordLimit(Integer userId) {
-        if (articleKeywordUserMapRepository.countByUserId(userId) >= ARTICLE_KEYWORD_LIMIT) {
-            throw KeywordLimitExceededException.withDetail("userId: " + userId);
+    private void validateKeywordLimit(Integer userId, KeywordCategory category) {
+        if (articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, category) >= ARTICLE_KEYWORD_LIMIT) {
+            throw KeywordLimitExceededException.withDetail("userId: " + userId + ", category: " + category);
         }
     }
 
     @ConcurrencyGuard(lockName = "createKeywordManagement")
-    private ArticleKeyword findOrRestoreKeyword(String keyword) {
-        return articleKeywordRepository.findByKeywordIncludingDeleted(keyword)
+    private ArticleKeyword findOrRestoreKeyword(String keyword, KeywordCategory category) {
+        return articleKeywordRepository.findByKeywordAndCategoryIncludingDeleted(keyword, category.name())
             .map(keywordEntity -> {
                 if (keywordEntity.getIsDeleted()) {
                     keywordEntity.restore();
                 }
                 return keywordEntity;
             })
-            .orElseGet(() -> createNewKeyword(keyword));
+            .orElseGet(() -> createNewKeyword(keyword, category));
     }
 
-    private ArticleKeyword createNewKeyword(String keyword) {
+    private ArticleKeyword createNewKeyword(String keyword, KeywordCategory category) {
         return articleKeywordRepository.save(
             ArticleKeyword.builder()
                 .keyword(keyword)
+                .category(category)
                 .lastUsedAt(LocalDateTime.now())
                 .build()
         );
@@ -133,14 +139,16 @@ public class KeywordService {
         }
     }
 
-    public ArticleKeywordsResponse getMyKeywords(Integer userId) {
-        List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository.findAllByUserId(userId);
+    public ArticleKeywordsResponse getMyKeywords(Integer userId, KeywordCategory category) {
+        List<ArticleKeywordUserMap> articleKeywordUserMaps = articleKeywordUserMapRepository
+            .findAllByUserIdAndArticleKeywordCategory(userId, category);
         return ArticleKeywordsResponse.from(articleKeywordUserMaps);
     }
 
-    public ArticleKeywordsSuggestionResponse suggestKeywords() {
+    public ArticleKeywordsSuggestionResponse suggestKeywords(KeywordCategory category) {
         List<String> suggestions = articleKeywordSuggestRepository.findTop15ByOrderByCountDesc()
             .stream()
+            .filter(hotKeyword -> hotKeyword.getCategory() == category)
             .map(ArticleKeywordSuggestCache::getKeyword)
             .collect(Collectors.toList());
 
@@ -169,7 +177,7 @@ public class KeywordService {
             })
             .toList();
 
-        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, null);
+        List<ArticleKeywordEvent> keywordEvents = keywordExtractor.matchKeyword(articles, null, KeywordCategory.KOREATECH);
         for (ArticleKeywordEvent event : keywordEvents) {
             eventPublisher.publishEvent(event);
         }
@@ -187,16 +195,21 @@ public class KeywordService {
         Pageable top15 = PageRequest.of(0, 15);
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
 
-        List<ArticleKeywordResult> topKeywords = articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(oneWeekAgo, top15);
+        List<ArticleKeywordResult> topKeywords = articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(
+            oneWeekAgo,
+            KeywordCategory.KOREATECH,
+            top15
+        );
 
         if (topKeywords.size() < 15) {
-            topKeywords = articleKeywordRepository.findTop15KeywordsExcludingFiltered(top15);
+            topKeywords = articleKeywordRepository.findTop15KeywordsExcludingFiltered(KeywordCategory.KOREATECH, top15);
         }
 
         List<ArticleKeywordSuggestCache> hotKeywords = topKeywords.stream()
             .map(result -> ArticleKeywordSuggestCache.builder()
                 .hotKeywordId(result.hotKeywordId())
                 .keyword(result.keyword())
+                .category(KeywordCategory.KOREATECH)
                 .count(result.count().intValue())
                 .build())
             .toList();

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -144,9 +144,8 @@ public class KeywordService {
     }
 
     public ArticleKeywordsSuggestionResponse suggestKeywords(KeywordCategory category) {
-        List<String> suggestions = articleKeywordSuggestRepository.findTop15ByOrderByCountDesc()
+        List<String> suggestions = articleKeywordSuggestRepository.findTop15ByCategoryOrderByCountDesc(category)
             .stream()
-            .filter(hotKeyword -> hotKeyword.getCategory() == category)
             .map(ArticleKeywordSuggestCache::getKeyword)
             .collect(Collectors.toList());
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -58,9 +58,7 @@ public class KeywordService {
 
     @Transactional
     public ArticleKeywordResponse createKeyword(
-        Integer userId,
-        ArticleKeywordCreateRequest request,
-        KeywordCategory category
+        Integer userId, ArticleKeywordCreateRequest request, KeywordCategory category
     ) {
         String keyword = validateAndGetKeyword(request.keyword());
 

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.keyword.enums.KeywordCategory;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
@@ -29,13 +30,13 @@ public class KeywordExtractor {
     private final ArticleKeywordRepository articleKeywordRepository;
     private final ArticleKeywordUserMapRepository articleKeywordUserMapRepository;
 
-    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId) {
+    public List<ArticleKeywordEvent> matchKeyword(List<Article> articles, Integer authorId, KeywordCategory category) {
         Map<Integer, Map<Integer, String>> matchedKeywordByUserIdByArticleId = new LinkedHashMap<>();
         int offset = 0;
 
         while (true) {
             Pageable pageable = PageRequest.of(offset / KEYWORD_BATCH_SIZE, KEYWORD_BATCH_SIZE);
-            List<ArticleKeyword> keywords = articleKeywordRepository.findAll(pageable);
+            List<ArticleKeyword> keywords = articleKeywordRepository.findAllByCategory(category, pageable);
 
             if (keywords.isEmpty()) {
                 break;
@@ -80,7 +81,7 @@ public class KeywordExtractor {
         for (Article article : articles) {
             Map<Integer, String> matchedKeywordByUserId = matchedKeywordByUserIdByArticleId.get(article.getId());
             if (matchedKeywordByUserId != null && !matchedKeywordByUserId.isEmpty()) {
-                keywordEvents.add(new ArticleKeywordEvent(article.getId(), authorId, matchedKeywordByUserId));
+                keywordEvents.add(new ArticleKeywordEvent(article.getId(), authorId, category, matchedKeywordByUserId));
             }
         }
 

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -1,7 +1,9 @@
 package in.koreatech.koin.domain.notification.eventlistener;
 
 import static in.koreatech.koin.common.model.MobileAppPath.KEYWORD;
-import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.ARTICLE_KEYWORD;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
+import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.*;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -26,6 +28,7 @@ import in.koreatech.koin.domain.community.keyword.service.KeywordService;
 import in.koreatech.koin.domain.notification.model.Notification;
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribe;
+import in.koreatech.koin.domain.notification.model.NotificationSubscribeType;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +57,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
         Board board = article.getBoard();
 
         Map<Integer, NotificationSubscribe> keywordSubscribersByUserId = notificationSubscribeRepository
-            .findAllBySubscribeTypeAndDetailTypeIsNullWithUser(ARTICLE_KEYWORD)
+            .findAllBySubscribeTypeAndDetailTypeIsNullWithUser(getSubscribeType(event))
             .stream()
             .filter(this::hasDeviceToken)
             .collect(Collectors.toMap(
@@ -96,6 +99,16 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
 
     private boolean hasDeviceToken(NotificationSubscribe subscribe) {
         return StringUtils.hasText(subscribe.getUser().getDeviceToken());
+    }
+
+    private NotificationSubscribeType getSubscribeType(ArticleKeywordEvent event) {
+        if (event.category() == KOREATECH) {
+            return ARTICLE_KEYWORD;
+        }
+        if (event.category() == LOST_ITEM) {
+            return LOST_ITEM_KEYWORD;
+        }
+        throw new IllegalArgumentException("지원하지 않는 키워드 카테고리입니다: " + event.category());
     }
 
     private Set<Integer> getAlreadyNotifiedUserIds(Integer articleId, Set<Integer> subscriberUserIds) {

--- a/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/eventlistener/ArticleKeywordEventListener.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
+import in.koreatech.koin.common.model.MobileAppPath;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.Board;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
@@ -55,6 +56,7 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
 
         Article article = articleRepository.getById(event.articleId());
         Board board = article.getBoard();
+        MobileAppPath appPath = getAppPath(event);
 
         Map<Integer, NotificationSubscribe> keywordSubscribersByUserId = notificationSubscribeRepository
             .findAllBySubscribeTypeAndDetailTypeIsNullWithUser(getSubscribeType(event))
@@ -83,6 +85,8 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             .map(subscribe -> createNotification(
                 article,
                 board,
+                appPath,
+                event,
                 matchedKeywordByUserId.get(subscribe.getUser().getId()),
                 subscribe
             ))
@@ -111,6 +115,16 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
         throw new IllegalArgumentException("지원하지 않는 키워드 카테고리입니다: " + event.category());
     }
 
+    private MobileAppPath getAppPath(ArticleKeywordEvent event) {
+        if (event.category() == KOREATECH) {
+            return KEYWORD;
+        }
+        if (event.category() == LOST_ITEM) {
+            return MobileAppPath.LOST_ITEM;
+        }
+        throw new IllegalArgumentException("지원하지 않는 키워드 카테고리입니다: " + event.category());
+    }
+
     private Set<Integer> getAlreadyNotifiedUserIds(Integer articleId, Set<Integer> subscriberUserIds) {
         if (subscriberUserIds.isEmpty()) {
             return Set.of();
@@ -129,13 +143,15 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
     private Notification createNotification(
         Article article,
         Board board,
+        MobileAppPath appPath,
+        ArticleKeywordEvent event,
         String keyword,
         NotificationSubscribe subscribe
     ) {
-        String description = generateDescription(keyword);
+        String description = generateDescription(event, keyword);
 
-        Notification notification = notificationFactory.generateKeywordNotification(
-            KEYWORD,
+        return notificationFactory.generateKeywordNotification(
+            appPath,
             article.getId(),
             keyword,
             article.getTitle(),
@@ -143,10 +159,12 @@ public class ArticleKeywordEventListener { // TODO : 리팩터링 필요 (비즈
             description,
             subscribe.getUser()
         );
-        return notification;
     }
 
-    private String generateDescription(String keyword) {
+    private String generateDescription(ArticleKeywordEvent event, String keyword) {
+        if (event.category() == LOST_ITEM) {
+            return "방금 등록된 %s 분실물 게시물을 확인해보세요!".formatted(keyword);
+        }
         return "방금 등록된 %s 공지를 확인해보세요!".formatted(keyword);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationFactory.java
@@ -212,6 +212,9 @@ public class NotificationFactory {
         if (keyword == null) {
             return generateSchemeUri(path, eventId);
         }
+        if (path == MobileAppPath.LOST_ITEM) {
+            return String.format("%s?id=%d&keyword=%s", path.getPath(), eventId, keyword);
+        }
         return String.format("%s?id=%d&keyword=%s&board-id=%s", path.getPath(), eventId, keyword, boardId);
     }
 

--- a/src/main/resources/db/migration/V235__add_category_to_article_keywords.sql
+++ b/src/main/resources/db/migration/V235__add_category_to_article_keywords.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `article_keywords`
+    ADD COLUMN `category` VARCHAR(20) NOT NULL DEFAULT 'KOREATECH' AFTER `keyword`;
+
+UPDATE `article_keywords`
+SET `category` = 'KOREATECH';
+
+ALTER TABLE `article_keywords`
+    DROP INDEX `keyword`,
+    ADD UNIQUE KEY `uk_article_keywords_keyword_category` (`keyword`, `category`);

--- a/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.unit.domain.community.keyword.service;
 
 import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -11,6 +12,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,10 +21,12 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
+import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
@@ -103,6 +107,34 @@ class KeywordServiceTest {
         verifyNoInteractions(articleRepository);
         verifyNoInteractions(keywordExtractor);
         verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("추천 키워드 갱신은 카테고리별로 탑 키워드를 선정한다.")
+    void fetchTopKeywordsFromLastWeek_fetchesTopKeywordsByCategory() {
+        ArticleKeywordResult koreatechKeyword = new ArticleKeywordResult(1, "장학금", 10L);
+        ArticleKeywordResult lostItemKeyword = new ArticleKeywordResult(2, "지갑", 5L);
+
+        when(articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(any(), eq(KOREATECH), any()))
+            .thenReturn(List.of(koreatechKeyword));
+        when(articleKeywordRepository.findTop15KeywordsExcludingFiltered(eq(KOREATECH), any()))
+            .thenReturn(List.of(koreatechKeyword));
+        when(articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(any(), eq(LOST_ITEM), any()))
+            .thenReturn(List.of(lostItemKeyword));
+        when(articleKeywordRepository.findTop15KeywordsExcludingFiltered(eq(LOST_ITEM), any()))
+            .thenReturn(List.of(lostItemKeyword));
+
+        keywordService.fetchTopKeywordsFromLastWeek();
+
+        ArgumentCaptor<ArticleKeywordSuggestCache> captor = ArgumentCaptor.forClass(ArticleKeywordSuggestCache.class);
+        verify(articleKeywordSuggestRepository).deleteAll();
+        verify(articleKeywordSuggestRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues())
+            .extracting(ArticleKeywordSuggestCache::getKeyword, ArticleKeywordSuggestCache::getCategory)
+            .containsExactlyInAnyOrder(
+                org.assertj.core.groups.Tuple.tuple("장학금", KOREATECH),
+                org.assertj.core.groups.Tuple.tuple("지갑", LOST_ITEM)
+            );
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
@@ -1,15 +1,21 @@
 package in.koreatech.koin.unit.domain.community.keyword.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,20 +24,29 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
+import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
+import in.koreatech.koin.domain.community.keyword.exception.KeywordDuplicationException;
+import in.koreatech.koin.domain.community.keyword.exception.KeywordLimitExceededException;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
+import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import in.koreatech.koin.domain.community.keyword.repository.UserNotificationStatusRepository;
 import in.koreatech.koin.domain.community.keyword.service.KeywordService;
 import in.koreatech.koin.domain.community.util.KeywordExtractor;
+import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.unit.fixture.UserFixture;
 
 @ExtendWith(MockitoExtension.class)
 class KeywordServiceTest {
@@ -76,22 +91,126 @@ class KeywordServiceTest {
         ArticleKeywordEvent event10 = new ArticleKeywordEvent(
             10,
             null,
+            KOREATECH,
             Map.of(1, "A")
         );
         ArticleKeywordEvent event11 = new ArticleKeywordEvent(
             11,
             null,
+            KOREATECH,
             Map.of(2, "B")
         );
-        when(keywordExtractor.matchKeyword(List.of(article10, article11), null)).thenReturn(List.of(event10, event11));
+        when(keywordExtractor.matchKeyword(List.of(article10, article11), null, KOREATECH))
+            .thenReturn(List.of(event10, event11));
 
         keywordService.sendKeywordNotification(request);
 
         verify(articleRepository).findAllByIdIn(List.of(10, 11));
-        verify(keywordExtractor).matchKeyword(List.of(article10, article11), null);
+        verify(keywordExtractor).matchKeyword(List.of(article10, article11), null, KOREATECH);
         verify(eventPublisher).publishEvent(event10);
         verify(eventPublisher).publishEvent(event11);
         verifyNoMoreInteractions(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("키워드 생성은 요청 카테고리 기준으로 제한과 기존 키워드를 조회한다.")
+    void createKeyword_usesCategoryForLimitAndKeywordLookup() {
+        Integer userId = 1;
+        User user = UserFixture.id_설정_코인_유저(userId);
+        ArticleKeywordCreateRequest request = new ArticleKeywordCreateRequest("지갑");
+
+        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(0L);
+        when(articleKeywordRepository.findByKeywordAndCategoryIncludingDeleted("지갑", LOST_ITEM.name()))
+            .thenReturn(Optional.empty());
+        when(articleKeywordRepository.save(any(ArticleKeyword.class))).thenAnswer(invocation -> {
+            ArticleKeyword keyword = invocation.getArgument(0);
+            ReflectionTestUtils.setField(keyword, "id", 10);
+            return keyword;
+        });
+        when(userRepository.getById(userId)).thenReturn(user);
+        when(articleKeywordUserMapRepository.findByArticleKeywordIdAndUserIdIncludingDeleted(10, userId))
+            .thenReturn(Optional.empty());
+        when(articleKeywordUserMapRepository.save(any(ArticleKeywordUserMap.class))).thenAnswer(invocation -> {
+            ArticleKeywordUserMap userMap = invocation.getArgument(0);
+            ReflectionTestUtils.setField(userMap, "id", 20);
+            return userMap;
+        });
+
+        var response = keywordService.createKeyword(userId, request, LOST_ITEM);
+
+        assertThat(response.id()).isEqualTo(20);
+        assertThat(response.keyword()).isEqualTo("지갑");
+        verify(articleKeywordRepository).save(argThatKeywordCategory(LOST_ITEM));
+    }
+
+    @Test
+    @DisplayName("같은 사용자와 같은 카테고리의 기존 활성 키워드는 중복으로 처리한다.")
+    void createKeyword_withSameCategoryExistingMapping_throwsDuplication() {
+        Integer userId = 1;
+        ArticleKeyword keyword = ArticleKeyword.builder()
+            .keyword("지갑")
+            .category(LOST_ITEM)
+            .build();
+        ReflectionTestUtils.setField(keyword, "id", 10);
+        ArticleKeywordUserMap userMap = ArticleKeywordUserMap.builder()
+            .articleKeyword(keyword)
+            .user(UserFixture.id_설정_코인_유저(userId))
+            .build();
+
+        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(0L);
+        when(articleKeywordRepository.findByKeywordAndCategoryIncludingDeleted("지갑", LOST_ITEM.name()))
+            .thenReturn(Optional.of(keyword));
+        when(articleKeywordUserMapRepository.findByArticleKeywordIdAndUserIdIncludingDeleted(10, userId))
+            .thenReturn(Optional.of(userMap));
+
+        assertThatThrownBy(() -> keywordService.createKeyword(userId, new ArticleKeywordCreateRequest("지갑"), LOST_ITEM))
+            .isInstanceOf(KeywordDuplicationException.class);
+    }
+
+    @Test
+    @DisplayName("키워드 등록 제한은 카테고리별로 계산한다.")
+    void createKeyword_whenCategoryLimitExceeded_throwsException() {
+        Integer userId = 1;
+        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(10L);
+
+        assertThatThrownBy(() -> keywordService.createKeyword(userId, new ArticleKeywordCreateRequest("지갑"), LOST_ITEM))
+            .isInstanceOf(KeywordLimitExceededException.class);
+    }
+
+    @Test
+    @DisplayName("내 키워드 조회는 요청 카테고리 기준으로 조회한다.")
+    void getMyKeywords_usesCategory() {
+        Integer userId = 1;
+        when(articleKeywordUserMapRepository.findAllByUserIdAndArticleKeywordCategory(userId, LOST_ITEM))
+            .thenReturn(List.of());
+
+        keywordService.getMyKeywords(userId, LOST_ITEM);
+
+        verify(articleKeywordUserMapRepository).findAllByUserIdAndArticleKeywordCategory(userId, LOST_ITEM);
+    }
+
+    @Test
+    @DisplayName("추천 키워드는 요청 카테고리의 캐시만 반환한다.")
+    void suggestKeywords_filtersByCategory() {
+        when(articleKeywordSuggestRepository.findTop15ByOrderByCountDesc())
+            .thenReturn(List.of(
+                ArticleKeywordSuggestCache.builder()
+                    .hotKeywordId(1)
+                    .keyword("장학금")
+                    .category(KOREATECH)
+                    .count(10)
+                    .build(),
+                ArticleKeywordSuggestCache.builder()
+                    .hotKeywordId(2)
+                    .keyword("지갑")
+                    .category(LOST_ITEM)
+                    .count(5)
+                    .build()
+            ));
+
+        var response = keywordService.suggestKeywords(LOST_ITEM);
+
+        assertThat(response.keywords()).containsExactly("지갑");
     }
 
     @Test
@@ -120,5 +239,9 @@ class KeywordServiceTest {
 
         assertThat(transactional).isNotNull();
         assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+    }
+
+    private ArticleKeyword argThatKeywordCategory(in.koreatech.koin.domain.community.keyword.enums.KeywordCategory category) {
+        return org.mockito.ArgumentMatchers.argThat(keyword -> keyword.getCategory() == category);
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
@@ -1,21 +1,12 @@
 package in.koreatech.koin.unit.domain.community.keyword.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
-import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,29 +15,21 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
-import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
-import in.koreatech.koin.domain.community.keyword.exception.KeywordDuplicationException;
-import in.koreatech.koin.domain.community.keyword.exception.KeywordLimitExceededException;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
-import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
-import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordUserMap;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
 import in.koreatech.koin.domain.community.keyword.repository.UserNotificationStatusRepository;
 import in.koreatech.koin.domain.community.keyword.service.KeywordService;
 import in.koreatech.koin.domain.community.util.KeywordExtractor;
-import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
-import in.koreatech.koin.unit.fixture.UserFixture;
 
 @ExtendWith(MockitoExtension.class)
 class KeywordServiceTest {
@@ -113,107 +96,6 @@ class KeywordServiceTest {
     }
 
     @Test
-    @DisplayName("키워드 생성은 요청 카테고리 기준으로 제한과 기존 키워드를 조회한다.")
-    void createKeyword_usesCategoryForLimitAndKeywordLookup() {
-        Integer userId = 1;
-        User user = UserFixture.id_설정_코인_유저(userId);
-        ArticleKeywordCreateRequest request = new ArticleKeywordCreateRequest("지갑");
-
-        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(0L);
-        when(articleKeywordRepository.findByKeywordAndCategoryIncludingDeleted("지갑", LOST_ITEM.name()))
-            .thenReturn(Optional.empty());
-        when(articleKeywordRepository.save(any(ArticleKeyword.class))).thenAnswer(invocation -> {
-            ArticleKeyword keyword = invocation.getArgument(0);
-            ReflectionTestUtils.setField(keyword, "id", 10);
-            return keyword;
-        });
-        when(userRepository.getById(userId)).thenReturn(user);
-        when(articleKeywordUserMapRepository.findByArticleKeywordIdAndUserIdIncludingDeleted(10, userId))
-            .thenReturn(Optional.empty());
-        when(articleKeywordUserMapRepository.save(any(ArticleKeywordUserMap.class))).thenAnswer(invocation -> {
-            ArticleKeywordUserMap userMap = invocation.getArgument(0);
-            ReflectionTestUtils.setField(userMap, "id", 20);
-            return userMap;
-        });
-
-        var response = keywordService.createKeyword(userId, request, LOST_ITEM);
-
-        assertThat(response.id()).isEqualTo(20);
-        assertThat(response.keyword()).isEqualTo("지갑");
-        verify(articleKeywordRepository).save(argThatKeywordCategory(LOST_ITEM));
-    }
-
-    @Test
-    @DisplayName("같은 사용자와 같은 카테고리의 기존 활성 키워드는 중복으로 처리한다.")
-    void createKeyword_withSameCategoryExistingMapping_throwsDuplication() {
-        Integer userId = 1;
-        ArticleKeyword keyword = ArticleKeyword.builder()
-            .keyword("지갑")
-            .category(LOST_ITEM)
-            .build();
-        ReflectionTestUtils.setField(keyword, "id", 10);
-        ArticleKeywordUserMap userMap = ArticleKeywordUserMap.builder()
-            .articleKeyword(keyword)
-            .user(UserFixture.id_설정_코인_유저(userId))
-            .build();
-
-        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(0L);
-        when(articleKeywordRepository.findByKeywordAndCategoryIncludingDeleted("지갑", LOST_ITEM.name()))
-            .thenReturn(Optional.of(keyword));
-        when(articleKeywordUserMapRepository.findByArticleKeywordIdAndUserIdIncludingDeleted(10, userId))
-            .thenReturn(Optional.of(userMap));
-
-        assertThatThrownBy(() -> keywordService.createKeyword(userId, new ArticleKeywordCreateRequest("지갑"), LOST_ITEM))
-            .isInstanceOf(KeywordDuplicationException.class);
-    }
-
-    @Test
-    @DisplayName("키워드 등록 제한은 카테고리별로 계산한다.")
-    void createKeyword_whenCategoryLimitExceeded_throwsException() {
-        Integer userId = 1;
-        when(articleKeywordUserMapRepository.countByUserIdAndArticleKeywordCategory(userId, LOST_ITEM)).thenReturn(10L);
-
-        assertThatThrownBy(() -> keywordService.createKeyword(userId, new ArticleKeywordCreateRequest("지갑"), LOST_ITEM))
-            .isInstanceOf(KeywordLimitExceededException.class);
-    }
-
-    @Test
-    @DisplayName("내 키워드 조회는 요청 카테고리 기준으로 조회한다.")
-    void getMyKeywords_usesCategory() {
-        Integer userId = 1;
-        when(articleKeywordUserMapRepository.findAllByUserIdAndArticleKeywordCategory(userId, LOST_ITEM))
-            .thenReturn(List.of());
-
-        keywordService.getMyKeywords(userId, LOST_ITEM);
-
-        verify(articleKeywordUserMapRepository).findAllByUserIdAndArticleKeywordCategory(userId, LOST_ITEM);
-    }
-
-    @Test
-    @DisplayName("추천 키워드는 요청 카테고리의 캐시만 반환한다.")
-    void suggestKeywords_filtersByCategory() {
-        when(articleKeywordSuggestRepository.findTop15ByOrderByCountDesc())
-            .thenReturn(List.of(
-                ArticleKeywordSuggestCache.builder()
-                    .hotKeywordId(1)
-                    .keyword("장학금")
-                    .category(KOREATECH)
-                    .count(10)
-                    .build(),
-                ArticleKeywordSuggestCache.builder()
-                    .hotKeywordId(2)
-                    .keyword("지갑")
-                    .category(LOST_ITEM)
-                    .count(5)
-                    .build()
-            ));
-
-        var response = keywordService.suggestKeywords(LOST_ITEM);
-
-        assertThat(response.keywords()).containsExactly("지갑");
-    }
-
-    @Test
     @DisplayName("업데이트 알림 대상 게시글이 없으면 아무 작업도 수행하지 않는다.")
     void sendKeywordNotification_withEmptyArticleIds_doesNothing() {
         keywordService.sendKeywordNotification(new KeywordNotificationRequest(List.of()));
@@ -241,7 +123,8 @@ class KeywordServiceTest {
         assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
     }
 
-    private ArticleKeyword argThatKeywordCategory(in.koreatech.koin.domain.community.keyword.enums.KeywordCategory category) {
+    private ArticleKeyword argThatKeywordCategory(
+        in.koreatech.koin.domain.community.keyword.enums.KeywordCategory category) {
         return org.mockito.ArgumentMatchers.argThat(keyword -> keyword.getCategory() == category);
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/keyword/service/KeywordServiceTest.java
@@ -1,7 +1,6 @@
 package in.koreatech.koin.unit.domain.community.keyword.service;
 
 import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
-import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -12,7 +11,6 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,12 +19,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.ArticleKeywordEvent;
-import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.keyword.dto.KeywordNotificationRequest;
 import in.koreatech.koin.domain.community.keyword.model.ArticleKeyword;
-import in.koreatech.koin.domain.community.keyword.model.ArticleKeywordSuggestCache;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordSuggestRepository;
 import in.koreatech.koin.domain.community.keyword.repository.ArticleKeywordUserMapRepository;
@@ -107,34 +103,6 @@ class KeywordServiceTest {
         verifyNoInteractions(articleRepository);
         verifyNoInteractions(keywordExtractor);
         verifyNoInteractions(eventPublisher);
-    }
-
-    @Test
-    @DisplayName("추천 키워드 갱신은 카테고리별로 탑 키워드를 선정한다.")
-    void fetchTopKeywordsFromLastWeek_fetchesTopKeywordsByCategory() {
-        ArticleKeywordResult koreatechKeyword = new ArticleKeywordResult(1, "장학금", 10L);
-        ArticleKeywordResult lostItemKeyword = new ArticleKeywordResult(2, "지갑", 5L);
-
-        when(articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(any(), eq(KOREATECH), any()))
-            .thenReturn(List.of(koreatechKeyword));
-        when(articleKeywordRepository.findTop15KeywordsExcludingFiltered(eq(KOREATECH), any()))
-            .thenReturn(List.of(koreatechKeyword));
-        when(articleKeywordRepository.findTopKeywordsInLastWeekExcludingFiltered(any(), eq(LOST_ITEM), any()))
-            .thenReturn(List.of(lostItemKeyword));
-        when(articleKeywordRepository.findTop15KeywordsExcludingFiltered(eq(LOST_ITEM), any()))
-            .thenReturn(List.of(lostItemKeyword));
-
-        keywordService.fetchTopKeywordsFromLastWeek();
-
-        ArgumentCaptor<ArticleKeywordSuggestCache> captor = ArgumentCaptor.forClass(ArticleKeywordSuggestCache.class);
-        verify(articleKeywordSuggestRepository).deleteAll();
-        verify(articleKeywordSuggestRepository, times(2)).save(captor.capture());
-        assertThat(captor.getAllValues())
-            .extracting(ArticleKeywordSuggestCache::getKeyword, ArticleKeywordSuggestCache::getCategory)
-            .containsExactlyInAnyOrder(
-                org.assertj.core.groups.Tuple.tuple("장학금", KOREATECH),
-                org.assertj.core.groups.Tuple.tuple("지갑", LOST_ITEM)
-            );
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
@@ -1,14 +1,10 @@
 package in.koreatech.koin.unit.domain.community.util;
 
 import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
-import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Map;
@@ -120,7 +116,8 @@ class KeywordExtractorTest {
                 secondKeyword.getArticleKeywordUserMaps().get(0)
             ));
 
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(firstArticle, secondArticle), null, KOREATECH);
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(firstArticle, secondArticle), null,
+            KOREATECH);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).articleId()).isEqualTo(1);
@@ -142,31 +139,6 @@ class KeywordExtractorTest {
 
         assertThat(result).isEmpty();
         verifyNoInteractions(articleKeywordUserMapRepository);
-    }
-
-    @Test
-    @DisplayName("키워드 매칭은 요청 카테고리의 키워드만 조회한다.")
-    void matchKeyword_usesRequestedCategory() {
-        Article article = mock(Article.class);
-        when(article.getId()).thenReturn(1);
-        when(article.getTitle()).thenReturn("검은 지갑 분실");
-
-        User subscriber = UserFixture.id_설정_코인_유저(1);
-        ArticleKeyword keyword = createKeyword(1, "지갑", subscriber);
-
-        when(articleKeywordRepository.findAllByCategory(eq(LOST_ITEM), any(Pageable.class)))
-            .thenReturn(List.of(keyword))
-            .thenReturn(List.of());
-        when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
-            .thenReturn(List.of(keyword.getArticleKeywordUserMaps().get(0)));
-
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), 100, LOST_ITEM);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).category()).isEqualTo(LOST_ITEM);
-        assertThat(result.get(0).authorId()).isEqualTo(100);
-        verify(articleKeywordRepository, org.mockito.Mockito.never())
-            .findAllByCategory(eq(KOREATECH), any(Pageable.class));
     }
 
     private ArticleKeyword createKeyword(Integer keywordId, String keyword, User... users) {

--- a/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/util/KeywordExtractorTest.java
@@ -1,8 +1,12 @@
 package in.koreatech.koin.unit.domain.community.util;
 
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +55,7 @@ class KeywordExtractorTest {
         ArticleKeyword keywordA = createKeyword(1, "근로", subscriber);
         ArticleKeyword keywordB = createKeyword(2, "근로장학", subscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
+        when(articleKeywordRepository.findAllByCategory(eq(KOREATECH), any(Pageable.class)))
             .thenReturn(List.of(keywordA, keywordB))
             .thenReturn(List.of());
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
@@ -60,12 +64,13 @@ class KeywordExtractorTest {
                 keywordB.getArticleKeywordUserMaps().get(0)
             ));
 
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null);
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null, KOREATECH);
 
         assertThat(result).hasSize(1);
         ArticleKeywordEvent event = result.get(0);
         assertThat(event.articleId()).isEqualTo(1);
         assertThat(event.authorId()).isNull();
+        assertThat(event.category()).isEqualTo(KOREATECH);
         assertThat(event.matchedKeywordByUserId()).isEqualTo(Map.of(1, "근로장학"));
     }
 
@@ -79,13 +84,13 @@ class KeywordExtractorTest {
         User subscriber = UserFixture.id_설정_코인_유저(1);
         ArticleKeyword keyword = createKeyword(1, "장학금", subscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
+        when(articleKeywordRepository.findAllByCategory(eq(KOREATECH), any(Pageable.class)))
             .thenReturn(List.of(keyword))
             .thenReturn(List.of());
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
             .thenReturn(List.of(keyword.getArticleKeywordUserMaps().get(0)));
 
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null);
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null, KOREATECH);
 
         assertThat(result).isEmpty();
     }
@@ -106,7 +111,7 @@ class KeywordExtractorTest {
         ArticleKeyword firstKeyword = createKeyword(1, "근로", firstSubscriber);
         ArticleKeyword secondKeyword = createKeyword(2, "장학금", secondSubscriber);
 
-        when(articleKeywordRepository.findAll(any(Pageable.class)))
+        when(articleKeywordRepository.findAllByCategory(eq(KOREATECH), any(Pageable.class)))
             .thenReturn(List.of(firstKeyword, secondKeyword))
             .thenReturn(List.of());
         when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
@@ -115,12 +120,14 @@ class KeywordExtractorTest {
                 secondKeyword.getArticleKeywordUserMaps().get(0)
             ));
 
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(firstArticle, secondArticle), null);
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(firstArticle, secondArticle), null, KOREATECH);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).articleId()).isEqualTo(1);
+        assertThat(result.get(0).category()).isEqualTo(KOREATECH);
         assertThat(result.get(0).matchedKeywordByUserId()).isEqualTo(Map.of(1, "근로"));
         assertThat(result.get(1).articleId()).isEqualTo(2);
+        assertThat(result.get(1).category()).isEqualTo(KOREATECH);
         assertThat(result.get(1).matchedKeywordByUserId()).isEqualTo(Map.of(2, "장학금"));
     }
 
@@ -129,12 +136,37 @@ class KeywordExtractorTest {
     void matchKeyword_whenNoKeywordsExist_returnsEmptyResult() {
         Article article = mock(Article.class);
         when(article.getId()).thenReturn(1);
-        when(articleKeywordRepository.findAll(any(Pageable.class))).thenReturn(List.of());
+        when(articleKeywordRepository.findAllByCategory(eq(KOREATECH), any(Pageable.class))).thenReturn(List.of());
 
-        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null);
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), null, KOREATECH);
 
         assertThat(result).isEmpty();
         verifyNoInteractions(articleKeywordUserMapRepository);
+    }
+
+    @Test
+    @DisplayName("키워드 매칭은 요청 카테고리의 키워드만 조회한다.")
+    void matchKeyword_usesRequestedCategory() {
+        Article article = mock(Article.class);
+        when(article.getId()).thenReturn(1);
+        when(article.getTitle()).thenReturn("검은 지갑 분실");
+
+        User subscriber = UserFixture.id_설정_코인_유저(1);
+        ArticleKeyword keyword = createKeyword(1, "지갑", subscriber);
+
+        when(articleKeywordRepository.findAllByCategory(eq(LOST_ITEM), any(Pageable.class)))
+            .thenReturn(List.of(keyword))
+            .thenReturn(List.of());
+        when(articleKeywordUserMapRepository.findAllByArticleKeywordIdIn(any()))
+            .thenReturn(List.of(keyword.getArticleKeywordUserMaps().get(0)));
+
+        List<ArticleKeywordEvent> result = keywordExtractor.matchKeyword(List.of(article), 100, LOST_ITEM);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).category()).isEqualTo(LOST_ITEM);
+        assertThat(result.get(0).authorId()).isEqualTo(100);
+        verify(articleKeywordRepository, org.mockito.Mockito.never())
+            .findAllByCategory(eq(KOREATECH), any(Pageable.class));
     }
 
     private ArticleKeyword createKeyword(Integer keywordId, String keyword, User... users) {

--- a/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
@@ -2,20 +2,9 @@ package in.koreatech.koin.unit.domain.notification.eventlistener;
 
 import static in.koreatech.koin.common.model.MobileAppPath.KEYWORD;
 import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
-import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.ARTICLE_KEYWORD;
-import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.LOST_ITEM_KEYWORD;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Map;
@@ -94,7 +83,8 @@ class ArticleKeywordEventListenerTest {
 
         Notification notification = mock(Notification.class);
         when(notification.getUser()).thenReturn(subscriber);
-        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(), anyString(), any()))
+        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(),
+            anyString(), any()))
             .thenReturn(notification);
         when(notificationService.pushNotificationsWithResult(any()))
             .thenReturn(List.of(new NotificationService.NotificationDeliveryResult(notification, true)));
@@ -213,7 +203,8 @@ class ArticleKeywordEventListenerTest {
             .thenReturn(List.of());
 
         Notification notification = mock(Notification.class);
-        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(), anyString(), any()))
+        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(),
+            anyString(), any()))
             .thenReturn(notification);
         when(notificationService.pushNotificationsWithResult(any()))
             .thenReturn(List.of(new NotificationService.NotificationDeliveryResult(notification, false)));
@@ -261,11 +252,13 @@ class ArticleKeywordEventListenerTest {
         when(board.getId()).thenReturn(boardId);
         when(notificationSubscribeRepository.findAllBySubscribeTypeAndDetailTypeIsNullWithUser(ARTICLE_KEYWORD))
             .thenReturn(List.of(matchedSubscribe, unmatchedSubscribe));
-        when(userNotificationStatusRepository.findUserIdsByNotifiedArticleIdAndUserIdIn(articleId, Set.of(matchedUserId)))
+        when(userNotificationStatusRepository.findUserIdsByNotifiedArticleIdAndUserIdIn(articleId,
+            Set.of(matchedUserId)))
             .thenReturn(List.of());
 
         Notification notification = mock(Notification.class);
-        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(), anyString(), any()))
+        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(),
+            anyString(), any()))
             .thenReturn(notification);
         when(notificationService.pushNotificationsWithResult(any())).thenReturn(List.of());
 
@@ -275,61 +268,9 @@ class ArticleKeywordEventListenerTest {
             .findUserIdsByNotifiedArticleIdAndUserIdIn(articleId, Set.of(matchedUserId));
     }
 
-    @Test
-    @DisplayName("분실물 키워드 이벤트는 분실물 키워드 구독 타입을 조회한다.")
-    void onKeywordRequest_withLostItemCategory_usesLostItemKeywordSubscription() {
-        Integer articleId = 600;
-        Integer boardId = 17;
-        Integer userId = 7;
-        User subscriber = UserFixture.id_설정_코인_유저(userId);
-        subscriber.permitNotification("device-token");
-
-        NotificationSubscribe subscribe = createLostItemKeywordSubscribe(subscriber);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, LOST_ITEM, Map.of(userId, "지갑"));
-
-        Article article = mock(Article.class);
-        Board board = mock(Board.class);
-        when(articleRepository.getById(articleId)).thenReturn(article);
-        when(article.getId()).thenReturn(articleId);
-        when(article.getTitle()).thenReturn("검은 지갑 습득");
-        when(article.getBoard()).thenReturn(board);
-        when(board.getId()).thenReturn(boardId);
-        when(notificationSubscribeRepository.findAllBySubscribeTypeAndDetailTypeIsNullWithUser(LOST_ITEM_KEYWORD))
-            .thenReturn(List.of(subscribe));
-        when(userNotificationStatusRepository.findUserIdsByNotifiedArticleIdAndUserIdIn(eq(articleId), any()))
-            .thenReturn(List.of());
-
-        Notification notification = mock(Notification.class);
-        when(notification.getUser()).thenReturn(subscriber);
-        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(), anyString(), any()))
-            .thenReturn(notification);
-        when(notificationService.pushNotificationsWithResult(any()))
-            .thenReturn(List.of(new NotificationService.NotificationDeliveryResult(notification, true)));
-
-        articleKeywordEventListener.onKeywordRequest(event);
-
-        verify(notificationSubscribeRepository).findAllBySubscribeTypeAndDetailTypeIsNullWithUser(LOST_ITEM_KEYWORD);
-        verify(notificationFactory).generateKeywordNotification(
-            eq(KEYWORD),
-            eq(articleId),
-            eq("지갑"),
-            eq("검은 지갑 습득"),
-            eq(boardId),
-            contains("지갑"),
-            eq(subscriber)
-        );
-    }
-
     private NotificationSubscribe createKeywordSubscribe(User user) {
         return NotificationSubscribe.builder()
             .subscribeType(ARTICLE_KEYWORD)
-            .user(user)
-            .build();
-    }
-
-    private NotificationSubscribe createLostItemKeywordSubscribe(User user) {
-        return NotificationSubscribe.builder()
-            .subscribeType(LOST_ITEM_KEYWORD)
             .user(user)
             .build();
     }

--- a/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
@@ -27,6 +27,7 @@ import in.koreatech.koin.domain.notification.eventlistener.ArticleKeywordEventLi
 import in.koreatech.koin.domain.notification.model.Notification;
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribe;
+import in.koreatech.koin.domain.notification.model.NotificationSubscribeType;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.notification.service.NotificationService;
 import in.koreatech.koin.domain.user.model.User;
@@ -269,8 +270,12 @@ class ArticleKeywordEventListenerTest {
     }
 
     private NotificationSubscribe createKeywordSubscribe(User user) {
+        return createSubscribe(user, ARTICLE_KEYWORD);
+    }
+
+    private NotificationSubscribe createSubscribe(User user, NotificationSubscribeType subscribeType) {
         return NotificationSubscribe.builder()
-            .subscribeType(ARTICLE_KEYWORD)
+            .subscribeType(subscribeType)
             .user(user)
             .build();
     }

--- a/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/notification/eventlistener/ArticleKeywordEventListenerTest.java
@@ -1,7 +1,10 @@
 package in.koreatech.koin.unit.domain.notification.eventlistener;
 
 import static in.koreatech.koin.common.model.MobileAppPath.KEYWORD;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.KOREATECH;
+import static in.koreatech.koin.domain.community.keyword.enums.KeywordCategory.LOST_ITEM;
 import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.ARTICLE_KEYWORD;
+import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.LOST_ITEM_KEYWORD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -75,7 +78,7 @@ class ArticleKeywordEventListenerTest {
 
         NotificationSubscribe subscribeA = createKeywordSubscribe(subscriber);
         NotificationSubscribe subscribeB = createKeywordSubscribe(subscriber);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, Map.of(userId, "근로장학"));
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, KOREATECH, Map.of(userId, "근로장학"));
 
         Article article = mock(Article.class);
         Board board = mock(Board.class);
@@ -122,7 +125,7 @@ class ArticleKeywordEventListenerTest {
         subscriber.permitNotification("device-token");
 
         NotificationSubscribe subscribe = createKeywordSubscribe(subscriber);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, userId, Map.of(userId, "A"));
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, userId, KOREATECH, Map.of(userId, "A"));
 
         Article article = mock(Article.class);
         Board board = mock(Board.class);
@@ -158,7 +161,7 @@ class ArticleKeywordEventListenerTest {
         subscriber.permitNotification("device-token");
 
         NotificationSubscribe subscribe = createKeywordSubscribe(subscriber);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, Map.of(userId, "C"));
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, KOREATECH, Map.of(userId, "C"));
 
         Article article = mock(Article.class);
         Board board = mock(Board.class);
@@ -195,7 +198,7 @@ class ArticleKeywordEventListenerTest {
         subscriber.permitNotification("device-token");
 
         NotificationSubscribe subscribe = createKeywordSubscribe(subscriber);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, Map.of(userId, "근로장학"));
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, KOREATECH, Map.of(userId, "근로장학"));
 
         Article article = mock(Article.class);
         Board board = mock(Board.class);
@@ -247,7 +250,7 @@ class ArticleKeywordEventListenerTest {
 
         NotificationSubscribe matchedSubscribe = createKeywordSubscribe(matchedUser);
         NotificationSubscribe unmatchedSubscribe = createKeywordSubscribe(unmatchedUser);
-        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, Map.of(matchedUserId, "근로장학"));
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, KOREATECH, Map.of(matchedUserId, "근로장학"));
 
         Article article = mock(Article.class);
         Board board = mock(Board.class);
@@ -272,9 +275,61 @@ class ArticleKeywordEventListenerTest {
             .findUserIdsByNotifiedArticleIdAndUserIdIn(articleId, Set.of(matchedUserId));
     }
 
+    @Test
+    @DisplayName("분실물 키워드 이벤트는 분실물 키워드 구독 타입을 조회한다.")
+    void onKeywordRequest_withLostItemCategory_usesLostItemKeywordSubscription() {
+        Integer articleId = 600;
+        Integer boardId = 17;
+        Integer userId = 7;
+        User subscriber = UserFixture.id_설정_코인_유저(userId);
+        subscriber.permitNotification("device-token");
+
+        NotificationSubscribe subscribe = createLostItemKeywordSubscribe(subscriber);
+        ArticleKeywordEvent event = new ArticleKeywordEvent(articleId, 999, LOST_ITEM, Map.of(userId, "지갑"));
+
+        Article article = mock(Article.class);
+        Board board = mock(Board.class);
+        when(articleRepository.getById(articleId)).thenReturn(article);
+        when(article.getId()).thenReturn(articleId);
+        when(article.getTitle()).thenReturn("검은 지갑 습득");
+        when(article.getBoard()).thenReturn(board);
+        when(board.getId()).thenReturn(boardId);
+        when(notificationSubscribeRepository.findAllBySubscribeTypeAndDetailTypeIsNullWithUser(LOST_ITEM_KEYWORD))
+            .thenReturn(List.of(subscribe));
+        when(userNotificationStatusRepository.findUserIdsByNotifiedArticleIdAndUserIdIn(eq(articleId), any()))
+            .thenReturn(List.of());
+
+        Notification notification = mock(Notification.class);
+        when(notification.getUser()).thenReturn(subscriber);
+        when(notificationFactory.generateKeywordNotification(any(), anyInt(), anyString(), anyString(), anyInt(), anyString(), any()))
+            .thenReturn(notification);
+        when(notificationService.pushNotificationsWithResult(any()))
+            .thenReturn(List.of(new NotificationService.NotificationDeliveryResult(notification, true)));
+
+        articleKeywordEventListener.onKeywordRequest(event);
+
+        verify(notificationSubscribeRepository).findAllBySubscribeTypeAndDetailTypeIsNullWithUser(LOST_ITEM_KEYWORD);
+        verify(notificationFactory).generateKeywordNotification(
+            eq(KEYWORD),
+            eq(articleId),
+            eq("지갑"),
+            eq("검은 지갑 습득"),
+            eq(boardId),
+            contains("지갑"),
+            eq(subscriber)
+        );
+    }
+
     private NotificationSubscribe createKeywordSubscribe(User user) {
         return NotificationSubscribe.builder()
             .subscribeType(ARTICLE_KEYWORD)
+            .user(user)
+            .build();
+    }
+
+    private NotificationSubscribe createLostItemKeywordSubscribe(User user) {
+        return NotificationSubscribe.builder()
+            .subscribeType(LOST_ITEM_KEYWORD)
             .user(user)
             .build();
     }


### PR DESCRIPTION
### 🔍 개요

- close #2233 

---

### 🚀 주요 변경 내용

* 키워드 생성, 조회, 추천 API에 대해서 분실물과 교내 공지를 분리하는 작업을 진행했습니다.
* 키워드 알림에 대해서 분실물과 교내 공지를 분리하는 작업을 진행했습니다.

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keywords are now categorized (e.g., platform vs. lost-item) — creation, suggestions, matching, admin filtering, and top-keyword refresh operate per-category.
  * Notifications adapt per category (including a lost-item route) and generate category-specific notification links.

* **Chores**
  * Database migration added to add categories and update uniqueness constraints.
  * CI workflow updated to flag DROP COLUMN as a dangerous SQL operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->