### PR TITLE
fix: 게시글 AI 요약 Upstage 빈 응답 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryProperties.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryProperties.java
@@ -32,7 +32,7 @@ public class ArticleAiSummaryProperties {
     private int failedRetryWindowStartHour = 0;
     private int failedRetryWindowEndHour = 4;
     private int requestTimeoutSeconds = 120;
-    private int chatRequestTimeoutSeconds = 120;
+    private int chatRequestTimeoutSeconds = 600;
     private int documentParseRequestTimeoutSeconds = 180;
     private int documentDownloadTimeoutSeconds = 60;
     private String model = "solar-pro4";

--- a/src/main/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClient.java
@@ -93,7 +93,6 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
             ),
             "temperature", 0.2,
             "top_p", 0.9,
-            "max_tokens", 500,
             "reasoning_effort", "low",
             "response_format", responseFormat(prompt.maxItems())
         );
@@ -143,9 +142,17 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
         if (response == null || response.choices() == null || response.choices().isEmpty()) {
             throw new ArticleSummaryExternalApiException("Upstage 요약 응답이 비어 있습니다.", true, null);
         }
-        String content = response.choices().get(0).message().content();
+        Choice choice = response.choices().get(0);
+        String content = choice.message() == null ? null : choice.message().content();
         if (!StringUtils.hasText(content)) {
-            throw new ArticleSummaryExternalApiException("Upstage 요약 본문이 비어 있습니다.", true, null);
+            String finishReason = StringUtils.hasText(choice.finishReason())
+                ? " finish_reason=%s".formatted(choice.finishReason())
+                : "";
+            throw new ArticleSummaryExternalApiException(
+                "Upstage 요약 본문이 비어 있습니다." + finishReason,
+                true,
+                null
+            );
         }
         return content;
     }
@@ -219,7 +226,8 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record Choice(
-        Message message
+        Message message,
+        @JsonProperty("finish_reason") String finishReason
     ) {
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -143,7 +143,7 @@ article:
     failed-retry-window-start-hour: ${ARTICLE_AI_SUMMARY_FAILED_RETRY_WINDOW_START_HOUR:0}
     failed-retry-window-end-hour: ${ARTICLE_AI_SUMMARY_FAILED_RETRY_WINDOW_END_HOUR:4}
     request-timeout-seconds: ${ARTICLE_AI_SUMMARY_REQUEST_TIMEOUT_SECONDS:120}
-    chat-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_CHAT_REQUEST_TIMEOUT_SECONDS:120}
+    chat-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_CHAT_REQUEST_TIMEOUT_SECONDS:600}
     document-parse-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_DOCUMENT_PARSE_REQUEST_TIMEOUT_SECONDS:180}
     document-download-timeout-seconds: ${ARTICLE_AI_SUMMARY_DOCUMENT_DOWNLOAD_TIMEOUT_SECONDS:60}
     model: ${ARTICLE_AI_SUMMARY_MODEL:solar-pro4}

--- a/src/test/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClientTest.java
+++ b/src/test/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClientTest.java
@@ -33,6 +33,8 @@ class UpstageArticleSummaryClientTest {
 
         assertThat(requestBody)
             .containsEntry("model", "solar-pro4")
-            .containsKey("response_format");
+            .containsEntry("reasoning_effort", "low")
+            .containsKey("response_format")
+            .doesNotContainKey("max_tokens");
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryPropertiesTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryPropertiesTest.java
@@ -14,5 +14,6 @@ class ArticleAiSummaryPropertiesTest {
 
         assertThat(properties.getModel()).isEqualTo("solar-pro4");
         assertThat(properties.getPromptVersion()).isEqualTo("v11");
+        assertThat(properties.getChatRequestTimeoutSeconds()).isEqualTo(600);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* `solar-pro4` 요약 요청에서 `reasoning_effort=low`와 `max_tokens=500`이 함께 적용되어, reasoning이 출력 토큰을 모두 사용하고 `message.content`가 비어 요약이 실패하는 문제를 수정함.
* Upstage 응답 본문이 비어 있을 때 실패 원인을 확인할 수 있도록 응답 처리를 보강함.

- close #2330

---

### 🚀 주요 변경 내용

* 요약 요청 body에서 `max_tokens=500`을 제거함.
* `response_format`의 JSON Schema와 `reasoning_effort=low` 설정은 유지함.
* Upstage `Choice` 응답에서 `finish_reason`을 파싱하도록 변경함.
* Upstage 응답의 `message`가 `null`이어도 `NullPointerException` 없이 빈 본문 오류로 처리하도록 변경함.
* 요약 본문이 비어 있으면 `finish_reason`을 실패 메시지에 포함하도록 변경함.
* 빈 본문 오류의 기존 재시도 가능한 예외 처리 흐름은 유지함.
* AI 요약 채팅 요청 타임아웃 기본값을 Java 설정과 `application.yml`에서 120초에서 600초로 변경함.
* 요약 요청 body에 `max_tokens`가 없고 `reasoning_effort=low`가 적용되는지 검증하는 테스트를 추가함.
* AI 요약 채팅 요청 타임아웃 기본값이 600초인지 검증하는 테스트를 추가함.

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved article AI-summary request handling for empty or incomplete responses.
  * Error messages now provide more context when summary generation finishes unexpectedly.

* **Improvements**
  * Increased the default AI-summary request timeout from 120 to 600 seconds.
  * Updated summary requests to use low reasoning effort and omit the unsupported token limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->