### PR TITLE
fix: 삭제된 게시판의 게시글을 AI 요약 큐 대상에서 제외

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/repository/ArticleRepository.java
@@ -201,6 +201,7 @@ public interface ArticleRepository extends Repository<Article, Integer> {
     @Query(value = """
         SELECT a.id
         FROM new_articles a
+        JOIN boards b ON b.id = a.board_id AND b.is_deleted = false
         LEFT JOIN article_ai_summaries s ON s.article_id = a.id AND s.is_deleted = false
         WHERE a.is_deleted = false
           AND a.board_id <> :excludedBoardId

--- a/src/test/java/in/koreatech/koin/acceptance/domain/ArticleAiSummaryApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/ArticleAiSummaryApiTest.java
@@ -25,7 +25,9 @@ import in.koreatech.koin.domain.community.article.model.ArticleAiSummary;
 import in.koreatech.koin.domain.community.article.model.ArticleAiSummaryStatus;
 import in.koreatech.koin.domain.community.article.model.Board;
 import in.koreatech.koin.domain.community.article.repository.ArticleAiSummaryRepository;
+import in.koreatech.koin.domain.community.article.repository.BoardRepository;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryProperties;
+import in.koreatech.koin.domain.community.article.service.summary.ArticleAiSummaryService;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleSummarySourceReader;
 import in.koreatech.koin.domain.community.article.service.summary.ArticleSummarySourceSeed;
 import in.koreatech.koin.domain.student.model.Department;
@@ -58,15 +60,41 @@ class ArticleAiSummaryApiTest extends AcceptanceTest {
     @Autowired
     private ArticleAiSummaryProperties properties;
 
+    @Autowired
+    private ArticleAiSummaryService articleAiSummaryService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
     private Article article;
+    private Student student;
 
     @BeforeEach
     void setUp() {
         clear();
         Department department = departmentFixture.컴퓨터공학부();
-        Student student = userFixture.준호_학생(department, null);
+        student = userFixture.준호_학생(department, null);
         Board board = boardFixture.자유게시판();
         article = articleFixture.자유글_1(board, student.getUser());
+    }
+
+    @Test
+    void 삭제된_게시판의_게시글은_요약_큐_등록_대상에서_제외된다() {
+        Board deletedBoard = boardRepository.save(
+            Board.builder()
+                .name("삭제된게시판")
+                .isAnonymous(false)
+                .articleCount(0)
+                .isDeleted(true)
+                .isNotice(false)
+                .build()
+        );
+        Article deletedBoardArticle = articleFixture.자유글_2(deletedBoard, student.getUser());
+
+        articleAiSummaryService.enqueueArticlesWithoutSummary(10);
+
+        assertThat(articleAiSummaryRepository.findByArticleId(deletedBoardArticle.getId())).isEmpty();
+        assertThat(articleAiSummaryRepository.findByArticleId(article.getId())).isPresent();
     }
 
     @Test


### PR DESCRIPTION
### 🔍 개요

* 게시글 AI 요약 스케줄러가 매번 실패해 요약이 하나도 만들어지지 않던 문제를 고칩니다.
* 삭제된 게시판에 남아 있는 게시글이 요약 대상으로 잡히면서 배치 전체가 중단되고 있었습니다.

---

### 🚀 주요 변경 내용

* 요약할 게시글을 고를 때 **삭제된 게시판의 게시글은 제외**하도록 조회 조건을 추가했습니다.
* 삭제된 게시판은 서비스에서 이미 보이지 않는 게시판이므로, 그 안의 글은 요약을 만들 필요가 없습니다.
* 기존에는 요약 대상이 항상 같은 순서로 뽑혀, 문제가 되는 게시글 하나 때문에 정상 게시글까지 계속 요약이 밀려 있었습니다. 이번 수정으로 다음 실행부터 정상 게시글이 다시 요약 대기열에 올라갑니다.
* 같은 상황이 다시 생기지 않도록 재현 테스트를 추가했습니다.

---

### 💬 참고 사항

* 발생 로그: `JpaObjectRetrievalFailureException: ... Board with identifier value 3 does not exist`
* 별도의 데이터 정리나 마이그레이션은 필요 없습니다. 배포 후 다음 스케줄 실행부터 자동으로 정상화됩니다.
* 추가한 테스트는 로컬에 Docker(Testcontainers) 환경이 없어 **실행 검증은 못 했고 컴파일까지만 확인**했습니다. CI 결과를 확인해 주세요.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted boards’ articles are no longer included in the AI summary processing queue.
  * Articles on active boards continue to be processed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->