### PR TITLE
fix: 부서정보 검색 및 응답 순서 개선

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/departmentcontact/service/DepartmentContactService.java
+++ b/src/main/java/in/koreatech/koin/domain/departmentcontact/service/DepartmentContactService.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.domain.departmentcontact.service;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -22,11 +23,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DepartmentContactService {
 
+    private static final String PRIORITY_DEPARTMENT_NAME = "학사팀";
+
     private final DepartmentContactDepartmentRepository departmentRepository;
 
     @Transactional(readOnly = true)
     public DepartmentContactsResponse getDepartmentContacts(String keyword) {
-        List<DepartmentContactDepartment> departments = departmentRepository.findAllByOrderByDisplayOrderAsc();
+        List<DepartmentContactDepartment> departments = prioritizeDepartments(
+            departmentRepository.findAllByOrderByDisplayOrderAsc()
+        );
         LocalDateTime updatedAt = findLatestUpdatedAt(departments);
         String normalizedKeyword = normalizeKeyword(keyword);
 
@@ -46,8 +51,9 @@ public class DepartmentContactService {
         DepartmentCategory category,
         String keyword
     ) {
-        List<DepartmentContactDepartment> departments =
-            departmentRepository.findAllByCategoryOrderByDisplayOrderAsc(category);
+        List<DepartmentContactDepartment> departments = prioritizeDepartments(
+            departmentRepository.findAllByCategoryOrderByDisplayOrderAsc(category)
+        );
         LocalDateTime updatedAt = findLatestUpdatedAt(departments);
         List<DepartmentContactDepartment> filteredDepartments = filterDepartments(
             category,
@@ -80,11 +86,26 @@ public class DepartmentContactService {
     }
 
     private boolean contains(String value, String keyword) {
-        return value.toLowerCase(Locale.ROOT).contains(keyword);
+        return normalizeText(value).contains(keyword);
     }
 
     private String normalizeKeyword(String keyword) {
-        return keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        return normalizeText(keyword == null ? "" : keyword);
+    }
+
+    private String normalizeText(String value) {
+        return value.replaceAll("\\s+", "").toLowerCase(Locale.ROOT);
+    }
+
+    private List<DepartmentContactDepartment> prioritizeDepartments(
+        List<DepartmentContactDepartment> departments
+    ) {
+        return departments.stream()
+            .sorted(Comparator.comparingInt(
+                (DepartmentContactDepartment department) ->
+                    PRIORITY_DEPARTMENT_NAME.equals(department.getName()) ? 0 : 1
+            ).thenComparing(DepartmentContactDepartment::getDisplayOrder))
+            .toList();
     }
 
     private LocalDateTime findLatestUpdatedAt(List<DepartmentContactDepartment> departments) {

--- a/src/test/java/in/koreatech/koin/acceptance/domain/DepartmentContactApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/DepartmentContactApiTest.java
@@ -34,6 +34,8 @@ class DepartmentContactApiTest extends AcceptanceTest {
         createDepartment(DepartmentCategory.STUDENT_SUPPORT, "학생지원팀", 1,
             new Contact("학생지도", "041-560-2531", 2),
             new Contact("학생지원팀 총괄", "041-560-2530", 1));
+        createDepartment(DepartmentCategory.ACADEMIC, "학사팀", 17,
+            new Contact("학사팀 업무총괄", "041-560-2539", 1));
         createDepartment(DepartmentCategory.ACADEMIC, "Edutech 센터", 1,
             new Contact("", "041-580-4707", 1));
         entityManager.flush();
@@ -48,8 +50,9 @@ class DepartmentContactApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.categories", hasSize(6)))
             .andExpect(jsonPath("$.categories[0].category").value("ACADEMIC"))
             .andExpect(jsonPath("$.categories[0].category_name").value("학사 / 수업"))
-            .andExpect(jsonPath("$.categories[0].departments[0].name").value("Edutech 센터"))
-            .andExpect(jsonPath("$.categories[0].departments[0].is_single_contact").value(true))
+            .andExpect(jsonPath("$.categories[0].departments", hasSize(2)))
+            .andExpect(jsonPath("$.categories[0].departments[0].name").value("학사팀"))
+            .andExpect(jsonPath("$.categories[0].departments[1].name").value("Edutech 센터"))
             .andExpect(jsonPath("$.categories[1].category").value("STUDENT_SUPPORT"))
             .andExpect(jsonPath("$.categories[2].category").value("EMPLOYMENT"))
             .andExpect(jsonPath("$.categories[2].departments", hasSize(2)))
@@ -57,6 +60,10 @@ class DepartmentContactApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.categories[2].departments[0].is_single_contact").value(true))
             .andExpect(jsonPath("$.categories[2].departments[1].name").value("취창업지원팀"))
             .andExpect(jsonPath("$.categories[2].departments[1].is_single_contact").value(false));
+
+        mockMvc.perform(get("/department-contacts/ACADEMIC"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.departments[0].name").value("학사팀"));
     }
 
     @Test
@@ -115,6 +122,15 @@ class DepartmentContactApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.categories", hasSize(1)))
             .andExpect(jsonPath("$.categories[0].departments[0].name").value("Edutech 센터"))
             .andExpect(jsonPath("$.categories[0].departments[0].is_single_contact").value(true));
+
+        mockMvc.perform(
+                get("/department-contacts")
+                    .param("keyword", "IPP센터")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.categories", hasSize(1)))
+            .andExpect(jsonPath("$.categories[0].category").value("EMPLOYMENT"))
+            .andExpect(jsonPath("$.categories[0].departments[0].name").value("IPP 센터"));
     }
 
     @Test


### PR DESCRIPTION
### 🔍 개요

* QA에서 확인된 부서정보 검색 및 응답 순서 문제를 수정했습니다.
* 검색어와 저장된 부서명·업무명의 띄어쓰기 차이로 검색이 누락되는 문제를 개선했습니다.

- close #2318

---

### 🚀 주요 변경 내용

* 검색어, 카테고리명, 부서명, 업무명의 공백을 제거한 뒤 비교합니다.
  * `IPP센터`로 `IPP 센터`를 검색할 수 있습니다.
* 전체 조회와 카테고리 조회에서 `학사팀`을 가장 먼저 반환합니다.
* `학사팀` 외 부서는 기존 `display_order` 순서를 유지합니다.
* 검색 결과가 여러 업무 부서에 걸치면 해당 부서의 연락처 전체를 반환하는 기존 정책을 유지합니다.


---

### 💬 참고 사항

* 부서정보 API 회귀 테스트를 추가·검증했습니다.
* 공백만 입력한 검색, 공백 없는 부서명 검색, 카테고리별 검색, 검색 결과 없음, 잘못된 카테고리 시나리오를 확인했습니다.
* `./gradlew test` 전체 테스트가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Department contact results now prioritize the 학사팀 department.
  * Existing display ordering is preserved for other departments.
  * Search is more flexible with whitespace and capitalization differences.
  * Academic department listings and search results now include updated contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->