### PR TITLE
release: 2026.08.20 배포

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryProperties.java
+++ b/src/main/java/in/koreatech/koin/domain/community/article/service/summary/ArticleAiSummaryProperties.java
@@ -32,7 +32,7 @@ public class ArticleAiSummaryProperties {
     private int failedRetryWindowStartHour = 0;
     private int failedRetryWindowEndHour = 4;
     private int requestTimeoutSeconds = 120;
-    private int chatRequestTimeoutSeconds = 120;
+    private int chatRequestTimeoutSeconds = 600;
     private int documentParseRequestTimeoutSeconds = 180;
     private int documentDownloadTimeoutSeconds = 60;
     private String model = "solar-pro4";

--- a/src/main/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClient.java
@@ -93,7 +93,6 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
             ),
             "temperature", 0.2,
             "top_p", 0.9,
-            "max_tokens", 500,
             "reasoning_effort", "low",
             "response_format", responseFormat(prompt.maxItems())
         );
@@ -143,9 +142,17 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
         if (response == null || response.choices() == null || response.choices().isEmpty()) {
             throw new ArticleSummaryExternalApiException("Upstage 요약 응답이 비어 있습니다.", true, null);
         }
-        String content = response.choices().get(0).message().content();
+        Choice choice = response.choices().get(0);
+        String content = choice.message() == null ? null : choice.message().content();
         if (!StringUtils.hasText(content)) {
-            throw new ArticleSummaryExternalApiException("Upstage 요약 본문이 비어 있습니다.", true, null);
+            String finishReason = StringUtils.hasText(choice.finishReason())
+                ? " finish_reason=%s".formatted(choice.finishReason())
+                : "";
+            throw new ArticleSummaryExternalApiException(
+                "Upstage 요약 본문이 비어 있습니다." + finishReason,
+                true,
+                null
+            );
         }
         return content;
     }
@@ -219,7 +226,8 @@ public class UpstageArticleSummaryClient implements ArticleSummaryAiClient {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record Choice(
-        Message message
+        Message message,
+        @JsonProperty("finish_reason") String finishReason
     ) {
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -143,7 +143,7 @@ article:
     failed-retry-window-start-hour: ${ARTICLE_AI_SUMMARY_FAILED_RETRY_WINDOW_START_HOUR:0}
     failed-retry-window-end-hour: ${ARTICLE_AI_SUMMARY_FAILED_RETRY_WINDOW_END_HOUR:4}
     request-timeout-seconds: ${ARTICLE_AI_SUMMARY_REQUEST_TIMEOUT_SECONDS:120}
-    chat-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_CHAT_REQUEST_TIMEOUT_SECONDS:120}
+    chat-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_CHAT_REQUEST_TIMEOUT_SECONDS:600}
     document-parse-request-timeout-seconds: ${ARTICLE_AI_SUMMARY_DOCUMENT_PARSE_REQUEST_TIMEOUT_SECONDS:180}
     document-download-timeout-seconds: ${ARTICLE_AI_SUMMARY_DOCUMENT_DOWNLOAD_TIMEOUT_SECONDS:60}
     model: ${ARTICLE_AI_SUMMARY_MODEL:solar-pro4}

--- a/src/test/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClientTest.java
+++ b/src/test/java/in/koreatech/koin/infrastructure/upstage/client/UpstageArticleSummaryClientTest.java
@@ -33,6 +33,8 @@ class UpstageArticleSummaryClientTest {
 
         assertThat(requestBody)
             .containsEntry("model", "solar-pro4")
-            .containsKey("response_format");
+            .containsEntry("reasoning_effort", "low")
+            .containsKey("response_format")
+            .doesNotContainKey("max_tokens");
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryPropertiesTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/community/article/service/summary/ArticleAiSummaryPropertiesTest.java
@@ -14,5 +14,6 @@ class ArticleAiSummaryPropertiesTest {
 
         assertThat(properties.getModel()).isEqualTo("solar-pro4");
         assertThat(properties.getPromptVersion()).isEqualTo("v11");
+        assertThat(properties.getChatRequestTimeoutSeconds()).isEqualTo(600);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 게시글 AI 요약 Upstage 빈 응답 수정 사항을 운영 배포 대상으로 반영함.

---

### 🚀 주요 변경 내용

* Upstage 요약 요청의 `max_tokens` 제한을 제거함.
* `reasoning_effort=low`를 유지함.
* Upstage 응답의 `message`가 `null`이어도 처리하도록 변경함.
* 요약 본문이 비어 있으면 `finish_reason`을 실패 메시지에 기록하도록 변경함.
* AI 요약 채팅 요청 타임아웃 기본값을 600초로 변경함.

---

### 💬 참고 사항

* 없음

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)