### PR TITLE
feat: 게시글 AI 요약 인라인 디자인 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryContentRenderer.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleSummaryContentRenderer.java
@@ -1,7 +1,7 @@
 package in.koreatech.koin.domain.community.article.service.summary;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -12,9 +12,26 @@ public class ArticleSummaryContentRenderer {
 
     private static final int MAX_SUMMARY_LINES = 3;
     private static final int MAX_SUMMARY_LINE_LENGTH = 220;
-    private static final Set<String> ALLOWED_LINE_PREFIXES = Set.of(
+    private static final List<String> ALLOWED_LINE_PREFIXES = List.of(
         "📅 ", "🎯 ", "📍 ", "📝 ", "💰 ", "📌 ", "📎 ", "✅ "
     );
+    private static final String SUMMARY_CONTAINER_STYLE =
+        "max-width:100%;margin:24px 0 28px;padding:0;background-color:transparent;"
+            + "color:#292e36;font-family:pretendard,-apple-system,BlinkMacSystemFont,"
+            + "'Apple SD Gothic Neo','Noto Sans KR',sans-serif;letter-spacing:0;"
+            + "text-align:left;text-indent:0;white-space:normal;box-sizing:border-box;";
+    private static final String SUMMARY_TITLE_STYLE =
+        "margin:0 0 15px;color:#17191d;font-size:16px;font-weight:700;line-height:1.5;";
+    private static final String SUMMARY_TITLE_LABEL_STYLE =
+        "display:inline-block;padding:0 0 6px;border-bottom:2px solid #0054a6;";
+    private static final String SUMMARY_LINE_STYLE =
+        "display:flex;align-items:flex-start;gap:8px;color:#343942;font-size:15px;"
+            + "font-weight:400;line-height:1.7;word-break:keep-all;word-wrap:break-word;"
+            + "overflow-wrap:break-word;";
+    private static final String SUMMARY_ICON_STYLE =
+        "display:block;flex:0 0 20px;width:20px;text-align:left;";
+    private static final String SUMMARY_TEXT_STYLE =
+        "display:block;min-width:0;flex:1 1 auto;";
 
     public String prependSummary(String content, List<String> summaryLines) {
         List<String> renderableSummaryLines = sanitize(summaryLines);
@@ -22,16 +39,49 @@ public class ArticleSummaryContentRenderer {
             return content;
         }
         StringBuilder builder = new StringBuilder();
-        builder.append("<div class=\"ai-summary\">\n");
-        builder.append("  <p><strong>✨ AI 요약</strong></p>\n");
-        for (String summaryLine : renderableSummaryLines) {
-            builder.append("  <p>")
-                .append(HtmlUtils.htmlEscape(summaryLine))
-                .append("</p>\n");
+        builder.append("<div class=\"ai-summary\" role=\"note\" aria-label=\"AI 요약\" lang=\"ko\" style=\"")
+            .append(SUMMARY_CONTAINER_STYLE)
+            .append("\">\n");
+        builder.append("  <p style=\"")
+            .append(SUMMARY_TITLE_STYLE)
+            .append("\">\n")
+            .append("    <span style=\"")
+            .append(SUMMARY_TITLE_LABEL_STYLE)
+            .append("\">AI 요약</span>\n")
+            .append("  </p>\n");
+        for (int index = 0; index < renderableSummaryLines.size(); index++) {
+            appendSummaryLine(
+                builder,
+                renderableSummaryLines.get(index),
+                index == renderableSummaryLines.size() - 1
+            );
         }
-        builder.append("</div>\n<hr>\n");
+        builder.append("</div>\n");
         builder.append(content == null ? "" : content);
         return builder.toString();
+    }
+
+    private void appendSummaryLine(StringBuilder builder, String summaryLine, boolean isLastLine) {
+        String prefix = findAllowedPrefix(summaryLine).orElseThrow();
+        String icon = prefix.trim();
+        String text = summaryLine.substring(prefix.length());
+        String margin = isLastLine ? "margin:0;" : "margin:0 0 11px;";
+
+        builder.append("  <p style=\"")
+            .append(SUMMARY_LINE_STYLE)
+            .append(margin)
+            .append("\">\n")
+            .append("    <span aria-hidden=\"true\" style=\"")
+            .append(SUMMARY_ICON_STYLE)
+            .append("\">")
+            .append(HtmlUtils.htmlEscape(icon))
+            .append("</span>\n")
+            .append("    <span style=\"")
+            .append(SUMMARY_TEXT_STYLE)
+            .append("\">")
+            .append(HtmlUtils.htmlEscape(text))
+            .append("</span>\n")
+            .append("  </p>\n");
     }
 
     private List<String> sanitize(List<String> summaryLines) {
@@ -49,15 +99,19 @@ public class ArticleSummaryContentRenderer {
     }
 
     private boolean hasAllowedPrefix(String summaryLine) {
-        return ALLOWED_LINE_PREFIXES.stream().anyMatch(summaryLine::startsWith);
+        return findAllowedPrefix(summaryLine).isPresent();
     }
 
     private boolean hasTextAfterPrefix(String summaryLine) {
-        return ALLOWED_LINE_PREFIXES.stream()
-            .filter(summaryLine::startsWith)
-            .findFirst()
+        return findAllowedPrefix(summaryLine)
             .map(prefix -> summaryLine.substring(prefix.length()))
             .filter(StringUtils::hasText)
             .isPresent();
+    }
+
+    private Optional<String> findAllowedPrefix(String summaryLine) {
+        return ALLOWED_LINE_PREFIXES.stream()
+            .filter(summaryLine::startsWith)
+            .findFirst();
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/ArticleAiSummaryApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/ArticleAiSummaryApiTest.java
@@ -136,8 +136,9 @@ class ArticleAiSummaryApiTest extends AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content").value(containsString("✨ AI 요약")))
-            .andExpect(jsonPath("$.content").value(containsString("<p>📅 신청은 5월 20일까지 접수됩니다.</p>")))
+            .andExpect(jsonPath("$.content").value(containsString("AI 요약")))
+            .andExpect(jsonPath("$.content").value(containsString(">📅</span>")))
+            .andExpect(jsonPath("$.content").value(containsString(">신청은 5월 20일까지 접수됩니다.</span>")))
             .andExpect(jsonPath("$.content").value(containsString("<p>내용</p>")));
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleSummaryContentRendererTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleSummaryContentRendererTest.java
@@ -19,9 +19,14 @@ class ArticleSummaryContentRendererTest {
             List.of("📅 신청은 5월 20일까지 접수됩니다.", "🎯 재학생을 대상으로 모집합니다.")
         );
 
-        assertThat(content).startsWith("<div class=\"ai-summary\">");
-        assertThat(content).contains("✨ AI 요약");
-        assertThat(content).contains("<p>📅 신청은 5월 20일까지 접수됩니다.</p>");
+        assertThat(content).startsWith("<div class=\"ai-summary\" role=\"note\"");
+        assertThat(content).contains("border-bottom:2px solid #0054a6");
+        assertThat(content).contains("margin:24px 0 28px");
+        assertThat(content).contains(">AI 요약</span>");
+        assertThat(content).contains(">📅</span>");
+        assertThat(content).contains(">신청은 5월 20일까지 접수됩니다.</span>");
+        assertThat(content).doesNotContain("✨");
+        assertThat(content).doesNotContain("<hr>");
         assertThat(content).doesNotContain("1. 📅");
         assertThat(content).endsWith("<p>원문</p>");
     }
@@ -38,9 +43,12 @@ class ArticleSummaryContentRendererTest {
             )
         );
 
-        assertThat(content).contains("📅 신청은 5월 20일까지 접수됩니다.");
-        assertThat(content).contains("📝 신청서를 제출해야 합니다.");
-        assertThat(content).doesNotContain("💰 장학금은 50만원입니다.");
+        assertThat(content).contains(">📅</span>");
+        assertThat(content).contains(">신청은 5월 20일까지 접수됩니다.</span>");
+        assertThat(content).contains(">📝</span>");
+        assertThat(content).contains(">신청서를 제출해야 합니다.</span>");
+        assertThat(content).doesNotContain(">💰</span>");
+        assertThat(content).doesNotContain("장학금은 50만원입니다.");
     }
 
     @Test
@@ -63,7 +71,8 @@ class ArticleSummaryContentRendererTest {
             List.of("📌 <script>alert(1)</script>")
         );
 
-        assertThat(content).contains("📌 &lt;script&gt;alert(1)&lt;/script&gt;");
+        assertThat(content).contains(">📌</span>");
+        assertThat(content).contains("&lt;script&gt;alert(1)&lt;/script&gt;");
         assertThat(content).doesNotContain("<script>alert(1)</script>");
     }
 }


### PR DESCRIPTION
### 🚀 주요 변경 내용

* 게시글 `content` 앞에 붙는 AI 요약 영역에 인라인 스타일을 적용했습니다.
* 이모지와 요약 문장을 분리해 긴 문장이 줄바꿈되어도 본문 시작 위치가 유지되도록 개선했습니다.
* 기존 `<hr>`를 제거하고 제목 포인트선과 상하 여백으로 요약과 원문을 구분했습니다.
* 요약 본문의 HTML escape와 최대 3줄 제한은 그대로 유지했습니다.

---

### 💬 참고 사항

* 관련 이슈: #2314
* 프론트 수정 없이 기존 게시글 상세 API의 `content` HTML에 적용됩니다.
* 스테이지 게시글의 렌더링 HTML을 기준으로 데스크톱과 390px 모바일 화면을 확인했습니다.
* `ArticleSummaryContentRendererTest`와 `ArticleAiSummaryApiTest`를 통과했습니다.


### 🖼️ 적용 화면

<img width="375" height="812" alt="KOIN 게시글 AI 요약 디자인 적용 화면" src="https://github.com/user-attachments/assets/30fb0a41-1f4f-45b5-8725-19e890176524" />

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI summary presentation with a clearly labeled, accessible summary panel.
  * Added icons and structured formatting for each summary line.
  * Preserved HTML escaping and limited displayed summaries to three lines.

* **Bug Fixes**
  * Removed outdated separators and legacy summary styling for a cleaner display.

* **Tests**
  * Updated coverage to verify the new layout, icons, escaping, and line limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->