### PR TITLE
hotfix: 영양사 페이지 이미지 다운로드 실패 수정 (main)

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -6,6 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -537,7 +539,12 @@ public class CoopService {
     private String extractS3KeyFrom(String imageUrl) {
         // URL format: https://<bucket-name>/<key(경로+파일명)>
         String cdnPath = s3Client.getDomainUrlPrefix();
-        return imageUrl.substring(imageUrl.indexOf(cdnPath) + cdnPath.length());
+        String encodedKey = imageUrl.substring(imageUrl.indexOf(cdnPath) + cdnPath.length());
+        try {
+            return URLDecoder.decode(encodedKey, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new KoinIllegalStateException("Response to String convert exception: " + e.getMessage());
+        }
     }
 
     private void preprocessPath(File localImageDirectory, File zipFilePath) {

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -543,7 +543,7 @@ public class CoopService {
         try {
             return URLDecoder.decode(encodedKey, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new KoinIllegalStateException("Response to String convert exception: " + e.getMessage());
+            throw new KoinIllegalStateException("Key 디코딩 중 문제가 발생했습니다. " + e.getMessage());
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
+++ b/src/main/java/in/koreatech/koin/domain/coop/service/CoopService.java
@@ -6,8 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -540,11 +540,7 @@ public class CoopService {
         // URL format: https://<bucket-name>/<key(경로+파일명)>
         String cdnPath = s3Client.getDomainUrlPrefix();
         String encodedKey = imageUrl.substring(imageUrl.indexOf(cdnPath) + cdnPath.length());
-        try {
-            return URLDecoder.decode(encodedKey, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new KoinIllegalStateException("Key 디코딩 중 문제가 발생했습니다. " + e.getMessage());
-        }
+        return URLDecoder.decode(encodedKey, StandardCharsets.UTF_8);
     }
 
     private void preprocessPath(File localImageDirectory, File zipFilePath) {


### PR DESCRIPTION
### 🔍 개요

* 영양사 페이지 식단 이미지 다운로드 실패를 수정했습니다.

- close #2286 

---

### 🚀 주요 변경 내용

* ~~영양사 페이지에서 이미지 다운로드 시, `image_url` 에 저장된 이미지 주소 (`https://static.koreatech.in/upload/COOP/연/월/일/이미지_경로.jpg`) 를 가져와 `extractS3KeyFrom()`를 호출해 key 값을 가져오게 됩니다. 이 경우 key 값은 `upload/COOP/연/월/일/이미지_경로.jpg`가 됩니다.~~
* ~~하지만, 천원의 아침 대표 이미지의 경우, `image_url`이 `https://static.koreatech.in/dining/천원의아침.png`기 때문에, `extractS3KeyFrom()`를 호출 할 경우 `dining/천원의아침.png`를 key 값으로 파싱하게 되고, 이는 S3 상에 없는 key이기 때문에 `Error Code: NoSuchKey;`가 발생하게 됩니다.~~
* 한글 인코딩 문제가 더 맞는 것 같습니다. 다른 경로에 업로드 되어 있었네요.
* `https://static.koreatech.in/dining/천원의아침.png`에서 key 추출 후 `dining/천원의아침.png`가 아닌 `dining/%EC%B2%9C%EC%9B%90%EC%9D%98%EC%95%84%EC%B9%A8.png`를 반환하던 것이 문제 같습니다.


---

### 💬 참고 사항

* 로컬 환경 구축 방법을 몰라서 테스트까지는 못했습니다. 나중에 알려주신다면 감사하겠습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dining image handling by refining the validation criteria used to filter image sources, ensuring only properly designated images are processed and downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->