### PR TITLE
feat: 게시글 AI 요약 관리자 API 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryApi.java
+++ b/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryApi.java
@@ -1,0 +1,67 @@
+package in.koreatech.koin.admin.article.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.global.auth.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(
+    name = "(Admin) ArticleAiSummary: 게시글 AI 요약",
+    description = "super_admin 여부와 관계없이 코인 어드민 로그인이 승인된 모든 관리자 계정이 게시글 AI 요약 작업 상태를 조회한다"
+)
+public interface AdminArticleAiSummaryApi {
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Operation(summary = "게시글 AI 요약 큐 상태 요약 조회")
+    @GetMapping("/admin/articles/ai-summaries/overview")
+    ResponseEntity<AdminArticleAiSummaryOverviewResponse> getOverview(
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Operation(summary = "게시글 AI 요약 작업 목록 조회")
+    @GetMapping("/admin/articles/ai-summaries")
+    ResponseEntity<AdminArticleAiSummariesResponse> getSummaries(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
+        @RequestParam(name = "status", required = false) ArticleAiSummaryStatus status,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Operation(summary = "게시글 AI 요약 작업 단건 조회")
+    @GetMapping("/admin/articles/ai-summaries/{summaryId}")
+    ResponseEntity<AdminArticleAiSummaryResponse> getSummary(
+        @Parameter(in = PATH) @PathVariable Integer summaryId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+}

--- a/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryApi.java
+++ b/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryApi.java
@@ -9,9 +9,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogsResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
 import in.koreatech.koin.global.auth.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,6 +52,23 @@ public interface AdminArticleAiSummaryApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
         @RequestParam(name = "status", required = false) ArticleAiSummaryStatus status,
+        @Auth(permit = {ADMIN}) Integer adminId
+    );
+
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @Operation(summary = "게시글 AI 요약 작업 로그 조회")
+    @GetMapping("/admin/articles/ai-summaries/logs")
+    ResponseEntity<AdminArticleAiSummaryLogsResponse> getLogs(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
+        @RequestParam(name = "summary_id", required = false) Integer summaryId,
+        @RequestParam(name = "article_id", required = false) Integer articleId,
+        @RequestParam(name = "event_type", required = false) ArticleAiSummaryLogType eventType,
+        @RequestParam(name = "failure_type", required = false) ArticleSummaryFailureType failureType,
         @Auth(permit = {ADMIN}) Integer adminId
     );
 

--- a/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryController.java
+++ b/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryController.java
@@ -1,0 +1,52 @@
+package in.koreatech.koin.admin.article.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.ADMIN;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
+import in.koreatech.koin.admin.article.service.AdminArticleAiSummaryService;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.global.auth.Auth;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminArticleAiSummaryController implements AdminArticleAiSummaryApi {
+
+    private final AdminArticleAiSummaryService adminArticleAiSummaryService;
+
+    @Override
+    @GetMapping("/admin/articles/ai-summaries/overview")
+    public ResponseEntity<AdminArticleAiSummaryOverviewResponse> getOverview(
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        return ResponseEntity.ok(adminArticleAiSummaryService.getOverview());
+    }
+
+    @Override
+    @GetMapping("/admin/articles/ai-summaries")
+    public ResponseEntity<AdminArticleAiSummariesResponse> getSummaries(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
+        @RequestParam(name = "status", required = false) ArticleAiSummaryStatus status,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        return ResponseEntity.ok(adminArticleAiSummaryService.getSummaries(page, limit, status));
+    }
+
+    @Override
+    @GetMapping("/admin/articles/ai-summaries/{summaryId}")
+    public ResponseEntity<AdminArticleAiSummaryResponse> getSummary(
+        @PathVariable Integer summaryId,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        return ResponseEntity.ok(adminArticleAiSummaryService.getSummary(summaryId));
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryController.java
+++ b/src/main/java/in/koreatech/koin/admin/article/controller/AdminArticleAiSummaryController.java
@@ -9,10 +9,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogsResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
 import in.koreatech.koin.admin.article.service.AdminArticleAiSummaryService;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
 import in.koreatech.koin.global.auth.Auth;
 import lombok.RequiredArgsConstructor;
 
@@ -39,6 +42,27 @@ public class AdminArticleAiSummaryController implements AdminArticleAiSummaryApi
         @Auth(permit = {ADMIN}) Integer adminId
     ) {
         return ResponseEntity.ok(adminArticleAiSummaryService.getSummaries(page, limit, status));
+    }
+
+    @Override
+    @GetMapping("/admin/articles/ai-summaries/logs")
+    public ResponseEntity<AdminArticleAiSummaryLogsResponse> getLogs(
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
+        @RequestParam(name = "summary_id", required = false) Integer summaryId,
+        @RequestParam(name = "article_id", required = false) Integer articleId,
+        @RequestParam(name = "event_type", required = false) ArticleAiSummaryLogType eventType,
+        @RequestParam(name = "failure_type", required = false) ArticleSummaryFailureType failureType,
+        @Auth(permit = {ADMIN}) Integer adminId
+    ) {
+        return ResponseEntity.ok(adminArticleAiSummaryService.getLogs(
+            page,
+            limit,
+            summaryId,
+            articleId,
+            eventType,
+            failureType
+        ));
     }
 
     @Override

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummariesResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummariesResponse.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.admin.article.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.common.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminArticleAiSummariesResponse(
+    @Schema(description = "게시글 AI 요약 작업 목록", requiredMode = REQUIRED)
+    List<AdminArticleAiSummaryResponse> summaries,
+
+    @Schema(description = "총 작업 수", example = "57", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지에 포함된 작업 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "총 페이지 수", example = "6", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "2", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+
+    public static AdminArticleAiSummariesResponse of(
+        Page<AdminArticleAiSummaryResponse> pagedResult,
+        Criteria criteria
+    ) {
+        return new AdminArticleAiSummariesResponse(
+            pagedResult.getContent(),
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogProjection.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogProjection.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.admin.article.dto;
+
+import java.time.LocalDateTime;
+
+public interface AdminArticleAiSummaryLogProjection {
+
+    Integer getLogId();
+
+    Integer getSummaryId();
+
+    Integer getArticleId();
+
+    Integer getBoardId();
+
+    String getArticleTitle();
+
+    String getEventType();
+
+    String getStatus();
+
+    String getFailureType();
+
+    String getMessage();
+
+    Integer getRetryCount();
+
+    LocalDateTime getNextAttemptAt();
+
+    String getWorkerId();
+
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogResponse.java
@@ -1,0 +1,53 @@
+package in.koreatech.koin.admin.article.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminArticleAiSummaryLogResponse(
+    @Schema(description = "로그 ID", example = "1", requiredMode = REQUIRED)
+    Integer logId,
+
+    @Schema(description = "요약 작업 ID", example = "12")
+    Integer summaryId,
+
+    @Schema(description = "게시글 ID", example = "17291")
+    Integer articleId,
+
+    @Schema(description = "게시판 ID", example = "5")
+    Integer boardId,
+
+    @Schema(description = "게시글 제목")
+    String articleTitle,
+
+    @Schema(description = "로그 유형", example = "FAILED", requiredMode = REQUIRED)
+    String eventType,
+
+    @Schema(description = "로그 발생 시점의 요약 상태", example = "FAILED")
+    String status,
+
+    @Schema(description = "실패 유형", example = "RATE_LIMIT")
+    String failureType,
+
+    @Schema(description = "안전하게 마스킹된 메시지")
+    String message,
+
+    @Schema(description = "로그 발생 시점의 재시도 횟수", example = "2")
+    Integer retryCount,
+
+    @Schema(description = "다음 시도 가능 시각")
+    LocalDateTime nextAttemptAt,
+
+    @Schema(description = "작업자 ID")
+    String workerId,
+
+    @Schema(description = "로그 생성 시각", requiredMode = REQUIRED)
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogsResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryLogsResponse.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.admin.article.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.common.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminArticleAiSummaryLogsResponse(
+    @Schema(description = "게시글 AI 요약 로그 목록", requiredMode = REQUIRED)
+    List<AdminArticleAiSummaryLogResponse> logs,
+
+    @Schema(description = "총 로그 수", example = "57", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지에 포함된 로그 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "총 페이지 수", example = "6", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "2", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+
+    public static AdminArticleAiSummaryLogsResponse of(
+        Page<AdminArticleAiSummaryLogResponse> pagedResult,
+        Criteria criteria
+    ) {
+        return new AdminArticleAiSummaryLogsResponse(
+            pagedResult.getContent(),
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryOverviewResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryOverviewResponse.java
@@ -1,0 +1,71 @@
+package in.koreatech.koin.admin.article.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminArticleAiSummaryOverviewResponse(
+    @Schema(description = "상태별 작업 수", requiredMode = REQUIRED)
+    List<StatusCountResponse> statusCounts,
+
+    @Schema(description = "큐 처리 상태", requiredMode = REQUIRED)
+    QueueResponse queue,
+
+    @Schema(description = "요약 설정", requiredMode = REQUIRED)
+    ConfigResponse config
+) {
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record StatusCountResponse(
+        @Schema(description = "요약 상태", example = "WAIT", requiredMode = REQUIRED)
+        String status,
+
+        @Schema(description = "작업 수", example = "12", requiredMode = REQUIRED)
+        Long count
+    ) {
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record QueueResponse(
+        @Schema(description = "즉시 처리 가능한 WAIT 수", example = "4", requiredMode = REQUIRED)
+        Long readyWaitCount,
+
+        @Schema(description = "next_attempt_at 대기 중인 WAIT 수", example = "2", requiredMode = REQUIRED)
+        Long delayedWaitCount,
+
+        @Schema(description = "처리 중인 수", example = "1", requiredMode = REQUIRED)
+        Long processingCount,
+
+        @Schema(description = "lock이 만료된 PROCESSING 수", example = "0", requiredMode = REQUIRED)
+        Long expiredProcessingCount,
+
+        @Schema(description = "재시도 가능한 FAILED 수", example = "3", requiredMode = REQUIRED)
+        Long retryableFailedCount
+    ) {
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record ConfigResponse(
+        @Schema(description = "스케줄러 실행 간격(ms)", example = "60000", requiredMode = REQUIRED)
+        Long schedulerFixedDelayMs,
+
+        @Schema(description = "스케줄러 batch size", example = "5", requiredMode = REQUIRED)
+        Integer batchSize,
+
+        @Schema(description = "최대 재시도 횟수", example = "5", requiredMode = REQUIRED)
+        Integer maxRetryCount,
+
+        @Schema(description = "FAILED 재처리 시작 시각", example = "0", requiredMode = REQUIRED)
+        Integer failedRetryWindowStartHour,
+
+        @Schema(description = "FAILED 재처리 종료 시각", example = "4", requiredMode = REQUIRED)
+        Integer failedRetryWindowEndHour
+    ) {
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryProjection.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryProjection.java
@@ -1,0 +1,38 @@
+package in.koreatech.koin.admin.article.dto;
+
+import java.time.LocalDateTime;
+
+public interface AdminArticleAiSummaryProjection {
+
+    Integer getSummaryId();
+
+    Integer getArticleId();
+
+    Integer getBoardId();
+
+    String getArticleTitle();
+
+    String getStatus();
+
+    String getFailureReason();
+
+    Integer getRetryCount();
+
+    LocalDateTime getNextAttemptAt();
+
+    LocalDateTime getLockedUntil();
+
+    String getWorkerId();
+
+    LocalDateTime getCreatedAt();
+
+    LocalDateTime getUpdatedAt();
+
+    LocalDateTime getSummarizedAt();
+
+    LocalDateTime getSourceUpdatedAt();
+
+    String getModel();
+
+    String getPromptVersion();
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryQueueCountProjection.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryQueueCountProjection.java
@@ -1,0 +1,14 @@
+package in.koreatech.koin.admin.article.dto;
+
+public interface AdminArticleAiSummaryQueueCountProjection {
+
+    Long getReadyWaitCount();
+
+    Long getDelayedWaitCount();
+
+    Long getProcessingCount();
+
+    Long getExpiredProcessingCount();
+
+    Long getRetryableFailedCount();
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryResponse.java
@@ -1,0 +1,66 @@
+package in.koreatech.koin.admin.article.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record AdminArticleAiSummaryResponse(
+    @Schema(description = "요약 작업 ID", example = "1", requiredMode = REQUIRED)
+    Integer summaryId,
+
+    @Schema(description = "게시글 ID", example = "17291", requiredMode = REQUIRED)
+    Integer articleId,
+
+    @Schema(description = "게시판 ID", example = "5", requiredMode = REQUIRED)
+    Integer boardId,
+
+    @Schema(description = "게시글 제목", requiredMode = REQUIRED)
+    String articleTitle,
+
+    @Schema(description = "요약 상태", example = "FAILED", requiredMode = REQUIRED)
+    String status,
+
+    @Schema(description = "실패 유형", example = "RATE_LIMIT")
+    ArticleSummaryFailureType failureType,
+
+    @Schema(description = "안전하게 마스킹된 실패 메시지")
+    String failureMessage,
+
+    @Schema(description = "재시도 횟수", example = "2", requiredMode = REQUIRED)
+    Integer retryCount,
+
+    @Schema(description = "다음 시도 가능 시각")
+    LocalDateTime nextAttemptAt,
+
+    @Schema(description = "작업 잠금 만료 시각")
+    LocalDateTime lockedUntil,
+
+    @Schema(description = "작업자 ID")
+    String workerId,
+
+    @Schema(description = "생성 시각", requiredMode = REQUIRED)
+    LocalDateTime createdAt,
+
+    @Schema(description = "수정 시각", requiredMode = REQUIRED)
+    LocalDateTime updatedAt,
+
+    @Schema(description = "요약 성공 시각")
+    LocalDateTime summarizedAt,
+
+    @Schema(description = "원본 수정 시각")
+    LocalDateTime sourceUpdatedAt,
+
+    @Schema(description = "모델명")
+    String model,
+
+    @Schema(description = "프롬프트 버전")
+    String promptVersion
+) {
+}

--- a/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryStatusCountProjection.java
+++ b/src/main/java/in/koreatech/koin/admin/article/dto/AdminArticleAiSummaryStatusCountProjection.java
@@ -1,0 +1,8 @@
+package in.koreatech.koin.admin.article.dto;
+
+public interface AdminArticleAiSummaryStatusCountProjection {
+
+    String getStatus();
+
+    Long getSummaryCount();
+}

--- a/src/main/java/in/koreatech/koin/admin/article/exception/AdminArticleAiSummaryNotFoundException.java
+++ b/src/main/java/in/koreatech/koin/admin/article/exception/AdminArticleAiSummaryNotFoundException.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.admin.article.exception;
+
+import in.koreatech.koin.global.exception.custom.DataNotFoundException;
+
+public class AdminArticleAiSummaryNotFoundException extends DataNotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "해당 게시글 AI 요약 작업을 찾을 수 없습니다.";
+
+    public AdminArticleAiSummaryNotFoundException(String message, String detail) {
+        super(message, detail);
+    }
+
+    public static AdminArticleAiSummaryNotFoundException withDetail(String detail) {
+        return new AdminArticleAiSummaryNotFoundException(DEFAULT_MESSAGE, detail);
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/service/AdminArticleAiSummaryService.java
+++ b/src/main/java/in/koreatech/koin/admin/article/service/AdminArticleAiSummaryService.java
@@ -1,0 +1,118 @@
+package in.koreatech.koin.admin.article.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryProjection;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryQueueCountProjection;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
+import in.koreatech.koin.admin.article.exception.AdminArticleAiSummaryNotFoundException;
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryProperties;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureReasonSanitizer;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminArticleAiSummaryService {
+
+    private final ArticleAiSummaryRepository articleAiSummaryRepository;
+    private final ArticleAiSummaryProperties properties;
+    private final ArticleSummaryFailureReasonSanitizer failureReasonSanitizer;
+    private final Clock clock;
+
+    @Value("${article.ai-summary.scheduler-fixed-delay-ms:60000}")
+    private Long schedulerFixedDelayMs;
+
+    public AdminArticleAiSummaryOverviewResponse getOverview() {
+        Map<String, Long> statusCounts = articleAiSummaryRepository.countAdminSummariesByStatus().stream()
+            .collect(Collectors.toMap(
+                count -> count.getStatus(),
+                count -> nullToZero(count.getSummaryCount()),
+                (first, second) -> first
+            ));
+        AdminArticleAiSummaryQueueCountProjection queue = articleAiSummaryRepository.countAdminQueue(
+            LocalDateTime.now(clock),
+            properties.getMaxRetryCount()
+        );
+
+        return new AdminArticleAiSummaryOverviewResponse(
+            Arrays.stream(ArticleAiSummaryStatus.values())
+                .map(status -> new AdminArticleAiSummaryOverviewResponse.StatusCountResponse(
+                    status.name(),
+                    statusCounts.getOrDefault(status.name(), 0L)
+                ))
+                .toList(),
+            new AdminArticleAiSummaryOverviewResponse.QueueResponse(
+                nullToZero(queue.getReadyWaitCount()),
+                nullToZero(queue.getDelayedWaitCount()),
+                nullToZero(queue.getProcessingCount()),
+                nullToZero(queue.getExpiredProcessingCount()),
+                nullToZero(queue.getRetryableFailedCount())
+            ),
+            new AdminArticleAiSummaryOverviewResponse.ConfigResponse(
+                schedulerFixedDelayMs,
+                properties.getBatchSize(),
+                properties.getMaxRetryCount(),
+                properties.getBoundedFailedRetryWindowStartHour(),
+                properties.getBoundedFailedRetryWindowEndHour()
+            )
+        );
+    }
+
+    public AdminArticleAiSummariesResponse getSummaries(Integer page, Integer limit, ArticleAiSummaryStatus status) {
+        Criteria criteria = Criteria.of(page, limit);
+        PageRequest pageable = PageRequest.of(criteria.getPage(), criteria.getLimit());
+        Page<AdminArticleAiSummaryResponse> summaries = articleAiSummaryRepository
+            .findAdminSummaries(status == null ? null : status.name(), pageable)
+            .map(this::toResponse);
+        return AdminArticleAiSummariesResponse.of(summaries, criteria);
+    }
+
+    public AdminArticleAiSummaryResponse getSummary(Integer summaryId) {
+        return articleAiSummaryRepository.findAdminSummaryById(summaryId)
+            .map(this::toResponse)
+            .orElseThrow(() -> AdminArticleAiSummaryNotFoundException.withDetail("summaryId: " + summaryId));
+    }
+
+    private AdminArticleAiSummaryResponse toResponse(AdminArticleAiSummaryProjection summary) {
+        String failureMessage = failureReasonSanitizer.sanitize(summary.getFailureReason());
+        return new AdminArticleAiSummaryResponse(
+            summary.getSummaryId(),
+            summary.getArticleId(),
+            summary.getBoardId(),
+            summary.getArticleTitle(),
+            summary.getStatus(),
+            failureReasonSanitizer.classify(failureMessage),
+            failureMessage,
+            summary.getRetryCount(),
+            summary.getNextAttemptAt(),
+            summary.getLockedUntil(),
+            summary.getWorkerId(),
+            summary.getCreatedAt(),
+            summary.getUpdatedAt(),
+            summary.getSummarizedAt(),
+            summary.getSourceUpdatedAt(),
+            summary.getModel(),
+            summary.getPromptVersion()
+        );
+    }
+
+    private Long nullToZero(Long value) {
+        return value == null ? 0L : value;
+    }
+}

--- a/src/main/java/in/koreatech/koin/admin/article/service/AdminArticleAiSummaryService.java
+++ b/src/main/java/in/koreatech/koin/admin/article/service/AdminArticleAiSummaryService.java
@@ -13,15 +13,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummariesResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogProjection;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogResponse;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogsResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryOverviewResponse;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryProjection;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryQueueCountProjection;
 import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryResponse;
 import in.koreatech.koin.admin.article.exception.AdminArticleAiSummaryNotFoundException;
 import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryLogRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryProperties;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureReasonSanitizer;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminArticleAiSummaryService {
 
     private final ArticleAiSummaryRepository articleAiSummaryRepository;
+    private final ArticleAiSummaryLogRepository articleAiSummaryLogRepository;
     private final ArticleAiSummaryProperties properties;
     private final ArticleSummaryFailureReasonSanitizer failureReasonSanitizer;
     private final Clock clock;
@@ -83,6 +90,28 @@ public class AdminArticleAiSummaryService {
         return AdminArticleAiSummariesResponse.of(summaries, criteria);
     }
 
+    public AdminArticleAiSummaryLogsResponse getLogs(
+        Integer page,
+        Integer limit,
+        Integer summaryId,
+        Integer articleId,
+        ArticleAiSummaryLogType eventType,
+        ArticleSummaryFailureType failureType
+    ) {
+        Criteria criteria = Criteria.of(page, limit);
+        PageRequest pageable = PageRequest.of(criteria.getPage(), criteria.getLimit());
+        Page<AdminArticleAiSummaryLogResponse> logs = articleAiSummaryLogRepository
+            .findAdminLogs(
+                summaryId,
+                articleId,
+                eventType == null ? null : eventType.name(),
+                failureType == null ? null : failureType.name(),
+                pageable
+            )
+            .map(this::toLogResponse);
+        return AdminArticleAiSummaryLogsResponse.of(logs, criteria);
+    }
+
     public AdminArticleAiSummaryResponse getSummary(Integer summaryId) {
         return articleAiSummaryRepository.findAdminSummaryById(summaryId)
             .map(this::toResponse)
@@ -109,6 +138,25 @@ public class AdminArticleAiSummaryService {
             summary.getSourceUpdatedAt(),
             summary.getModel(),
             summary.getPromptVersion()
+        );
+    }
+
+    private AdminArticleAiSummaryLogResponse toLogResponse(AdminArticleAiSummaryLogProjection log) {
+        String message = failureReasonSanitizer.sanitize(log.getMessage());
+        return new AdminArticleAiSummaryLogResponse(
+            log.getLogId(),
+            log.getSummaryId(),
+            log.getArticleId(),
+            log.getBoardId(),
+            log.getArticleTitle(),
+            log.getEventType(),
+            log.getStatus(),
+            log.getFailureType(),
+            message,
+            log.getRetryCount(),
+            log.getNextAttemptAt(),
+            log.getWorkerId(),
+            log.getCreatedAt()
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleAiSummaryLog.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleAiSummaryLog.java
@@ -1,0 +1,120 @@
+package in.koreatech.koin.domain.community.article.model;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDateTime;
+
+import in.koreatech.koin.common.model.BaseEntity;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "article_ai_summary_logs")
+@NoArgsConstructor(access = PROTECTED)
+public class ArticleAiSummaryLog extends BaseEntity {
+
+    private static final int MESSAGE_LIMIT = 500;
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Integer id;
+
+    @Column(name = "summary_id")
+    private Integer summaryId;
+
+    @Column(name = "article_id")
+    private Integer articleId;
+
+    @Column(name = "board_id")
+    private Integer boardId;
+
+    @Enumerated(STRING)
+    @Column(name = "event_type", nullable = false)
+    private ArticleAiSummaryLogType eventType;
+
+    @Enumerated(STRING)
+    @Column(name = "status")
+    private ArticleAiSummaryStatus status;
+
+    @Enumerated(STRING)
+    @Column(name = "failure_type")
+    private ArticleSummaryFailureType failureType;
+
+    @Column(name = "message", length = MESSAGE_LIMIT)
+    private String message;
+
+    @Column(name = "retry_count")
+    private Integer retryCount;
+
+    @Column(name = "next_attempt_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime nextAttemptAt;
+
+    @Column(name = "worker_id", length = 100)
+    private String workerId;
+
+    @Builder
+    private ArticleAiSummaryLog(
+        Integer summaryId,
+        Integer articleId,
+        Integer boardId,
+        ArticleAiSummaryLogType eventType,
+        ArticleAiSummaryStatus status,
+        ArticleSummaryFailureType failureType,
+        String message,
+        Integer retryCount,
+        LocalDateTime nextAttemptAt,
+        String workerId
+    ) {
+        this.summaryId = summaryId;
+        this.articleId = articleId;
+        this.boardId = boardId;
+        this.eventType = eventType;
+        this.status = status;
+        this.failureType = failureType;
+        this.message = truncate(message);
+        this.retryCount = retryCount;
+        this.nextAttemptAt = nextAttemptAt;
+        this.workerId = workerId;
+    }
+
+    public static ArticleAiSummaryLog of(
+        ArticleAiSummary summary,
+        ArticleAiSummaryLogType eventType,
+        ArticleSummaryFailureType failureType,
+        String message,
+        String workerId
+    ) {
+        Article article = summary.getArticle();
+        Board board = article == null ? null : article.getBoard();
+        return ArticleAiSummaryLog.builder()
+            .summaryId(summary.getId())
+            .articleId(article == null ? null : article.getId())
+            .boardId(board == null ? null : board.getId())
+            .eventType(eventType)
+            .status(summary.getStatus())
+            .failureType(failureType)
+            .message(message)
+            .retryCount(summary.getRetryCount())
+            .nextAttemptAt(summary.getNextAttemptAt())
+            .workerId(workerId)
+            .build();
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.length() <= MESSAGE_LIMIT) {
+            return value;
+        }
+        return value.substring(0, MESSAGE_LIMIT);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleAiSummaryLogType.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/model/ArticleAiSummaryLogType.java
@@ -1,0 +1,8 @@
+package in.koreatech.koin.domain.community.article.model;
+
+public enum ArticleAiSummaryLogType {
+    RETRY_WAITING,
+    FAILED,
+    TERMINAL_FAILED,
+    SKIPPED
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleAiSummaryLogRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleAiSummaryLogRepository.java
@@ -1,0 +1,65 @@
+package in.koreatech.koin.domain.community.article.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryLogProjection;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLog;
+
+public interface ArticleAiSummaryLogRepository extends Repository<ArticleAiSummaryLog, Integer> {
+
+    ArticleAiSummaryLog save(ArticleAiSummaryLog log);
+
+    @Modifying
+    @Query("""
+        DELETE FROM ArticleAiSummaryLog l
+        WHERE l.createdAt < :threshold
+        """)
+    int deleteOlderThan(@Param("threshold") LocalDateTime threshold);
+
+    @Query(value = """
+        SELECT
+          l.id AS logId,
+          l.summary_id AS summaryId,
+          l.article_id AS articleId,
+          l.board_id AS boardId,
+          a.title AS articleTitle,
+          l.event_type AS eventType,
+          l.status AS status,
+          l.failure_type AS failureType,
+          l.message AS message,
+          l.retry_count AS retryCount,
+          l.next_attempt_at AS nextAttemptAt,
+          l.worker_id AS workerId,
+          l.created_at AS createdAt
+        FROM article_ai_summary_logs l
+        LEFT JOIN new_articles a ON a.id = l.article_id AND a.is_deleted = 0
+        WHERE (:summaryId IS NULL OR l.summary_id = :summaryId)
+          AND (:articleId IS NULL OR l.article_id = :articleId)
+          AND (:eventType IS NULL OR l.event_type = :eventType)
+          AND (:failureType IS NULL OR l.failure_type = :failureType)
+        ORDER BY l.created_at DESC, l.id DESC
+        """,
+        countQuery = """
+        SELECT COUNT(*)
+        FROM article_ai_summary_logs l
+        WHERE (:summaryId IS NULL OR l.summary_id = :summaryId)
+          AND (:articleId IS NULL OR l.article_id = :articleId)
+          AND (:eventType IS NULL OR l.event_type = :eventType)
+          AND (:failureType IS NULL OR l.failure_type = :failureType)
+        """,
+        nativeQuery = true)
+    Page<AdminArticleAiSummaryLogProjection> findAdminLogs(
+        @Param("summaryId") Integer summaryId,
+        @Param("articleId") Integer articleId,
+        @Param("eventType") String eventType,
+        @Param("failureType") String failureType,
+        Pageable pageable
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleAiSummaryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleAiSummaryRepository.java
@@ -4,11 +4,16 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryProjection;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryQueueCountProjection;
+import in.koreatech.koin.admin.article.dto.AdminArticleAiSummaryStatusCountProjection;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
 
 public interface ArticleAiSummaryRepository extends Repository<ArticleAiSummary, Integer> {
@@ -101,6 +106,109 @@ public interface ArticleAiSummaryRepository extends Repository<ArticleAiSummary,
     List<ArticleAiSummary> findRetryableFailedSummariesForUpdate(
         @Param("now") LocalDateTime now,
         @Param("limit") int limit,
+        @Param("maxRetryCount") int maxRetryCount
+    );
+
+    @Query(value = """
+        SELECT
+          s.id AS summaryId,
+          a.id AS articleId,
+          a.board_id AS boardId,
+          a.title AS articleTitle,
+          s.status AS status,
+          s.failure_reason AS failureReason,
+          s.retry_count AS retryCount,
+          s.next_attempt_at AS nextAttemptAt,
+          s.locked_until AS lockedUntil,
+          s.worker_id AS workerId,
+          s.created_at AS createdAt,
+          s.updated_at AS updatedAt,
+          s.summarized_at AS summarizedAt,
+          s.source_updated_at AS sourceUpdatedAt,
+          s.model AS model,
+          s.prompt_version AS promptVersion
+        FROM article_ai_summaries s
+        JOIN new_articles a ON a.id = s.article_id AND a.is_deleted = 0
+        WHERE s.is_deleted = 0
+          AND (:status IS NULL OR s.status = :status)
+        ORDER BY s.updated_at DESC, s.id DESC
+        """,
+        countQuery = """
+        SELECT COUNT(*)
+        FROM article_ai_summaries s
+        JOIN new_articles a ON a.id = s.article_id AND a.is_deleted = 0
+        WHERE s.is_deleted = 0
+          AND (:status IS NULL OR s.status = :status)
+        """,
+        nativeQuery = true)
+    Page<AdminArticleAiSummaryProjection> findAdminSummaries(
+        @Param("status") String status,
+        Pageable pageable
+    );
+
+    @Query(value = """
+        SELECT
+          s.id AS summaryId,
+          a.id AS articleId,
+          a.board_id AS boardId,
+          a.title AS articleTitle,
+          s.status AS status,
+          s.failure_reason AS failureReason,
+          s.retry_count AS retryCount,
+          s.next_attempt_at AS nextAttemptAt,
+          s.locked_until AS lockedUntil,
+          s.worker_id AS workerId,
+          s.created_at AS createdAt,
+          s.updated_at AS updatedAt,
+          s.summarized_at AS summarizedAt,
+          s.source_updated_at AS sourceUpdatedAt,
+          s.model AS model,
+          s.prompt_version AS promptVersion
+        FROM article_ai_summaries s
+        JOIN new_articles a ON a.id = s.article_id AND a.is_deleted = 0
+        WHERE s.is_deleted = 0
+          AND s.id = :summaryId
+        """, nativeQuery = true)
+    Optional<AdminArticleAiSummaryProjection> findAdminSummaryById(@Param("summaryId") Integer summaryId);
+
+    @Query(value = """
+        SELECT s.status AS status, COUNT(*) AS summaryCount
+        FROM article_ai_summaries s
+        WHERE s.is_deleted = 0
+        GROUP BY s.status
+        """, nativeQuery = true)
+    List<AdminArticleAiSummaryStatusCountProjection> countAdminSummariesByStatus();
+
+    @Query(value = """
+        SELECT
+          COALESCE(SUM(CASE
+            WHEN status = 'WAIT'
+             AND (locked_until IS NULL OR locked_until < :now)
+             AND (next_attempt_at IS NULL OR next_attempt_at <= :now)
+            THEN 1 ELSE 0 END), 0) AS readyWaitCount,
+          COALESCE(SUM(CASE
+            WHEN status = 'WAIT'
+             AND next_attempt_at > :now
+            THEN 1 ELSE 0 END), 0) AS delayedWaitCount,
+          COALESCE(SUM(CASE
+            WHEN status = 'PROCESSING'
+             AND (locked_until IS NULL OR locked_until >= :now)
+            THEN 1 ELSE 0 END), 0) AS processingCount,
+          COALESCE(SUM(CASE
+            WHEN status = 'PROCESSING'
+             AND locked_until < :now
+            THEN 1 ELSE 0 END), 0) AS expiredProcessingCount,
+          COALESCE(SUM(CASE
+            WHEN status = 'FAILED'
+             AND retry_count < :maxRetryCount
+             AND (next_attempt_at IS NULL OR next_attempt_at <= :now)
+             AND (locked_until IS NULL OR locked_until < :now)
+            THEN 1 ELSE 0 END), 0) AS retryableFailedCount
+        FROM article_ai_summaries
+        WHERE is_deleted = 0
+        """, nativeQuery = true)
+    AdminArticleAiSummaryQueueCountProjection countAdminQueue(
+        @Param("now") LocalDateTime now,
         @Param("maxRetryCount") int maxRetryCount
     );
 

--- a/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleAiSummaryScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/scheduler/ArticleAiSummaryScheduler.java
@@ -60,6 +60,19 @@ public class ArticleAiSummaryScheduler {
         }
     }
 
+    // 기본 FAILED 재처리 창 안의 저트래픽 시간대이며, 정각 배치와 겹치지 않도록 03:20에 실행한다.
+    @Scheduled(cron = "0 20 3 * * *")
+    public void deleteOldArticleAiSummaryLogs() {
+        try {
+            int deletedCount = articleAiSummaryService.deleteOldLogs();
+            if (deletedCount > 0) {
+                log.info("90일 지난 게시글 AI 요약 로그를 삭제했습니다. count: {}", deletedCount);
+            }
+        } catch (Exception e) {
+            log.warn("게시글 AI 요약 로그 삭제 중 오류가 발생했습니다.", e);
+        }
+    }
+
     private int resolveClaimLimit() {
         ThreadPoolExecutor executor = articleSummaryTaskExecutor.getThreadPoolExecutor();
         int idleWorkerCount = Math.max(0, articleSummaryTaskExecutor.getMaxPoolSize() - articleSummaryTaskExecutor.getActiveCount());

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryService.java
@@ -34,6 +34,7 @@ public class ArticleAiSummaryService {
     private final ArticleRepository articleRepository;
     private final ArticleSummarySourceReader sourceReader;
     private final ArticleSummaryContentRenderer contentRenderer;
+    private final ArticleSummaryFailureReasonSanitizer failureReasonSanitizer;
     private final ArticleAiSummaryProperties properties;
     private final UpstageProperties upstageProperties;
     private final Clock clock;
@@ -151,16 +152,17 @@ public class ArticleAiSummaryService {
         articleAiSummaryRepository.findById(summaryId)
             .filter(summary -> summary.isProcessingBy(workerId))
             .ifPresent(summary -> {
+                String sanitizedReason = failureReasonSanitizer.sanitize(reason);
                 int nextRetryCount = summary.getRetryCount() + 1;
                 LocalDateTime nextAttemptAt = null;
                 if (nextRetryCount < properties.getMaxRetryCount()) {
                     nextAttemptAt = LocalDateTime.now(clock).plus(resolveRetryDelay(nextRetryCount, retryAfter));
                 }
                 if (retryAfter != null && nextAttemptAt != null) {
-                    summary.waitForRetry(reason, nextAttemptAt);
+                    summary.waitForRetry(sanitizedReason, nextAttemptAt);
                     return;
                 }
-                summary.completeFailure(reason, nextAttemptAt);
+                summary.completeFailure(sanitizedReason, nextAttemptAt);
             });
     }
 
@@ -168,14 +170,17 @@ public class ArticleAiSummaryService {
     public void completeFailureWithoutRetry(Integer summaryId, String workerId, String reason) {
         articleAiSummaryRepository.findById(summaryId)
             .filter(summary -> summary.isProcessingBy(workerId))
-            .ifPresent(summary -> summary.completeFailureWithoutRetry(reason, properties.getMaxRetryCount()));
+            .ifPresent(summary -> summary.completeFailureWithoutRetry(
+                failureReasonSanitizer.sanitize(reason),
+                properties.getMaxRetryCount()
+            ));
     }
 
     @Transactional
     public void skip(Integer summaryId, String workerId, String reason) {
         articleAiSummaryRepository.findById(summaryId)
             .filter(summary -> summary.isProcessingBy(workerId))
-            .ifPresent(summary -> summary.skip(reason));
+            .ifPresent(summary -> summary.skip(failureReasonSanitizer.sanitize(reason)));
     }
 
     private void enqueueIfEnabled(Article article, String fingerprint, LocalDateTime sourceUpdatedAt) {

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryService.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryService.java
@@ -20,17 +20,25 @@ import org.springframework.util.StringUtils;
 
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLog;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryLogRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.infrastructure.upstage.client.UpstageProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ArticleAiSummaryService {
 
+    private static final int LOG_RETENTION_DAYS = 90;
+
     private final ArticleAiSummaryRepository articleAiSummaryRepository;
+    private final ArticleAiSummaryLogRepository articleAiSummaryLogRepository;
     private final ArticleRepository articleRepository;
     private final ArticleSummarySourceReader sourceReader;
     private final ArticleSummaryContentRenderer contentRenderer;
@@ -160,9 +168,23 @@ public class ArticleAiSummaryService {
                 }
                 if (retryAfter != null && nextAttemptAt != null) {
                     summary.waitForRetry(sanitizedReason, nextAttemptAt);
+                    ArticleSummaryFailureType failureType = saveLog(
+                        summary,
+                        ArticleAiSummaryLogType.RETRY_WAITING,
+                        sanitizedReason,
+                        workerId
+                    );
+                    logRetryWaiting(summary, workerId, failureType, sanitizedReason, nextAttemptAt);
                     return;
                 }
                 summary.completeFailure(sanitizedReason, nextAttemptAt);
+                ArticleSummaryFailureType failureType = saveLog(
+                    summary,
+                    nextAttemptAt == null ? ArticleAiSummaryLogType.TERMINAL_FAILED : ArticleAiSummaryLogType.FAILED,
+                    sanitizedReason,
+                    workerId
+                );
+                logFailure(summary, workerId, failureType, sanitizedReason, nextAttemptAt);
             });
     }
 
@@ -170,17 +192,39 @@ public class ArticleAiSummaryService {
     public void completeFailureWithoutRetry(Integer summaryId, String workerId, String reason) {
         articleAiSummaryRepository.findById(summaryId)
             .filter(summary -> summary.isProcessingBy(workerId))
-            .ifPresent(summary -> summary.completeFailureWithoutRetry(
-                failureReasonSanitizer.sanitize(reason),
-                properties.getMaxRetryCount()
-            ));
+            .ifPresent(summary -> {
+                String sanitizedReason = failureReasonSanitizer.sanitize(reason);
+                summary.completeFailureWithoutRetry(sanitizedReason, properties.getMaxRetryCount());
+                ArticleSummaryFailureType failureType = saveLog(
+                    summary,
+                    ArticleAiSummaryLogType.TERMINAL_FAILED,
+                    sanitizedReason,
+                    workerId
+                );
+                logTerminalFailure(summary, workerId, failureType, sanitizedReason, "재시도 불가능한 오류입니다.");
+            });
     }
 
     @Transactional
     public void skip(Integer summaryId, String workerId, String reason) {
         articleAiSummaryRepository.findById(summaryId)
             .filter(summary -> summary.isProcessingBy(workerId))
-            .ifPresent(summary -> summary.skip(failureReasonSanitizer.sanitize(reason)));
+            .ifPresent(summary -> {
+                String sanitizedReason = failureReasonSanitizer.sanitize(reason);
+                summary.skip(sanitizedReason);
+                ArticleSummaryFailureType failureType = saveLog(
+                    summary,
+                    ArticleAiSummaryLogType.SKIPPED,
+                    sanitizedReason,
+                    workerId
+                );
+                logSkipped(summary, workerId, failureType, sanitizedReason);
+            });
+    }
+
+    @Transactional
+    public int deleteOldLogs() {
+        return articleAiSummaryLogRepository.deleteOlderThan(LocalDateTime.now(clock).minusDays(LOG_RETENTION_DAYS));
     }
 
     private void enqueueIfEnabled(Article article, String fingerprint, LocalDateTime sourceUpdatedAt) {
@@ -231,5 +275,126 @@ public class ArticleAiSummaryService {
         long multiplier = 1L << Math.min(Math.max(nextRetryCount - 1, 0), 10);
         Duration configuredBackoff = Duration.ofMinutes((long)properties.getRetryBackoffMinutes() * multiplier);
         return configuredBackoff.compareTo(maxBackoff) > 0 ? maxBackoff : configuredBackoff;
+    }
+
+    private void logRetryWaiting(
+        ArticleAiSummary summary,
+        String workerId,
+        ArticleSummaryFailureType failureType,
+        String reason,
+        LocalDateTime nextAttemptAt
+    ) {
+        log.debug(
+            "게시글 AI 요약 일시 오류로 재시도 대기합니다. summaryId: {}, articleId: {}, boardId: {}, status: {}, "
+                + "failureType: {}, retryCount: {}/{}, nextAttemptAt: {}, workerId: {}, reason: {}, "
+                + "impact: 요약은 아직 노출되지 않고 원문만 반환됩니다.",
+            summary.getId(),
+            articleId(summary),
+            boardId(summary),
+            summary.getStatus(),
+            failureType,
+            summary.getRetryCount(),
+            properties.getMaxRetryCount(),
+            nextAttemptAt,
+            workerId,
+            reason
+        );
+    }
+
+    private void logFailure(
+        ArticleAiSummary summary,
+        String workerId,
+        ArticleSummaryFailureType failureType,
+        String reason,
+        LocalDateTime nextAttemptAt
+    ) {
+        if (nextAttemptAt == null) {
+            logTerminalFailure(summary, workerId, failureType, reason, "최대 재시도 횟수에 도달했습니다.");
+            return;
+        }
+        log.debug(
+            "게시글 AI 요약 생성 실패로 FAILED 재처리 큐에 등록했습니다. summaryId: {}, articleId: {}, boardId: {}, "
+                + "status: {}, failureType: {}, retryCount: {}/{}, nextAttemptAt: {}, retryWindow: {}:00-{}:00, "
+                + "workerId: {}, reason: {}, impact: 요약은 아직 노출되지 않고 원문만 반환됩니다.",
+            summary.getId(),
+            articleId(summary),
+            boardId(summary),
+            summary.getStatus(),
+            failureType,
+            summary.getRetryCount(),
+            properties.getMaxRetryCount(),
+            nextAttemptAt,
+            properties.getBoundedFailedRetryWindowStartHour(),
+            properties.getBoundedFailedRetryWindowEndHour(),
+            workerId,
+            reason
+        );
+    }
+
+    private void logTerminalFailure(
+        ArticleAiSummary summary,
+        String workerId,
+        ArticleSummaryFailureType failureType,
+        String reason,
+        String cause
+    ) {
+        log.debug(
+            "게시글 AI 요약 생성이 중단되었습니다. summaryId: {}, articleId: {}, boardId: {}, status: {}, "
+                + "failureType: {}, retryCount: {}/{}, workerId: {}, cause: {}, reason: {}, "
+                + "impact: 해당 게시글은 요약 없이 원문만 반환됩니다. action: Admin AI 요약 상세 API로 상태를 확인하고 원문/첨부/Upstage 상태를 점검하세요.",
+            summary.getId(),
+            articleId(summary),
+            boardId(summary),
+            summary.getStatus(),
+            failureType,
+            summary.getRetryCount(),
+            properties.getMaxRetryCount(),
+            workerId,
+            cause,
+            reason
+        );
+    }
+
+    private void logSkipped(
+        ArticleAiSummary summary,
+        String workerId,
+        ArticleSummaryFailureType failureType,
+        String reason
+    ) {
+        log.debug(
+            "게시글 AI 요약 생성을 스킵했습니다. summaryId: {}, articleId: {}, boardId: {}, status: {}, "
+                + "failureType: {}, workerId: {}, reason: {}, impact: 요약 없이 원문만 반환됩니다.",
+            summary.getId(),
+            articleId(summary),
+            boardId(summary),
+            summary.getStatus(),
+            failureType,
+            workerId,
+            reason
+        );
+    }
+
+    private ArticleSummaryFailureType saveLog(
+        ArticleAiSummary summary,
+        ArticleAiSummaryLogType eventType,
+        String reason,
+        String workerId
+    ) {
+        ArticleSummaryFailureType failureType = failureReasonSanitizer.classify(reason);
+        articleAiSummaryLogRepository.save(ArticleAiSummaryLog.of(summary, eventType, failureType, reason, workerId));
+        return failureType;
+    }
+
+    private Integer articleId(ArticleAiSummary summary) {
+        Article article = summary.getArticle();
+        return article == null ? null : article.getId();
+    }
+
+    private Integer boardId(ArticleAiSummary summary) {
+        Article article = summary.getArticle();
+        if (article == null || article.getBoard() == null) {
+            return null;
+        }
+        return article.getBoard().getId();
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryWorker.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryWorker.java
@@ -29,15 +29,19 @@ public class ArticleAiSummaryWorker {
                 .ifPresent(seed -> generate(summaryId, workerId, seed));
         } catch (ArticleSummaryExternalApiException e) {
             if (e.isRetryable()) {
-                log.warn("게시글 AI 요약 외부 API가 일시 실패했습니다. summaryId: {}, reason: {}", summaryId, e.getMessage());
                 articleAiSummaryService.completeFailure(summaryId, workerId, e.getMessage(), e.getRetryAfter());
                 return;
             }
-            log.error("게시글 AI 요약 외부 API가 재시도 불가능한 오류를 반환했습니다. summaryId: {}", summaryId, e);
             articleAiSummaryService.completeFailureWithoutRetry(summaryId, workerId, e.getMessage());
         } catch (Exception e) {
-            log.error("게시글 AI 요약 생성 중 오류가 발생했습니다. summaryId: {}", summaryId, e);
-            articleAiSummaryService.completeFailure(summaryId, workerId, e.getMessage());
+            log.error(
+                "게시글 AI 요약 워커에서 예기치 못한 예외가 발생했습니다. summaryId: {}, workerId: {}, exception: {}",
+                summaryId,
+                workerId,
+                e.getClass().getSimpleName(),
+                e
+            );
+            articleAiSummaryService.completeFailure(summaryId, workerId, exceptionSummary(e));
         }
     }
 
@@ -81,7 +85,6 @@ public class ArticleAiSummaryWorker {
         try {
             summaryLines = validateOrCorrect(result, prompt);
         } catch (ArticleSummaryValidationException e) {
-            log.warn("게시글 AI 요약이 최종 검증을 통과하지 못해 재시도 대기로 전환합니다. summaryId: {}, reason: {}", summaryId, e.getMessage());
             articleAiSummaryService.completeFailure(summaryId, workerId, e.getMessage());
             return;
         }
@@ -195,6 +198,13 @@ public class ArticleAiSummaryWorker {
             return "";
         }
         return value.toLowerCase(Locale.ROOT).replaceAll("\\s+", "");
+    }
+
+    private String exceptionSummary(Exception e) {
+        if (!StringUtils.hasText(e.getMessage())) {
+            return e.getClass().getSimpleName();
+        }
+        return e.getClass().getSimpleName() + ": " + e.getMessage();
     }
 
     private record RefinementResult(

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryWorker.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryWorker.java
@@ -53,6 +53,10 @@ public class ArticleAiSummaryWorker {
         if (shouldWaitForTemporaryAttachment(source)) {
             throw new ArticleSummaryExternalApiException("첨부 중심 게시글의 문서 파싱이 일시 실패해 요약 생성을 보류합니다.", true, null);
         }
+        if (isAttachmentOnlyContent(source) && source.attachmentTexts().isEmpty()) {
+            articleAiSummaryService.skip(summaryId, workerId, "첨부 중심 게시글이지만 요약에 사용할 첨부 문서 내용이 없습니다.");
+            return;
+        }
 
         ArticleSummaryPrompt prompt = promptBuilder.build(source);
         ArticleSummaryResult result = articleSummaryAiClient.summarize(prompt);
@@ -169,6 +173,10 @@ public class ArticleAiSummaryWorker {
         if (!source.hasTemporaryAttachmentFailure() || !source.attachmentTexts().isEmpty()) {
             return false;
         }
+        return isAttachmentOnlyContent(source);
+    }
+
+    private boolean isAttachmentOnlyContent(ArticleSummarySource source) {
         String normalizedContent = normalize(source.contentText());
         if (!StringUtils.hasText(normalizedContent)) {
             return true;

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryFailureReasonSanitizer.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryFailureReasonSanitizer.java
@@ -1,0 +1,77 @@
+package in.koreatech.koin.domain.community.article.service.summary;
+
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class ArticleSummaryFailureReasonSanitizer {
+
+    private static final int MAX_LENGTH = 500;
+    private static final Pattern BEARER_TOKEN_PATTERN = Pattern.compile("(?i)bearer\\s+[a-z0-9._~+/=-]+");
+    private static final Pattern UPSTAGE_KEY_PATTERN = Pattern.compile("up_[A-Za-z0-9]+");
+    private static final Pattern URL_QUERY_PATTERN = Pattern.compile("(https?://[^\\s,]+)\\?[^\\s,]*");
+    private static final Pattern BODY_PATTERN = Pattern.compile("(?i)(,?\\s*body=).*$");
+
+    public String sanitize(String reason) {
+        if (!StringUtils.hasText(reason)) {
+            return null;
+        }
+        String sanitized = reason.replaceAll("\\s+", " ").trim();
+        sanitized = BEARER_TOKEN_PATTERN.matcher(sanitized).replaceAll("Bearer <redacted>");
+        sanitized = UPSTAGE_KEY_PATTERN.matcher(sanitized).replaceAll("up_<redacted>");
+        sanitized = URL_QUERY_PATTERN.matcher(sanitized).replaceAll("$1?<redacted>");
+        sanitized = BODY_PATTERN.matcher(sanitized).replaceAll("$1<redacted>");
+        return truncate(sanitized);
+    }
+
+    public ArticleSummaryFailureType classify(String reason) {
+        String sanitized = sanitize(reason);
+        if (!StringUtils.hasText(sanitized)) {
+            return ArticleSummaryFailureType.UNKNOWN;
+        }
+        String value = sanitized.toLowerCase();
+        if (value.contains("status=429") || value.contains("rate limit") || value.contains("too many requests")) {
+            return ArticleSummaryFailureType.RATE_LIMIT;
+        }
+        if (value.contains("문서 다운로드")) {
+            return ArticleSummaryFailureType.DOCUMENT_DOWNLOAD;
+        }
+        if (value.contains("문서 파싱") || value.contains("document parse")) {
+            return ArticleSummaryFailureType.DOCUMENT_PARSE;
+        }
+        if (value.contains("prematurecloseexception") || value.contains("timeout") || value.contains("timed out")) {
+            return ArticleSummaryFailureType.NETWORK_TRANSIENT;
+        }
+        if (value.contains("status=5")) {
+            return ArticleSummaryFailureType.UPSTAGE_SERVER_ERROR;
+        }
+        if (value.contains("status=4")) {
+            return ArticleSummaryFailureType.UPSTAGE_CLIENT_ERROR;
+        }
+        if (value.contains("json 파싱") || value.contains("응답이 비어") || value.contains("본문이 비어")) {
+            return ArticleSummaryFailureType.MODEL_RESPONSE_INVALID;
+        }
+        if (value.contains("요약에 사용할 본문") || value.contains("내용이 없습니다")) {
+            return ArticleSummaryFailureType.EMPTY_SOURCE;
+        }
+        if (value.contains("요약할 핵심 정보") || value.contains("결과가 비어")) {
+            return ArticleSummaryFailureType.EMPTY_RESULT;
+        }
+        if (value.contains("upstage api key")) {
+            return ArticleSummaryFailureType.CONFIG;
+        }
+        if (value.contains("검증") || value.contains("출처에 없는") || value.contains("초과") || value.contains("중복")) {
+            return ArticleSummaryFailureType.VALIDATION;
+        }
+        return ArticleSummaryFailureType.UNKNOWN;
+    }
+
+    private String truncate(String value) {
+        if (value.length() <= MAX_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_LENGTH);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryFailureType.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryFailureType.java
@@ -1,0 +1,16 @@
+package in.koreatech.koin.domain.community.article.service.summary;
+
+public enum ArticleSummaryFailureType {
+    RATE_LIMIT,
+    NETWORK_TRANSIENT,
+    UPSTAGE_SERVER_ERROR,
+    UPSTAGE_CLIENT_ERROR,
+    DOCUMENT_DOWNLOAD,
+    DOCUMENT_PARSE,
+    MODEL_RESPONSE_INVALID,
+    VALIDATION,
+    EMPTY_SOURCE,
+    EMPTY_RESULT,
+    CONFIG,
+    UNKNOWN
+}

--- a/src/main/resources/db/migration/V4__create_article_ai_summary_logs.sql
+++ b/src/main/resources/db/migration/V4__create_article_ai_summary_logs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `article_ai_summary_logs` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `summary_id` INT UNSIGNED NULL,
+    `article_id` INT UNSIGNED NULL,
+    `board_id` INT UNSIGNED NULL,
+    `event_type` VARCHAR(30) NOT NULL,
+    `status` VARCHAR(20) NULL,
+    `failure_type` VARCHAR(50) NULL,
+    `message` VARCHAR(500) CHARACTER SET 'utf8mb4' NULL,
+    `retry_count` INT UNSIGNED NULL,
+    `next_attempt_at` TIMESTAMP NULL,
+    `worker_id` VARCHAR(100) NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    INDEX `idx_article_ai_summary_logs_created_at` (`created_at`),
+    INDEX `idx_article_ai_summary_logs_summary_created` (`summary_id`, `created_at`),
+    INDEX `idx_article_ai_summary_logs_article_created` (`article_id`, `created_at`),
+    INDEX `idx_article_ai_summary_logs_type_created` (`event_type`, `failure_type`, `created_at`),
+    CONSTRAINT `fk_article_ai_summary_logs_summary_id`
+        FOREIGN KEY (`summary_id`) REFERENCES `article_ai_summaries` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/in/koreatech/koin/acceptance/admin/AdminArticleAiSummaryApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/admin/AdminArticleAiSummaryApiTest.java
@@ -21,8 +21,12 @@ import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
 import in.koreatech.koin.admin.manager.model.Admin;
 import in.koreatech.koin.domain.community.article.model.Article;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLog;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
 import in.koreatech.koin.domain.community.article.model.Board;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryLogRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
 import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 
@@ -43,10 +47,14 @@ class AdminArticleAiSummaryApiTest extends AcceptanceTest {
     @Autowired
     private ArticleAiSummaryRepository articleAiSummaryRepository;
 
+    @Autowired
+    private ArticleAiSummaryLogRepository articleAiSummaryLogRepository;
+
     private String koinAdminToken;
     private String studentToken;
     private Article failedArticle;
     private ArticleAiSummary failedSummary;
+    private String rawFailureReason;
 
     @BeforeEach
     void setUp() {
@@ -74,12 +82,18 @@ class AdminArticleAiSummaryApiTest extends AcceptanceTest {
             "solar-pro3",
             "v9"
         );
-        failedSummary.completeFailure(
-            "Upstage 요약 API 호출에 실패했습니다. status=429, body={\"url\":\"https://koreatech.in/file.pdf?token=abc\"} "
-                + "Authorization: Bearer abc.def up_TESTKEYDOESNOTEXIST1234567890",
-            LocalDateTime.now(clock).minusMinutes(1)
-        );
+        rawFailureReason = "Upstage 요약 API 호출에 실패했습니다. status=429, "
+            + "body={\"url\":\"https://koreatech.in/file.pdf?token=abc\"} "
+            + "Authorization: Bearer abc.def up_TESTKEYDOESNOTEXIST1234567890";
+        failedSummary.completeFailure(rawFailureReason, LocalDateTime.now(clock).minusMinutes(1));
         articleAiSummaryRepository.save(failedSummary);
+        articleAiSummaryLogRepository.save(ArticleAiSummaryLog.of(
+            failedSummary,
+            ArticleAiSummaryLogType.FAILED,
+            ArticleSummaryFailureType.RATE_LIMIT,
+            rawFailureReason,
+            "worker-test"
+        ));
     }
 
     @Test
@@ -131,6 +145,26 @@ class AdminArticleAiSummaryApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.content").doesNotExist())
             .andExpect(jsonPath("$.prompt").doesNotExist())
             .andExpect(jsonPath("$.parsed_text").doesNotExist());
+    }
+
+    @Test
+    void 관리자가_게시글_AI_요약_로그를_조회한다() throws Exception {
+        mockMvc.perform(
+                get("/admin/articles/ai-summaries/logs")
+                    .header("Authorization", "Bearer " + koinAdminToken)
+                    .param("failure_type", "RATE_LIMIT")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.total_count").value(1))
+            .andExpect(jsonPath("$.logs[0].summary_id").value(failedSummary.getId()))
+            .andExpect(jsonPath("$.logs[0].article_id").value(failedArticle.getId()))
+            .andExpect(jsonPath("$.logs[0].event_type").value("FAILED"))
+            .andExpect(jsonPath("$.logs[0].failure_type").value("RATE_LIMIT"))
+            .andExpect(jsonPath("$.logs[0].message").value(containsString("body=<redacted>")))
+            .andExpect(jsonPath("$.logs[0].message").value(not(containsString("abc.def"))))
+            .andExpect(jsonPath("$.logs[0].message").value(not(containsString("up_TESTKEY"))))
+            .andExpect(jsonPath("$.logs[0].message").value(not(containsString("token=abc"))));
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/admin/AdminArticleAiSummaryApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/admin/AdminArticleAiSummaryApiTest.java
@@ -1,0 +1,145 @@
+package in.koreatech.koin.acceptance.admin;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.ArticleAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.BoardAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.admin.manager.model.Admin;
+import in.koreatech.koin.domain.community.article.model.Article;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
+import in.koreatech.koin.domain.community.article.model.Board;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+
+class AdminArticleAiSummaryApiTest extends AcceptanceTest {
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private BoardAcceptanceFixture boardFixture;
+
+    @Autowired
+    private ArticleAcceptanceFixture articleFixture;
+
+    @Autowired
+    private ArticleAiSummaryRepository articleAiSummaryRepository;
+
+    private String koinAdminToken;
+    private String studentToken;
+    private Article failedArticle;
+    private ArticleAiSummary failedSummary;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student student = userFixture.준호_학생(department, null);
+        Admin admin = userFixture.영희_운영자();
+        studentToken = userFixture.getToken(student.getUser());
+        koinAdminToken = userFixture.getToken(admin.getUser());
+        Board board = boardFixture.자유게시판();
+        Article waitingArticle = articleFixture.자유글_1(board, student.getUser());
+        failedArticle = articleFixture.자유글_2(board, student.getUser());
+
+        articleAiSummaryRepository.save(ArticleAiSummary.waiting(
+            waitingArticle,
+            "fingerprint-wait",
+            waitingArticle.getUpdatedAt(),
+            "solar-pro3",
+            "v9"
+        ));
+        failedSummary = ArticleAiSummary.waiting(
+            failedArticle,
+            "fingerprint-failed",
+            failedArticle.getUpdatedAt(),
+            "solar-pro3",
+            "v9"
+        );
+        failedSummary.completeFailure(
+            "Upstage 요약 API 호출에 실패했습니다. status=429, body={\"url\":\"https://koreatech.in/file.pdf?token=abc\"} "
+                + "Authorization: Bearer abc.def up_TESTKEYDOESNOTEXIST1234567890",
+            LocalDateTime.now(clock).minusMinutes(1)
+        );
+        articleAiSummaryRepository.save(failedSummary);
+    }
+
+    @Test
+    void 승인된_코인_어드민은_super_admin이_아니어도_게시글_AI_요약_큐_상태를_조회한다() throws Exception {
+        mockMvc.perform(
+                get("/admin/articles/ai-summaries/overview")
+                    .header("Authorization", "Bearer " + koinAdminToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status_counts[0].status").value("WAIT"))
+            .andExpect(jsonPath("$.status_counts[0].count").value(1))
+            .andExpect(jsonPath("$.status_counts[3].status").value("FAILED"))
+            .andExpect(jsonPath("$.status_counts[3].count").value(1))
+            .andExpect(jsonPath("$.queue.ready_wait_count").value(1))
+            .andExpect(jsonPath("$.queue.retryable_failed_count").value(1))
+            .andExpect(jsonPath("$.config.batch_size").value(5));
+    }
+
+    @Test
+    void 관리자가_실패한_게시글_AI_요약_목록과_마스킹된_오류를_조회한다() throws Exception {
+        mockMvc.perform(
+                get("/admin/articles/ai-summaries")
+                    .header("Authorization", "Bearer " + koinAdminToken)
+                    .param("status", "FAILED")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.total_count").value(1))
+            .andExpect(jsonPath("$.summaries[0].summary_id").value(failedSummary.getId()))
+            .andExpect(jsonPath("$.summaries[0].article_id").value(failedArticle.getId()))
+            .andExpect(jsonPath("$.summaries[0].failure_type").value("RATE_LIMIT"))
+            .andExpect(jsonPath("$.summaries[0].failure_message").value(containsString("body=<redacted>")))
+            .andExpect(jsonPath("$.summaries[0].failure_message").value(not(containsString("abc.def"))))
+            .andExpect(jsonPath("$.summaries[0].failure_message").value(not(containsString("up_TESTKEY"))))
+            .andExpect(jsonPath("$.summaries[0].failure_message").value(not(containsString("token=abc"))));
+    }
+
+    @Test
+    void 관리자가_게시글_AI_요약_상세를_조회해도_원문과_raw_오류는_노출되지_않는다() throws Exception {
+        mockMvc.perform(
+                get("/admin/articles/ai-summaries/{summaryId}", failedSummary.getId())
+                    .header("Authorization", "Bearer " + koinAdminToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.article_title").value(failedArticle.getTitle()))
+            .andExpect(jsonPath("$.failure_message").value(containsString("body=<redacted>")))
+            .andExpect(jsonPath("$.content").doesNotExist())
+            .andExpect(jsonPath("$.prompt").doesNotExist())
+            .andExpect(jsonPath("$.parsed_text").doesNotExist());
+    }
+
+    @Test
+    void 관리자가_아니면_게시글_AI_요약_큐를_조회할_수_없다() throws Exception {
+        mockMvc.perform(
+                get("/admin/articles/ai-summaries/overview")
+                    .header("Authorization", "Bearer " + studentToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryServiceTest.java
@@ -17,11 +17,15 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLog;
+import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryLogType;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
+import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryLogRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
 import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryProperties;
@@ -36,6 +40,9 @@ class ArticleAiSummaryServiceTest {
 
     @Mock
     private ArticleAiSummaryRepository articleAiSummaryRepository;
+
+    @Mock
+    private ArticleAiSummaryLogRepository articleAiSummaryLogRepository;
 
     @Mock
     private ArticleRepository articleRepository;
@@ -59,6 +66,11 @@ class ArticleAiSummaryServiceTest {
         assertThat(summary.getRetryCount()).isEqualTo(1);
         assertThat(summary.getNextAttemptAt()).isEqualTo(LocalDateTime.now(clock).plusMinutes(1));
         assertThat(summary.getLockedUntil()).isNull();
+
+        ArgumentCaptor<ArticleAiSummaryLog> logCaptor = ArgumentCaptor.forClass(ArticleAiSummaryLog.class);
+        verify(articleAiSummaryLogRepository).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getEventType()).isEqualTo(ArticleAiSummaryLogType.RETRY_WAITING);
+        assertThat(logCaptor.getValue().getStatus()).isEqualTo(ArticleAiSummaryStatus.WAIT);
     }
 
     @Test
@@ -73,6 +85,16 @@ class ArticleAiSummaryServiceTest {
         assertThat(summary.getStatus()).isEqualTo(ArticleAiSummaryStatus.FAILED);
         assertThat(summary.getRetryCount()).isEqualTo(1);
         assertThat(summary.getNextAttemptAt()).isEqualTo(LocalDateTime.now(clock).plusMinutes(5));
+    }
+
+    @Test
+    void 게시글_AI_요약_로그는_90일_이전_데이터를_삭제한다() {
+        Clock clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+        ArticleAiSummaryService service = service(clock);
+
+        service.deleteOldLogs();
+
+        verify(articleAiSummaryLogRepository).deleteOlderThan(LocalDateTime.now(clock).minusDays(90));
     }
 
     @Test
@@ -121,6 +143,7 @@ class ArticleAiSummaryServiceTest {
         upstageProperties.setApiKey("test-api-key");
         return new ArticleAiSummaryService(
             articleAiSummaryRepository,
+            articleAiSummaryLogRepository,
             articleRepository,
             sourceReader,
             contentRenderer,

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryServiceTest.java
@@ -27,6 +27,7 @@ import in.koreatech.koin.domain.community.article.repository.ArticleRepository;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryProperties;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryService;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryContentRenderer;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureReasonSanitizer;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleSummarySourceReader;
 import in.koreatech.koin.infrastructure.upstage.client.UpstageProperties;
 
@@ -123,6 +124,7 @@ class ArticleAiSummaryServiceTest {
             articleRepository,
             sourceReader,
             contentRenderer,
+            new ArticleSummaryFailureReasonSanitizer(),
             properties,
             upstageProperties,
             clock

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryWorkerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryWorkerTest.java
@@ -241,6 +241,31 @@ class ArticleAiSummaryWorkerTest {
     }
 
     @Test
+    void 첨부_중심_게시글인데_첨부_내용이_없으면_Solar를_호출하지_않고_스킵한다() {
+        ArticleSummarySourceSeed seed = sourceSeed();
+        ArticleSummarySource source = new ArticleSummarySource(
+            1,
+            "장학금 신청 안내",
+            "첨부파일을 확인하세요.",
+            "학생처",
+            LocalDate.of(2026, 5, 1),
+            LocalDateTime.of(2026, 5, 1, 10, 0),
+            List.of(),
+            false,
+            "fingerprint"
+        );
+        when(articleAiSummaryService.getGenerationSeed(1, "worker")).thenReturn(Optional.of(seed));
+        when(sourceReader.read(seed)).thenReturn(source);
+
+        worker.process(1, "worker");
+
+        verify(articleAiSummaryService).skip(eq(1), eq("worker"), contains("첨부 중심 게시글"));
+        verify(articleSummaryAiClient, never()).summarize(any());
+        verify(articleAiSummaryService, never()).completeFailure(any(), any(), any());
+        verify(articleAiSummaryService, never()).completeSuccess(any(), any(), any(), any());
+    }
+
+    @Test
     void retry_after가_있는_외부_API_일시_오류는_재시도_시간과_함께_실패_처리한다() {
         ArticleSummarySourceSeed seed = sourceSeed();
         ArticleSummarySource source = source();

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleSummaryFailureReasonSanitizerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleSummaryFailureReasonSanitizerTest.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.unit.domain.community.article.service.summary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureReasonSanitizer;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleSummaryFailureType;
+
+class ArticleSummaryFailureReasonSanitizerTest {
+
+    private final ArticleSummaryFailureReasonSanitizer sanitizer = new ArticleSummaryFailureReasonSanitizer();
+
+    @Test
+    void 민감한_토큰_URL_query_provider_body를_마스킹한다() {
+        String reason = "Upstage 요약 API 호출에 실패했습니다. status=429, body={\"url\":\"https://x.com/a.pdf?token=abc\"} "
+            + "Authorization: Bearer abc.def up_TESTKEYDOESNOTEXIST1234567890";
+
+        String sanitized = sanitizer.sanitize(reason);
+
+        assertThat(sanitized).contains("status=429");
+        assertThat(sanitized).contains("body=<redacted>");
+        assertThat(sanitized).doesNotContain("abc.def");
+        assertThat(sanitized).doesNotContain("up_TESTKEY");
+        assertThat(sanitized).doesNotContain("token=abc");
+    }
+
+    @Test
+    void 실패_원인을_운영자가_볼_수_있는_유형으로_분류한다() {
+        assertThat(sanitizer.classify("Upstage 요약 API 호출에 실패했습니다. status=429"))
+            .isEqualTo(ArticleSummaryFailureType.RATE_LIMIT);
+        assertThat(sanitizer.classify("Upstage 요약 처리 중 오류가 발생했습니다. cause=PrematureCloseException"))
+            .isEqualTo(ArticleSummaryFailureType.NETWORK_TRANSIENT);
+        assertThat(sanitizer.classify("Upstage 문서 파싱 API 호출에 실패했습니다. status=500"))
+            .isEqualTo(ArticleSummaryFailureType.DOCUMENT_PARSE);
+        assertThat(sanitizer.classify("출처에 없는 날짜/숫자 정보가 포함되었습니다. token=5월 21일"))
+            .isEqualTo(ArticleSummaryFailureType.VALIDATION);
+    }
+}


### PR DESCRIPTION
### 🚀 주요 변경 내용

* 게시글 AI 요약의 상태별 개수와 대기열 현황을 조회하는 Admin API를 추가했습니다.
* 요약 목록과 단건 상태, 실패 사유, 재시도 횟수와 처리 로그를 조회할 수 있도록 추가했습니다.
* API 키, Bearer 토큰, URL query와 외부 API 응답 본문을 마스킹하도록 적용했습니다.
* 요약 처리 로그를 DB에 저장하고 90일이 지난 로그를 삭제하도록 구성했습니다.

---

### 💬 참고 사항

* 관련 이슈: #2248
* 게시글 AI 요약 큐 처리 및 조회 적용 PR을 기반으로 합니다.
* `super_admin` 여부와 관계없이 로그인이 승인된 코인 어드민 계정이 조회할 수 있습니다.
* 관리자 인수 테스트와 오류 마스킹 단위 테스트를 통과했습니다.

#### 게시글 AI 요약 처리 흐름

![게시글 AI 요약 처리 흐름](https://github.com/user-attachments/assets/f42d09ff-d8d4-4423-b1ed-11991e942cb8)

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin APIs to monitor AI article-summary queues, statuses, details, and processing logs.
  * Added filtering and pagination for summaries and logs.
  * Added failure categorization, sensitive-message masking, and retry information.
  * Added automatic cleanup of logs older than 90 days.
* **Bug Fixes**
  * Articles without available attachment text are now skipped safely.
* **Tests**
  * Added coverage for admin access, queue monitoring, log masking, failure classification, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->