### PR TITLE
feat: 학교 부서 업무 연락처 조회 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/controller/DepartmentContactApi.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/controller/DepartmentContactApi.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.domain.departmentcontact.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.domain.departmentcontact.dto.DepartmentContactResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "(Normal) DepartmentContact: 부서 업무 연락처", description = "학교 부서의 업무별 전화번호를 조회한다")
+@RequestMapping("/department-contacts")
+public interface DepartmentContactApi {
+
+    @Operation(summary = "부서 업무 연락처 조회", description = "부서명을 전달하지 않으면 전체 연락처를 반환합니다.")
+    @GetMapping
+    ResponseEntity<List<DepartmentContactResponse>> getDepartmentContacts(
+        @RequestParam(name = "department", required = false) String department
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/controller/DepartmentContactController.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/controller/DepartmentContactController.java
@@ -1,0 +1,28 @@
+package in.koreatech.koin.domain.departmentcontact.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.departmentcontact.dto.DepartmentContactResponse;
+import in.koreatech.koin.domain.departmentcontact.service.DepartmentContactService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/department-contacts")
+public class DepartmentContactController implements DepartmentContactApi {
+
+    private final DepartmentContactService departmentContactService;
+
+    @GetMapping
+    public ResponseEntity<List<DepartmentContactResponse>> getDepartmentContacts(
+        @RequestParam(name = "department", required = false) String department
+    ) {
+        return ResponseEntity.ok(departmentContactService.getDepartmentContacts(department));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/dto/DepartmentContactResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/dto/DepartmentContactResponse.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.domain.departmentcontact.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.departmentcontact.model.DepartmentContact;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record DepartmentContactResponse(
+    @Schema(description = "부서명", example = "학사팀", requiredMode = REQUIRED)
+    String department,
+
+    @Schema(description = "업무", example = "교육과정", requiredMode = REQUIRED)
+    String task,
+
+    @Schema(description = "전화번호", example = "041-560-2527", requiredMode = REQUIRED)
+    String phoneNumber
+) {
+
+    public static DepartmentContactResponse from(DepartmentContact contact) {
+        return new DepartmentContactResponse(
+            contact.getDepartment(),
+            contact.getTask(),
+            contact.getPhoneNumber()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/model/DepartmentContact.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/model/DepartmentContact.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.domain.departmentcontact.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import in.koreatech.koin.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "department_contacts")
+@NoArgsConstructor(access = PROTECTED)
+public class DepartmentContact extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Column(name = "department", nullable = false, length = 100)
+    private String department;
+
+    @Column(name = "task", nullable = false, length = 255)
+    private String task;
+
+    @Column(name = "phone_number", nullable = false, length = 20)
+    private String phoneNumber;
+
+    public DepartmentContact(String department, String task, String phoneNumber) {
+        this.department = department;
+        this.task = task;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/repository/DepartmentContactRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/repository/DepartmentContactRepository.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.domain.departmentcontact.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import in.koreatech.koin.domain.departmentcontact.model.DepartmentContact;
+
+public interface DepartmentContactRepository extends Repository<DepartmentContact, Integer> {
+
+    List<DepartmentContact> findAllByOrderByIdAsc();
+
+    List<DepartmentContact> findAllByDepartmentOrderByIdAsc(String department);
+}

--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/service/DepartmentContactService.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/service/DepartmentContactService.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.domain.departmentcontact.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.departmentcontact.dto.DepartmentContactResponse;
+import in.koreatech.koin.domain.departmentcontact.model.DepartmentContact;
+import in.koreatech.koin.domain.departmentcontact.repository.DepartmentContactRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentContactService {
+
+    private final DepartmentContactRepository departmentContactRepository;
+
+    @Transactional(readOnly = true)
+    public List<DepartmentContactResponse> getDepartmentContacts(String department) {
+        String normalizedDepartment = normalizeDepartment(department);
+        List<DepartmentContact> contacts = normalizedDepartment == null
+            ? departmentContactRepository.findAllByOrderByIdAsc()
+            : departmentContactRepository.findAllByDepartmentOrderByIdAsc(normalizedDepartment);
+
+        return contacts.stream()
+            .map(DepartmentContactResponse::from)
+            .toList();
+    }
+
+    private String normalizeDepartment(String department) {
+        if (department == null || department.isBlank()) {
+            return null;
+        }
+        return department.trim();
+    }
+}

--- a/src/main/resources/db/migration/V2__create_department_contacts.sql
+++ b/src/main/resources/db/migration/V2__create_department_contacts.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `department_contacts` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `department` VARCHAR(100) NOT NULL,
+    `task` VARCHAR(255) NOT NULL DEFAULT '',
+    `phone_number` VARCHAR(20) NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    INDEX `idx_department_contacts_department` (`department`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO `department_contacts` (`id`, `department`, `task`, `phone_number`)
+VALUES
+    (1, '전문대학원 교학팀', '', '041-521-8203'),
+    (2, '대학원 교학팀', '', '041-560-2577'),
+    (3, '미래교육지원팀', '', '041-580-4702'),
+    (4, 'Edutech 센터', '', '041-580-4707'),
+    (5, '교무팀', '', '041-560-2524'),
+    (6, '기계공학부 학부사무실', '', '041-560-1290'),
+    (7, '메카트로닉스공학부 학부사무실', '', '041-560-1376'),
+    (8, '전전통 학부사무실', '', '041-560-1292'),
+    (9, '컴퓨터공학부 학부사무실', '', '041-560-1461'),
+    (10, '디자인건축공학부 학부사무실', '', '041-560-1221'),
+    (11, '에신화 학부사무실', '', '041-560-1302'),
+    (12, '경영학부 학부사무실', '', '041-560-1437'),
+    (13, '고용 학부사무실', '', '041-560-1761'),
+    (14, '교양학부', '', '041-560-1294'),
+    (15, 'HRD학부', '', '041-560-1295'),
+    (16, '미래융합학부', '', '041-560-1489'),
+    (17, '학사팀', '학사팀 업무총괄', '041-560-2539'),
+    (18, '학사팀', '교육과정', '041-560-2527'),
+    (19, '학사팀', '수업', '041-560-2528'),
+    (20, '학사팀', '학적', '041-560-2537'),
+    (21, '학사팀', '성적', '041-560-2589'),
+    (22, '학사팀', '졸업관리, 출석인정', '041-560-2526');

--- a/src/test/java/in/koreatech/koin/acceptance/domain/DepartmentContactApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/DepartmentContactApiTest.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.domain.departmentcontact.model.DepartmentContact;
+
+class DepartmentContactApiTest extends AcceptanceTest {
+
+    @Test
+    void 전체_연락처를_조회하고_부서명으로_필터링한다() throws Exception {
+        clear();
+        entityManager.persist(new DepartmentContact("교무팀", "", "041-560-2524"));
+        entityManager.persist(new DepartmentContact("학사팀", "교육과정", "041-560-2527"));
+        entityManager.persist(new DepartmentContact("학사팀", "수업", "041-560-2528"));
+        entityManager.flush();
+
+        mockMvc.perform(get("/department-contacts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[0].department").value("교무팀"))
+            .andExpect(jsonPath("$[0].task").value(""))
+            .andExpect(jsonPath("$[0].phone_number").value("041-560-2524"));
+
+        mockMvc.perform(
+                get("/department-contacts")
+                    .param("department", " 학사팀 ")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[0].department").value("학사팀"))
+            .andExpect(jsonPath("$[0].task").value("교육과정"))
+            .andExpect(jsonPath("$[0].phone_number").value("041-560-2527"))
+            .andExpect(jsonPath("$[1].task").value("수업"))
+            .andExpect(jsonPath("$[1].phone_number").value("041-560-2528"));
+    }
+}


### PR DESCRIPTION
### 🔍 개요
* 제공받은 학교 부서 업무 연락처 22건을 DB에 저장하고 조회하는 API를 추가했습니다.
* 외부 홈페이지 수집과 주기적 동기화는 요구사항에서 제외되어 관련 코드는 포함하지 않았습니다.

- close #2293

---

### 🚀 주요 변경 내용
* `department_contacts` 테이블 추가
  * 저장 항목: 부서명, 업무, 전화번호
  * 제공받은 연락처 22건을 초기 데이터로 저장
  * 업무가 없는 연락처는 빈 문자열로 저장
* 부서 업무 연락처 조회 API 추가
  * `GET /department-contacts`: 전체 22건 조회
  * `GET /department-contacts?department=학사팀`: 부서명이 일치하는 연락처만 조회
  * 일치하는 부서가 없으면 빈 배열 반환

```json
[
  {
    "department": "학사팀",
    "task": "교육과정",
    "phone_number": "041-560-2527"
  }
]
```

---

### 💬 참고 사항
* 이후 연락처 수정은 운영 DB의 `department_contacts` 데이터를 직접 수정하는 방식입니다.
* 데이터가 22건으로 적어 별도 페이지네이션은 적용하지 않았습니다.
* 외부 사이트 요청, 스케줄러, 재시도, 버전 관리 테이블은 사용하지 않습니다.
* `./gradlew check --rerun-tasks`: 689 tests, 0 failures, 0 errors, 3 skipped
* 로컬 DB 마이그레이션과 전체 22건/학사팀 6건 API 응답을 확인했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일과 기존 레이어 컨벤션을 준수했습니다.
- [x] 전체 조회와 부서명 필터 조회를 테스트했습니다.
- [x] 제공받은 연락처 22건을 초기 데이터로 추가했습니다.
- [x] 불필요한 외부 동기화 코드를 제거했습니다.
