### PR TITLE
feat: FCM 404 에러 핸들링 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/notification/service/AdminNotificationService.java
+++ b/src/main/java/in/koreatech/koin/admin/notification/service/AdminNotificationService.java
@@ -7,44 +7,39 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import in.koreatech.koin.admin.manager.model.Admin;
 import in.koreatech.koin.admin.manager.repository.AdminRepository;
 import in.koreatech.koin.admin.notification.dto.AdminNotificationRequest;
-import in.koreatech.koin.admin.notification.repository.AdminNotificationRepository;
 import in.koreatech.koin.admin.notification.repository.AdminNotificationSubscribeRepository;
 import in.koreatech.koin.domain.notification.model.Notification;
 import in.koreatech.koin.domain.notification.model.NotificationDetailSubscribeType;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribe;
 import in.koreatech.koin.domain.notification.model.NotificationSubscribeType;
+import in.koreatech.koin.domain.notification.service.NotificationService;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.global.exception.CustomException;
-import in.koreatech.koin.infrastructure.fcm.FcmClient;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminNotificationService {
 
     private final AdminNotificationSubscribeRepository adminNotificationSubscribeRepository;
-    private final AdminNotificationRepository adminNotificationRepository;
     private final AdminRepository adminRepository;
-    private final FcmClient fcmClient;
+    private final NotificationService notificationService;
 
     @Transactional
     public void sendNotification(AdminNotificationRequest request, Integer adminId) {
-        Admin admin = adminRepository.getById(adminId);
+        adminRepository.getById(adminId);
         validateDetailTypeMatchesSubscribeType(request.subscribeType(), request.detailSubscribeType());
         List<NotificationSubscribe> notificationSubscribes = getNotificationSubscribes(
             request.subscribeType(), request.detailSubscribeType()
         );
 
-        for (NotificationSubscribe notificationSubscribe : notificationSubscribes) {
-            try {
+        List<Notification> notifications = notificationSubscribes.stream()
+            .map(notificationSubscribe -> {
                 User user = notificationSubscribe.getUser();
-                Notification notification = Notification.of(
+                return Notification.of(
                     request.mobileAppPath(),
                     request.schemaUrl(),
                     request.title(),
@@ -52,20 +47,10 @@ public class AdminNotificationService {
                     request.imageUrl(),
                     user
                 );
-                adminNotificationRepository.save(notification);
-                fcmClient.sendMessage(
-                    user.getDeviceToken(),
-                    notification.getTitle(),
-                    notification.getMessage(),
-                    notification.getImageUrl(),
-                    notification.getMobileAppPath(),
-                    notification.getSchemeUri(),
-                    notification.getType().toLowerCase()
-                );
-            } catch (Exception e) {
-                log.warn("FCM 알림 전송 과정에서 에러 발생", e);
-            }
-        }
+            })
+            .toList();
+
+        notificationService.pushNotifications(notifications);
     }
 
     private void validateDetailTypeMatchesSubscribeType(

--- a/src/main/java/in/koreatech/koin/domain/notification/model/Notification.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/model/Notification.java
@@ -57,6 +57,15 @@ public class Notification extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
+    @Column(name = "is_push_success")
+    private Boolean pushSuccess;
+
+    @Column(name = "fcm_error_code")
+    private String fcmErrorCode;
+
+    @Column(name = "fcm_messaging_error_code")
+    private String fcmMessagingErrorCode;
+
     public Notification(
         MobileAppPath appPath,
         String schemeUri,
@@ -96,6 +105,18 @@ public class Notification extends BaseEntity {
 
     public void read() {
         this.isRead = true;
+    }
+
+    public void markPushSuccess() {
+        this.pushSuccess = true;
+        this.fcmErrorCode = null;
+        this.fcmMessagingErrorCode = null;
+    }
+
+    public void markPushFailure(String fcmErrorCode, String fcmMessagingErrorCode) {
+        this.pushSuccess = false;
+        this.fcmErrorCode = fcmErrorCode;
+        this.fcmMessagingErrorCode = fcmMessagingErrorCode;
     }
 
     public String getType() {

--- a/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationJdbcRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationJdbcRepository.java
@@ -32,9 +32,12 @@ public class NotificationJdbcRepository {
                 type,
                 users_id,
                 is_read,
+                is_push_success,
+                fcm_error_code,
+                fcm_messaging_error_code,
                 created_at,
                 updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
         LocalDateTime now = LocalDateTime.now();
@@ -52,9 +55,13 @@ public class NotificationJdbcRepository {
                 preparedStatement.setString(6, notification.getType().toUpperCase());
                 preparedStatement.setInt(7, notification.getUser().getId());
                 preparedStatement.setBoolean(8, notification.isRead());
-                preparedStatement.setObject(9, now);
-                preparedStatement.setObject(10, now);
+                preparedStatement.setObject(9, notification.getPushSuccess());
+                preparedStatement.setString(10, notification.getFcmErrorCode());
+                preparedStatement.setString(11, notification.getFcmMessagingErrorCode());
+                preparedStatement.setObject(12, now);
+                preparedStatement.setObject(13, now);
             }
         );
     }
+
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.notification.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.Query;
@@ -23,5 +24,20 @@ public interface NotificationRepository extends Repository<Notification, Long> {
     List<Integer> findUserIdsBySchemeUriLikeAndUserIdIn(
         @Param("schemeUriPattern") String schemeUriPattern,
         @Param("userIds") List<Integer> userIds
+    );
+
+    @Query("""
+        SELECT DISTINCT n.user.id
+        FROM Notification n
+        WHERE n.pushSuccess = false
+        AND n.fcmMessagingErrorCode = 'UNREGISTERED'
+        AND n.createdAt >= :start
+        AND n.createdAt < :end
+        AND n.user.deviceToken IS NOT NULL
+        AND n.user.updatedAt <= n.createdAt
+        """)
+    List<Integer> findUnregisteredPushFailureUserIds(
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end
     );
 }

--- a/src/main/java/in/koreatech/koin/domain/notification/scheduler/NotificationDeviceTokenCleanupScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/scheduler/NotificationDeviceTokenCleanupScheduler.java
@@ -1,0 +1,25 @@
+package in.koreatech.koin.domain.notification.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.domain.notification.service.NotificationDeviceTokenCleanupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationDeviceTokenCleanupScheduler {
+
+    private final NotificationDeviceTokenCleanupService notificationDeviceTokenCleanupService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void cleanupUnregisteredDeviceTokens() {
+        try {
+            notificationDeviceTokenCleanupService.cleanupYesterdayUnregisteredDeviceTokens();
+        } catch (Exception e) {
+            log.warn("FCM 무효 토큰 정리 과정에서 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationDeviceTokenCleanupService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationDeviceTokenCleanupService.java
@@ -1,0 +1,44 @@
+package in.koreatech.koin.domain.notification.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.notification.repository.NotificationRepository;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationDeviceTokenCleanupService {
+
+    private final Clock clock;
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void cleanupYesterdayUnregisteredDeviceTokens() {
+        LocalDate today = LocalDate.now(clock);
+        LocalDateTime start = today.minusDays(1).atStartOfDay();
+        LocalDateTime end = today.atStartOfDay();
+
+        List<Integer> userIds = notificationRepository.findUnregisteredPushFailureUserIds(start, end);
+        log.info("전날 UNREGISTERED 실패 알림 기준 deviceToken 삭제 대상 조회. start={}, end={}, count={}",
+            start,
+            end,
+            userIds.size()
+        );
+
+        if (!userIds.isEmpty()) {
+            userRepository.clearDeviceTokensByIdIn(userIds);
+        }
+        log.info("deviceToken 삭제 요청 완료. count={}", userIds.size());
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/notification/service/NotificationService.java
@@ -19,6 +19,7 @@ import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
 import in.koreatech.koin.infrastructure.fcm.FcmClient;
 import in.koreatech.koin.infrastructure.fcm.FcmSendRequest;
+import in.koreatech.koin.infrastructure.fcm.FcmSendResponse;
 import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,12 +57,25 @@ public class NotificationService {
                 notification.getType().toLowerCase()
             ))
             .toList();
-        fcmClient.sendMessages(fcmSendRequests);
+        List<FcmSendResponse> fcmSendResponses = fcmClient.sendMessages(fcmSendRequests);
+        markPushResults(notifications, fcmSendResponses);
 
         try {
             notificationJdbcRepository.batchInsert(notifications);
         } catch (Exception e) {
             log.error("알림 이력 저장 실패. size={}", notifications.size(), e);
+        }
+    }
+
+    private void markPushResults(List<Notification> notifications, List<FcmSendResponse> responses) {
+        for (int index = 0; index < notifications.size(); index++) {
+            Notification notification = notifications.get(index);
+            FcmSendResponse response = responses.get(index);
+            if (response.success()) {
+                notification.markPushSuccess();
+                continue;
+            }
+            notification.markPushFailure(response.errorCode(), response.messagingErrorCode());
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/user/repository/UserRepository.java
@@ -5,7 +5,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import in.koreatech.koin.global.exception.CustomException;
 import in.koreatech.koin.global.code.ApiResponseCode;
@@ -47,6 +50,15 @@ public interface UserRepository extends Repository<User, Integer> {
     boolean existsById(Integer id);
 
     void delete(User user);
+
+    @Modifying
+    @Query("""
+        UPDATE User u
+        SET u.deviceToken = null
+        WHERE u.id IN :userIds
+        AND u.deviceToken IS NOT NULL
+        """)
+    void clearDeviceTokensByIdIn(@Param("userIds") List<Integer> userIds);
 
     default User getById(Integer userId) {
         return findById(userId)

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -2,9 +2,11 @@ package in.koreatech.koin.infrastructure.fcm;
 
 import static com.google.firebase.messaging.AndroidConfig.Priority.HIGH;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -15,8 +17,11 @@ import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.ApnsFcmOptions;
 import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.ApsAlert;
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.SendResponse;
 
 import in.koreatech.koin.common.model.MobileAppPath;
 import lombok.extern.slf4j.Slf4j;
@@ -59,37 +64,55 @@ public class FcmClient {
         }
     }
 
-    public void sendMessages(List<FcmSendRequest> requests) {
-        try {
-            for (int start = 0; start < requests.size(); start += FCM_MESSAGE_BATCH_SIZE) {
-                int end = Math.min(start + FCM_MESSAGE_BATCH_SIZE, requests.size());
-                List<Message> messages = requests.subList(start, end).stream()
-                    .map(request -> Message.builder()
-                        .setToken(request.targetDeviceToken())
-                        .setApnsConfig(generateAppleConfig(
-                            request.title(),
-                            request.content(),
-                            request.imageUrl(),
-                            request.path(),
-                            request.type(),
-                            request.schemeUri()
-                        ))
-                        .setAndroidConfig(generateAndroidConfig(
-                            request.title(),
-                            request.content(),
-                            request.imageUrl(),
-                            request.schemeUri(),
-                            request.type()
-                        ))
-                        .build()
-                    )
-                    .toList();
+    public List<FcmSendResponse> sendMessages(List<FcmSendRequest> requests) {
+        List<FcmSendResponse> responses = new ArrayList<>(requests.size());
+        for (int start = 0; start < requests.size(); start += FCM_MESSAGE_BATCH_SIZE) {
+            int end = Math.min(start + FCM_MESSAGE_BATCH_SIZE, requests.size());
+            List<Message> messages = requests.subList(start, end).stream()
+                .map(request -> Message.builder()
+                    .setToken(request.targetDeviceToken())
+                    .setApnsConfig(generateAppleConfig(
+                        request.title(),
+                        request.content(),
+                        request.imageUrl(),
+                        request.path(),
+                        request.type(),
+                        request.schemeUri()
+                    ))
+                    .setAndroidConfig(generateAndroidConfig(
+                        request.title(),
+                        request.content(),
+                        request.imageUrl(),
+                        request.schemeUri(),
+                        request.type()
+                    ))
+                    .build()
+                )
+                .toList();
 
-                FirebaseMessaging.getInstance().sendEach(messages);
+            try {
+                BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEach(messages);
+                responses.addAll(batchResponse.getResponses().stream()
+                    .map(this::toFcmSendResponse)
+                    .toList());
+            } catch (Exception e) {
+                log.warn("FCM 알림 전송 실패. batchSize={}", messages.size(), e);
+                for (int i = 0; i < messages.size(); i++) {
+                    responses.add(FcmSendResponse.failed(e.getClass().getSimpleName(), null));
+                }
             }
-        } catch (Exception e) {
-            log.warn("FCM 알림 전송 실패", e);
         }
+        return responses;
+    }
+
+    private FcmSendResponse toFcmSendResponse(SendResponse response) {
+        if (response.isSuccessful()) {
+            return FcmSendResponse.succeeded();
+        }
+        FirebaseMessagingException exception = response.getException();
+        String errorCode = exception.getErrorCode().name();
+        String messagingErrorCode = Objects.toString(exception.getMessagingErrorCode(), null);
+        return FcmSendResponse.failed(errorCode, messagingErrorCode);
     }
 
     private ApnsConfig generateAppleConfig(

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendResponse.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendResponse.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.infrastructure.fcm;
+
+public record FcmSendResponse(
+    boolean success,
+    String errorCode,
+    String messagingErrorCode
+) {
+    public static FcmSendResponse succeeded() {
+        return new FcmSendResponse(true, null, null);
+    }
+
+    public static FcmSendResponse failed(String errorCode, String messagingErrorCode) {
+        return new FcmSendResponse(false, errorCode, messagingErrorCode);
+    }
+}

--- a/src/main/resources/db/migration/V236__add_fcm_result_to_notification.sql
+++ b/src/main/resources/db/migration/V236__add_fcm_result_to_notification.sql
@@ -1,0 +1,4 @@
+ALTER TABLE notification
+    ADD COLUMN is_push_success TINYINT(1) NULL COMMENT 'FCM 전송 성공 여부',
+    ADD COLUMN fcm_error_code VARCHAR(100) NULL COMMENT 'FCM 에러 코드',
+    ADD COLUMN fcm_messaging_error_code VARCHAR(100) NULL COMMENT 'FCM 메시징 에러 코드';


### PR DESCRIPTION
### 🔍 개요

- close #2282 

---

### 🚀 주요 변경 내용

* FCM 배치 전송 결과를 `FcmSendResponse`로 반환하도록 변경했습니다.
* 알림 이력에 FCM 전송 성공 여부, FCM 에러 코드, Messaging 에러 코드를 저장하도록 추가했습니다.
* 어드민 알림 발송도 공통 `NotificationService` 경로를 사용하도록 변경해 전송 결과가 저장되도록 했습니다.
* 매일 0시에 전날 `UNREGISTERED` 실패 알림을 기준으로 유저 `device_token`을 정리하는 스케줄러를 추가했습니다.
* `notification` 테이블에 FCM 전송 결과 저장 컬럼을 추가했습니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated daily cleanup of unregistered device tokens from failed push notifications.
  * Push notification system now tracks delivery success status and captures FCM error codes.

* **Improvements**
  * Enhanced notification service with improved error handling and status tracking.
  * Optimized FCM integration for detailed failure diagnostics.

* **Infrastructure**
  * Database schema updated to store push delivery results and error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_API_V2/pull/2283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->