### PR TITLE
feat: Notification 배치 저장 로직 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationJdbcRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationJdbcRepository.java
@@ -1,0 +1,60 @@
+package in.koreatech.koin.domain.notification.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import in.koreatech.koin.domain.notification.model.Notification;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationJdbcRepository {
+
+    private static final int BATCH_SIZE = 1_000;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void batchInsert(List<Notification> notifications) {
+        if (notifications.isEmpty()) {
+            return;
+        }
+
+        String sql = """
+            INSERT INTO notification (
+                app_path,
+                scheme_uri,
+                title,
+                message,
+                image_url,
+                type,
+                users_id,
+                is_read,
+                created_at,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            notifications,
+            BATCH_SIZE,
+            (preparedStatement, notification) -> {
+                preparedStatement.setString(1, notification.getMobileAppPath().name());
+                preparedStatement.setString(2, notification.getSchemeUri());
+                preparedStatement.setString(3, notification.getTitle());
+                preparedStatement.setString(4, notification.getMessage());
+                preparedStatement.setString(5, notification.getImageUrl());
+                preparedStatement.setString(6, notification.getType().toUpperCase());
+                preparedStatement.setInt(7, notification.getUser().getId());
+                preparedStatement.setBoolean(8, notification.isRead());
+                preparedStatement.setObject(9, now);
+                preparedStatement.setObject(10, now);
+            }
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
@@ -20,7 +20,7 @@ import in.koreatech.koin.domain.notification.model.NotificationDetailSubscribeTy
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribeType;
-import in.koreatech.koin.domain.notification.repository.NotificationRepository;
+import in.koreatech.koin.domain.notification.repository.NotificationJdbcRepository;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
@@ -38,19 +38,27 @@ public class NotificationService {
     public record NotificationDeliveryResult(Notification notification, boolean delivered) {}
 
     private final UserRepository userRepository;
-    private final NotificationRepository notificationRepository;
     private final NotificationPersistenceService notificationPersistenceService;
     private final FcmClient fcmClient;
     private final NotificationSubscribeRepository notificationSubscribeRepository;
     private final NotificationFactory notificationFactory;
+    private final NotificationJdbcRepository notificationJdbcRepository;
 
     @Transactional
     public void pushNotifications(List<Notification> notifications) {
         if (notifications.isEmpty()) {
             return;
         }
-        notificationRepository.saveAll(notifications);
-        runAfterCommit(() -> notifications.forEach(this::sendNotificationSafely));
+        notificationJdbcRepository.batchInsert(notifications);
+        notifications.forEach(notification -> fcmClient.sendMessage(
+            notification.getUser().getDeviceToken(),
+            notification.getTitle(),
+            notification.getMessage(),
+            notification.getImageUrl(),
+            notification.getMobileAppPath(),
+            notification.getSchemeUri(),
+            notification.getType().toLowerCase()
+        ));
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/unit/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/notification/service/NotificationServiceTest.java
@@ -3,26 +3,21 @@ package in.koreatech.koin.unit.domain.notification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.InOrder;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import in.koreatech.koin.domain.notification.model.Notification;
 import in.koreatech.koin.domain.notification.model.NotificationFactory;
-import in.koreatech.koin.domain.notification.repository.NotificationRepository;
+import in.koreatech.koin.domain.notification.repository.NotificationJdbcRepository;
 import in.koreatech.koin.domain.notification.repository.NotificationSubscribeRepository;
 import in.koreatech.koin.domain.notification.service.NotificationPersistenceService;
 import in.koreatech.koin.domain.notification.service.NotificationService;
@@ -41,9 +36,6 @@ class NotificationServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private NotificationRepository notificationRepository;
-
-    @Mock
     private NotificationPersistenceService notificationPersistenceService;
 
     @Mock
@@ -54,6 +46,9 @@ class NotificationServiceTest {
 
     @Mock
     private NotificationFactory notificationFactory;
+
+    @Mock
+    private NotificationJdbcRepository notificationJdbcRepository;
 
     @Test
     @DisplayName("알림 전송 결과 조회는 전송 성공 시에만 알림 레코드를 저장한다.")
@@ -137,12 +132,11 @@ class NotificationServiceTest {
 
         notificationService.pushNotification(notification);
 
-        InOrder inOrder = inOrder(notificationRepository, fcmClient);
-        inOrder.verify(notificationRepository).saveAll(List.of(notification));
+        InOrder inOrder = inOrder(notificationJdbcRepository, fcmClient);
+        inOrder.verify(notificationJdbcRepository).batchInsert(List.of(notification));
         inOrder.verify(fcmClient).sendMessage(
             anyString(), anyString(), anyString(), any(), any(), anyString(), anyString()
         );
-        verify(notificationRepository, never()).save(notification);
     }
 
     private Notification createNotification(String deviceToken) {


### PR DESCRIPTION
### 🔍 개요

- close #2264

---

### 🚀 주요 변경 내용

#### NotificationJdbcRepository 클래스 추가
- jpa의 saveAll 메소드의 경우 N개를 저장한다고 가정을 하면 insert 쿼리를 N개를 호출했습니다.
- 키워드 기능에서 평균 50개의 단일 insert 쿼리가 발생하고 있습니다.
- 이를 한 번에 insert 하고자 jdbctemplate를 활용하여 배치처리를 할 수 있도록 클래스를 추가했습니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
