### PR TITLE
feat: FCM 병렬 동기 전송 메소드 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -75,34 +75,32 @@ public class FcmClient {
 
     public void sendMessages(List<FcmSendRequest> requests) {
         try {
-            if (requests.size() > FCM_MESSAGE_BATCH_SIZE) {
-                log.warn("FCM 전송 최대 개수를 초과했습니다.");
-                return ;
+            for (int start = 0; start < requests.size(); start += FCM_MESSAGE_BATCH_SIZE) {
+                int end = Math.min(start + FCM_MESSAGE_BATCH_SIZE, requests.size());
+                List<Message> messages = requests.subList(start, end).stream()
+                    .map(request -> Message.builder()
+                        .setToken(request.targetDeviceToken())
+                        .setApnsConfig(generateAppleConfig(
+                            request.title(),
+                            request.content(),
+                            request.imageUrl(),
+                            request.path(),
+                            request.type(),
+                            request.schemeUri()
+                        ))
+                        .setAndroidConfig(generateAndroidConfig(
+                            request.title(),
+                            request.content(),
+                            request.imageUrl(),
+                            request.schemeUri(),
+                            request.type()
+                        ))
+                        .build()
+                    )
+                    .toList();
+
+                FirebaseMessaging.getInstance().sendEach(messages);
             }
-
-            List<Message> messages = requests.stream()
-                .map(request -> Message.builder()
-                    .setToken(request.targetDeviceToken())
-                    .setApnsConfig(generateAppleConfig(
-                        request.title(),
-                        request.content(),
-                        request.imageUrl(),
-                        request.path(),
-                        request.type(),
-                        request.schemeUri()
-                    ))
-                    .setAndroidConfig(generateAndroidConfig(
-                        request.title(),
-                        request.content(),
-                        request.imageUrl(),
-                        request.schemeUri(),
-                        request.type()
-                    ))
-                    .build()
-                )
-                .toList();
-
-            FirebaseMessaging.getInstance().sendEach(messages);
         } catch (Exception e) {
             log.warn("FCM 알림 전송 실패", e);
         }

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class FcmClient {
 
+    private static final int FCM_MESSAGE_BATCH_SIZE = 500;
+
     @Async
     public void sendMessage(
         String targetDeviceToken,
@@ -73,6 +75,11 @@ public class FcmClient {
 
     public void sendMessages(List<FcmSendRequest> requests) {
         try {
+            if (requests.size() > FCM_MESSAGE_BATCH_SIZE) {
+                log.warn("FCM 전송 최대 개수를 초과했습니다.");
+                return ;
+            }
+
             List<Message> messages = requests.stream()
                 .map(request -> Message.builder()
                     .setToken(request.targetDeviceToken())

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -71,25 +71,25 @@ public class FcmClient {
         }
     }
 
-    public void sendMessages(List<FcmSendCommand> commands) {
+    public void sendMessages(List<FcmSendRequest> requests) {
         try {
-            List<Message> messages = commands.stream()
-                .map(command -> Message.builder()
-                    .setToken(command.targetDeviceToken())
+            List<Message> messages = requests.stream()
+                .map(request -> Message.builder()
+                    .setToken(request.targetDeviceToken())
                     .setApnsConfig(generateAppleConfig(
-                        command.title(),
-                        command.content(),
-                        command.imageUrl(),
-                        command.path(),
-                        command.type(),
-                        command.schemeUri()
+                        request.title(),
+                        request.content(),
+                        request.imageUrl(),
+                        request.path(),
+                        request.type(),
+                        request.schemeUri()
                     ))
                     .setAndroidConfig(generateAndroidConfig(
-                        command.title(),
-                        command.content(),
-                        command.imageUrl(),
-                        command.schemeUri(),
-                        command.type()
+                        request.title(),
+                        request.content(),
+                        request.imageUrl(),
+                        request.schemeUri(),
+                        request.type()
                     ))
                     .build()
                 )

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.infrastructure.fcm;
 import static com.google.firebase.messaging.AndroidConfig.Priority.HIGH;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.scheduling.annotation.Async;
@@ -67,6 +68,36 @@ public class FcmClient {
         } catch (Exception e) {
             log.warn("FCM 알림 전송 실패", e);
             return false;
+        }
+    }
+
+    public void sendMessages(List<FcmSendCommand> commands) {
+        try {
+            List<Message> messages = commands.stream()
+                .map(command -> Message.builder()
+                    .setToken(command.targetDeviceToken())
+                    .setApnsConfig(generateAppleConfig(
+                        command.title(),
+                        command.content(),
+                        command.imageUrl(),
+                        command.path(),
+                        command.type(),
+                        command.schemeUri()
+                    ))
+                    .setAndroidConfig(generateAndroidConfig(
+                        command.title(),
+                        command.content(),
+                        command.imageUrl(),
+                        command.schemeUri(),
+                        command.type()
+                    ))
+                    .build()
+                )
+                .toList();
+
+            FirebaseMessaging.getInstance().sendEach(messages);
+        } catch (Exception e) {
+            log.warn("FCM 알림 전송 실패", e);
         }
     }
 

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendCommand.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendCommand.java
@@ -2,7 +2,7 @@ package in.koreatech.koin.infrastructure.fcm;
 
 import in.koreatech.koin.common.model.MobileAppPath;
 
-public record FcmSendRequest(
+public record FcmSendCommand(
     String targetDeviceToken,
     String title,
     String content,
@@ -11,7 +11,7 @@ public record FcmSendRequest(
     String schemeUri,
     String type
 ) {
-    public static FcmSendRequest of(
+    public static FcmSendCommand of(
         String targetDeviceToken,
         String title,
         String content,
@@ -20,7 +20,7 @@ public record FcmSendRequest(
         String schemeUri,
         String type
     ) {
-        return new FcmSendRequest(
+        return new FcmSendCommand(
             targetDeviceToken,
             title,
             content,

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.infrastructure.fcm;
+
+import in.koreatech.koin.common.model.MobileAppPath;
+
+public record FcmSendRequest(
+    String targetDeviceToken,
+    String title,
+    String content,
+    String imageUrl,
+    MobileAppPath path,
+    String schemeUri,
+    String type
+) {
+    public static FcmSendRequest of(
+        String targetDeviceToken,
+        String title,
+        String content,
+        String imageUrl,
+        MobileAppPath path,
+        String schemeUri,
+        String type
+    ) {
+        return new FcmSendRequest(
+            targetDeviceToken,
+            title,
+            content,
+            imageUrl,
+            path,
+            schemeUri,
+            type
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
@@ -2,7 +2,7 @@ package in.koreatech.koin.infrastructure.fcm;
 
 import in.koreatech.koin.common.model.MobileAppPath;
 
-public record FcmSendCommand(
+public record FcmSendRequest(
     String targetDeviceToken,
     String title,
     String content,
@@ -11,7 +11,7 @@ public record FcmSendCommand(
     String schemeUri,
     String type
 ) {
-    public static FcmSendCommand of(
+    public static FcmSendRequest of(
         String targetDeviceToken,
         String title,
         String content,
@@ -20,7 +20,7 @@ public record FcmSendCommand(
         String schemeUri,
         String type
     ) {
-        return new FcmSendCommand(
+        return new FcmSendRequest(
             targetDeviceToken,
             title,
             content,


### PR DESCRIPTION
### 🔍 개요

<img width="982" height="430" alt="image" src="https://github.com/user-attachments/assets/418aee2d-6146-4d57-b4a3-7734d5a6b0dd" />

- 키워드 알림 이벤트 처리는 `@Async`를 통해 별도 스레드에서 병렬로 동작하고 있으나, APM 확인 결과 각 이벤트 처리에 수 초가 소요되는 문제가 있었습니다.
- 두 작업이 순차 및 동기적으로 진행되어 병목이 발생함을 확인했습니다.
  - FCM 알림을 순차적으로 전송
  - 각 전송이 끝날 때마다 알림 이력을 DB에 저장
- 게시물 키워드 알림 기능의 경우 속도가 핵심인 기능이라고 생각했습니다.
  - 선착순 마감과 같은 게시글이 올라올 경우, 알림이 몇 초만 늦어도 사용자가 참여 기회를 놓칠 수 있는 상황이 발생할 수 있다고 생각했습니다. 
- 해당 상황을 예방하고자, FCM 전송 로직을 개선하는 작업을 진행합니다.

- close #2262 

---

### 🚀 주요 변경 내용

#### FCM 병렬 동기 전송 메소드 추가
- FCM 라이브러리에서 제공하는 `sendEach` 메소드를 활용하는 메소드를 추가했습니다. 
- 해당 메소드는 FCM 서버에서 메시지를 최대 500개를 병렬로 전송하도록 요청하는 메소드입니다.
- 키워드 알림 메시지를 병렬 및 동기적으로 전송하고자 해당 메소드를 추가했습니다.
- 토픽 기능 마이그레이션을 생각했지만 다음과 같은 이유로 적용하지 않았습니다.
  - 게시물 키워드 알림은 한 번 알림을 보낸 게시글에 대해서 중복해서 보내지 않는 비즈니스 로직이 존재합니다.
  - 토픽을 활용할 경우 개개인의 알림 전송 성공 여부를 확인할 수 없기 때문에, 중복 방지 로직에서 문제가 발생합니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)