### PR TITLE
fix: Article 1+4N 문제 해결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/model/readmodel/ArticleSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/readmodel/ArticleSummary.java
@@ -1,0 +1,8 @@
+package in.koreatech.koin.domain.community.article.model.readmodel;
+
+public record ArticleSummary(
+    Integer id,
+    String title
+) {
+
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/readmodel/ArticleSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/readmodel/ArticleSummary.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.community.article.model.readmodel;
 
 public record ArticleSummary(
     Integer id,
+    Integer boardId,
     String title
 ) {
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -36,6 +36,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     @Query("""
         SELECT new in.koreatech.koin.domain.community.article.model.readmodel.ArticleSummary(
             a.id,
+            a.board.id,
             a.title
         )
         FROM Article a

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -20,6 +20,7 @@ import in.koreatech.koin.domain.community.article.exception.ArticleNotFoundExcep
 import in.koreatech.koin.domain.community.article.exception.BoardNotFoundException;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.Board;
+import in.koreatech.koin.domain.community.article.model.readmodel.ArticleSummary;
 import jakarta.persistence.EntityNotFoundException;
 
 public interface ArticleRepository extends Repository<Article, Integer> {
@@ -31,6 +32,16 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     Optional<Article> findById(Integer articleId);
 
     List<Article> findAllByIdIn(Collection<Integer> articleIds);
+
+    @Query("""
+        SELECT new in.koreatech.koin.domain.community.article.model.readmodel.ArticleSummary(
+            a.id,
+            a.title
+        )
+        FROM Article a
+        WHERE a.id IN :articleIds
+        """)
+    List<ArticleSummary> findAllSummariesByIdIn(@Param("articleIds") Collection<Integer> articleIds);
 
     Page<Article> findAll(Pageable pageable);
 

--- a/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/service/KeywordService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.common.event.KoreatechArticleKeywordEvent;
 import in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult;
-import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.article.model.readmodel.ArticleSummary;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordCreateRequest;
 import in.koreatech.koin.domain.community.keyword.dto.ArticleKeywordResponse;
@@ -153,10 +153,10 @@ public class KeywordService {
 
     public void sendKeywordNotification(KeywordNotificationRequest request) {
         Set<Integer> updateNotificationIds = request.updateNotification();
-        List<Article> articles = articleRepository.findAllByIdIn(updateNotificationIds);
+        List<ArticleSummary> articleSummaries = articleRepository.findAllSummariesByIdIn(updateNotificationIds);
 
-        for (Article article : articles) {
-            List<String> matchedKeywords = keywordExtractor.matchKeywords(article.getTitle(), KeywordCategory.KOREATECH);
+        for (ArticleSummary articleSummary : articleSummaries) {
+            List<String> matchedKeywords = keywordExtractor.matchKeywords(articleSummary.title(), KeywordCategory.KOREATECH);
             if (matchedKeywords.isEmpty()) {
                 continue;
             }
@@ -170,9 +170,9 @@ public class KeywordService {
             }
 
             eventPublisher.publishEvent(KoreatechArticleKeywordEvent.of(
-                article.getId(),
-                article.getBoard().getId(),
-                article.getTitle(),
+                articleSummary.id(),
+                articleSummary.boardId(),
+                articleSummary.title(),
                 keywordByUserId
             ));
         }


### PR DESCRIPTION
### 🔍 개요


<img width="2132" height="144" alt="Image" src="https://github.com/user-attachments/assets/7f39f3c3-7178-404a-91b7-5480187ff531" />

- 키워드 알림 API 요청값으로 들어온 articleId들을 통해 Article를 조회하는 과정에서 다음과 같이 쿼리 발생
    
    
| # | 쿼리 전문 | 횟수 |
|---|---|---|
| 1 | `select a1_0.id, a1_0.board_id, a1_0.content, a1_0.created_at, a1_0.hit, a1_0.is_deleted, a1_0.is_notice, a1_0.title, a1_0.updated_at from new_articles a1_0 where ( a1_0.is_deleted = ? ) and a1_0.id in ( ? )` | 1 |
| 2 | `select k1_0.id, k1_0.article_id, k1_0.created_at, k1_0.is_deleted, k1_0.updated_at, k1_0.user_id from new_koin_articles k1_0 where k1_0.article_id = ? and ( k1_0.is_deleted = ? )` | 4 |
| 3 | `select k1_0.id, k1_0.article_id, k1_0.author, k1_0.created_at, k1_0.is_deleted, k1_0.portal_hit, k1_0.portal_num, k1_0.registered_at, k1_0.updated_at, k1_0.url from new_koreatech_articles k1_0 where k1_0.article_id = ? and ( k1_0.is_deleted = ? )` | 4 |
| 4 | `select l1_0.id, l1_0.article_id, l1_0.author_id, l1_0.category, l1_0.created_at, l1_0.found_at, l1_0.found_date, l1_0.found_place, l1_0.is_council, l1_0.is_deleted, l1_0.is_found, l1_0.type, l1_0.updated_at from lost_item_articles l1_0 where l1_0.article_id = ?` | 4 |
| 5 | `select k1_0.id, k1_0.admin_id, k1_0.article_id, k1_0.created_at, k1_0.is_deleted, k1_0.updated_at from koin_notice k1_0 where k1_0.article_id = ? and ( k1_0.is_deleted = ? )` | 4 |
| | **합계** | **17** |

- new_articles과 new_koin_articles, new_koreatech_articles, lost_item_articles, koin_notice의 OneToOne 관계로 인해 발생하는 문제이다.
- new_articles은 연관관계의 주인이 아니기 때문에 직접 참조하기 전까지는 연관 객체를 가지고 있는지 확인할 수 없다.
- 그렇기 때문에 Hibernate에서는 new_articles에서 LAZY로 설정했더라도 조회하는 시점에서 연관 객체를 즉시 로딩한다.
- 해당 문제를 개선한다.

- close #2266

---

### 🚀 주요 변경 내용

- Fetch Join
    - 키워드 알림 발송에는 new_articles의 id, board_id, title 필드만 필요하다
    - 4개의 자식 테이블을 모두 join하면 사용하지 않는 데이터까지 가져오게 된다.
    - 또한, OneToOne 4개에 대한 LEFT JOIN은 카테시안 곱과 NULL 컬럼 다수를 유발한다. 리소스 낭비라고 판단
- DTO Projection
    - 필요한 id, board_id, title 만 골라 DTO로 직접 조회한다.
    - Article 엔티티를 로딩하지 않으므로 OneToOne의 즉시 로딩 메커니즘 자체가 트리거되지 않아 N+1을 원천 차단할 수 있다.
    - 또한 네트워크 전송량과 영속성 컨텍스트 부담도 함께 줄어든다.

-> DTO Project으로 Article를 조회하도록 수정

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized article data retrieval to use lightweight summaries instead of loading full article entities, improving system performance for keyword notification operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_API_V2/pull/2268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->