### PR TITLE
feat: 팀원 모집 지원 조회 및 API 5종 연결

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
@@ -1,0 +1,148 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.CREATED;
+import static in.koreatech.koin.global.code.ApiResponseCode.ILLEGAL_ARGUMENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.OPTIMISTIC_LOCKING_FAILURE;
+import static in.koreatech.koin.global.code.ApiResponseCode.REQUEST_TOO_FAST;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_DUPLICATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_FINALIZED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CAPACITY_FULL;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_PROFILE_REQUIRED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicationCreatedResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.CreateApplicationRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplicationListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateApplicationStatusRequest;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.code.ApiResponseCodes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "(Normal) Team Recruitment: 팀원 모집", description = "팀원 모집 지원서와 지원자를 관리한다")
+@RequestMapping("/team-recruitments")
+public interface TeamRecruitmentApplicationApi {
+
+    @ApiResponseCodes({
+        CREATED,
+        INVALID_REQUEST_BODY,
+        UNAUTHORIZED_USER,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_PROFILE_REQUIRED,
+        TEAM_RECRUITMENT_CLOSED,
+        TEAM_RECRUITMENT_ROLE_CLOSED,
+        TEAM_RECRUITMENT_CAPACITY_FULL,
+        TEAM_RECRUITMENT_APPLICATION_DUPLICATE,
+        REQUEST_TOO_FAST
+    })
+    @Operation(summary = "지원서 작성")
+    @PostMapping("/{recruitmentId}/applications")
+    ResponseEntity<ApplicationCreatedResponse> createApplication(
+        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @RequestBody @Valid CreateApplicationRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        ILLEGAL_ARGUMENT,
+        UNAUTHORIZED_USER,
+        TEAM_RECRUITMENT_FORBIDDEN
+    })
+    @Operation(summary = "내가 지원한 모집 목록")
+    @GetMapping("/me/applications")
+    ResponseEntity<MyApplicationListResponse> getMyApplications(
+        @RequestParam(name = "statuses", required = false) List<TeamRecruitmentApplicationStatus> statuses,
+        @RequestParam(name = "sort", defaultValue = "LATEST_DESC") TeamRecruitmentApplicationSort sort,
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        ILLEGAL_ARGUMENT,
+        UNAUTHORIZED_USER,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        TEAM_RECRUITMENT_NOT_FOUND
+    })
+    @Operation(summary = "지원자 목록 조회")
+    @GetMapping("/{recruitmentId}/applications")
+    ResponseEntity<ApplicantListResponse> getApplications(
+        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @RequestParam(name = "statuses", required = false) List<TeamRecruitmentApplicationStatus> statuses,
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        ILLEGAL_ARGUMENT,
+        UNAUTHORIZED_USER,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_APPLICATION_NOT_FOUND
+    })
+    @Operation(summary = "지원자 상세 조회")
+    @GetMapping("/{recruitmentId}/applications/{applicationId}")
+    ResponseEntity<ApplicantDetail> getApplicationDetail(
+        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @Parameter(description = "지원서 ID", example = "51", required = true)
+        @PathVariable("applicationId") Integer applicationId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        NO_CONTENT,
+        INVALID_REQUEST_BODY,
+        UNAUTHORIZED_USER,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_APPLICATION_NOT_FOUND,
+        TEAM_RECRUITMENT_CLOSED,
+        TEAM_RECRUITMENT_ROLE_CLOSED,
+        TEAM_RECRUITMENT_CAPACITY_FULL,
+        TEAM_RECRUITMENT_APPLICATION_FINALIZED,
+        OPTIMISTIC_LOCKING_FAILURE
+    })
+    @Operation(summary = "지원 승인 또는 거절")
+    @PutMapping("/{recruitmentId}/applications/{applicationId}/status")
+    ResponseEntity<Void> updateApplicationStatus(
+        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @Parameter(description = "지원서 ID", example = "51", required = true)
+        @PathVariable("applicationId") Integer applicationId,
+        @RequestBody @Valid UpdateApplicationStatusRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
@@ -34,6 +34,7 @@ import in.koreatech.koin.global.auth.Auth;
 import in.koreatech.koin.global.code.ApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +52,7 @@ public interface TeamRecruitmentApplicationApi {
 
     @ApiResponseCodes({
         CREATED,
+        ILLEGAL_ARGUMENT,
         INVALID_REQUEST_BODY,
         NOT_READABLE_HTTP_MESSAGE,
         UNAUTHORIZED_USER,
@@ -66,7 +68,7 @@ public interface TeamRecruitmentApplicationApi {
     @Operation(summary = "지원서 작성")
     @PostMapping("/{recruitmentId}/applications")
     ResponseEntity<ApplicationCreatedResponse> createApplication(
-        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @Parameter(description = "모집글 ID", example = "17", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("recruitmentId") Integer recruitmentId,
         @RequestBody @Valid CreateApplicationRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
@@ -98,7 +100,7 @@ public interface TeamRecruitmentApplicationApi {
     @Operation(summary = "지원자 목록 조회")
     @GetMapping("/{recruitmentId}/applications")
     ResponseEntity<ApplicantListResponse> getApplications(
-        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @Parameter(description = "모집글 ID", example = "17", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("recruitmentId") Integer recruitmentId,
         @RequestParam(name = "statuses", required = false) List<TeamRecruitmentApplicationStatus> statuses,
         @RequestParam(name = "page", defaultValue = "1") Integer page,
@@ -117,16 +119,18 @@ public interface TeamRecruitmentApplicationApi {
     @Operation(summary = "지원자 상세 조회")
     @GetMapping("/{recruitmentId}/applications/{applicationId}")
     ResponseEntity<ApplicantDetail> getApplicationDetail(
-        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @Parameter(description = "모집글 ID", example = "17", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("recruitmentId") Integer recruitmentId,
-        @Parameter(description = "지원서 ID", example = "51", required = true)
+        @Parameter(description = "지원서 ID", example = "51", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("applicationId") Integer applicationId,
         @Auth(permit = {STUDENT}) Integer studentId
     );
 
     @ApiResponseCodes({
         NO_CONTENT,
+        ILLEGAL_ARGUMENT,
         INVALID_REQUEST_BODY,
+        NOT_READABLE_HTTP_MESSAGE,
         UNAUTHORIZED_USER,
         TEAM_RECRUITMENT_FORBIDDEN,
         TEAM_RECRUITMENT_NOT_FOUND,
@@ -140,9 +144,9 @@ public interface TeamRecruitmentApplicationApi {
     @Operation(summary = "지원 승인 또는 거절")
     @PutMapping("/{recruitmentId}/applications/{applicationId}/status")
     ResponseEntity<Void> updateApplicationStatus(
-        @Parameter(description = "모집글 ID", example = "17", required = true)
+        @Parameter(description = "모집글 ID", example = "17", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("recruitmentId") Integer recruitmentId,
-        @Parameter(description = "지원서 ID", example = "51", required = true)
+        @Parameter(description = "지원서 ID", example = "51", required = true, schema = @Schema(minimum = "1"))
         @PathVariable("applicationId") Integer applicationId,
         @RequestBody @Valid UpdateApplicationStatusRequest request,
         @Auth(permit = {STUDENT}) Integer studentId

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationApi.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.global.code.ApiResponseCode.CREATED;
 import static in.koreatech.koin.global.code.ApiResponseCode.ILLEGAL_ARGUMENT;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.NOT_READABLE_HTTP_MESSAGE;
 import static in.koreatech.koin.global.code.ApiResponseCode.OK;
 import static in.koreatech.koin.global.code.ApiResponseCode.OPTIMISTIC_LOCKING_FAILURE;
 import static in.koreatech.koin.global.code.ApiResponseCode.REQUEST_TOO_FAST;
@@ -51,6 +52,7 @@ public interface TeamRecruitmentApplicationApi {
     @ApiResponseCodes({
         CREATED,
         INVALID_REQUEST_BODY,
+        NOT_READABLE_HTTP_MESSAGE,
         UNAUTHORIZED_USER,
         TEAM_RECRUITMENT_FORBIDDEN,
         TEAM_RECRUITMENT_NOT_FOUND,

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationController.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationController.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.team.recruitment.controller;
 
 import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.ILLEGAL_ARGUMENT;
 
 import java.util.List;
 
@@ -15,6 +16,7 @@ import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicatio
 import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentApplicationQueryService;
 import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentApplicationService;
 import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.exception.CustomException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,6 +44,7 @@ public class TeamRecruitmentApplicationController implements TeamRecruitmentAppl
         @RequestBody @Valid CreateApplicationRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
+        validatePositiveId(recruitmentId);
         ApplicationCreatedResponse response = applicationService.createApplication(request, recruitmentId, studentId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -68,6 +71,7 @@ public class TeamRecruitmentApplicationController implements TeamRecruitmentAppl
         @RequestParam(name = "limit", defaultValue = "10") Integer limit,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
+        validatePositiveId(recruitmentId);
         ApplicantListResponse response = applicationQueryService.getApplications(
             recruitmentId, statuses, page, limit, studentId
         );
@@ -80,6 +84,8 @@ public class TeamRecruitmentApplicationController implements TeamRecruitmentAppl
         @PathVariable("applicationId") Integer applicationId,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
+        validatePositiveId(recruitmentId);
+        validatePositiveId(applicationId);
         ApplicantDetail response = applicationQueryService.getApplicationDetail(
             recruitmentId, applicationId, studentId
         );
@@ -93,7 +99,15 @@ public class TeamRecruitmentApplicationController implements TeamRecruitmentAppl
         @RequestBody @Valid UpdateApplicationStatusRequest request,
         @Auth(permit = {STUDENT}) Integer studentId
     ) {
+        validatePositiveId(recruitmentId);
+        validatePositiveId(applicationId);
         applicationService.updateApplicationStatus(request, recruitmentId, applicationId, studentId);
         return ResponseEntity.noContent().build();
+    }
+
+    private void validatePositiveId(Integer id) {
+        if (id == null || id < 1) {
+            throw CustomException.of(ILLEGAL_ARGUMENT);
+        }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationController.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApplicationController.java
@@ -1,0 +1,99 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import java.util.List;
+
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicationCreatedResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.CreateApplicationRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplicationListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateApplicationStatusRequest;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentApplicationQueryService;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentApplicationService;
+import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/team-recruitments")
+public class TeamRecruitmentApplicationController implements TeamRecruitmentApplicationApi {
+
+    private final TeamRecruitmentApplicationService applicationService;
+    private final TeamRecruitmentApplicationQueryService applicationQueryService;
+
+    @PostMapping("/{recruitmentId}/applications")
+    public ResponseEntity<ApplicationCreatedResponse> createApplication(
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @RequestBody @Valid CreateApplicationRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ApplicationCreatedResponse response = applicationService.createApplication(request, recruitmentId, studentId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/me/applications")
+    public ResponseEntity<MyApplicationListResponse> getMyApplications(
+        @RequestParam(name = "statuses", required = false) List<TeamRecruitmentApplicationStatus> statuses,
+        @RequestParam(name = "sort", defaultValue = "LATEST_DESC") TeamRecruitmentApplicationSort sort,
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        MyApplicationListResponse response = applicationQueryService.getMyApplications(
+            statuses, sort, page, limit, studentId
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{recruitmentId}/applications")
+    public ResponseEntity<ApplicantListResponse> getApplications(
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @RequestParam(name = "statuses", required = false) List<TeamRecruitmentApplicationStatus> statuses,
+        @RequestParam(name = "page", defaultValue = "1") Integer page,
+        @RequestParam(name = "limit", defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ApplicantListResponse response = applicationQueryService.getApplications(
+            recruitmentId, statuses, page, limit, studentId
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{recruitmentId}/applications/{applicationId}")
+    public ResponseEntity<ApplicantDetail> getApplicationDetail(
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @PathVariable("applicationId") Integer applicationId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        ApplicantDetail response = applicationQueryService.getApplicationDetail(
+            recruitmentId, applicationId, studentId
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{recruitmentId}/applications/{applicationId}/status")
+    public ResponseEntity<Void> updateApplicationStatus(
+        @PathVariable("recruitmentId") Integer recruitmentId,
+        @PathVariable("applicationId") Integer applicationId,
+        @RequestBody @Valid UpdateApplicationStatusRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        applicationService.updateApplicationStatus(request, recruitmentId, applicationId, studentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantDetail.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantDetail.java
@@ -1,0 +1,37 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ApplicantDetail(
+    @Schema(description = "지원서 ID", example = "51", requiredMode = REQUIRED)
+    Integer applicationId,
+
+    @Schema(description = "지원 상태", example = "PENDING", requiredMode = REQUIRED)
+    TeamRecruitmentApplicationStatus status,
+
+    @Schema(description = "지원 당시 프로필 snapshot", requiredMode = REQUIRED)
+    ProfileSnapshot profileSnapshot,
+
+    @Schema(description = "지원 동기", example = "지원 동기입니다.", requiredMode = REQUIRED)
+    String motivation,
+
+    @Schema(description = "가능 시간", example = "월수금 20시 이후", requiredMode = REQUIRED)
+    String availability,
+
+    @Schema(description = "선택 역할, GENERAL 모집은 null", nullable = true, requiredMode = REQUIRED)
+    ApplicationRole role,
+
+    @Schema(description = "현재 사용자가 승인/거절할 수 있는지", example = "true", requiredMode = REQUIRED)
+    Boolean canDecide,
+
+    @Schema(description = "개인 채팅을 시작할 수 있는지", example = "false", requiredMode = REQUIRED)
+    Boolean canOpenDirectChat
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantListResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantListResponse.java
@@ -1,0 +1,32 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ApplicantListResponse(
+    @Schema(description = "모집 카드 및 팀 채팅 정보", requiredMode = REQUIRED)
+    ApplicantRecruitment recruitment,
+
+    @Schema(description = "지원자 목록", requiredMode = REQUIRED)
+    List<ApplicantSummary> applications,
+
+    @Schema(description = "전체 결과 수", example = "4", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지 결과 수", example = "4", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "전체 페이지 수", example = "1", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantRecruitment.java
@@ -1,0 +1,68 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ApplicantRecruitment(
+    @Schema(description = "모집글 ID", example = "17", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate deadlineDate,
+
+    @Schema(description = "D-day", example = "8", nullable = true, requiredMode = REQUIRED)
+    Integer dDay,
+
+    @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)
+    TeamRecruitmentStatus status,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "승인된 전체 지원자 수", example = "2", requiredMode = REQUIRED)
+    Integer currentParticipants,
+
+    @Schema(description = "전체 모집 정원", example = "5", requiredMode = REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록", requiredMode = REQUIRED)
+    List<RecruitmentRole> roles,
+
+    @Schema(description = "팀 채팅 이용 가능 여부", example = "true", requiredMode = REQUIRED)
+    Boolean teamChatAvailable,
+
+    @Schema(description = "팀 채팅방 ID", example = "31", nullable = true, requiredMode = REQUIRED)
+    Integer teamChatRoomId
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantSummary.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ApplicantSummary(
+    @Schema(description = "지원서 ID", example = "51", requiredMode = REQUIRED)
+    Integer applicationId,
+
+    @Schema(description = "지원자 닉네임", example = "김철수", requiredMode = REQUIRED)
+    String nickname,
+
+    @Schema(description = "지원자 학과", example = "컴퓨터공학부", requiredMode = REQUIRED)
+    String department,
+
+    @Schema(description = "지원자 입학 연도", example = "2023", requiredMode = REQUIRED)
+    Integer studentYear,
+
+    @Schema(description = "선택 역할, GENERAL 모집은 null", nullable = true, requiredMode = REQUIRED)
+    ApplicationRole role,
+
+    @Schema(description = "지원 상태", example = "PENDING", requiredMode = REQUIRED)
+    TeamRecruitmentApplicationStatus status,
+
+    @Schema(description = "개인 채팅 시작 가능 여부", example = "false", requiredMode = REQUIRED)
+    Boolean canOpenDirectChat
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateApplicationRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateApplicationRequest.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.team.recruitment.dto;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +18,7 @@ public record CreateApplicationRequest(
         nullable = true,
         requiredMode = REQUIRED
     )
+    @JsonProperty(value = "role_id", required = true)
     Integer roleId,
 
     @Schema(description = "지원 동기", example = "지원 동기입니다.", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/MyApplication.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/MyApplication.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record MyApplication(
+    @Schema(description = "지원서 ID", example = "51", requiredMode = REQUIRED)
+    Integer applicationId,
+
+    @Schema(description = "지원 상태", example = "ACCEPTED", requiredMode = REQUIRED)
+    TeamRecruitmentApplicationStatus status,
+
+    @Schema(description = "팀 채팅 이용 가능 여부", example = "true", requiredMode = REQUIRED)
+    Boolean teamChatAvailable,
+
+    @Schema(description = "팀 채팅방 ID", example = "31", nullable = true, requiredMode = REQUIRED)
+    Integer teamChatRoomId,
+
+    @Schema(description = "개인 채팅방 ID", example = "null", nullable = true, requiredMode = REQUIRED)
+    Integer directChatRoomId,
+
+    @Schema(description = "선택 역할, GENERAL 모집은 null", nullable = true, requiredMode = REQUIRED)
+    ApplicationRole role,
+
+    @Schema(description = "모집 카드", requiredMode = REQUIRED)
+    RecruitmentCard recruitment
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/MyApplicationListResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/MyApplicationListResponse.java
@@ -1,0 +1,29 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record MyApplicationListResponse(
+    @Schema(description = "내 지원 목록", requiredMode = REQUIRED)
+    List<MyApplication> applications,
+
+    @Schema(description = "전체 결과 수", example = "1", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지 결과 수", example = "1", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "전체 페이지 수", example = "1", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCard.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCard.java
@@ -1,0 +1,62 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record RecruitmentCard(
+    @Schema(description = "모집글 ID", example = "17", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate deadlineDate,
+
+    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    Integer dDay,
+
+    @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)
+    TeamRecruitmentStatus status,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "승인된 전체 지원자 수", example = "2", requiredMode = REQUIRED)
+    Integer currentParticipants,
+
+    @Schema(description = "전체 모집 정원", example = "5", requiredMode = REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록", requiredMode = REQUIRED)
+    List<RecruitmentRole> roles
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRole.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRole.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record RecruitmentRole(
+    @Schema(description = "역할 ID", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "역할명", example = "프론트엔드", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "승인된 지원자 수", example = "1", requiredMode = REQUIRED)
+    Integer currentParticipants,
+
+    @Schema(description = "역할 정원", example = "2", requiredMode = REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 모집 마감 여부", example = "false", requiredMode = REQUIRED)
+    Boolean isClosed
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateApplicationStatusRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateApplicationStatusRequest.java
@@ -11,7 +11,12 @@ import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record UpdateApplicationStatusRequest(
-    @Schema(description = "변경할 상태", example = "ACCEPTED", requiredMode = REQUIRED)
+    @Schema(
+        description = "변경할 상태",
+        example = "ACCEPTED",
+        allowableValues = {"ACCEPTED", "REJECTED"},
+        requiredMode = REQUIRED
+    )
     @NotNull(message = "지원 상태는 필수입니다.")
     TeamRecruitmentApplicationStatus status
 ) {

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentApplicationSort.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentApplicationSort.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin.domain.team.recruitment.enums;
+
+public enum TeamRecruitmentApplicationSort {
+    LATEST_DESC,
+    DEADLINE_ASC
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/repository/TeamRecruitmentChatRoomRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/repository/TeamRecruitmentChatRoomRepository.java
@@ -3,13 +3,13 @@ package in.koreatech.koin.domain.team.recruitment.repository;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
 import jakarta.persistence.LockModeType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface TeamRecruitmentChatRoomRepository extends Repository<TeamRecruitmentChatRoom, Integer> {
 
@@ -57,6 +57,17 @@ public interface TeamRecruitmentChatRoomRepository extends Repository<TeamRecrui
     Optional<TeamRecruitmentChatRoom> findByRecruitment_IdAndApplication_IdAndRoomType(
         Integer recruitmentId,
         Integer applicationId,
+        TeamRecruitmentChatRoomType roomType
+    );
+
+    List<TeamRecruitmentChatRoom> findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+        Collection<Integer> recruitmentIds,
+        String roomScopeKey,
+        TeamRecruitmentChatRoomType roomType
+    );
+
+    List<TeamRecruitmentChatRoom> findAllByApplication_IdInAndRoomType(
+        Collection<Integer> applicationIds,
         TeamRecruitmentChatRoomType roomType
     );
 

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -1,0 +1,379 @@
+package in.koreatech.koin.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantRecruitment;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantSummary;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicationRole;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplication;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplicationListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.ProfileSnapshot;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCard;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamRecruitmentApplicationQueryService {
+
+    private static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final List<TeamRecruitmentApplicationStatus> ALL_STATUSES = List.of(
+        PENDING,
+        ACCEPTED,
+        TeamRecruitmentApplicationStatus.REJECTED
+    );
+
+    private final TeamRecruitmentRepository recruitmentRepository;
+    private final TeamRecruitmentApplicationRepository applicationRepository;
+    private final TeamRecruitmentChatRoomRepository chatRoomRepository;
+    private final StudentRepository studentRepository;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public MyApplicationListResponse getMyApplications(
+        List<TeamRecruitmentApplicationStatus> statuses,
+        TeamRecruitmentApplicationSort sort,
+        Integer page,
+        Integer limit,
+        Integer studentId
+    ) {
+        studentRepository.getById(studentId);
+        Collection<TeamRecruitmentApplicationStatus> selectedStatuses = normalizeStatuses(statuses);
+        long totalCount = applicationRepository.countByApplicant_IdAndStatusIn(studentId, selectedStatuses);
+        Criteria criteria = Criteria.of(page, limit, safeInt(totalCount));
+        Page<TeamRecruitmentApplication> applications = applicationRepository.findAllByApplicant_IdAndStatusIn(
+            studentId,
+            selectedStatuses,
+            pageRequest(criteria, sort, true)
+        );
+        List<MyApplication> content = applications.getContent().stream()
+            .map(this::toMyApplication)
+            .toList();
+        return new MyApplicationListResponse(
+            content,
+            totalCount,
+            content.size(),
+            totalPage(totalCount, criteria.getLimit()),
+            criteria.getPage() + 1
+        );
+    }
+
+    public ApplicantListResponse getApplications(
+        Integer recruitmentId,
+        List<TeamRecruitmentApplicationStatus> statuses,
+        Integer page,
+        Integer limit,
+        Integer authorId
+    ) {
+        studentRepository.getById(authorId);
+        TeamRecruitment recruitment = getRecruitment(recruitmentId);
+        validateAuthor(recruitment, authorId);
+        if (recruitment.isDeleted()) {
+            throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND);
+        }
+
+        Collection<TeamRecruitmentApplicationStatus> selectedStatuses = normalizeStatuses(statuses);
+        long totalCount = applicationRepository.countByRecruitment_IdAndStatusIn(recruitmentId, selectedStatuses);
+        Criteria criteria = Criteria.of(page, limit, safeInt(totalCount));
+        Page<TeamRecruitmentApplication> applications = applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            recruitmentId,
+            selectedStatuses,
+            pageRequest(criteria, TeamRecruitmentApplicationSort.LATEST_DESC, false)
+        );
+        List<ApplicantSummary> content = applications.getContent().stream()
+            .map(this::toApplicantSummary)
+            .toList();
+        return new ApplicantListResponse(
+            toApplicantRecruitment(recruitment),
+            content,
+            totalCount,
+            content.size(),
+            totalPage(totalCount, criteria.getLimit()),
+            criteria.getPage() + 1
+        );
+    }
+
+    public ApplicantDetail getApplicationDetail(
+        Integer recruitmentId,
+        Integer applicationId,
+        Integer authorId
+    ) {
+        studentRepository.getById(authorId);
+        TeamRecruitment recruitment = getRecruitment(recruitmentId);
+        validateAuthor(recruitment, authorId);
+        if (recruitment.isDeleted()) {
+            throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND);
+        }
+        TeamRecruitmentApplication application = applicationRepository.findById(applicationId)
+            .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND));
+        validateApplicationBelongsToRecruitment(application, recruitmentId);
+
+        boolean canDecide = application.getStatus() == PENDING
+            && recruitment.getStatus() == RECRUITING
+            && !isPastDeadline(recruitment);
+        return new ApplicantDetail(
+            application.getId(),
+            application.getStatus(),
+            readProfileSnapshot(application.getProfileSnapshot()),
+            application.getMotivation(),
+            application.getAvailability(),
+            toApplicationRole(application.getRole()),
+            canDecide,
+            application.getStatus() == ACCEPTED
+        );
+    }
+
+    private TeamRecruitment getRecruitment(Integer recruitmentId) {
+        if (recruitmentId == null) {
+            throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND);
+        }
+        return recruitmentRepository.findById(recruitmentId)
+            .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_NOT_FOUND));
+    }
+
+    private void validateAuthor(TeamRecruitment recruitment, Integer authorId) {
+        if (authorId == null || recruitment.getAuthor() == null
+            || !Objects.equals(recruitment.getAuthor().getId(), authorId)) {
+            throw CustomException.of(TEAM_RECRUITMENT_FORBIDDEN);
+        }
+    }
+
+    private void validateApplicationBelongsToRecruitment(
+        TeamRecruitmentApplication application,
+        Integer recruitmentId
+    ) {
+        if (application.getRecruitment() == null
+            || !Objects.equals(application.getRecruitment().getId(), recruitmentId)) {
+            throw CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND);
+        }
+    }
+
+    private Collection<TeamRecruitmentApplicationStatus> normalizeStatuses(
+        List<TeamRecruitmentApplicationStatus> statuses
+    ) {
+        return statuses == null || statuses.isEmpty() ? ALL_STATUSES : statuses;
+    }
+
+    private PageRequest pageRequest(
+        Criteria criteria,
+        TeamRecruitmentApplicationSort sort,
+        boolean includeRecruitmentSort
+    ) {
+        Sort ordering = sorting(sort, includeRecruitmentSort);
+        return PageRequest.of(criteria.getPage(), criteria.getLimit(), ordering);
+    }
+
+    private Sort sorting(TeamRecruitmentApplicationSort sort, boolean includeRecruitmentSort) {
+        if (sort == TeamRecruitmentApplicationSort.DEADLINE_ASC && includeRecruitmentSort) {
+            return Sort.by(Sort.Direction.ASC, "recruitment.deadlineDate")
+                .and(Sort.by(Sort.Direction.DESC, "createdAt"))
+                .and(Sort.by(Sort.Direction.DESC, "id"));
+        }
+        return Sort.by(Sort.Direction.DESC, "createdAt")
+            .and(Sort.by(Sort.Direction.DESC, "id"));
+    }
+
+    private int totalPage(long totalCount, int limit) {
+        if (totalCount == 0) {
+            return 1;
+        }
+        return (int)Math.ceil((double)totalCount / limit);
+    }
+
+    private int safeInt(long value) {
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)value;
+    }
+
+    private MyApplication toMyApplication(TeamRecruitmentApplication application) {
+        TeamRecruitment recruitment = application.getRecruitment();
+        boolean accepted = application.getStatus() == ACCEPTED;
+        TeamRecruitmentChatRoom teamRoom = accepted
+            ? requireAcceptedTeamRoom(recruitment, application.getId())
+            : null;
+        Optional<TeamRecruitmentChatRoom> directRoom = !accepted || application.getId() == null
+            ? Optional.empty()
+            : chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(
+                recruitment.getId(),
+                application.getId(),
+                TeamRecruitmentChatRoomType.DIRECT
+            );
+        return new MyApplication(
+            application.getId(),
+            application.getStatus(),
+            accepted && teamRoom != null,
+            accepted && teamRoom != null ? teamRoom.getId() : null,
+            directRoom.map(TeamRecruitmentChatRoom::getId).orElse(null),
+            toApplicationRole(application.getRole()),
+            toRecruitmentCard(recruitment)
+        );
+    }
+
+    private TeamRecruitmentChatRoom requireAcceptedTeamRoom(
+        TeamRecruitment recruitment,
+        Integer applicationId
+    ) {
+        return findTeamRoom(recruitment.getId()).orElseThrow(() ->
+            new KoinIllegalStateException(
+                "ACCEPTED 지원서에 TEAM 채팅방이 없습니다. recruitmentId: "
+                    + recruitment.getId() + ", applicationId: " + applicationId
+            )
+        );
+    }
+
+    private ApplicantSummary toApplicantSummary(TeamRecruitmentApplication application) {
+        ProfileSnapshot snapshot = readProfileSnapshot(application.getProfileSnapshot());
+        return new ApplicantSummary(
+            application.getId(),
+            snapshot.nickname(),
+            snapshot.department(),
+            snapshot.studentYear(),
+            toApplicationRole(application.getRole()),
+            application.getStatus(),
+            application.getStatus() == ACCEPTED
+        );
+    }
+
+    private RecruitmentCard toRecruitmentCard(TeamRecruitment recruitment) {
+        return new RecruitmentCard(
+            recruitment.getId(),
+            recruitment.getCategory(),
+            recruitment.getTitle(),
+            recruitment.getMeetingType(),
+            recruitment.getActivityStartDate(),
+            recruitment.getActivityEndDate(),
+            recruitment.getDeadlineDate(),
+            dDay(recruitment),
+            effectiveStatus(recruitment),
+            recruitment.getRecruitmentType(),
+            recruitment.getCurrentParticipants(),
+            recruitment.getMaxParticipants(),
+            toRecruitmentRoles(recruitment)
+        );
+    }
+
+    private ApplicantRecruitment toApplicantRecruitment(TeamRecruitment recruitment) {
+        TeamRecruitmentChatRoom teamRoom = findTeamRoom(recruitment.getId()).orElseThrow(() ->
+            new KoinIllegalStateException(
+                "팀원 모집글에 TEAM 채팅방이 없습니다. recruitmentId: " + recruitment.getId()
+            )
+        );
+        return new ApplicantRecruitment(
+            recruitment.getId(),
+            recruitment.getCategory(),
+            recruitment.getTitle(),
+            recruitment.getMeetingType(),
+            recruitment.getActivityStartDate(),
+            recruitment.getActivityEndDate(),
+            recruitment.getDeadlineDate(),
+            dDay(recruitment),
+            effectiveStatus(recruitment),
+            recruitment.getRecruitmentType(),
+            recruitment.getCurrentParticipants(),
+            recruitment.getMaxParticipants(),
+            toRecruitmentRoles(recruitment),
+            true,
+            teamRoom.getId()
+        );
+    }
+
+    private List<RecruitmentRole> toRecruitmentRoles(TeamRecruitment recruitment) {
+        if (recruitment.getRoles() == null) {
+            return List.of();
+        }
+        boolean recruitmentClosed = recruitment.getStatus() != RECRUITING || isPastDeadline(recruitment);
+        return recruitment.getRoles().stream()
+            .map(role -> new RecruitmentRole(
+                role.getId(),
+                role.getName(),
+                role.getCurrentParticipants(),
+                role.getMaxParticipants(),
+                recruitmentClosed || role.isClosed()
+            ))
+            .toList();
+    }
+
+    private TeamRecruitmentStatus effectiveStatus(TeamRecruitment recruitment) {
+        if (recruitment.getStatus() == RECRUITING && isPastDeadline(recruitment)) {
+            return TeamRecruitmentStatus.CLOSED;
+        }
+        return recruitment.getStatus();
+    }
+
+    private ApplicationRole toApplicationRole(TeamRecruitmentRole role) {
+        if (role == null) {
+            return null;
+        }
+        return new ApplicationRole(role.getId(), role.getName());
+    }
+
+    private Optional<TeamRecruitmentChatRoom> findTeamRoom(Integer recruitmentId) {
+        return chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(recruitmentId, TEAM_ROOM_SCOPE_KEY)
+            .filter(room -> room.getRoomType() == TeamRecruitmentChatRoomType.TEAM);
+    }
+
+    private Integer dDay(TeamRecruitment recruitment) {
+        if (recruitment.getStatus() != RECRUITING || recruitment.getDeadlineDate() == null) {
+            return null;
+        }
+        LocalDate today = LocalDate.now(clock.withZone(KST));
+        if (today.isAfter(recruitment.getDeadlineDate())) {
+            return null;
+        }
+        return Math.toIntExact(ChronoUnit.DAYS.between(today, recruitment.getDeadlineDate()));
+    }
+
+    private boolean isPastDeadline(TeamRecruitment recruitment) {
+        return recruitment.getDeadlineDate() != null
+            && LocalDate.now(clock.withZone(KST)).isAfter(recruitment.getDeadlineDate());
+    }
+
+    private ProfileSnapshot readProfileSnapshot(String profileSnapshot) {
+        if (profileSnapshot == null || profileSnapshot.isBlank()) {
+            throw new IllegalStateException("팀 모집 지원 프로필 snapshot이 비어 있습니다.");
+        }
+        try {
+            return objectMapper.readValue(profileSnapshot, ProfileSnapshot.class);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("팀 모집 지원 프로필 snapshot을 읽을 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -2,6 +2,8 @@ package in.koreatech.koin.domain.team.recruitment.service;
 
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
@@ -40,8 +42,11 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -85,8 +90,9 @@ public class TeamRecruitmentApplicationQueryService {
             selectedStatuses,
             pageRequest(criteria, sort, true)
         );
+        AcceptedChatRooms acceptedChatRooms = findAcceptedChatRooms(applications.getContent());
         List<MyApplication> content = applications.getContent().stream()
-            .map(this::toMyApplication)
+            .map(application -> toMyApplication(application, acceptedChatRooms))
             .toList();
         return new MyApplicationListResponse(
             content,
@@ -223,25 +229,28 @@ public class TeamRecruitmentApplicationQueryService {
         return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)value;
     }
 
-    private MyApplication toMyApplication(TeamRecruitmentApplication application) {
+    private MyApplication toMyApplication(
+        TeamRecruitmentApplication application,
+        AcceptedChatRooms acceptedChatRooms
+    ) {
         TeamRecruitment recruitment = application.getRecruitment();
         boolean accepted = application.getStatus() == ACCEPTED;
         TeamRecruitmentChatRoom teamRoom = accepted
-            ? requireAcceptedTeamRoom(recruitment, application.getId())
-            : null;
-        Optional<TeamRecruitmentChatRoom> directRoom = !accepted || application.getId() == null
-            ? Optional.empty()
-            : chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(
-                recruitment.getId(),
+            ? requireAcceptedTeamRoom(
+                recruitment,
                 application.getId(),
-                TeamRecruitmentChatRoomType.DIRECT
-            );
+                acceptedChatRooms.teamRoomsByRecruitmentId().get(recruitment.getId())
+            )
+            : null;
+        TeamRecruitmentChatRoom directRoom = accepted
+            ? acceptedChatRooms.directRoomsByApplicationId().get(application.getId())
+            : null;
         return new MyApplication(
             application.getId(),
             application.getStatus(),
             accepted && teamRoom != null,
             accepted && teamRoom != null ? teamRoom.getId() : null,
-            directRoom.map(TeamRecruitmentChatRoom::getId).orElse(null),
+            directRoom == null ? null : directRoom.getId(),
             toApplicationRole(application.getRole()),
             toRecruitmentCard(recruitment)
         );
@@ -249,14 +258,52 @@ public class TeamRecruitmentApplicationQueryService {
 
     private TeamRecruitmentChatRoom requireAcceptedTeamRoom(
         TeamRecruitment recruitment,
-        Integer applicationId
+        Integer applicationId,
+        TeamRecruitmentChatRoom teamRoom
     ) {
-        return findTeamRoom(recruitment.getId()).orElseThrow(() ->
-            new KoinIllegalStateException(
+        if (teamRoom == null) {
+            throw new KoinIllegalStateException(
                 "ACCEPTED 지원서에 TEAM 채팅방이 없습니다. recruitmentId: "
                     + recruitment.getId() + ", applicationId: " + applicationId
-            )
-        );
+            );
+        }
+        return teamRoom;
+    }
+
+    private AcceptedChatRooms findAcceptedChatRooms(List<TeamRecruitmentApplication> applications) {
+        List<TeamRecruitmentApplication> acceptedApplications = applications.stream()
+            .filter(application -> application.getStatus() == ACCEPTED)
+            .toList();
+        if (acceptedApplications.isEmpty()) {
+            return new AcceptedChatRooms(Map.of(), Map.of());
+        }
+
+        List<Integer> recruitmentIds = acceptedApplications.stream()
+            .map(TeamRecruitmentApplication::getRecruitment)
+            .map(TeamRecruitment::getId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+        List<Integer> applicationIds = acceptedApplications.stream()
+            .map(TeamRecruitmentApplication::getId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        Map<Integer, TeamRecruitmentChatRoom> teamRoomsByRecruitmentId = chatRoomRepository
+            .findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(recruitmentIds, TEAM_ROOM_SCOPE_KEY, TEAM)
+            .stream()
+            .collect(Collectors.toMap(
+                room -> room.getRecruitment().getId(),
+                Function.identity()
+            ));
+        Map<Integer, TeamRecruitmentChatRoom> directRoomsByApplicationId = chatRoomRepository
+            .findAllByApplication_IdInAndRoomType(applicationIds, DIRECT)
+            .stream()
+            .collect(Collectors.toMap(
+                room -> room.getApplication().getId(),
+                Function.identity()
+            ));
+        return new AcceptedChatRooms(teamRoomsByRecruitmentId, directRoomsByApplicationId);
     }
 
     private ApplicantSummary toApplicantSummary(TeamRecruitmentApplication application) {
@@ -375,5 +422,11 @@ public class TeamRecruitmentApplicationQueryService {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("팀 모집 지원 프로필 snapshot을 읽을 수 없습니다.", exception);
         }
+    }
+
+    private record AcceptedChatRooms(
+        Map<Integer, TeamRecruitmentChatRoom> teamRoomsByRecruitmentId,
+        Map<Integer, TeamRecruitmentChatRoom> directRoomsByApplicationId
+    ) {
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -338,11 +338,7 @@ public class TeamRecruitmentApplicationQueryService {
     }
 
     private ApplicantRecruitment toApplicantRecruitment(TeamRecruitment recruitment) {
-        TeamRecruitmentChatRoom teamRoom = findTeamRoom(recruitment.getId()).orElseThrow(() ->
-            new KoinIllegalStateException(
-                "팀원 모집글에 TEAM 채팅방이 없습니다. recruitmentId: " + recruitment.getId()
-            )
-        );
+        Optional<TeamRecruitmentChatRoom> teamRoom = findTeamRoom(recruitment.getId());
         return new ApplicantRecruitment(
             recruitment.getId(),
             recruitment.getCategory(),
@@ -357,8 +353,8 @@ public class TeamRecruitmentApplicationQueryService {
             recruitment.getCurrentParticipants(),
             recruitment.getMaxParticipants(),
             toRecruitmentRoles(recruitment),
-            true,
-            teamRoom.getId()
+            teamRoom.isPresent(),
+            teamRoom.map(TeamRecruitmentChatRoom::getId).orElse(null)
         );
     }
 

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationService.java
@@ -566,6 +566,10 @@ public class TeamRecruitmentApplicationService {
         List<TeamRecruitmentProfileSkill> skills,
         List<TeamRecruitmentProfileActivity> activities
     ) {
+        Integer admissionYear = studentYear(student.getStudentNumber());
+        if (student.getDepartment() == null || admissionYear == null) {
+            throw CustomException.of(TEAM_RECRUITMENT_PROFILE_REQUIRED);
+        }
         List<String> snapshotSkills = skills == null
             ? List.of()
             : skills.stream().map(TeamRecruitmentProfileSkill::getSkill).toList();
@@ -576,8 +580,8 @@ public class TeamRecruitmentApplicationService {
                 .toList();
         ProfileSnapshot snapshot = new ProfileSnapshot(
             profile.getProfileNickname(),
-            student.getDepartment() == null ? null : student.getDepartment().getName(),
-            studentYear(student.getStudentNumber()),
+            student.getDepartment().getName(),
+            admissionYear,
             profile.getPreferredRole(),
             snapshotSkills,
             snapshotActivities,

--- a/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/in/koreatech/koin/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.catalina.connector.ClientAbortException;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -128,6 +129,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             return handleCustomException(request, ce);
         }
         return buildErrorResponse(request, ApiResponseCode.NOT_READABLE_HTTP_MESSAGE, e.getMessage());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+        TypeMismatchException e,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest webRequest
+    ) {
+        HttpServletRequest request = ((ServletWebRequest)webRequest).getRequest();
+        return buildErrorResponse(request, ApiResponseCode.ILLEGAL_ARGUMENT, e.getMessage());
     }
 
     @ExceptionHandler(UnsupportedOperationException.class)
@@ -356,7 +368,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         HttpServletRequest request,
         AuthenticationException e
     ) {
-        return buildErrorResponse(request, HttpStatus.UNAUTHORIZED, e.getFullMessage());
+        return buildErrorResponse(request, ApiResponseCode.UNAUTHORIZED_USER, e.getFullMessage());
     }
 
     @ExceptionHandler(DataNotFoundException.class)

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -1,0 +1,316 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfile;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+
+class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private TeamRecruitmentProfileRepository profileRepository;
+
+    @Autowired
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Autowired
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private TeamRecruitmentChatMemberRepository chatMemberRepository;
+
+    private Student author;
+    private Student applicant;
+    private String authorToken;
+    private String applicantToken;
+    private RecruitmentContext recruitmentContext;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        author = userFixture.준호_학생(department, null);
+        applicant = userFixture.성빈_학생(department);
+        authorToken = userFixture.getToken(author.getUser());
+        applicantToken = userFixture.getToken(applicant.getUser());
+        profileRepository.save(TeamRecruitmentProfile.builder()
+            .user(applicant.getUser())
+            .profileNickname("지원자")
+            .preferredRole("백엔드")
+            .selfIntroduction("소개")
+            .build());
+        recruitmentContext = saveRecruitmentAndTeamRoom("팀원 모집", 2);
+    }
+
+    @Test
+    void 모집글과_TEAM_방이_생성된_상태에서_지원하고_승인하면_TEAM_방에_참여한다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentChatRoom teamRoom = recruitmentContext.teamRoom();
+
+        apply(recruitment, applicantToken)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.recruitment_id").value(recruitment.getId()))
+            .andExpect(jsonPath("$.status").value("PENDING"));
+
+        TeamRecruitmentApplication application = applicationRepository
+            .findByRecruitment_IdAndApplicant_Id(recruitment.getId(), applicant.getUser().getId())
+            .orElseThrow();
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/team-recruitments/me/applications")
+                .header("Authorization", "Bearer " + applicantToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applications[0].application_id").value(application.getId()))
+            .andExpect(jsonPath("$.applications[0].status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.applications[0].team_chat_available").value(true))
+            .andExpect(jsonPath("$.applications[0].team_chat_room_id").value(teamRoom.getId()));
+
+        assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
+            .isEqualTo(ACCEPTED);
+        assertThat(chatMemberRepository.existsByChatRoom_IdAndUser_Id(teamRoom.getId(), author.getUser().getId()))
+            .isTrue();
+        assertThat(chatMemberRepository.existsByChatRoom_IdAndUser_Id(teamRoom.getId(), applicant.getUser().getId()))
+            .isTrue();
+    }
+
+    @Test
+    void 마지막_지원자를_승인하면_모집글은_마감되고_TEAM_방은_ACTIVE를_유지한다() throws Exception {
+        RecruitmentContext lastSeatContext = saveRecruitmentAndTeamRoom("한 명 모집", 1);
+        TeamRecruitment recruitment = lastSeatContext.recruitment();
+        TeamRecruitmentChatRoom teamRoom = lastSeatContext.teamRoom();
+
+        apply(recruitment, applicantToken)
+            .andExpect(status().isCreated());
+
+        TeamRecruitmentApplication application = applicationRepository
+            .findByRecruitment_IdAndApplicant_Id(recruitment.getId(), applicant.getUser().getId())
+            .orElseThrow();
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        TeamRecruitment closedRecruitment = recruitmentRepository.findById(recruitment.getId()).orElseThrow();
+        TeamRecruitmentChatRoom activeTeamRoom = chatRoomRepository.findById(teamRoom.getId()).orElseThrow();
+        assertThat(closedRecruitment.getStatus()).isEqualTo(CLOSED);
+        assertThat(closedRecruitment.getCurrentParticipants()).isOne();
+        assertThat(activeTeamRoom.getStatus()).isEqualTo(ACTIVE);
+        assertThat(chatMemberRepository.existsByChatRoom_IdAndUser_Id(teamRoom.getId(), applicant.getUser().getId()))
+            .isTrue();
+
+        mockMvc.perform(get("/team-recruitments/me/applications")
+                .header("Authorization", "Bearer " + applicantToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applications[0].recruitment.status").value("CLOSED"))
+            .andExpect(jsonPath("$.applications[0].team_chat_available").value(true))
+            .andExpect(jsonPath("$.applications[0].team_chat_room_id").value(teamRoom.getId()));
+    }
+
+    @Test
+    void 다른_모집글의_applicationId로_조회하거나_상태를_변경할_수_없다() throws Exception {
+        RecruitmentContext otherContext = saveRecruitmentAndTeamRoom("다른 팀원 모집", 2);
+        TeamRecruitmentApplication otherApplication = savePendingApplication(otherContext.recruitment());
+        Integer recruitmentId = recruitmentContext.recruitment().getId();
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
+                recruitmentId, otherApplication.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_APPLICATION_NOT_FOUND"));
+
+        accept(recruitmentContext.recruitment(), otherApplication, authorToken)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_APPLICATION_NOT_FOUND"));
+
+        entityManager.clear();
+        assertThat(applicationRepository.findById(otherApplication.getId()).orElseThrow().getStatus())
+            .isEqualTo(PENDING);
+    }
+
+    @Test
+    void 로그인하지_않으면_작성자용_지원자_API를_사용할_수_없다() throws Exception {
+        TeamRecruitmentApplication application = savePendingApplication(recruitmentContext.recruitment());
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications",
+                recruitmentContext.recruitment().getId()))
+            .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
+                recruitmentContext.recruitment().getId(), application.getId()))
+            .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(put("/team-recruitments/{recruitmentId}/applications/{applicationId}/status",
+                recruitmentContext.recruitment().getId(), application.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "status": "ACCEPTED"
+                    }
+                    """))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 작성자가_아니면_작성자용_지원자_API를_사용할_수_없다() throws Exception {
+        TeamRecruitmentApplication application = savePendingApplication(recruitmentContext.recruitment());
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications",
+                recruitmentContext.recruitment().getId())
+                .header("Authorization", "Bearer " + applicantToken))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_FORBIDDEN"));
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
+                recruitmentContext.recruitment().getId(), application.getId())
+                .header("Authorization", "Bearer " + applicantToken))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_FORBIDDEN"));
+
+        accept(recruitmentContext.recruitment(), application, applicantToken)
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_FORBIDDEN"));
+
+        entityManager.clear();
+        assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
+            .isEqualTo(PENDING);
+    }
+
+    private ResultActions apply(
+        TeamRecruitment recruitment,
+        String token
+    ) throws Exception {
+        return mockMvc.perform(post("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                  "role_id": null,
+                  "motivation": "지원 동기",
+                  "availability": "월수금 20시 이후"
+                }
+                """));
+    }
+
+    private ResultActions accept(
+        TeamRecruitment recruitment,
+        TeamRecruitmentApplication application,
+        String token
+    ) throws Exception {
+        return mockMvc.perform(put("/team-recruitments/{recruitmentId}/applications/{applicationId}/status",
+                recruitment.getId(), application.getId())
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                  "status": "ACCEPTED"
+                }
+                """));
+    }
+
+    private RecruitmentContext saveRecruitmentAndTeamRoom(String title, int maxParticipants) {
+        TeamRecruitment recruitment = recruitmentRepository.save(TeamRecruitment.builder()
+            .author(author.getUser())
+            .category(PROJECT)
+            .title(title)
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(2))
+            .activityEndDate(LocalDate.now(clock).plusDays(10))
+            .deadlineDate(LocalDate.now(clock).plusDays(1))
+            .recruitmentType(GENERAL)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(RECRUITING)
+            .build());
+        TeamRecruitmentChatRoom teamRoom = chatRoomRepository.save(TeamRecruitmentChatRoom.builder()
+            .recruitment(recruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(ACTIVE)
+            .build());
+        chatMemberRepository.save(TeamRecruitmentChatMember.builder()
+            .chatRoom(teamRoom)
+            .user(author.getUser())
+            .build());
+        return new RecruitmentContext(recruitment, teamRoom);
+    }
+
+    private TeamRecruitmentApplication savePendingApplication(TeamRecruitment recruitment) {
+        return applicationRepository.save(TeamRecruitmentApplication.builder()
+            .recruitment(recruitment)
+            .applicant(applicant.getUser())
+            .motivation("지원 동기")
+            .availability("월수금 20시 이후")
+            .status(PENDING)
+            .profileSnapshot("""
+                {
+                  "nickname": "지원자",
+                  "department": "컴퓨터공학부",
+                  "student_year": 2023,
+                  "preferred_role": "백엔드",
+                  "skills": [],
+                  "activities": [],
+                  "self_introduction": "소개"
+                }
+                """)
+            .snapshotVersion(1)
+            .build());
+    }
+
+    private record RecruitmentContext(
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoom teamRoom
+    ) {
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.acceptance.domain;
 
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
@@ -10,6 +11,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSta
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -93,8 +95,11 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
 
         apply(recruitment, applicantToken)
             .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.application_id").isNumber())
             .andExpect(jsonPath("$.recruitment_id").value(recruitment.getId()))
-            .andExpect(jsonPath("$.status").value("PENDING"));
+            .andExpect(jsonPath("$.status").value("PENDING"))
+            .andExpect(jsonPath("$.role").value(nullValue()))
+            .andExpect(jsonPath("$.created_at").isString());
 
         TeamRecruitmentApplication application = applicationRepository
             .findByRecruitment_IdAndApplicant_Id(recruitment.getId(), applicant.getUser().getId())
@@ -224,6 +229,92 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
         entityManager.clear();
         assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
             .isEqualTo(PENDING);
+    }
+
+    @Test
+    void 로그인하지_않으면_지원하거나_내_지원_목록을_조회할_수_없다() throws Exception {
+        mockMvc.perform(post("/team-recruitments/{recruitmentId}/applications",
+                recruitmentContext.recruitment().getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "role_id": null,
+                      "motivation": "지원 동기",
+                      "availability": "월수금 20시 이후"
+                    }
+                    """))
+            .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/team-recruitments/me/applications"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 작성자는_지원자_목록과_상세를_조회하고_지원을_거절할_수_있다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.recruitment.id").value(recruitment.getId()))
+            .andExpect(jsonPath("$.recruitment.team_chat_available").value(true))
+            .andExpect(jsonPath("$.recruitment.team_chat_room_id").value(recruitmentContext.teamRoom().getId()))
+            .andExpect(jsonPath("$.applications[0].application_id").value(application.getId()))
+            .andExpect(jsonPath("$.applications[0].nickname").value("지원자"))
+            .andExpect(jsonPath("$.applications[0].department").value("컴퓨터공학부"))
+            .andExpect(jsonPath("$.applications[0].student_year").value(2023))
+            .andExpect(jsonPath("$.applications[0].role").value(nullValue()))
+            .andExpect(jsonPath("$.applications[0].status").value("PENDING"))
+            .andExpect(jsonPath("$.total_count").value(1))
+            .andExpect(jsonPath("$.current_count").value(1))
+            .andExpect(jsonPath("$.total_page").value(1))
+            .andExpect(jsonPath("$.current_page").value(1));
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.application_id").value(application.getId()))
+            .andExpect(jsonPath("$.status").value("PENDING"))
+            .andExpect(jsonPath("$.profile_snapshot.nickname").value("지원자"))
+            .andExpect(jsonPath("$.motivation").value("지원 동기"))
+            .andExpect(jsonPath("$.availability").value("월수금 20시 이후"))
+            .andExpect(jsonPath("$.role").value(nullValue()))
+            .andExpect(jsonPath("$.can_decide").value(true))
+            .andExpect(jsonPath("$.can_open_direct_chat").value(false));
+
+        mockMvc.perform(put("/team-recruitments/{recruitmentId}/applications/{applicationId}/status",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "status": "REJECTED"
+                    }
+                    """))
+            .andExpect(status().isNoContent());
+
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
+            .isEqualTo(REJECTED);
+    }
+
+    @Test
+    void GENERAL_지원에서_role_id를_생략하면_잘못된_요청으로_응답한다() throws Exception {
+        mockMvc.perform(post("/team-recruitments/{recruitmentId}/applications",
+                recruitmentContext.recruitment().getId())
+                .header("Authorization", "Bearer " + applicantToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "motivation": "지원 동기",
+                      "availability": "월수금 20시 이후"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("NOT_READABLE_HTTP_MESSAGE"));
     }
 
     private ResultActions apply(

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -189,11 +189,13 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
 
         mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications",
                 recruitmentContext.recruitment().getId()))
-            .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"));
 
         mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
                 recruitmentContext.recruitment().getId(), application.getId()))
-            .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"));
 
         mockMvc.perform(put("/team-recruitments/{recruitmentId}/applications/{applicationId}/status",
                 recruitmentContext.recruitment().getId(), application.getId())
@@ -203,7 +205,8 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                       "status": "ACCEPTED"
                     }
                     """))
-            .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"));
     }
 
     @Test
@@ -243,10 +246,77 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                       "availability": "월수금 20시 이후"
                     }
                     """))
-            .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"));
 
         mockMvc.perform(get("/team-recruitments/me/applications"))
-            .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"));
+    }
+
+    @Test
+    void 양수가_아닌_경로_ID는_잘못된_요청으로_응답한다() throws Exception {
+        mockMvc.perform(post("/team-recruitments/{recruitmentId}/applications", 0)
+                .header("Authorization", "Bearer " + applicantToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "role_id": null,
+                      "motivation": "지원 동기",
+                      "availability": "월수금 20시 이후"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", -1)
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications/{applicationId}",
+                recruitmentContext.recruitment().getId(), 0)
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+
+        mockMvc.perform(put("/team-recruitments/{recruitmentId}/applications/{applicationId}/status",
+                recruitmentContext.recruitment().getId(), -1)
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "status": "ACCEPTED"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+    }
+
+    @Test
+    void 변환할_수_없는_경로와_query_값은_잘못된_인자로_응답한다() throws Exception {
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", "invalid")
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+
+        mockMvc.perform(get("/team-recruitments/me/applications")
+                .queryParam("sort", "INVALID")
+                .header("Authorization", "Bearer " + applicantToken))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+    }
+
+    @Test
+    void TEAM_방이_아직_없는_모집글은_지원자_목록에서_채팅_불가로_응답한다() throws Exception {
+        TeamRecruitment recruitment = saveRecruitment("TEAM 방 생성 전 모집글", 2);
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.recruitment.team_chat_available").value(false))
+            .andExpect(jsonPath("$.recruitment.team_chat_room_id").value(nullValue()))
+            .andExpect(jsonPath("$.applications").isEmpty());
     }
 
     @Test
@@ -350,7 +420,22 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
     }
 
     private RecruitmentContext saveRecruitmentAndTeamRoom(String title, int maxParticipants) {
-        TeamRecruitment recruitment = recruitmentRepository.save(TeamRecruitment.builder()
+        TeamRecruitment recruitment = saveRecruitment(title, maxParticipants);
+        TeamRecruitmentChatRoom teamRoom = chatRoomRepository.save(TeamRecruitmentChatRoom.builder()
+            .recruitment(recruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(ACTIVE)
+            .build());
+        chatMemberRepository.save(TeamRecruitmentChatMember.builder()
+            .chatRoom(teamRoom)
+            .user(author.getUser())
+            .build());
+        return new RecruitmentContext(recruitment, teamRoom);
+    }
+
+    private TeamRecruitment saveRecruitment(String title, int maxParticipants) {
+        return recruitmentRepository.save(TeamRecruitment.builder()
             .author(author.getUser())
             .category(PROJECT)
             .title(title)
@@ -364,17 +449,6 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
             .description("모집 내용")
             .status(RECRUITING)
             .build());
-        TeamRecruitmentChatRoom teamRoom = chatRoomRepository.save(TeamRecruitmentChatRoom.builder()
-            .recruitment(recruitment)
-            .roomScopeKey("TEAM")
-            .roomType(TEAM)
-            .status(ACTIVE)
-            .build());
-        chatMemberRepository.save(TeamRecruitmentChatMember.builder()
-            .chatRoom(teamRoom)
-            .user(author.getUser())
-            .build());
-        return new RecruitmentContext(recruitment, teamRoom);
     }
 
     private TeamRecruitmentApplication savePendingApplication(TeamRecruitment recruitment) {

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/TeamRecruitmentApplicationDtoContractTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/TeamRecruitmentApplicationDtoContractTest.java
@@ -1,0 +1,19 @@
+package in.koreatech.koin.unit.domain.team.recruitment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateApplicationStatusRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.junit.jupiter.api.Test;
+
+class TeamRecruitmentApplicationDtoContractTest {
+
+    @Test
+    void 지원_상태_변경_요청은_승인과_거절만_안내한다() throws NoSuchFieldException {
+        Schema schema = UpdateApplicationStatusRequest.class
+            .getDeclaredField("status")
+            .getAnnotation(Schema.class);
+
+        assertThat(schema.allowableValues()).containsExactly("ACCEPTED", "REJECTED");
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -126,10 +127,13 @@ class TeamRecruitmentApplicationQueryServiceTest {
             any(),
             any(Pageable.class)
         )).thenReturn(new PageImpl<>(List.of(pending, rejected, accepted)));
-        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
-            .thenReturn(Optional.of(teamRoom));
-        when(chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(any(), any(), any()))
-            .thenReturn(Optional.of(directRoom));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(22), DIRECT))
+            .thenReturn(List.of(directRoom));
 
         MyApplicationListResponse response = queryService.getMyApplications(
             null,
@@ -152,6 +156,70 @@ class TeamRecruitmentApplicationQueryServiceTest {
         assertThat(acceptedResponse.teamChatAvailable()).isTrue();
         assertThat(acceptedResponse.teamChatRoomId()).isEqualTo(TEAM_ROOM_ID);
         assertThat(acceptedResponse.directChatRoomId()).isEqualTo(DIRECT_ROOM_ID);
+    }
+
+    @Test
+    void 여러_ACCEPTED_지원서의_채팅방을_건별로_조회하지_않는다() {
+        TeamRecruitment firstRecruitment = recruitment();
+        TeamRecruitment secondRecruitment = TeamRecruitment.builder()
+            .id(11)
+            .author(UserFixture.id_설정_코인_유저(AUTHOR_ID))
+            .title("두 번째 팀원 모집")
+            .activityStartDate(LocalDate.of(2026, 9, 1))
+            .activityEndDate(LocalDate.of(2026, 9, 30))
+            .deadlineDate(LocalDate.of(2026, 8, 31))
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .build();
+        TeamRecruitmentApplication firstApplication = application(20, firstRecruitment, ACCEPTED);
+        TeamRecruitmentApplication secondApplication = application(21, secondRecruitment, ACCEPTED);
+        TeamRecruitmentChatRoom firstTeamRoom = teamRoom(firstRecruitment);
+        TeamRecruitmentChatRoom secondTeamRoom = TeamRecruitmentChatRoom.builder()
+            .id(42)
+            .recruitment(secondRecruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(ACTIVE)
+            .build();
+
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(2L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(firstApplication, secondApplication)));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(10, 11),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(firstTeamRoom, secondTeamRoom));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20, 21), DIRECT))
+            .thenReturn(List.of());
+
+        MyApplicationListResponse response = queryService.getMyApplications(
+            List.of(ACCEPTED),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        );
+
+        assertThat(response.applications())
+            .extracting(MyApplication::teamChatRoomId)
+            .containsExactly(TEAM_ROOM_ID, 42);
+        verify(chatRoomRepository).findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(10, 11),
+            "TEAM",
+            TEAM
+        );
+        verify(chatRoomRepository).findAllByApplication_IdInAndRoomType(List.of(20, 21), DIRECT);
+        verify(chatRoomRepository, never()).findByRecruitment_IdAndRoomScopeKey(any(), any());
+        verify(chatRoomRepository, never())
+            .findByRecruitment_IdAndApplication_IdAndRoomType(any(), any(), any());
     }
 
     @Test
@@ -421,8 +489,13 @@ class TeamRecruitmentApplicationQueryServiceTest {
             any(),
             any(Pageable.class)
         )).thenReturn(new PageImpl<>(List.of(accepted)));
-        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
-            .thenReturn(Optional.empty());
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of());
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(22), DIRECT))
+            .thenReturn(List.of());
 
         assertThatThrownBy(() -> queryService.getMyApplications(
             List.of(ACCEPTED),

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -1,0 +1,569 @@
+package in.koreatech.koin.unit.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantSummary;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplication;
+import in.koreatech.koin.domain.team.recruitment.dto.MyApplicationListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCard;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentApplicationQueryService;
+import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
+import in.koreatech.koin.unit.fixture.UserFixture;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentApplicationQueryServiceTest {
+
+    private static final Integer APPLICANT_ID = 2;
+    private static final Integer AUTHOR_ID = 1;
+    private static final Integer RECRUITMENT_ID = 10;
+    private static final Integer TEAM_ROOM_ID = 40;
+    private static final Integer DIRECT_ROOM_ID = 41;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Mock
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Mock
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private StudentRepository studentRepository;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TeamRecruitmentApplicationQueryService queryService;
+
+    @BeforeEach
+    void setUpClock() {
+        lenient().when(clock.instant()).thenReturn(Instant.parse("2026-08-28T03:00:00Z"));
+        lenient().when(clock.getZone()).thenReturn(KST);
+        lenient().when(clock.withZone(KST)).thenReturn(clock);
+    }
+
+    @Test
+    void PENDING과_REJECTED는_TEAM_room이_있어도_팀채팅을_사용할_수_없고_ACCEPTED만_사용할_수_있다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentApplication pending = application(20, recruitment, PENDING);
+        TeamRecruitmentApplication rejected = application(21, recruitment, REJECTED);
+        TeamRecruitmentApplication accepted = application(22, recruitment, ACCEPTED);
+        TeamRecruitmentChatRoom teamRoom = TeamRecruitmentChatRoom.builder()
+            .id(TEAM_ROOM_ID)
+            .recruitment(recruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(ACTIVE)
+            .build();
+        TeamRecruitmentChatRoom directRoom = TeamRecruitmentChatRoom.builder()
+            .id(DIRECT_ROOM_ID)
+            .recruitment(recruitment)
+            .roomScopeKey("DIRECT:22")
+            .roomType(DIRECT)
+            .application(accepted)
+            .status(ACTIVE)
+            .build();
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(3L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(pending, rejected, accepted)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.of(teamRoom));
+        when(chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(any(), any(), any()))
+            .thenReturn(Optional.of(directRoom));
+
+        MyApplicationListResponse response = queryService.getMyApplications(
+            null,
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        );
+
+        assertThat(response.applications()).hasSize(3);
+        MyApplication pendingResponse = response.applications().get(0);
+        MyApplication rejectedResponse = response.applications().get(1);
+        MyApplication acceptedResponse = response.applications().get(2);
+        assertThat(pendingResponse.teamChatAvailable()).isFalse();
+        assertThat(pendingResponse.teamChatRoomId()).isNull();
+        assertThat(rejectedResponse.teamChatAvailable()).isFalse();
+        assertThat(rejectedResponse.teamChatRoomId()).isNull();
+        assertThat(pendingResponse.directChatRoomId()).isNull();
+        assertThat(rejectedResponse.directChatRoomId()).isNull();
+        assertThat(acceptedResponse.teamChatAvailable()).isTrue();
+        assertThat(acceptedResponse.teamChatRoomId()).isEqualTo(TEAM_ROOM_ID);
+        assertThat(acceptedResponse.directChatRoomId()).isEqualTo(DIRECT_ROOM_ID);
+    }
+
+    @Test
+    void KST_마감일이_지난_RECRUITING_모집글은_두_목록에서_CLOSED와_전체_역할_마감으로_응답된다() {
+        TeamRecruitment recruitment = recruitment(LocalDate.of(2026, 8, 27));
+        recruitment.addRole(role(50, "백엔드", 1, 1, 1));
+        recruitment.addRole(role(51, "프론트엔드", 2, 0, 2));
+        TeamRecruitmentApplication application = applicationWithSnapshot(20, recruitment, PENDING);
+
+        // 2026-08-27T15:30Z is 2026-08-28T00:30 in KST, so the 2026-08-27
+        // deadline is past even though the UTC calendar date is still the 27th.
+        when(clock.instant()).thenReturn(Instant.parse("2026-08-27T15:30:00Z"));
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+
+        MyApplicationListResponse myResponse = queryService.getMyApplications(
+            List.of(PENDING),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        );
+
+        RecruitmentCard card = myResponse.applications().get(0).recruitment();
+        assertThat(card.status()).isEqualTo(CLOSED);
+        assertThat(card.dDay()).isNull();
+        assertThat(card.roles()).extracting(RecruitmentRole::isClosed).containsExactly(true, true);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.of(teamRoom(recruitment)));
+
+        ApplicantListResponse authorResponse = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(PENDING),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(authorResponse.recruitment().status()).isEqualTo(CLOSED);
+        assertThat(authorResponse.recruitment().dDay()).isNull();
+        assertThat(authorResponse.recruitment().roles())
+            .extracting(RecruitmentRole::isClosed)
+            .containsExactly(true, true);
+    }
+
+    @Test
+    void 역할_하나가_정원에_도달해도_마감_전_모집글은_RECRUITING이고_해당_역할만_닫힌다() {
+        TeamRecruitment recruitment = recruitment();
+        recruitment.addRole(role(50, "백엔드", 1, 1, 1));
+        recruitment.addRole(role(51, "프론트엔드", 2, 0, 2));
+        TeamRecruitmentApplication application = applicationWithSnapshot(20, recruitment, PENDING);
+
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+
+        MyApplicationListResponse myResponse = queryService.getMyApplications(
+            List.of(PENDING),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        );
+
+        RecruitmentCard card = myResponse.applications().get(0).recruitment();
+        assertThat(card.status()).isEqualTo(RECRUITING);
+        assertThat(card.dDay()).isEqualTo(3);
+        assertThat(card.roles()).extracting(RecruitmentRole::isClosed).containsExactly(true, false);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.of(teamRoom(recruitment)));
+
+        ApplicantListResponse authorResponse = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(PENDING),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(authorResponse.recruitment().status()).isEqualTo(RECRUITING);
+        assertThat(authorResponse.recruitment().dDay()).isEqualTo(3);
+        assertThat(authorResponse.recruitment().roles())
+            .extracting(RecruitmentRole::isClosed)
+            .containsExactly(true, false);
+    }
+
+    @Test
+    void 내_지원_목록의_초과_페이지는_마지막_페이지로_보정되어_조회된다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentApplication pending = application(20, recruitment, PENDING);
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(21L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(pending)));
+
+        MyApplicationListResponse response = queryService.getMyApplications(
+            List.of(PENDING),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            99,
+            10,
+            APPLICANT_ID
+        );
+
+        verify(applicationRepository).findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            eq(List.of(PENDING)),
+            pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(2);
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(10);
+        assertThat(response.totalCount()).isEqualTo(21L);
+        assertThat(response.currentCount()).isEqualTo(1);
+        assertThat(response.totalPage()).isEqualTo(3);
+        assertThat(response.currentPage()).isEqualTo(3);
+    }
+
+    @Test
+    void 작성자_지원자_목록은_지원_당시_snapshot의_프로필을_사용한다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentApplication application = application(20, recruitment, PENDING);
+        application = TeamRecruitmentApplication.builder()
+            .id(application.getId())
+            .recruitment(recruitment)
+            .applicant(application.getApplicant())
+            .motivation(application.getMotivation())
+            .availability(application.getAvailability())
+            .status(PENDING)
+            .profileSnapshot(
+                "{\"nickname\":\"지원 당시 이름\","
+                    + "\"department\":\"컴퓨터공학부\","
+                    + "\"student_year\":2023,"
+                    + "\"preferred_role\":\"백엔드\","
+                    + "\"skills\":[],\"activities\":[],"
+                    + "\"self_introduction\":\"지원 당시 소개\"}"
+            )
+            .build();
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.of(teamRoom(recruitment)));
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            null,
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        ApplicantSummary summary = response.applications().get(0);
+        assertThat(summary.nickname()).isEqualTo("지원 당시 이름");
+        assertThat(summary.department()).isEqualTo("컴퓨터공학부");
+        assertThat(summary.studentYear()).isEqualTo(2023);
+        assertThat(summary.status()).isEqualTo(PENDING);
+        assertThat(summary.canOpenDirectChat()).isFalse();
+    }
+
+    @Test
+    void 작성자_지원자_목록의_초과_페이지는_마지막_페이지로_보정되어_조회된다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentApplication pending = TeamRecruitmentApplication.builder()
+            .id(20)
+            .recruitment(recruitment)
+            .applicant(UserFixture.id_설정_코인_유저(APPLICANT_ID))
+            .motivation("지원 동기")
+            .availability("가능")
+            .status(PENDING)
+            .profileSnapshot(
+                "{\"nickname\":\"지원 당시 이름\","
+                    + "\"department\":\"컴퓨터공학부\","
+                    + "\"student_year\":2023,"
+                    + "\"preferred_role\":\"백엔드\","
+                    + "\"skills\":[],\"activities\":[],"
+                    + "\"self_introduction\":\"지원 당시 소개\"}"
+            )
+            .build();
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(21L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(pending)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.of(teamRoom(recruitment)));
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(PENDING),
+            99,
+            10,
+            AUTHOR_ID
+        );
+
+        verify(applicationRepository).findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            eq(List.of(PENDING)),
+            pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(2);
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(10);
+        assertThat(response.totalCount()).isEqualTo(21L);
+        assertThat(response.currentCount()).isEqualTo(1);
+        assertThat(response.totalPage()).isEqualTo(3);
+        assertThat(response.currentPage()).isEqualTo(3);
+    }
+
+    @Test
+    void ACCEPTED인데_TEAM_room이_없으면_내부_무결성_예외가_발생한다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentApplication accepted = application(22, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> queryService.getMyApplications(
+            List.of(ACCEPTED),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        ))
+            .isInstanceOf(KoinIllegalStateException.class)
+            .hasMessageContaining("TEAM 채팅방이 없습니다")
+            .hasMessageContaining("recruitmentId: 10")
+            .hasMessageContaining("applicationId: 22");
+    }
+
+    @Test
+    void 작성자_지원자_목록에_TEAM_room이_없으면_내부_무결성_예외가_발생한다() {
+        TeamRecruitment recruitment = recruitment();
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(0L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> queryService.getApplications(
+            RECRUITMENT_ID,
+            null,
+            1,
+            10,
+            AUTHOR_ID
+        ))
+            .isInstanceOf(KoinIllegalStateException.class)
+            .hasMessageContaining("팀원 모집글에 TEAM 채팅방이 없습니다")
+            .hasMessageContaining("recruitmentId: 10");
+    }
+
+    @Test
+    void 삭제된_모집글의_지원자_상세는_모집글_없음으로_응답된다() {
+        TeamRecruitment deletedRecruitment = recruitment();
+        deletedRecruitment.markDeleted(LocalDateTime.of(2026, 8, 28, 12, 0));
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID))
+            .thenReturn(Optional.of(deletedRecruitment));
+
+        assertThatThrownBy(() -> queryService.getApplicationDetail(
+            RECRUITMENT_ID,
+            20,
+            AUTHOR_ID
+        ))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_NOT_FOUND);
+    }
+
+    private TeamRecruitmentChatRoom teamRoom(TeamRecruitment recruitment) {
+        return TeamRecruitmentChatRoom.builder()
+            .id(TEAM_ROOM_ID)
+            .recruitment(recruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(ACTIVE)
+            .build();
+    }
+
+    private TeamRecruitment recruitment() {
+        return recruitment(LocalDate.of(2026, 8, 31));
+    }
+
+    private TeamRecruitment recruitment(LocalDate deadlineDate) {
+        return TeamRecruitment.builder()
+            .id(RECRUITMENT_ID)
+            .author(UserFixture.id_설정_코인_유저(1))
+            .title("팀원 모집")
+            .activityStartDate(LocalDate.of(2026, 9, 1))
+            .activityEndDate(LocalDate.of(2026, 9, 30))
+            .deadlineDate(deadlineDate)
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .build();
+    }
+
+    private TeamRecruitmentApplication application(
+        Integer id,
+        TeamRecruitment recruitment,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        return TeamRecruitmentApplication.builder()
+            .id(id)
+            .recruitment(recruitment)
+            .applicant(UserFixture.id_설정_코인_유저(APPLICANT_ID))
+            .motivation("지원 동기")
+            .availability("가능")
+            .status(status)
+            .profileSnapshot("{}")
+            .build();
+    }
+
+    private TeamRecruitmentApplication applicationWithSnapshot(
+        Integer id,
+        TeamRecruitment recruitment,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        return TeamRecruitmentApplication.builder()
+            .id(id)
+            .recruitment(recruitment)
+            .applicant(UserFixture.id_설정_코인_유저(APPLICANT_ID))
+            .motivation("지원 동기")
+            .availability("가능")
+            .status(status)
+            .profileSnapshot(
+                "{\"nickname\":\"지원 당시 이름\","
+                    + "\"department\":\"컴퓨터공학부\","
+                    + "\"student_year\":2023,"
+                    + "\"preferred_role\":\"백엔드\","
+                    + "\"skills\":[],\"activities\":[],"
+                    + "\"self_introduction\":\"지원 당시 소개\"}"
+            )
+            .build();
+    }
+
+    private TeamRecruitmentRole role(
+        Integer id,
+        String name,
+        Integer maxParticipants,
+        Integer currentParticipants,
+        Integer displayOrder
+    ) {
+        return TeamRecruitmentRole.builder()
+            .id(id)
+            .name(name)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(currentParticipants)
+            .displayOrder(displayOrder)
+            .build();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -511,7 +511,7 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     @Test
-    void 작성자_지원자_목록에_TEAM_room이_없으면_내부_무결성_예외가_발생한다() {
+    void 작성자_지원자_목록에_TEAM_room이_없으면_채팅_불가로_응답한다() {
         TeamRecruitment recruitment = recruitment();
 
         when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
@@ -526,16 +526,16 @@ class TeamRecruitmentApplicationQueryServiceTest {
         when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
             .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> queryService.getApplications(
+        ApplicantListResponse response = queryService.getApplications(
             RECRUITMENT_ID,
             null,
             1,
             10,
             AUTHOR_ID
-        ))
-            .isInstanceOf(KoinIllegalStateException.class)
-            .hasMessageContaining("팀원 모집글에 TEAM 채팅방이 없습니다")
-            .hasMessageContaining("recruitmentId: 10");
+        );
+
+        assertThat(response.recruitment().teamChatAvailable()).isFalse();
+        assertThat(response.recruitment().teamChatRoomId()).isNull();
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import in.koreatech.koin.domain.student.model.Department;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
 import in.koreatech.koin.domain.team.recruitment.dto.ApplicationCreatedResponse;
@@ -281,6 +282,44 @@ class TeamRecruitmentApplicationServiceTest {
             ))
                 .isInstanceOfSatisfying(CustomException.class, exception ->
                     assertThat(exception.getErrorCode()).isEqualTo(TEAM_RECRUITMENT_PROFILE_REQUIRED));
+        }
+
+        @Test
+        void 지원자의_학과가_없으면_지원을_생성할_수_없다() {
+            TeamRecruitment recruitment = recruitment(GENERAL, 0, 5, TODAY.plusDays(1));
+            Student student = StudentFixture.익명_학생(APPLICANT_ID, null);
+            ReflectionTestUtils.setField(student.getUser(), "id", APPLICANT_ID);
+            stubRecruitment(recruitment);
+            stubNoExistingApplication();
+            stubApplicantAndProfile(student);
+
+            assertThatThrownBy(() -> applicationService.createApplication(
+                new CreateApplicationRequest(null, "지원 동기", "가능"),
+                RECRUITMENT_ID,
+                APPLICANT_ID
+            ))
+                .isInstanceOfSatisfying(CustomException.class, exception ->
+                    assertThat(exception.getErrorCode()).isEqualTo(TEAM_RECRUITMENT_PROFILE_REQUIRED));
+            verify(applicationRepository, never()).save(any());
+        }
+
+        @Test
+        void 지원자의_학번에서_입학_연도를_확인할_수_없으면_지원을_생성할_수_없다() {
+            TeamRecruitment recruitment = recruitment(GENERAL, 0, 5, TODAY.plusDays(1));
+            Student student = applicant();
+            student.updateStudentNumber("학번없음");
+            stubRecruitment(recruitment);
+            stubNoExistingApplication();
+            stubApplicantAndProfile(student);
+
+            assertThatThrownBy(() -> applicationService.createApplication(
+                new CreateApplicationRequest(null, "지원 동기", "가능"),
+                RECRUITMENT_ID,
+                APPLICANT_ID
+            ))
+                .isInstanceOfSatisfying(CustomException.class, exception ->
+                    assertThat(exception.getErrorCode()).isEqualTo(TEAM_RECRUITMENT_PROFILE_REQUIRED));
+            verify(applicationRepository, never()).save(any());
         }
 
         @Test
@@ -718,7 +757,10 @@ class TeamRecruitmentApplicationServiceTest {
     }
 
     private void stubApplicantAndProfile() {
-        Student student = applicant();
+        stubApplicantAndProfile(applicant());
+    }
+
+    private void stubApplicantAndProfile(Student student) {
         TeamRecruitmentProfile profile = TeamRecruitmentProfile.builder()
             .userId(APPLICANT_ID)
             .user(student.getUser())
@@ -751,7 +793,10 @@ class TeamRecruitmentApplicationServiceTest {
     }
 
     private Student applicant() {
-        Student student = StudentFixture.익명_학생(APPLICANT_ID, null);
+        Student student = StudentFixture.익명_학생(
+            APPLICANT_ID,
+            Department.builder().name("컴퓨터공학부").build()
+        );
         ReflectionTestUtils.setField(student.getUser(), "id", APPLICANT_ID);
         return student;
     }


### PR DESCRIPTION
### 🔍 개요

- 팀원 모집 지원 조회 서비스와 지원 API 5종의 HTTP 요청 및 응답을 연결합니다.
- close #2343

---

### 🚀 주요 변경 내용

- 지원 생성과 승인 및 거절 API 연결
- 내 지원 목록, 지원자 목록, 지원자 상세 조회 구현
- 작성자 권한, 삭제된 모집글, TEAM 채팅방 무결성 검증
- KOIN snake_case JSON과 1-based page 및 limit 응답 적용
- Swagger 오류 응답 코드 반영

---

### 💬 참고 사항

- 선행 PR: #2347
- 기준 명세: [팀원 모집 Swagger](https://team-recruitment-api.peridot-ocean.workers.dev/)
- 검증: `TeamRecruitmentApplicationServiceTest`, `TeamRecruitmentApplicationQueryServiceTest` 통과

---

### ✅ Checklist

- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Assignee 및 Labels 지정
- [x] 민감 정보 검토
