### PR TITLE
fix: 상점 삭제 시 혜택 매핑 정리 (develop)

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/benefit/repository/AdminBenefitCategoryMapRepository.java
+++ b/src/main/java/in/koreatech/koin/admin/benefit/repository/AdminBenefitCategoryMapRepository.java
@@ -45,6 +45,13 @@ public interface AdminBenefitCategoryMapRepository extends CrudRepository<Benefi
     @Modifying
     @Query("""
         DELETE FROM BenefitCategoryMap bcm 
+        WHERE bcm.shop.id = :shopId
+        """)
+    void deleteByShopId(@Param("shopId") Integer shopId);
+
+    @Modifying
+    @Query("""
+        DELETE FROM BenefitCategoryMap bcm
         WHERE bcm.benefitCategory.id = :benefitId
         """)
     void deleteByBenefitCategoryId(@Param("benefitId") Integer benefitId);

--- a/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
+++ b/src/main/java/in/koreatech/koin/admin/shop/service/AdminShopService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.admin.benefit.repository.AdminBenefitCategoryMapRepository;
 import in.koreatech.koin.admin.shop.dto.shop.AdminCreateShopCategoryRequest;
 import in.koreatech.koin.admin.shop.dto.shop.AdminCreateShopRequest;
 import in.koreatech.koin.admin.shop.dto.shop.AdminModifyShopCategoriesOrderRequest;
@@ -57,6 +58,7 @@ public class AdminShopService {
     private final AdminShopCategoryRepository adminShopCategoryRepository;
     private final AdminShopCategoryMapRepository adminShopCategoryMapRepository;
     private final AdminShopParentCategoryRepository adminShopParentCategoryRepository;
+    private final AdminBenefitCategoryMapRepository adminBenefitCategoryMapRepository;
 
     public AdminShopsResponse getShops(Integer page, Integer limit, Boolean isDeleted) {
         Integer total = adminShopRepository.countAllByIsDeleted(isDeleted);
@@ -221,6 +223,7 @@ public class AdminShopService {
     @RefreshShopsCache
     public void deleteShop(Integer shopId) {
         Shop shop = adminShopRepository.getById(shopId);
+        adminBenefitCategoryMapRepository.deleteByShopId(shopId);
         shop.delete();
     }
 

--- a/src/main/java/in/koreatech/koin/common/model/MobileAppPath.java
+++ b/src/main/java/in/koreatech/koin/common/model/MobileAppPath.java
@@ -10,6 +10,8 @@ public enum MobileAppPath {
     DINING("dining"),
     KEYWORD("keyword"),
     CHAT("chat"),
+    CALLVAN("callvan"),
+    CALLVAN_CHAT("callvan-chat"),
     CLUB("club"),
     TIMETABLE("timetable"),
     ;

--- a/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanApi.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageRequest;
 import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageResponse;
@@ -19,6 +20,7 @@ import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateRequest;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostDetailResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostSearchResponse;
+import in.koreatech.koin.domain.callvan.dto.CallvanRestrictionResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanUserReportCreateRequest;
 import in.koreatech.koin.domain.callvan.model.enums.CallvanLocation;
 import in.koreatech.koin.domain.callvan.model.filter.CallvanAuthorFilter;
@@ -28,9 +30,6 @@ import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.auth.UserId;
 
 import java.util.List;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.global.code.ApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
@@ -122,6 +121,29 @@ public interface CallvanApi {
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer limit,
         @UserId Integer userId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        NOT_FOUND_USER
+    })
+    @Operation(summary = "내 콜밴 이용 제한 상태 조회", description = """
+        ### 내 콜밴 이용 제한 상태 조회 API
+        로그인한 사용자의 현재 활성화된 콜밴 이용 제한 상태를 조회합니다.
+
+        #### 인증 조건
+        - **학생(STUDENT)** 권한을 가진 사용자만 호출 가능합니다.
+
+        #### 비즈니스 로직
+        1. 현재 활성화된 정지 상태가 있으면 `is_restricted=true`를 반환합니다.
+        2. 14일 이용 정지인 경우 `restriction_type=TEMPORARY_RESTRICTION_14_DAYS`와 `restricted_until`을 반환합니다.
+        3. 영구 이용 정지인 경우 `restriction_type=PERMANENT_RESTRICTION`을 반환하고 `restricted_until`은 null입니다.
+        4. 경고(`WARNING`)와 만료된 14일 정지는 이 API에서 반환하지 않습니다.
+        5. 활성화된 정지가 없으면 `is_restricted=false`와 null 필드들을 반환합니다.
+        """)
+    @GetMapping("/restriction")
+    ResponseEntity<CallvanRestrictionResponse> getCallvanRestriction(
+        @Auth(permit = {STUDENT}) Integer userId
     );
 
     @ApiResponseCodes({

--- a/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanController.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/controller/CallvanController.java
@@ -12,26 +12,28 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageRequest;
+import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageResponse;
+import in.koreatech.koin.domain.callvan.dto.CallvanNotificationResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateRequest;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostCreateResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostDetailResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostSearchResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanPostSearchResponse.CallvanPostResponse;
+import in.koreatech.koin.domain.callvan.dto.CallvanRestrictionResponse;
 import in.koreatech.koin.domain.callvan.dto.CallvanUserReportCreateRequest;
 import in.koreatech.koin.domain.callvan.model.enums.CallvanLocation;
 import in.koreatech.koin.domain.callvan.model.filter.CallvanAuthorFilter;
 import in.koreatech.koin.domain.callvan.model.filter.CallvanPostSortCriteria;
 import in.koreatech.koin.domain.callvan.model.filter.CallvanPostStatusFilter;
-import in.koreatech.koin.domain.callvan.service.CallvanPostQueryService;
-import in.koreatech.koin.domain.callvan.service.CallvanPostCreateService;
-import in.koreatech.koin.domain.callvan.service.CallvanPostJoinService;
-import in.koreatech.koin.domain.callvan.service.CallvanPostStatusService;
 import in.koreatech.koin.domain.callvan.service.CallvanChatService;
 import in.koreatech.koin.domain.callvan.service.CallvanNotificationService;
+import in.koreatech.koin.domain.callvan.service.CallvanPostCreateService;
+import in.koreatech.koin.domain.callvan.service.CallvanPostJoinService;
+import in.koreatech.koin.domain.callvan.service.CallvanPostQueryService;
+import in.koreatech.koin.domain.callvan.service.CallvanPostStatusService;
+import in.koreatech.koin.domain.callvan.service.CallvanRestrictionQueryService;
 import in.koreatech.koin.domain.callvan.service.CallvanUserReportService;
-import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageRequest;
-import in.koreatech.koin.domain.callvan.dto.CallvanNotificationResponse;
-import in.koreatech.koin.domain.callvan.dto.CallvanChatMessageResponse;
 import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.auth.UserId;
 import jakarta.validation.Valid;
@@ -52,6 +54,7 @@ public class CallvanController implements CallvanApi {
     private final CallvanPostStatusService callvanPostStatusService;
     private final CallvanChatService callvanChatService;
     private final CallvanNotificationService callvanNotificationService;
+    private final CallvanRestrictionQueryService callvanRestrictionQueryService;
     private final CallvanUserReportService callvanUserReportService;
 
     @PostMapping
@@ -82,6 +85,14 @@ public class CallvanController implements CallvanApi {
             author, departures, departureKeyword, arrivals, arrivalKeyword, statuses, title, sort, isJoined, page, limit,
             userId);
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/restriction")
+    public ResponseEntity<CallvanRestrictionResponse> getCallvanRestriction(
+        @Auth(permit = {STUDENT}) Integer userId
+    ) {
+        CallvanRestrictionResponse response = callvanRestrictionQueryService.getRestriction(userId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/posts/{postId}/summary")

--- a/src/main/java/in/koreatech/koin/domain/callvan/dto/CallvanRestrictionResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/dto/CallvanRestrictionResponse.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.domain.callvan.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.callvan.model.CallvanReportProcess;
+import in.koreatech.koin.domain.callvan.model.enums.CallvanReportProcessType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CallvanRestrictionResponse(
+    @Schema(description = "콜벤 기능 이용 제한 여부", example = "true", requiredMode = REQUIRED)
+    boolean isRestricted,
+
+    @Schema(
+        description = "현재 활성화된 이용 제한 유형. 제한이 없으면 null이며 WARNING(1차 경고)는 반환되지 않습니다.",
+        example = "TEMPORARY_RESTRICTION_14_DAYS"
+    )
+    CallvanReportProcessType restrictionType,
+
+    @Schema(
+        description = "임시 이용 제한 종료 시각. 영구 제한 또는 미제한이면 null입니다.",
+        example = "2026-04-21T12:00:00"
+    )
+    LocalDateTime restrictedUntil
+) {
+
+    public static CallvanRestrictionResponse from(CallvanReportProcess process) {
+        return new CallvanRestrictionResponse(
+            true,
+            process.getProcessType(),
+            process.getRestrictedUntil()
+        );
+    }
+
+    public static CallvanRestrictionResponse unrestricted() {
+        return new CallvanRestrictionResponse(false, null, null);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/event/CallvanPushNotificationEvent.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/event/CallvanPushNotificationEvent.java
@@ -1,0 +1,9 @@
+package in.koreatech.koin.domain.callvan.event;
+
+import java.util.List;
+
+public record CallvanPushNotificationEvent(
+    List<Integer> notificationIds
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/model/CallvanPushNotification.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/model/CallvanPushNotification.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.callvan.model;
+
+import in.koreatech.koin.common.model.MobileAppPath;
+import in.koreatech.koin.domain.user.model.User;
+
+public record CallvanPushNotification(
+    MobileAppPath mobileAppPath,
+    String schemeUri,
+    String title,
+    String message,
+    String imageUrl,
+    String type,
+    User recipient
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/model/CallvanPushNotificationFactory.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/model/CallvanPushNotificationFactory.java
@@ -1,0 +1,71 @@
+package in.koreatech.koin.domain.callvan.model;
+
+import static in.koreatech.koin.common.model.MobileAppPath.CALLVAN;
+import static in.koreatech.koin.common.model.MobileAppPath.CALLVAN_CHAT;
+import static in.koreatech.koin.domain.callvan.model.enums.CallvanNotificationType.DEPARTURE_UPCOMING;
+import static in.koreatech.koin.domain.callvan.model.enums.CallvanNotificationType.NEW_MESSAGE;
+import static in.koreatech.koin.domain.callvan.model.enums.CallvanNotificationType.PARTICIPANT_JOINED;
+import static in.koreatech.koin.domain.callvan.model.enums.CallvanNotificationType.RECRUITMENT_COMPLETE;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import in.koreatech.koin.common.model.MobileAppPath;
+
+@Component
+public class CallvanPushNotificationFactory {
+
+    public CallvanPushNotification from(CallvanNotification notification) {
+        MobileAppPath path = notification.getNotificationType() == NEW_MESSAGE ? CALLVAN_CHAT : CALLVAN;
+        String schemeUri = generateSchemeUri(notification);
+        String title = generateTitle(notification);
+        String message = generateMessage(notification);
+
+        return new CallvanPushNotification(
+            path,
+            schemeUri,
+            title,
+            message,
+            null,
+            notification.getNotificationType().name().toLowerCase(),
+            notification.getRecipient()
+        );
+    }
+
+    private String generateTitle(CallvanNotification notification) {
+        return switch (notification.getNotificationType()) {
+            case NEW_MESSAGE -> "콜벤팟 %s님의 메시지".formatted(notification.getSenderNickname());
+            case PARTICIPANT_JOINED -> "콜벤팟 새 참여자";
+            case RECRUITMENT_COMPLETE -> "콜벤팟 인원 모집 완료";
+            case DEPARTURE_UPCOMING -> "콜벤팟 출발 30분 전";
+            case REPORT_WARNING, REPORT_RESTRICTION_14_DAYS, REPORT_PERMANENT_RESTRICTION -> "콜벤팟 이용 안내";
+        };
+    }
+
+    private String generateMessage(CallvanNotification notification) {
+        return switch (notification.getNotificationType()) {
+            case PARTICIPANT_JOINED -> "%s님이 콜벤팟에 참여했어요".formatted(notification.getJoinedMemberNickname());
+            case DEPARTURE_UPCOMING -> "%s -> %s 콜벤팟이 30분 뒤 출발해요".formatted(
+                getLocationName(notification.getDepartureCustomName(), notification.getDepartureType().getName()),
+                getLocationName(notification.getArrivalCustomName(), notification.getArrivalType().getName())
+            );
+            case NEW_MESSAGE, RECRUITMENT_COMPLETE, REPORT_WARNING, REPORT_RESTRICTION_14_DAYS,
+                 REPORT_PERMANENT_RESTRICTION -> notification.getMessagePreview();
+        };
+    }
+
+    private String generateSchemeUri(CallvanNotification notification) {
+        Integer postId = notification.getPost() != null ? notification.getPost().getId() : null;
+        if (notification.getNotificationType() == NEW_MESSAGE) {
+            return "callvan-chat?postId=%d&chatRoomId=%d".formatted(postId, notification.getChatRoom().getId());
+        }
+        return "callvan?id=%d".formatted(postId);
+    }
+
+    private String getLocationName(String customName, String defaultName) {
+        if (StringUtils.hasText(customName)) {
+            return customName;
+        }
+        return defaultName;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanNotificationRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanNotificationRepository.java
@@ -13,6 +13,17 @@ public interface CallvanNotificationRepository extends JpaRepository<CallvanNoti
 
     List<CallvanNotification> findAllByRecipientIdOrderByCreatedAtDesc(Integer recipientId);
 
+    @Query("""
+        SELECT DISTINCT n
+        FROM CallvanNotification n
+        JOIN FETCH n.recipient
+        LEFT JOIN FETCH n.post
+        LEFT JOIN FETCH n.chatRoom
+        WHERE n.id IN :notificationIds
+        AND n.isDeleted = false
+        """)
+    List<CallvanNotification> findAllByIdInWithRelations(@Param("notificationIds") List<Integer> notificationIds);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE CallvanNotification n SET n.isRead = true WHERE n.recipient.id = :recipientId AND n.isDeleted = false")
     void updateIsReadByRecipientId(@Param("recipientId") Integer recipientId);

--- a/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanReportProcessRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/repository/CallvanReportProcessRepository.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.callvan.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -18,7 +19,7 @@ public interface CallvanReportProcessRepository extends Repository<CallvanReport
     boolean existsByReportIdAndIsDeletedFalse(Integer reportId);
 
     @Query("""
-        SELECT CASE WHEN COUNT(process) > 0 THEN true ELSE false END
+        SELECT process
         FROM CallvanReportProcess process
         WHERE process.report.reported.id = :userId
           AND process.isDeleted = false
@@ -30,9 +31,24 @@ public interface CallvanReportProcessRepository extends Repository<CallvanReport
                   AND process.restrictedUntil >= :now
               )
           )
+        ORDER BY CASE
+            WHEN process.processType = in.koreatech.koin.domain.callvan.model.enums.CallvanReportProcessType.PERMANENT_RESTRICTION
+                THEN 0
+            ELSE 1
+        END ASC,
+        process.createdAt DESC,
+        process.id DESC
         """)
-    boolean existsActiveRestrictionByReportedUserId(
+    List<CallvanReportProcess> findAllActiveRestrictionsByReportedUserId(
         @Param("userId") Integer userId,
         @Param("now") LocalDateTime now
     );
+
+    default Optional<CallvanReportProcess> findActiveRestrictionByReportedUserId(Integer userId, LocalDateTime now) {
+        return findAllActiveRestrictionsByReportedUserId(userId, now).stream().findFirst();
+    }
+
+    default boolean existsActiveRestrictionByReportedUserId(Integer userId, LocalDateTime now) {
+        return findActiveRestrictionByReportedUserId(userId, now).isPresent();
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanNotificationScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanNotificationScheduler.java
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import in.koreatech.koin.domain.callvan.event.CallvanPushNotificationEvent;
 import in.koreatech.koin.domain.callvan.model.CallvanNotification;
 import in.koreatech.koin.domain.callvan.model.CallvanPost;
 import in.koreatech.koin.domain.callvan.model.enums.CallvanNotificationType;
@@ -29,12 +31,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CallvanNotificationScheduler {
 
+    private static final String NOTIFICATION_QUEUE_KEY = "callvan:notification:queue";
+
     private final CallvanPostRepository callvanPostRepository;
     private final CallvanNotificationRepository callvanNotificationRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
     private final ZoneId systemZone = ZoneId.of("Asia/Seoul");
-    private static final String NOTIFICATION_QUEUE_KEY = "callvan:notification:queue";
 
     public void scheduleNotification(CallvanPost post) {
         LocalDateTime departureTime = LocalDateTime.of(
@@ -45,8 +49,10 @@ public class CallvanNotificationScheduler {
         LocalDateTime now = LocalDateTime.now();
 
         if (notificationTime.isBefore(now) || notificationTime.isEqual(now)) {
-            log.info("콜벤팟 알림 시간이 이미 지나서 스케줄링하지 않음 - postId: {}, notificationTime: {}",
-                post.getId(), notificationTime
+            log.info(
+                "콜벤팟 알림 시간이 이미 지나서 스케줄링하지 않음 - postId: {}, notificationTime: {}",
+                post.getId(),
+                notificationTime
             );
             return;
         }
@@ -71,9 +77,7 @@ public class CallvanNotificationScheduler {
     public void processScheduledNotifications() {
         long now = ZonedDateTime.now(systemZone).toEpochSecond();
 
-        Set<String> tasks = redisTemplate.opsForZSet()
-            .rangeByScore(NOTIFICATION_QUEUE_KEY, 0, now);
-
+        Set<String> tasks = redisTemplate.opsForZSet().rangeByScore(NOTIFICATION_QUEUE_KEY, 0, now);
         if (tasks == null || tasks.isEmpty()) {
             return;
         }
@@ -82,7 +86,6 @@ public class CallvanNotificationScheduler {
             try {
                 CallvanNotificationTask task = objectMapper.readValue(taskJson, CallvanNotificationTask.class);
                 processNotification(task);
-
                 redisTemplate.opsForZSet().remove(NOTIFICATION_QUEUE_KEY, taskJson);
             } catch (Exception e) {
                 log.info("콜벤팟 알림 작업 처리 실패 : {}", e.getMessage());
@@ -91,9 +94,7 @@ public class CallvanNotificationScheduler {
     }
 
     private void processNotification(CallvanNotificationTask task) {
-        CallvanPost post = callvanPostRepository.findById(task.getPostId())
-            .orElse(null);
-
+        CallvanPost post = callvanPostRepository.findById(task.getPostId()).orElse(null);
         if (post == null || post.getIsDeleted()) {
             return;
         }
@@ -115,12 +116,25 @@ public class CallvanNotificationScheduler {
                 .build())
             .toList();
 
-        callvanNotificationRepository.saveAll(notifications);
+        List<CallvanNotification> savedNotifications = callvanNotificationRepository.saveAllAndFlush(notifications);
+        publishPushNotifications(savedNotifications);
+    }
+
+    private void publishPushNotifications(List<CallvanNotification> notifications) {
+        if (notifications.isEmpty()) {
+            return;
+        }
+
+        List<Integer> notificationIds = notifications.stream()
+            .map(CallvanNotification::getId)
+            .toList();
+        eventPublisher.publishEvent(new CallvanPushNotificationEvent(notificationIds));
     }
 
     @Builder
     @Getter
     private static class CallvanNotificationTask {
+
         private Integer postId;
         private CallvanNotificationType type;
     }

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanNotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanNotificationService.java
@@ -2,10 +2,12 @@ package in.koreatech.koin.domain.callvan.service;
 
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.domain.callvan.dto.CallvanNotificationResponse;
+import in.koreatech.koin.domain.callvan.event.CallvanPushNotificationEvent;
 import in.koreatech.koin.domain.callvan.model.CallvanNotification;
 import in.koreatech.koin.domain.callvan.model.CallvanPost;
 import in.koreatech.koin.domain.callvan.model.enums.CallvanMessageType;
@@ -27,9 +29,11 @@ public class CallvanNotificationService {
     private static final String CALLVAN_WARNING_MESSAGE = "콜벤팟 이용 과정에서 신고가 접수되어 운영 검토 후 주의 안내가 전달되었습니다. 이후 동일한 문제가 반복될 경우 콜벤 기능 이용이 제한될 수 있습니다.";
     private static final String CALLVAN_RESTRICTION_14_DAYS_MESSAGE = "콜벤팟 이용 과정에서 신고가 접수되어 운영 검토 후 14일간 콜벤 기능 이용이 제한되었습니다.";
     private static final String CALLVAN_PERMANENT_RESTRICTION_MESSAGE = "콜벤팟 이용 과정에서 신고가 접수되어 운영 검토 후 콜벤 기능 이용이 영구적으로 제한되었습니다.";
+
     private final CallvanPostRepository callvanPostRepository;
     private final CallvanNotificationRepository callvanNotificationRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public List<CallvanNotificationResponse> getNotifications(Integer userId) {
         return callvanNotificationRepository.findAllByRecipientIdOrderByCreatedAtDesc(userId).stream()
@@ -63,12 +67,19 @@ public class CallvanNotificationService {
 
         List<CallvanNotification> notifications = post.getParticipants().stream()
             .filter(p -> !p.getIsDeleted())
-            .map(p -> buildNotification(p.getMember(), CallvanNotificationType.RECRUITMENT_COMPLETE, post,
-                null, "해당 콜벤팟 인원이 모두 모집되었습니다. 콜벤을 예약하세요", null))
+            .map(p -> buildNotification(
+                p.getMember(),
+                CallvanNotificationType.RECRUITMENT_COMPLETE,
+                post,
+                null,
+                "해당 콜벤팟 인원이 모두 모집되었습니다. 콜벤을 예약하세요",
+                null
+            ))
             .toList();
 
         if (!notifications.isEmpty()) {
-            callvanNotificationRepository.saveAll(notifications);
+            List<CallvanNotification> savedNotifications = callvanNotificationRepository.saveAllAndFlush(notifications);
+            publishPushNotifications(savedNotifications);
         }
     }
 
@@ -79,17 +90,28 @@ public class CallvanNotificationService {
         List<CallvanNotification> notifications = post.getParticipants().stream()
             .filter(p -> !p.getIsDeleted())
             .filter(p -> !p.getMember().getId().equals(joinUserId))
-            .map(p -> buildNotification(p.getMember(), CallvanNotificationType.PARTICIPANT_JOINED, post,
-                null, null, joinUserNickname))
+            .map(p -> buildNotification(
+                p.getMember(),
+                CallvanNotificationType.PARTICIPANT_JOINED,
+                post,
+                null,
+                null,
+                joinUserNickname
+            ))
             .toList();
 
         if (!notifications.isEmpty()) {
-            callvanNotificationRepository.saveAll(notifications);
+            List<CallvanNotification> savedNotifications = callvanNotificationRepository.saveAllAndFlush(notifications);
+            publishPushNotifications(savedNotifications);
         }
     }
 
     @Transactional
-    public void notifyNewMessageReceived(Integer postId, Integer senderId, String senderNickname, String messageContent,
+    public void notifyNewMessageReceived(
+        Integer postId,
+        Integer senderId,
+        String senderNickname,
+        String messageContent,
         CallvanMessageType messageType
     ) {
         CallvanPost post = callvanPostRepository.getById(postId);
@@ -98,12 +120,19 @@ public class CallvanNotificationService {
         List<CallvanNotification> notifications = post.getParticipants().stream()
             .filter(p -> !p.getIsDeleted())
             .filter(p -> !p.getMember().getId().equals(senderId))
-            .map(p -> buildNotification(p.getMember(), CallvanNotificationType.NEW_MESSAGE, post,
-                senderNickname, notificationContent, null))
+            .map(p -> buildNotification(
+                p.getMember(),
+                CallvanNotificationType.NEW_MESSAGE,
+                post,
+                senderNickname,
+                notificationContent,
+                null
+            ))
             .toList();
 
         if (!notifications.isEmpty()) {
-            callvanNotificationRepository.saveAll(notifications);
+            List<CallvanNotification> savedNotifications = callvanNotificationRepository.saveAllAndFlush(notifications);
+            publishPushNotifications(savedNotifications);
         }
     }
 
@@ -126,14 +155,20 @@ public class CallvanNotificationService {
             default -> throw CustomException.of(ApiResponseCode.ILLEGAL_ARGUMENT);
         };
 
-        CallvanNotification callvanNotification = buildNotification(
-            recipient, notificationType, post, null, message, null);
-
-        callvanNotificationRepository.save(callvanNotification);
+        CallvanNotification callvanNotification = buildNotification(recipient, notificationType, post, null, message,
+            null);
+        CallvanNotification savedNotification = callvanNotificationRepository.saveAndFlush(callvanNotification);
+        publishPushNotifications(List.of(savedNotification));
     }
 
-    private CallvanNotification buildNotification(User recipient, CallvanNotificationType type, CallvanPost post,
-        String senderNickname, String messagePreview, String joinedMemberNickname) {
+    private CallvanNotification buildNotification(
+        User recipient,
+        CallvanNotificationType type,
+        CallvanPost post,
+        String senderNickname,
+        String messagePreview,
+        String joinedMemberNickname
+    ) {
         return CallvanNotification.builder()
             .recipient(recipient)
             .notificationType(type)
@@ -151,5 +186,16 @@ public class CallvanNotificationService {
             .chatRoom(post.getChatRoom())
             .joinedMemberNickname(joinedMemberNickname)
             .build();
+    }
+
+    private void publishPushNotifications(List<CallvanNotification> notifications) {
+        if (notifications.isEmpty()) {
+            return;
+        }
+
+        List<Integer> notificationIds = notifications.stream()
+            .map(CallvanNotification::getId)
+            .toList();
+        eventPublisher.publishEvent(new CallvanPushNotificationEvent(notificationIds));
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPushNotificationEventListener.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPushNotificationEventListener.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.callvan.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import in.koreatech.koin.domain.callvan.event.CallvanPushNotificationEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CallvanPushNotificationEventListener {
+
+    private final CallvanPushNotificationService callvanPushNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCallvanPushRequested(CallvanPushNotificationEvent event) {
+        callvanPushNotificationService.pushNotifications(event.notificationIds());
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPushNotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanPushNotificationService.java
@@ -1,0 +1,57 @@
+package in.koreatech.koin.domain.callvan.service;
+
+import static in.koreatech.koin.domain.notification.model.NotificationSubscribeType.CALLVAN;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import in.koreatech.koin.domain.callvan.model.CallvanNotification;
+import in.koreatech.koin.domain.callvan.model.CallvanPushNotification;
+import in.koreatech.koin.domain.callvan.model.CallvanPushNotificationFactory;
+import in.koreatech.koin.domain.callvan.repository.CallvanNotificationRepository;
+import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
+import in.koreatech.koin.infrastructure.fcm.FcmClient;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CallvanPushNotificationService {
+
+    private final CallvanNotificationRepository callvanNotificationRepository;
+    private final NotificationSubscribeRepository notificationSubscribeRepository;
+    private final CallvanPushNotificationFactory callvanPushNotificationFactory;
+    private final FcmClient fcmClient;
+
+    public void pushNotifications(List<Integer> notificationIds) {
+        if (notificationIds.isEmpty()) {
+            return;
+        }
+
+        List<CallvanNotification> notifications = callvanNotificationRepository.findAllByIdInWithRelations(notificationIds);
+        notifications.forEach(this::pushNotificationIfEligible);
+    }
+
+    private void pushNotificationIfEligible(CallvanNotification notification) {
+        String deviceToken = notification.getRecipient().getDeviceToken();
+        Integer recipientId = notification.getRecipient().getId();
+        if (!StringUtils.hasText(deviceToken)
+            || !notificationSubscribeRepository.existsByUserIdAndSubscribeTypeAndDetailTypeIsNull(recipientId, CALLVAN)) {
+            return;
+        }
+
+        CallvanPushNotification pushNotification = callvanPushNotificationFactory.from(notification);
+        fcmClient.sendMessage(
+            deviceToken,
+            pushNotification.title(),
+            pushNotification.message(),
+            pushNotification.imageUrl(),
+            pushNotification.mobileAppPath(),
+            pushNotification.schemeUri(),
+            pushNotification.type()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanRestrictionQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/callvan/service/CallvanRestrictionQueryService.java
@@ -6,27 +6,23 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import in.koreatech.koin.domain.callvan.dto.CallvanRestrictionResponse;
 import in.koreatech.koin.domain.callvan.repository.CallvanReportProcessRepository;
-import in.koreatech.koin.global.code.ApiResponseCode;
-import in.koreatech.koin.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CallvanRestrictionService {
+public class CallvanRestrictionQueryService {
 
     private final CallvanReportProcessRepository callvanReportProcessRepository;
     private final Clock clock;
 
-    public void validateNotRestricted(Integer userId) {
-        boolean isRestricted = callvanReportProcessRepository.existsActiveRestrictionByReportedUserId(
-            userId,
-            LocalDateTime.now(clock)
-        );
+    public CallvanRestrictionResponse getRestriction(Integer userId) {
+        LocalDateTime now = LocalDateTime.now(clock);
 
-        if (isRestricted) {
-            throw CustomException.of(ApiResponseCode.FORBIDDEN_CALLVAN_RESTRICTED_USER);
-        }
+        return callvanReportProcessRepository.findActiveRestrictionByReportedUserId(userId, now)
+            .map(CallvanRestrictionResponse::from)
+            .orElseGet(CallvanRestrictionResponse::unrestricted);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopResponse.java
@@ -36,6 +36,9 @@ public record CoopShopResponse(
     @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
     String remarks,
 
+    @Schema(example = "https://kap-test.s3.ap-northeast-2.amazonaws.com/assets/img/coopshop/bookstore.svg", description = "아이콘 url")
+    String iconUrl,
+
     @JsonFormat(pattern = "yyyy-MM-dd")
     @Schema(example = "2024-06-26", description = "학식 운영시간 업데이트 날짜", requiredMode = REQUIRED)
     LocalDateTime updatedAt
@@ -52,6 +55,7 @@ public record CoopShopResponse(
             coopShop.getPhone(),
             coopShop.getLocation(),
             coopShop.getRemarks(),
+            coopShop.getCoopName().getIconUrl(),
             coopShop.getUpdatedAt()
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/dto/CoopShopsResponse.java
@@ -66,7 +66,10 @@ public record CoopShopsResponse(
         String location,
 
         @Schema(example = "공휴일 휴무", description = "생협 매장 특이사항")
-        String remarks
+        String remarks,
+
+        @Schema(example = "https://kap-test.s3.ap-northeast-2.amazonaws.com/assets/img/coopshop/bookstore.svg", description = "아이콘 url")
+        String iconUrl
     ) {
 
         public static InnerCoopShop from(CoopShop coopShop) {
@@ -78,7 +81,8 @@ public record CoopShopsResponse(
                     .toList(),
                 coopShop.getPhone(),
                 coopShop.getLocation(),
-                coopShop.getRemarks()
+                coopShop.getRemarks(),
+                coopShop.getCoopName().getIconUrl()
             );
         }
 

--- a/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopName.java
+++ b/src/main/java/in/koreatech/koin/domain/coopshop/model/CoopName.java
@@ -27,6 +27,9 @@ public class CoopName {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "icon_url")
+    private String iconUrl;
+
     @Builder
     private CoopName(
         String name

--- a/src/main/java/in/koreatech/koin/domain/notification/model/NotificationSubscribeType.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/NotificationSubscribeType.java
@@ -18,6 +18,7 @@ public enum NotificationSubscribeType {
     DINING_IMAGE_UPLOAD(List.of()),
     ARTICLE_KEYWORD(List.of()),
     LOST_ITEM_CHAT(List.of()),
+    CALLVAN(List.of()),
     MARKETING(List.of()),
     ;
 

--- a/src/main/resources/db/migration/V234__add_coopshop_icon.sql
+++ b/src/main/resources/db/migration/V234__add_coopshop_icon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `coop_names` ADD `icon_url` VARCHAR(500) NULL AFTER `name`;

--- a/src/test/java/in/koreatech/koin/acceptance/admin/AdminShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/admin/AdminShopApiTest.java
@@ -17,6 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.BenefitCategoryAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.BenefitCategoryMapAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.MenuAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.MenuCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopAcceptanceFixture;
@@ -24,12 +26,14 @@ import in.koreatech.koin.acceptance.fixture.ShopCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopNotificationMessageAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.ShopParentCategoryAcceptanceFixture;
 import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.admin.benefit.repository.AdminBenefitCategoryMapRepository;
+import in.koreatech.koin.admin.manager.model.Admin;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.menu.AdminMenuRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopParentCategoryRepository;
 import in.koreatech.koin.admin.shop.repository.shop.AdminShopRepository;
-import in.koreatech.koin.admin.manager.model.Admin;
+import in.koreatech.koin.domain.benefit.model.BenefitCategory;
 import in.koreatech.koin.domain.owner.model.Owner;
 import in.koreatech.koin.domain.shop.model.menu.Menu;
 import in.koreatech.koin.domain.shop.model.menu.MenuCategory;
@@ -63,6 +67,9 @@ class AdminShopApiTest extends AcceptanceTest {
     private AdminShopRepository adminShopRepository;
 
     @Autowired
+    private AdminBenefitCategoryMapRepository adminBenefitCategoryMapRepository;
+
+    @Autowired
     private AdminMenuRepository adminMenuRepository;
 
     @Autowired
@@ -88,6 +95,12 @@ class AdminShopApiTest extends AcceptanceTest {
 
     @Autowired
     private MenuCategoryAcceptanceFixture menuCategoryFixture;
+
+    @Autowired
+    private BenefitCategoryAcceptanceFixture benefitCategoryFixture;
+
+    @Autowired
+    private BenefitCategoryMapAcceptanceFixture benefitCategoryMapFixture;
 
     private Owner owner_현수;
     private Owner owner_준영;
@@ -935,6 +948,8 @@ class AdminShopApiTest extends AcceptanceTest {
     @Test
     void 어드민이_상점을_삭제한다() throws Exception {
         Shop shop = shopFixture.영업중이_아닌_신전_떡볶이(owner_현수);
+        BenefitCategory benefitCategory = benefitCategoryFixture.배달비_무료();
+        benefitCategoryMapFixture.혜택_추가(shop, benefitCategory);
 
         mockMvc.perform(
                 delete("/admin/shops/{id}", shop.getId())
@@ -943,7 +958,13 @@ class AdminShopApiTest extends AcceptanceTest {
             .andExpect(status().isOk());
 
         Shop deletedShop = adminShopRepository.getById(shop.getId());
-        assertSoftly(softly -> softly.assertThat(deletedShop.isDeleted()).isTrue());
+        assertSoftly(softly -> {
+            softly.assertThat(deletedShop.isDeleted()).isTrue();
+            softly.assertThat(adminBenefitCategoryMapRepository.findAllByBenefitCategoryIdAndShopIds(
+                benefitCategory.getId(),
+                List.of(shop.getId())
+            )).isEmpty();
+        });
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/NotificationApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/NotificationApiTest.java
@@ -127,6 +127,13 @@ class NotificationApiTest extends AcceptanceTest {
                                  ]
                              },
                              {
+                                 "type": "CALLVAN",
+                                 "is_permit": false,
+                                 "detail_subscribes": [
+                                    \s
+                                 ]
+                             },
+                             {
                                  "type": "MARKETING",
                                  "is_permit": false,
                                  "detail_subscribes": [
@@ -252,6 +259,13 @@ class NotificationApiTest extends AcceptanceTest {
                              ]
                          },
                          {
+                             "type": "CALLVAN",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
                              "type": "MARKETING",
                              "is_permit": false,
                              "detail_subscribes": [
@@ -371,6 +385,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "LOST_ITEM_CHAT",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "CALLVAN",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s
@@ -510,6 +531,13 @@ class NotificationApiTest extends AcceptanceTest {
                              ]
                          },
                          {
+                             "type": "CALLVAN",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
                              "type": "MARKETING",
                              "is_permit": false,
                              "detail_subscribes": [
@@ -634,6 +662,13 @@ class NotificationApiTest extends AcceptanceTest {
                          },
                          {
                              "type": "LOST_ITEM_CHAT",
+                             "is_permit": false,
+                             "detail_subscribes": [
+                                \s
+                             ]
+                         },
+                         {
+                             "type": "CALLVAN",
                              "is_permit": false,
                              "detail_subscribes": [
                                 \s


### PR DESCRIPTION
### 🔍 개요

* 상점을 soft delete할 때 남아 있던 혜택 매핑도 함께 정리하도록 수정했습니다.
* 삭제된 상점이 `shop_benefit_category_map`에 남아 혜택 상점 조회에서 오류를 유발하는 상태를 방지합니다.

---

### 🚀 주요 변경 내용

* 상점 삭제 흐름에서 해당 상점의 혜택 매핑을 삭제합니다.
* 상점 삭제 API 테스트에 혜택 매핑 삭제 검증을 추가했습니다.

---

### 💬 참고 사항

* main 대상 PR과 같은 브랜치입니다.
* 검증: `./gradlew test --tests 'in.koreatech.koin.acceptance.admin.AdminShopApiTest.어드민이_상점을_삭제한다' --rerun-tasks`
* 결과: `AdminShopApiTest.어드민이_상점을_삭제한다` 통과, failures 0, errors 0

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
