### PR TITLE
feat: 팀원 모집 파일 업로드 도메인 추가

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/upload/controller/UploadApi.java
+++ b/src/main/java/in/koreatech/koin/domain/upload/controller/UploadApi.java
@@ -57,6 +57,7 @@ public interface UploadApi {
         - callvan_chat
         - lost_items
         - club
+        - team_recruitment
         """)
     @PostMapping("/{domain}/upload/url")
     ResponseEntity<UploadUrlResponse> getPresignedUrl(
@@ -87,6 +88,7 @@ public interface UploadApi {
         - coop
         - admin
         - banner
+        - team_recruitment
         """)
     @PostMapping(
         value = "/{domain}/upload/file",
@@ -121,6 +123,7 @@ public interface UploadApi {
         - coop
         - admin
         - banner
+        - team_recruitment
         """)
     @PostMapping(
         value = "/{domain}/upload/files",

--- a/src/main/java/in/koreatech/koin/infrastructure/s3/model/ImageUploadDomain.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/s3/model/ImageUploadDomain.java
@@ -21,7 +21,8 @@ public enum ImageUploadDomain {
     BANNER,
     CLUB,
     CALLVAN_REPORT,
-    CALLVAN_CHAT
+    CALLVAN_CHAT,
+    TEAM_RECRUITMENT
     ;
 
     public static ImageUploadDomain from(String domain) {

--- a/src/test/java/in/koreatech/koin/infrastructure/s3/convertor/ImageUploadDomainEnumConverterTest.java
+++ b/src/test/java/in/koreatech/koin/infrastructure/s3/convertor/ImageUploadDomainEnumConverterTest.java
@@ -1,0 +1,18 @@
+package in.koreatech.koin.infrastructure.s3.convertor;
+
+import static in.koreatech.koin.infrastructure.s3.model.ImageUploadDomain.TEAM_RECRUITMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ImageUploadDomainEnumConverterTest {
+
+    private final ImageUploadDomainEnumConverter converter = new ImageUploadDomainEnumConverter();
+
+    @Test
+    void 팀원_모집_업로드_도메인을_변환한다() {
+        var result = converter.convert("team_recruitment");
+
+        assertThat(result).isEqualTo(TEAM_RECRUITMENT);
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 기존 공용 파일 업로드 API에서 팀원 모집 도메인을 지원합니다.

- close #2333

---

### 🚀 주요 변경 내용

* `ImageUploadDomain`에 `TEAM_RECRUITMENT`를 추가했습니다.
* 공용 URL 생성, 단건 및 다중 업로드 API의 Swagger 지원 목록에 `team_recruitment`를 추가했습니다.
* `team_recruitment` 경로 파라미터 변환 테스트를 추가했습니다.

---

### 💬 참고 사항

* 팀원 모집 클라이언트는 `POST /team_recruitment/upload/url`을 사용합니다.
* 검증: `./gradlew clean test`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `team_recruitment` as an image upload domain.
  * Updated upload API documentation to list the new supported domain.

* **Tests**
  * Added coverage verifying correct recognition of the new image upload domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->