### PR TITLE
fix: 키워드 페이지 네이션 조회 로직 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/keyword/repository/ArticleKeywordRepository.java
@@ -31,7 +31,7 @@ public interface ArticleKeywordRepository extends Repository<ArticleKeyword, Int
 
     Optional<ArticleKeyword> findById(Integer id);
 
-    List<ArticleKeyword> findAllByCategory(KeywordCategory category, Pageable pageable);
+    List<ArticleKeyword> findAllByCategory(KeywordCategory category);
 
     @Query("""
     SELECT new in.koreatech.koin.domain.community.article.dto.ArticleKeywordResult(k.id, k.keyword, COUNT(u))

--- a/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
+++ b/src/main/java/in/koreatech/koin/domain/community/util/KeywordExtractor.java
@@ -3,8 +3,6 @@ package in.koreatech.koin.domain.community.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,27 +16,16 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class KeywordExtractor {
 
-    private static final int KEYWORD_BATCH_SIZE = 100;
-
     private final ArticleKeywordRepository articleKeywordRepository;
 
     public List<String> matchKeywords(String title, KeywordCategory category) {
         List<String> matchedKeywords = new ArrayList<>();
-        int offset = 0;
+        List<ArticleKeyword> keywords = articleKeywordRepository.findAllByCategory(category);
 
-        while (true) {
-            Pageable pageable = PageRequest.of(offset / KEYWORD_BATCH_SIZE, KEYWORD_BATCH_SIZE);
-            List<ArticleKeyword> keywords = articleKeywordRepository.findAllByCategory(category, pageable);
-
-            if (keywords.isEmpty()) {
-                break;
+        for (ArticleKeyword keyword : keywords) {
+            if (title.contains(keyword.getKeyword())) {
+                matchedKeywords.add(keyword.getKeyword());
             }
-            for (ArticleKeyword keyword : keywords) {
-                if (title.contains(keyword.getKeyword())) {
-                    matchedKeywords.add(keyword.getKeyword());
-                }
-            }
-            offset += KEYWORD_BATCH_SIZE;
         }
 
         return matchedKeywords;


### PR DESCRIPTION
### 🔍 개요

<img width="1374" height="144" alt="Image" src="https://github.com/user-attachments/assets/97817f08-45be-4d56-bf1b-bb1b424acf2c" />

- 현재 `ArticleKeyword` 테이블에서 데이터를 100개 단위로 배치 조회하고 있음
- 그러나 데이터 규모가 200개 내외인 현 시점에서는 불필요한 배치 조회로 판단됨
    - 해당 배치 조회 과정에서 총 쿼리 소요 시간은 약 40ms
- 스테이지 환경 테스트 결과, `ArticleKeywordUserMap`이 8,100건을 초과하는 시점부터 처리 시간이 증가함을 확인
- DA에 데이터 증가 추이 예측을 요청한 결과, 8,100건에 도달하는 시점은 **2052년 3월경**으로 전달받음

→ 따라서 현 시점뿐 아니라 향후 수십 년간 페이징 처리는 불필요하다고 판단됨

- close #2270

---

### 🚀 주요 변경 내용

* ArticleKeyword 페이징 처리를 일괄 조회로 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified keyword retrieval mechanism by removing pagination logic from the keyword matching system, streamlining how article keywords are fetched and processed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_API_V2/pull/2275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->