### PR TITLE
fix: 상점 삭제 시 혜택 매핑 정리 (develop)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/benefit/repository/AdminBenefitCategoryMapRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/benefit/repository/AdminBenefitCategoryMapRepository.java
@@ -45,6 +45,13 @@ public interface AdminBenefitCategoryMapRepository extends CrudRepository<Benefi
     @Modifying
     @Query("""
         DELETE FROM BenefitCategoryMap bcm 
+        WHERE bcm.shop.id = :shopId
+        """)
+    void deleteByShopId(@Param("shopId") Integer shopId);
+
+    @Modifying
+    @Query("""
+        DELETE FROM BenefitCategoryMap bcm
         WHERE bcm.benefitCategory.id = :benefitId
         """)
     void deleteByBenefitCategoryId(@Param("benefitId") Integer benefitId);

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.benefit.repository.AdminBenefitCategoryMapRepository;
 import in.koreatech.koin.admin.shop.dto.shop.AdminCreateShopCategoryRequest;
 import in.koreatech.koin.admin.shop.dto.shop.AdminCreateShopRequest;
 import in.koreatech.koin.admin.shop.dto.shop.AdminModifyShopCategoriesOrderRequest;
@@ -57,6 +58,7 @@ public class AdminShopService {
     private final AdminShopCategoryRepository adminShopCategoryRepository;
     private final AdminShopCategoryMapRepository adminShopCategoryMapRepository;
     private final AdminShopParentCategoryRepository adminShopParentCategoryRepository;
+    private final AdminBenefitCategoryMapRepository adminBenefitCategoryMapRepository;
 
     public AdminShopsResponse getShops(Integer page, Integer limit, Boolean isDeleted) {
         Integer total = adminShopRepository.countAllByIsDeleted(isDeleted);
@@ -221,6 +223,7 @@ public class AdminShopService {
     @RefreshShopsCache
     public void deleteShop(Integer shopId) {
         Shop shop = adminShopRepository.getById(shopId);
+        adminBenefitCategoryMapRepository.deleteByShopId(shopId);
         shop.delete();
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/admin/AdminShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/admin/AdminShopApiTest.java
@@ -17,6 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.BenefitCategoryAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.BenefitCategoryMapAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.MenuAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.MenuCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopAcceptanceFixture;
@@ -24,12 +26,14 @@ import in.koreatech.koin.acceptance.fixture.ShopCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopNotificationMessageAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopParentCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.admin.benefit.repository.AdminBenefitCategoryMapRepository;
+import in.koreatech.koin.admin.manager.model.Admin;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopParentCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopRepository;
-import in.koreatech.koin.admin.manager.model.Admin;
+import in.koreatech.koin.domain.benefit.model.BenefitCategory;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
@@ -63,6 +67,9 @@ class AdminShopApiTest extends AcceptanceTest {
     private AdminShopRepository adminShopRepository;
 
     @Autowired
+    private AdminBenefitCategoryMapRepository adminBenefitCategoryMapRepository;
+
+    @Autowired
     private AdminMenuRepository adminMenuRepository;
 
     @Autowired
@@ -88,6 +95,12 @@ class AdminShopApiTest extends AcceptanceTest {
 
     @Autowired
     private MenuCategoryAcceptanceFixture menuCategoryFixture;
+
+    @Autowired
+    private BenefitCategoryAcceptanceFixture benefitCategoryFixture;
+
+    @Autowired
+    private BenefitCategoryMapAcceptanceFixture benefitCategoryMapFixture;
 
     private Owner owner_현수;
     private Owner owner_준영;
@@ -935,6 +948,8 @@ class AdminShopApiTest extends AcceptanceTest {
     @Test
     void 어드민이_상점을_삭제한다() throws Exception {
         Shop shop = shopFixture.영업중이_아닌_신전_떡볶이(owner_현수);
+        BenefitCategory benefitCategory = benefitCategoryFixture.배달비_무료();
+        benefitCategoryMapFixture.혜택_추가(shop, benefitCategory);
 
         mockMvc.perform(
                 delete("/admin/shops/{id}", shop.getId())
@@ -943,7 +958,13 @@ class AdminShopApiTest extends AcceptanceTest {
             .andExpect(status().isOk());
 
         Shop deletedShop = adminShopRepository.getById(shop.getId());
-        assertSoftly(softly -> softly.assertThat(deletedShop.isDeleted()).isTrue());
+        assertSoftly(softly -> {
+            softly.assertThat(deletedShop.isDeleted()).isTrue();
+            softly.assertThat(adminBenefitCategoryMapRepository.findAllByBenefitCategoryIdAndShopIds(
+                benefitCategory.getId(),
+                List.of(shop.getId())
+            )).isEmpty();
+        });
     }
 
     @Test


### PR DESCRIPTION
### 🔍 개요

* 상점을 soft delete할 때 남아 있던 혜택 매핑도 함께 정리하도록 수정했습니다.
* 삭제된 상점이 `shop_benefit_category_map`에 남아 혜택 상점 조회에서 오류를 유발하는 상태를 방지합니다.

---

### 🚀 주요 변경 내용

* 상점 삭제 흐름에서 해당 상점의 혜택 매핑을 삭제합니다.
* 상점 삭제 API 테스트에 혜택 매핑 삭제 검증을 추가했습니다.

---

### 💬 참고 사항

* develop 기준 별도 브랜치에서 main 핫픽스 커밋만 cherry-pick했습니다.
* 검증: `./gradlew test --tests 'in.koreatech.koin.acceptance.admin.AdminShopApiTest.어드민이_상점을_삭제한다' --rerun-tasks`
* 결과: `AdminShopApiTest.어드민이_상점을_삭제한다` 통과, failures 0, errors 0

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---
