### PR TITLE
fix: 기상청 API 호출 제한에도 날씨 캐시 유지

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/weather/client/WeatherClient.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/client/WeatherClient.java
@@ -4,15 +4,20 @@ import static java.net.URLEncoder.encode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +26,7 @@ import in.koreatech.koin.domain.weather.client.dto.WeatherApiResponse;
 import in.koreatech.koin.domain.weather.client.dto.WeatherApiResponse.WeatherForecastItem;
 import in.koreatech.koin.domain.weather.client.dto.WeatherForecastRequestTime;
 import in.koreatech.koin.domain.weather.exception.WeatherOpenApiException;
+import in.koreatech.koin.domain.weather.exception.WeatherOpenApiRateLimitException;
 import in.koreatech.koin.domain.weather.model.WeatherForecast;
 import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
 
@@ -33,49 +39,75 @@ public class WeatherClient {
     private static final int BYEONGCHEON_NX = 66;
     private static final int BYEONGCHEON_NY = 109;
     private static final int ROW_COUNT = 1000;
+    private static final int FORECAST_RANGE_HOURS = 24;
+    private static final DateTimeFormatter FORECAST_DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final String openApiKey;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
+    private final RetryTemplate retryTemplate;
 
     public WeatherClient(
         @Value("${OPEN_API_KEY_PUBLIC}") String openApiKey,
         RestTemplate restTemplate,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        @Qualifier("weatherRetryTemplate") RetryTemplate retryTemplate
     ) {
         this.openApiKey = openApiKey;
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
+        this.retryTemplate = retryTemplate;
     }
 
-    public WeatherForecast getWeatherForecast(WeatherForecastRequestTime requestTime) {
+    public Map<String, WeatherForecast> getWeatherForecasts(WeatherForecastRequestTime requestTime) {
+        return retryTemplate.execute(context -> getWeatherForecastsWithFallback(requestTime));
+    }
+
+    private Map<String, WeatherForecast> getWeatherForecastsWithFallback(WeatherForecastRequestTime requestTime) {
         try {
-            return getWeatherForecastWithoutFallback(requestTime);
+            return getWeatherForecastsWithoutFallback(requestTime);
         } catch (WeatherOpenApiException e) {
             if (!canRetryWithPreviousBaseTime(e)) {
                 throw e;
             }
-            return getWeatherForecastWithoutFallback(requestTime.previousBaseTime());
+            return getWeatherForecastsWithoutFallback(requestTime.previousBaseTime());
         }
     }
 
-    private WeatherForecast getWeatherForecastWithoutFallback(WeatherForecastRequestTime requestTime) {
+    private Map<String, WeatherForecast> getWeatherForecastsWithoutFallback(WeatherForecastRequestTime requestTime) {
         WeatherApiResponse response = getOpenApiResponse(requestTime);
         List<WeatherForecastItem> items = extractForecastItems(response);
-        Map<String, String> forecasts = items.stream()
-            .filter(item -> requestTime.forecastDate().equals(item.fcstDate()))
-            .filter(item -> requestTime.forecastTime().equals(item.fcstTime()))
-            .collect(Collectors.toMap(
-                WeatherForecastItem::category,
-                WeatherForecastItem::fcstValue,
-                (previous, current) -> current
+        String forecastStartDateTime = forecastDateTime(requestTime);
+        String forecastEndDateTime = LocalDateTime.parse(forecastStartDateTime, FORECAST_DATE_TIME_FORMATTER)
+            .plusHours(FORECAST_RANGE_HOURS)
+            .format(FORECAST_DATE_TIME_FORMATTER);
+        // 한 번의 API 응답에 포함된 예보를 시간대별로 묶어 Redis에서 현재 시각의 예보를 선택할 수 있게 한다.
+        Map<String, Map<String, String>> forecastsByDateTime = items.stream()
+            // 달력 날짜가 아닌 갱신 시각을 기준으로 향후 24시간의 예보만 캐시에 저장한다.
+            .filter(item -> isWithinForecastRange(item, forecastStartDateTime, forecastEndDateTime))
+            .collect(Collectors.groupingBy(
+                item -> item.fcstDate() + item.fcstTime(),
+                Collectors.toMap(
+                    WeatherForecastItem::category,
+                    WeatherForecastItem::fcstValue,
+                    (previous, current) -> current
+                )
             ));
 
-        if (forecasts.isEmpty()) {
+        if (!forecastsByDateTime.containsKey(forecastDateTime(requestTime))) {
             throw WeatherOpenApiException.withDetail("forecastDateTime: "
                 + requestTime.forecastDate() + requestTime.forecastTime());
         }
 
+        return forecastsByDateTime.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> toWeatherForecast(entry.getValue())
+            ));
+    }
+
+    private WeatherForecast toWeatherForecast(Map<String, String> forecasts) {
         String temperature = requireForecastValue(forecasts, "TMP");
         String sky = requireForecastValue(forecasts, "SKY");
         String precipitationType = requireForecastValue(forecasts, "PTY");
@@ -91,6 +123,20 @@ public class WeatherClient {
                 "invalid category: TMP, value: " + temperature
             );
         }
+    }
+
+    private String forecastDateTime(WeatherForecastRequestTime requestTime) {
+        return requestTime.forecastDate() + requestTime.forecastTime();
+    }
+
+    private boolean isWithinForecastRange(
+        WeatherForecastItem item,
+        String forecastStartDateTime,
+        String forecastEndDateTime
+    ) {
+        String itemForecastDateTime = item.fcstDate() + item.fcstTime();
+        return itemForecastDateTime.compareTo(forecastStartDateTime) >= 0
+            && itemForecastDateTime.compareTo(forecastEndDateTime) < 0;
     }
 
     private String requireForecastValue(Map<String, String> forecasts, String category) {
@@ -127,6 +173,9 @@ public class WeatherClient {
         } catch (WeatherOpenApiException e) {
             throw e;
         } catch (HttpStatusCodeException e) {
+            if (e.getStatusCode().value() == 429) {
+                throw rateLimitException(requestTime, "httpStatus: " + e.getStatusCode());
+            }
             String responseBody = e.getResponseBodyAsString();
             if (responseBody != null && !responseBody.isBlank()) {
                 return parseResponse(responseBody, requestTime);
@@ -145,6 +194,10 @@ public class WeatherClient {
                 + requestTime.baseDate() + requestTime.baseTime() + ", response body is empty");
         }
 
+        if (isRateLimitResponse(responseBody)) {
+            throw rateLimitException(requestTime, responseBody.trim());
+        }
+
         if (!responseBody.trim().startsWith("{")) {
             throw WeatherOpenApiException.withDetail("baseDateTime: "
                 + requestTime.baseDate() + requestTime.baseTime() + ", " + extractXmlErrorMessage(responseBody));
@@ -156,6 +209,20 @@ public class WeatherClient {
             throw WeatherOpenApiException.withDetail("baseDateTime: "
                 + requestTime.baseDate() + requestTime.baseTime() + ", invalid JSON response");
         }
+    }
+
+    private boolean isRateLimitResponse(String responseBody) {
+        String normalizedResponse = responseBody.toUpperCase(Locale.ROOT);
+        return normalizedResponse.contains("API RATE LIMIT EXCEEDED")
+            || normalizedResponse.contains("LIMITED_NUMBER_OF_SERVICE_REQUESTS_PER_SECOND_EXCEEDS_ERROR");
+    }
+
+    private WeatherOpenApiRateLimitException rateLimitException(
+        WeatherForecastRequestTime requestTime,
+        String cause
+    ) {
+        return WeatherOpenApiRateLimitException.withDetail("baseDateTime: "
+            + requestTime.baseDate() + requestTime.baseTime() + ", cause: " + cause);
     }
 
     private String getRequestURL(WeatherForecastRequestTime requestTime) {

--- a/src/main/java/in/koreatech/koin/domain/weather/config/WeatherRetryConfig.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/config/WeatherRetryConfig.java
@@ -1,0 +1,24 @@
+package in.koreatech.koin.domain.weather.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
+
+import in.koreatech.koin.domain.weather.exception.WeatherOpenApiRateLimitException;
+
+@Configuration
+public class WeatherRetryConfig {
+
+    private static final int MAX_ATTEMPTS = 6;
+    private static final long RETRY_INTERVAL_MILLIS = 5_000L;
+
+    @Bean
+    public RetryTemplate weatherRetryTemplate() {
+        // 최초 호출 이후 5회 재시도해 기상청 제공 서버의 순간적인 동시 호출 제한을 흡수한다.
+        return RetryTemplate.builder()
+            .maxAttempts(MAX_ATTEMPTS)
+            .fixedBackoff(RETRY_INTERVAL_MILLIS)
+            .retryOn(WeatherOpenApiRateLimitException.class)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/weather/exception/WeatherOpenApiException.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/exception/WeatherOpenApiException.java
@@ -4,7 +4,7 @@ import in.koreatech.koin.global.exception.custom.ExternalServiceException;
 
 public class WeatherOpenApiException extends ExternalServiceException {
 
-    private static final String DEFAULT_MESSAGE = "기상청 단기예보 API 응답이 정상적이지 않습니다.";
+    protected static final String DEFAULT_MESSAGE = "기상청 단기예보 API 응답이 정상적이지 않습니다.";
 
     public WeatherOpenApiException(String message) {
         super(message);

--- a/src/main/java/in/koreatech/koin/domain/weather/exception/WeatherOpenApiRateLimitException.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/exception/WeatherOpenApiRateLimitException.java
@@ -1,0 +1,12 @@
+package in.koreatech.koin.domain.weather.exception;
+
+public class WeatherOpenApiRateLimitException extends WeatherOpenApiException {
+
+    private WeatherOpenApiRateLimitException(String detail) {
+        super(DEFAULT_MESSAGE, detail);
+    }
+
+    public static WeatherOpenApiRateLimitException withDetail(String detail) {
+        return new WeatherOpenApiRateLimitException(detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/weather/model/WeatherCache.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/model/WeatherCache.java
@@ -1,5 +1,6 @@
 package in.koreatech.koin.domain.weather.model;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.annotation.Id;
@@ -15,12 +16,12 @@ import lombok.Getter;
 public class WeatherCache {
 
     public static final String BYEONGCHEON_ID = "byeongcheon";
-    private static final long CACHE_EXPIRE_HOUR = 2L;
+    private static final long CACHE_EXPIRE_HOUR = 24L;
 
     @Id
     private String id;
 
-    private WeatherResponse weather;
+    private Map<String, WeatherResponse> hourlyWeathers;
 
     @TimeToLive(unit = TimeUnit.HOURS)
     private final Long expiration;
@@ -28,18 +29,18 @@ public class WeatherCache {
     @Builder
     private WeatherCache(
         String id,
-        WeatherResponse weather,
+        Map<String, WeatherResponse> hourlyWeathers,
         Long expiration
     ) {
         this.id = id;
-        this.weather = weather;
+        this.hourlyWeathers = hourlyWeathers;
         this.expiration = expiration == null ? CACHE_EXPIRE_HOUR : expiration;
     }
 
-    public static WeatherCache of(WeatherResponse weather) {
+    public static WeatherCache of(Map<String, WeatherResponse> hourlyWeathers) {
         return WeatherCache.builder()
             .id(BYEONGCHEON_ID)
-            .weather(weather)
+            .hourlyWeathers(hourlyWeathers)
             .build();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/weather/service/WeatherService.java
+++ b/src/main/java/in/koreatech/koin/domain/weather/service/WeatherService.java
@@ -2,6 +2,10 @@ package in.koreatech.koin.domain.weather.service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -17,20 +21,37 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WeatherService {
 
+    private static final DateTimeFormatter FORECAST_DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
     private final Clock clock;
     private final WeatherClient weatherClient;
     private final WeatherCacheRepository weatherCacheRepository;
 
     public WeatherResponse getWeather() {
+        String forecastDateTime = LocalDateTime.now(clock)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .format(FORECAST_DATE_TIME_FORMATTER);
+
         return weatherCacheRepository.findById(WeatherCache.BYEONGCHEON_ID)
-            .map(WeatherCache::getWeather)
-            .orElseThrow(() -> WeatherOpenApiException.withDetail("weather cache is empty"));
+            .flatMap(cache -> Optional.ofNullable(cache.getHourlyWeathers()))
+            .map(hourlyWeathers -> hourlyWeathers.get(forecastDateTime))
+            .orElseThrow(() -> WeatherOpenApiException.withDetail(
+                "weather cache is empty, forecastDateTime: " + forecastDateTime
+            ));
     }
 
     public synchronized void refreshWeather() {
         LocalDateTime now = LocalDateTime.now(clock);
         WeatherForecastRequestTime requestTime = WeatherForecastRequestTime.from(now);
-        WeatherResponse response = weatherClient.getWeatherForecast(requestTime).toResponse();
-        weatherCacheRepository.save(WeatherCache.of(response));
+        // 외부 API의 시간대별 도메인 예보를 조회 API가 바로 사용할 수 있는 응답 Map으로 한 번에 변환한다.
+        Map<String, WeatherResponse> hourlyWeathers = weatherClient.getWeatherForecasts(requestTime).entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().toResponse()
+            ));
+        weatherCacheRepository.save(WeatherCache.of(hourlyWeathers));
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/WeatherApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/WeatherApiTest.java
@@ -4,6 +4,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -21,9 +23,9 @@ class WeatherApiTest extends AcceptanceTest {
     @Test
     void 병천_날씨를_조회한다() throws Exception {
         clear();
-        weatherCacheRepository.save(WeatherCache.of(
-            new WeatherResponse(21, "맑음")
-        ));
+        weatherCacheRepository.save(WeatherCache.of(Map.of(
+            "202401151200", new WeatherResponse(21, "맑음")
+        )));
 
         mockMvc.perform(
                 get("/weather")

--- a/src/test/java/in/koreatech/koin/unit/domain/weather/WeatherClientTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/weather/WeatherClientTest.java
@@ -3,12 +3,18 @@ package in.koreatech.koin.unit.domain.weather;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.ExpectedCount.times;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
@@ -17,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import in.koreatech.koin.domain.weather.client.WeatherClient;
 import in.koreatech.koin.domain.weather.client.dto.WeatherForecastRequestTime;
 import in.koreatech.koin.domain.weather.exception.WeatherOpenApiException;
+import in.koreatech.koin.domain.weather.exception.WeatherOpenApiRateLimitException;
 import in.koreatech.koin.domain.weather.model.WeatherForecast;
 
 class WeatherClientTest {
@@ -35,23 +42,57 @@ class WeatherClientTest {
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.bindTo(restTemplate).build();
-        weatherClient = new WeatherClient("test-api-key", restTemplate, new ObjectMapper());
+        RetryTemplate retryTemplate = RetryTemplate.builder()
+            .maxAttempts(6)
+            .noBackoff()
+            .retryOn(WeatherOpenApiRateLimitException.class)
+            .build();
+        weatherClient = new WeatherClient("test-api-key", restTemplate, new ObjectMapper(), retryTemplate);
     }
 
     @Test
-    void 기상청_예보_응답에서_기온_하늘상태_강수형태를_추출한다() {
+    void 기상청_예보_응답에서_시간대별_기온_하늘상태_강수형태를_추출한다() {
         server.expect(once(), anything())
             .andRespond(withSuccess(weatherApiResponse("""
                 {"category":"TMP","fcstDate":"20240115","fcstTime":"1200","fcstValue":"21"},
                 {"category":"SKY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"1"},
-                {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"}
+                {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"},
+                {"category":"TMP","fcstDate":"20240115","fcstTime":"1300","fcstValue":"22"},
+                {"category":"SKY","fcstDate":"20240115","fcstTime":"1300","fcstValue":"3"},
+                {"category":"PTY","fcstDate":"20240115","fcstTime":"1300","fcstValue":"0"}
                 """), MediaType.APPLICATION_JSON));
 
-        WeatherForecast forecast = weatherClient.getWeatherForecast(REQUEST_TIME);
+        Map<String, WeatherForecast> forecasts = weatherClient.getWeatherForecasts(REQUEST_TIME);
 
-        assertThat(forecast.temperature()).isEqualTo(21);
-        assertThat(forecast.sky()).isEqualTo("1");
-        assertThat(forecast.precipitationType()).isEqualTo("0");
+        assertThat(forecasts).containsOnlyKeys("202401151200", "202401151300");
+        assertThat(forecasts.get("202401151200"))
+            .isEqualTo(new WeatherForecast(21, "1", "0"));
+        assertThat(forecasts.get("202401151300"))
+            .isEqualTo(new WeatherForecast(22, "3", "0"));
+        server.verify();
+    }
+
+    @Test
+    void 갱신_시각부터_향후_24시간의_예보만_추출한다() {
+        server.expect(once(), anything())
+            .andRespond(withSuccess(weatherApiResponse("""
+                {"category":"TMP","fcstDate":"20240115","fcstTime":"1100","fcstValue":"20"},
+                {"category":"SKY","fcstDate":"20240115","fcstTime":"1100","fcstValue":"1"},
+                {"category":"PTY","fcstDate":"20240115","fcstTime":"1100","fcstValue":"0"},
+                {"category":"TMP","fcstDate":"20240115","fcstTime":"1200","fcstValue":"21"},
+                {"category":"SKY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"1"},
+                {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"},
+                {"category":"TMP","fcstDate":"20240116","fcstTime":"1100","fcstValue":"19"},
+                {"category":"SKY","fcstDate":"20240116","fcstTime":"1100","fcstValue":"3"},
+                {"category":"PTY","fcstDate":"20240116","fcstTime":"1100","fcstValue":"0"},
+                {"category":"TMP","fcstDate":"20240116","fcstTime":"1200","fcstValue":"18"},
+                {"category":"SKY","fcstDate":"20240116","fcstTime":"1200","fcstValue":"4"},
+                {"category":"PTY","fcstDate":"20240116","fcstTime":"1200","fcstValue":"1"}
+                """), MediaType.APPLICATION_JSON));
+
+        Map<String, WeatherForecast> forecasts = weatherClient.getWeatherForecasts(REQUEST_TIME);
+
+        assertThat(forecasts).containsOnlyKeys("202401151200", "202401161100");
         server.verify();
     }
 
@@ -70,11 +111,10 @@ class WeatherClientTest {
                 {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"}
                 """), MediaType.APPLICATION_JSON));
 
-        WeatherForecast forecast = weatherClient.getWeatherForecast(REQUEST_TIME);
+        Map<String, WeatherForecast> forecasts = weatherClient.getWeatherForecasts(REQUEST_TIME);
 
-        assertThat(forecast.temperature()).isEqualTo(20);
-        assertThat(forecast.sky()).isEqualTo("3");
-        assertThat(forecast.precipitationType()).isEqualTo("0");
+        assertThat(forecasts.get("202401151200"))
+            .isEqualTo(new WeatherForecast(20, "3", "0"));
         server.verify();
     }
 
@@ -86,11 +126,42 @@ class WeatherClientTest {
                 {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"}
                 """), MediaType.APPLICATION_JSON));
 
-        assertThatThrownBy(() -> weatherClient.getWeatherForecast(REQUEST_TIME))
+        assertThatThrownBy(() -> weatherClient.getWeatherForecasts(REQUEST_TIME))
             .isInstanceOf(WeatherOpenApiException.class)
             .hasMessage("기상청 단기예보 API 응답이 정상적이지 않습니다.")
             .satisfies(exception -> assertThat(((WeatherOpenApiException) exception).getFullMessage())
                 .contains("missing category: SKY"));
+
+        server.verify();
+    }
+
+    @Test
+    void 동시_호출_제한이_발생하면_5회까지_재시도한다() {
+        server.expect(times(5), anything())
+            .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS)
+                .body("API rate limit exceeded"));
+        server.expect(once(), anything())
+            .andRespond(withSuccess(weatherApiResponse("""
+                {"category":"TMP","fcstDate":"20240115","fcstTime":"1200","fcstValue":"21"},
+                {"category":"SKY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"1"},
+                {"category":"PTY","fcstDate":"20240115","fcstTime":"1200","fcstValue":"0"}
+                """), MediaType.APPLICATION_JSON));
+
+        Map<String, WeatherForecast> forecasts = weatherClient.getWeatherForecasts(REQUEST_TIME);
+
+        assertThat(forecasts.get("202401151200"))
+            .isEqualTo(new WeatherForecast(21, "1", "0"));
+        server.verify();
+    }
+
+    @Test
+    void 동시_호출_제한이_6번_연속_발생하면_최종_예외를_반환한다() {
+        server.expect(times(6), anything())
+            .andRespond(withStatus(HttpStatus.TOO_MANY_REQUESTS)
+                .body("API rate limit exceeded"));
+
+        assertThatThrownBy(() -> weatherClient.getWeatherForecasts(REQUEST_TIME))
+            .isInstanceOf(WeatherOpenApiRateLimitException.class);
 
         server.verify();
     }

--- a/src/test/java/in/koreatech/koin/unit/domain/weather/WeatherServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/weather/WeatherServiceTest.java
@@ -10,10 +10,12 @@ import static org.mockito.Mockito.when;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,13 +48,17 @@ class WeatherServiceTest {
             "1200"
         );
         WeatherResponse cachedWeather = new WeatherResponse(21, "맑음");
+        WeatherResponse nextWeather = new WeatherResponse(22, "구름많음");
         when(weatherCacheRepository.findById(WeatherCache.BYEONGCHEON_ID))
-            .thenReturn(Optional.of(WeatherCache.of(cachedWeather)));
+            .thenReturn(Optional.of(WeatherCache.of(Map.of(
+                "202401151200", cachedWeather,
+                "202401151300", nextWeather
+            ))));
 
         WeatherResponse response = weatherService.getWeather();
 
         assertThat(response).isEqualTo(cachedWeather);
-        verify(weatherClient, never()).getWeatherForecast(requestTime);
+        verify(weatherClient, never()).getWeatherForecasts(requestTime);
     }
 
     @Test
@@ -64,7 +70,19 @@ class WeatherServiceTest {
 
         assertThrows(WeatherOpenApiException.class, weatherService::getWeather);
 
-        verify(weatherClient, never()).getWeatherForecast(any());
+        verify(weatherClient, never()).getWeatherForecasts(any());
+    }
+
+    @Test
+    void 현재_시간대의_예보가_캐시에_없으면_비정상_응답으로_처리한다() {
+        Clock clock = Clock.fixed(Instant.parse("2024-01-15T03:35:00Z"), ZoneId.of("Asia/Seoul"));
+        WeatherService weatherService = new WeatherService(clock, weatherClient, weatherCacheRepository);
+        when(weatherCacheRepository.findById(WeatherCache.BYEONGCHEON_ID))
+            .thenReturn(Optional.of(WeatherCache.builder().build()));
+
+        assertThrows(WeatherOpenApiException.class, weatherService::getWeather);
+
+        verify(weatherClient, never()).getWeatherForecasts(any());
     }
 
     @Test
@@ -77,12 +95,21 @@ class WeatherServiceTest {
             "20240115",
             "1200"
         );
-        when(weatherClient.getWeatherForecast(requestTime))
-            .thenReturn(new WeatherForecast(21, "1", "0"));
+        when(weatherClient.getWeatherForecasts(requestTime))
+            .thenReturn(Map.of(
+                "202401151200", new WeatherForecast(21, "1", "0"),
+                "202401151300", new WeatherForecast(22, "3", "0")
+            ));
 
         weatherService.refreshWeather();
 
-        verify(weatherClient).getWeatherForecast(requestTime);
-        verify(weatherCacheRepository).save(any(WeatherCache.class));
+        ArgumentCaptor<WeatherCache> cacheCaptor = ArgumentCaptor.forClass(WeatherCache.class);
+        verify(weatherClient).getWeatherForecasts(requestTime);
+        verify(weatherCacheRepository).save(cacheCaptor.capture());
+        assertThat(cacheCaptor.getValue().getHourlyWeathers()).containsOnlyKeys(
+            "202401151200",
+            "202401151300"
+        );
+        assertThat(cacheCaptor.getValue().getExpiration()).isEqualTo(24L);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 기상청 단기예보 API 요청이 몰려 429가 발생하더라도 기존 예보를 계속 제공하고, 다음 갱신 기회를 확보합니다.
* 기존에는 매시간 단 한 번의 수집이 실패하면 캐시 만료 후 날씨 조회가 불가능했지만, 이제 향후 24시간 예보를 미리 보관해 일시적인 외부 장애가 사용자 요청으로 전파되지 않습니다.

- close #2291

---

### 🚀 주요 변경 내용

* 갱신 시점부터 향후 24시간 예보를 시간대별 Map으로 구성해 Redis 단일 키에 24시간 동안 저장합니다.
* `/weather` 요청은 외부 API를 호출하지 않고 현재 정시의 예보만 캐시에서 선택하며, 공개 응답 형식은 유지합니다.
* HTTP 429와 기상청 초당 요청 제한 응답만 분리해 5초 간격으로 5회 재시도합니다.
* 모든 재시도가 실패하면 저장을 수행하지 않아 기존 캐시가 삭제되거나 불완전한 데이터로 교체되지 않습니다.

---

### 💬 참고 사항

* 전역 `@EnableRetry`를 사용하지 않고 날씨 전용 `RetryTemplate`을 구성해 기존 Slack, SMS, 메일 재시도 동작에 영향을 주지 않습니다.
* `./gradlew check --rerun-tasks --no-daemon`으로 단위 테스트, Redis 인수 테스트와 전체 회귀 테스트를 검증했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weather data now supports multiple hourly forecasts within a 24-hour window.
  * Weather results are cached and served by time slot, improving hourly accuracy.

* **Bug Fixes**
  * Added automatic retry handling for temporary weather-provider rate limits.
  * Improved fallback behavior when the requested forecast time is unavailable.
  * Better error reporting when weather data cannot be found or refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->