### PR TITLE
feat: 이벤트 진행 상점 수 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventApi.java
@@ -1,8 +1,11 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventCountResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithBannerUrlResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithThumbnailUrlResponse;
+import in.koreatech.koin.global.code.ApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,14 +45,9 @@ public interface ShopEventApi {
     @GetMapping("/shops/events")
     ResponseEntity<ShopEventsWithBannerUrlResponse> getShopAllEvent();
 
-    @ApiResponses(
-        value = {
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
-        }
-    )
+    @ApiResponseCodes({
+        OK
+    })
     @Operation(summary = "이벤트 진행 중인 상점 개수 조회")
     @GetMapping("/shops/events/count")
     ResponseEntity<ShopEventCountResponse> getEventShopCount();

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventApi.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventApi.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import in.koreatech.koin.domain.shop.dto.event.response.ShopEventCountResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithBannerUrlResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithThumbnailUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,4 +41,16 @@ public interface ShopEventApi {
     @Operation(summary = "모든 상점의 모든 이벤트 조회")
     @GetMapping("/shops/events")
     ResponseEntity<ShopEventsWithBannerUrlResponse> getShopAllEvent();
+
+    @ApiResponses(
+        value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true))),
+        }
+    )
+    @Operation(summary = "이벤트 진행 중인 상점 개수 조회")
+    @GetMapping("/shops/events/count")
+    ResponseEntity<ShopEventCountResponse> getEventShopCount();
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventController.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/controller/ShopEventController.java
@@ -1,9 +1,9 @@
 package in.koreatech.koin.domain.shop.controller;
 
+import in.koreatech.koin.domain.shop.dto.event.response.ShopEventCountResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithBannerUrlResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithThumbnailUrlResponse;
 import in.koreatech.koin.domain.shop.service.ShopEventService;
-import in.koreatech.koin.domain.shop.service.ShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +27,12 @@ public class ShopEventController implements ShopEventApi {
     @GetMapping("/shops/events")
     public ResponseEntity<ShopEventsWithBannerUrlResponse> getShopAllEvent() {
         var response = shopEventService.getAllEvents();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/shops/events/count")
+    public ResponseEntity<ShopEventCountResponse> getEventShopCount() {
+        var response = shopEventService.getEventShopCount();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/shop/dto/event/response/ShopEventCountResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/dto/event/response/ShopEventCountResponse.java
@@ -1,0 +1,11 @@
+package in.koreatech.koin.domain.shop.dto.event.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ShopEventCountResponse(
+    @Schema(example = "5", description = "이벤트 진행 중인 상점 개수", requiredMode = REQUIRED)
+    Integer count
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/repository/shop/ShopRepository.java
@@ -47,6 +47,17 @@ public interface ShopRepository extends Repository<Shop, Integer> {
     List<Shop> findAllWithEventArticles();
 
     @Query("""
+        SELECT COUNT(DISTINCT s.id)
+        FROM Shop s
+        JOIN s.eventArticles e
+        WHERE s.isDeleted = false
+        AND e.isDeleted = false
+        AND e.startDate <= :now
+        AND e.endDate >= :now
+    """)
+    Long countShopsWithOngoingEvent(@Param("now") LocalDate now);
+
+    @Query("""
         SELECT new in.koreatech.koin.domain.shop.dto.shop.ShopNotificationQueryResponse(
             s.id,
             s.name,

--- a/src/main/java/in/koreatech/koin/domain/shop/service/ShopEventService.java
+++ b/src/main/java/in/koreatech/koin/domain/shop/service/ShopEventService.java
@@ -1,10 +1,12 @@
 package in.koreatech.koin.domain.shop.service;
 
+import in.koreatech.koin.domain.shop.dto.event.response.ShopEventCountResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithBannerUrlResponse;
 import in.koreatech.koin.domain.shop.dto.event.response.ShopEventsWithThumbnailUrlResponse;
 import in.koreatech.koin.domain.shop.model.shop.Shop;
 import in.koreatech.koin.domain.shop.repository.shop.ShopRepository;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,5 +28,11 @@ public class ShopEventService {
     public ShopEventsWithBannerUrlResponse getAllEvents() {
         List<Shop> shops = shopRepository.findAllWithEventArticles();
         return ShopEventsWithBannerUrlResponse.of(shops, clock);
+    }
+
+    public ShopEventCountResponse getEventShopCount() {
+        LocalDate now = LocalDate.now(clock);
+        Long count = shopRepository.countShopsWithOngoingEvent(now);
+        return new ShopEventCountResponse(Math.toIntExact(count));
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/ShopApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/ShopApiTest.java
@@ -561,6 +561,26 @@ class ShopApiTest extends AcceptanceTest {
     }
 
     @Test
+    void 이벤트_진행중인_상점_개수를_조회한다() throws Exception {
+        Shop 영업중인_티바 = shopFixture.영업중인_티바(owner);
+        Shop 영업중이_아닌_신전떡볶이 = shopFixture.영업중이_아닌_신전_떡볶이(owner);
+        eventArticleFixture.할인_이벤트(마슬랜, LocalDate.now(clock).minusDays(3), LocalDate.now(clock).plusDays(3));
+        eventArticleFixture.참여_이벤트(마슬랜, LocalDate.now(clock).minusDays(3), LocalDate.now(clock).plusDays(3));
+        eventArticleFixture.참여_이벤트(영업중인_티바, LocalDate.now(clock), LocalDate.now(clock).plusDays(10));
+        eventArticleFixture.할인_이벤트(영업중이_아닌_신전떡볶이, LocalDate.now(clock).minusDays(10), LocalDate.now(clock).minusDays(1));
+
+        mockMvc.perform(
+                get("/shops/events/count")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().json("""
+                {
+                    "count": 2
+                }
+                """));
+    }
+
+    @Test
     void 리뷰_평점순으로_정렬하여_모든_상점을_조회한다() throws Exception {
         Shop 영업중인_티바 = shopFixture.영업중인_티바(owner);
         shopReviewFixture.리뷰_4점(익명_학생, 영업중인_티바);


### PR DESCRIPTION
### 🔍 개요

* 주변상점 이벤트 영역에서 현재 진행 중인 이벤트를 가진 상점 수를 조회할 수 있게 했습니다.
* 같은 상점에 진행 중인 이벤트가 여러 개 있어도 상점 기준으로 한 번만 집계합니다.

- close #2272

---

### 🚀 주요 변경 내용

* `GET /shops/events/count` API를 추가했습니다.
* 현재 날짜 기준으로 `startDate <= today <= endDate`인 이벤트만 집계합니다.
* 삭제된 상점과 삭제된 이벤트는 집계에서 제외합니다.
* 이벤트가 여러 개인 상점의 중복 집계를 막기 위해 `COUNT(DISTINCT shop)` 쿼리를 사용했습니다.

---

### 💬 참고 사항

* 검증: `./gradlew test --tests 'in.koreatech.koin.acceptance.domain.ShopApiTest' --rerun-tasks`
* 결과: `BUILD SUCCESSFUL`, `5 actionable tasks: 5 executed`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
