### PR TITLE
feat: 팀원 모집 마감 자동 처리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
@@ -1,0 +1,282 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.CHAT_ROOM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamRecruitmentDeadlineCloseProcessor {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final int CANDIDATE_BATCH_SIZE = 100;
+    private static final Pageable CANDIDATE_PAGE = PageRequest.of(
+        0,
+        CANDIDATE_BATCH_SIZE,
+        Sort.by(Sort.Direction.ASC, "id")
+    );
+
+    private static final String RECRUITMENT_CLOSED_REASON = "RECRUITMENT_CLOSED";
+    private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
+    private static final String AGGREGATE_TYPE = "TEAM_RECRUITMENT";
+    private static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
+
+    private final TeamRecruitmentRepository recruitmentRepository;
+    private final TeamRecruitmentApplicationRepository applicationRepository;
+    private final TeamRecruitmentChatRoomRepository chatRoomRepository;
+    private final TeamRecruitmentNotificationRepository notificationRepository;
+    private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
+    private final Clock clock;
+
+    @Transactional
+    public void closeExpiredRecruitments() {
+        LocalDate today = LocalDate.now(clock.withZone(KST));
+        Page<TeamRecruitment> candidatePage = recruitmentRepository
+            .findAllByStatusAndDeadlineDateBefore(RECRUITING, today, CANDIDATE_PAGE);
+        if (candidatePage == null) {
+            return;
+        }
+
+        List<Integer> candidateIds = candidatePage
+            .getContent()
+            .stream()
+            .map(TeamRecruitment::getId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        for (Integer recruitmentId : candidateIds) {
+            closeIfExpired(recruitmentId, today);
+        }
+    }
+
+    private void closeIfExpired(Integer recruitmentId, LocalDate today) {
+        Optional<TeamRecruitment> lockedRecruitment = recruitmentRepository.findByIdWithLock(recruitmentId);
+        if (lockedRecruitment.isEmpty()) {
+            return;
+        }
+
+        TeamRecruitment recruitment = lockedRecruitment.get();
+        if (recruitment.getStatus() != RECRUITING
+            || recruitment.getDeadlineDate() == null
+            || !today.isAfter(recruitment.getDeadlineDate())) {
+            return;
+        }
+
+        List<TeamRecruitmentApplication> pendingApplications = findApplications(recruitmentId, PENDING);
+        List<TeamRecruitmentApplication> acceptedApplications = findApplications(recruitmentId, ACCEPTED);
+        TeamRecruitmentChatRoom teamRoom = findTeamRoom(recruitmentId);
+
+        recruitment.close();
+        recruitmentRepository.save(recruitment);
+        rejectPendingApplications(recruitment, pendingApplications);
+        markRoomsReadOnly(recruitmentId);
+        notifyRejectedApplications(recruitment, pendingApplications);
+        notifyAcceptedMembers(recruitment, teamRoom, acceptedApplications);
+    }
+
+    private List<TeamRecruitmentApplication> findApplications(
+        Integer recruitmentId,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        Page<TeamRecruitmentApplication> applicationPage = applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            recruitmentId,
+            List.of(status),
+            Pageable.unpaged()
+        );
+        return applicationPage == null ? List.of() : applicationPage.getContent();
+    }
+
+    private TeamRecruitmentChatRoom findTeamRoom(Integer recruitmentId) {
+        Optional<TeamRecruitmentChatRoom> teamRoom = chatRoomRepository
+            .findByRecruitment_IdAndRoomScopeKey(recruitmentId, TEAM_ROOM_SCOPE_KEY);
+        if (teamRoom == null) {
+            return null;
+        }
+        return teamRoom.filter(chatRoom -> chatRoom.getRoomType() == TEAM).orElse(null);
+    }
+
+    private void rejectPendingApplications(
+        TeamRecruitment recruitment,
+        List<TeamRecruitmentApplication> pendingApplications
+    ) {
+        for (TeamRecruitmentApplication application : pendingApplications) {
+            application.reject(RECRUITMENT_CLOSED_REASON);
+            applicationRepository.save(application);
+        }
+    }
+
+    private void markRoomsReadOnly(Integer recruitmentId) {
+        List<TeamRecruitmentChatRoom> chatRooms = chatRoomRepository.findAllByRecruitment_Id(recruitmentId);
+        if (chatRooms == null) {
+            return;
+        }
+        for (TeamRecruitmentChatRoom chatRoom : chatRooms) {
+            if (chatRoom.getStatus() == ACTIVE) {
+                chatRoom.markReadOnly();
+                chatRoomRepository.save(chatRoom);
+            }
+        }
+    }
+
+    private void notifyRejectedApplications(
+        TeamRecruitment recruitment,
+        List<TeamRecruitmentApplication> pendingApplications
+    ) {
+        for (TeamRecruitmentApplication application : pendingApplications) {
+            TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+                .recipient(application.getApplicant())
+                .type(APPLICATION_REJECTED)
+                .targetType(MY_APPLICATIONS)
+                .messagePreview(rejectedMessage(recruitment))
+                .recruitment(recruitment)
+                .application(application)
+                .build();
+
+            saveNotificationAndOutbox(
+                notification,
+                notificationEventKey(application.getId(), APPLICATION_REJECTED),
+                application.getId(),
+                null
+            );
+        }
+    }
+
+    private void notifyAcceptedMembers(
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoom teamRoom,
+        List<TeamRecruitmentApplication> acceptedApplications
+    ) {
+        if (teamRoom == null) {
+            if (!acceptedApplications.isEmpty()) {
+                throw new IllegalStateException(
+                    "승인된 지원자가 존재하지만 팀 모집 TEAM 채팅방이 없습니다. recruitmentId: "
+                        + recruitment.getId()
+                );
+            }
+            return;
+        }
+
+        for (TeamRecruitmentApplication application : acceptedApplications) {
+            TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+                .recipient(application.getApplicant())
+                .type(RECRUITMENT_CLOSED)
+                .targetType(CHAT_ROOM)
+                .messagePreview(closedMessage(recruitment))
+                .recruitment(recruitment)
+                .application(application)
+                .chatRoom(teamRoom)
+                .build();
+
+            saveNotificationAndOutbox(
+                notification,
+                notificationEventKey(application.getId(), RECRUITMENT_CLOSED),
+                application.getId(),
+                teamRoom.getId()
+            );
+        }
+    }
+
+    private void saveNotificationAndOutbox(
+        TeamRecruitmentNotification notification,
+        String eventKey,
+        Integer applicationId,
+        Integer chatRoomId
+    ) {
+        if (outboxEventRepository.findByEventKey(eventKey).isPresent()) {
+            return;
+        }
+
+        TeamRecruitmentNotification savedNotification = notificationRepository.save(notification);
+        if (savedNotification == null) {
+            savedNotification = notification;
+        }
+        outboxEventRepository.save(TeamRecruitmentOutboxEvent.builder()
+            .eventKey(eventKey)
+            .eventType(OUTBOX_EVENT_TYPE)
+            .aggregateType(AGGREGATE_TYPE)
+            .aggregateId(notification.getRecruitment().getId())
+            .payload(payload(savedNotification, applicationId, chatRoomId))
+            .status(TeamRecruitmentOutboxEventStatus.PENDING)
+            .build());
+    }
+
+    private String payload(
+        TeamRecruitmentNotification notification,
+        Integer applicationId,
+        Integer chatRoomId
+    ) {
+        Integer recipientId = notification.getRecipient() == null ? null : notification.getRecipient().getId();
+        return "{"
+            + "\"type\":\"" + notification.getType().name() + "\","
+            + "\"target_type\":\"" + notification.getTargetType().name() + "\","
+            + "\"recipient_id\":" + jsonNumber(recipientId) + ","
+            + "\"recruitment_id\":" + jsonNumber(notification.getRecruitment().getId()) + ","
+            + "\"application_id\":" + jsonNumber(applicationId) + ","
+            + "\"chat_room_id\":" + jsonNumber(chatRoomId) + ","
+            + "\"notification_id\":" + jsonNumber(notification.getId())
+            + "}";
+    }
+
+    private String notificationEventKey(
+        Integer applicationId,
+        TeamRecruitmentNotificationType type
+    ) {
+        return "team-recruitment:application:" + applicationId + ":" + type.name();
+    }
+
+    private String jsonNumber(Integer value) {
+        return value == null ? "null" : value.toString();
+    }
+
+    private String rejectedMessage(TeamRecruitment recruitment) {
+        return truncate("지원하신 " + recruitmentTitle(recruitment) + " 모집이 마감되어 지원이 거절되었어요.");
+    }
+
+    private String closedMessage(TeamRecruitment recruitment) {
+        return truncate(recruitmentTitle(recruitment) + " 모집이 마감되었어요.");
+    }
+
+    private String recruitmentTitle(TeamRecruitment recruitment) {
+        return recruitment.getTitle() == null ? "팀원 모집" : recruitment.getTitle();
+    }
+
+    private String truncate(String message) {
+        return message.length() <= 255 ? message : message.substring(0, 255);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineScheduler.java
@@ -1,0 +1,23 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamRecruitmentDeadlineScheduler {
+
+    private final TeamRecruitmentDeadlineCloseProcessor deadlineCloseProcessor;
+
+    @Scheduled(fixedDelayString = "${team-recruitment.deadline-scheduler.fixed-delay-ms:60000}")
+    public void closeExpiredRecruitments() {
+        try {
+            deadlineCloseProcessor.closeExpiredRecruitments();
+        } catch (Exception exception) {
+            log.error("팀원 모집 마감 스케줄러 처리 중 오류가 발생했습니다.", exception);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
@@ -1,0 +1,313 @@
+package in.koreatech.koin.unit.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineCloseProcessor;
+import in.koreatech.koin.unit.fixture.UserFixture;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentDeadlineCloseProcessorTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 28);
+
+    @Mock
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Mock
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Mock
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private TeamRecruitmentNotificationRepository notificationRepository;
+
+    @Mock
+    private TeamRecruitmentOutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TeamRecruitmentDeadlineCloseProcessor processor;
+
+    private Clock fixedClock;
+
+    @BeforeEach
+    void setUpClock() {
+        fixedClock = Clock.fixed(Instant.parse("2026-08-28T03:00:00Z"), KST);
+        when(clock.withZone(KST)).thenReturn(fixedClock);
+    }
+
+    @Nested
+    class CloseExpiredRecruitments {
+
+        @Test
+        void 기한이_지난_모집을_닫고_PENDING_지원과_모든_채팅방을_정리한다() {
+            TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
+            TeamRecruitmentApplication pending = application(11, recruitment, PENDING);
+            TeamRecruitmentApplication accepted = application(12, recruitment, ACCEPTED);
+            TeamRecruitmentChatRoom teamRoom = chatRoom(21, recruitment, TEAM, ACTIVE);
+            TeamRecruitmentChatRoom directRoom = chatRoom(22, recruitment, DIRECT, ACTIVE);
+            stubCandidates(recruitment);
+            stubApplications(pending, accepted);
+            when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
+                .thenReturn(Optional.of(teamRoom));
+            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of(teamRoom, directRoom));
+            when(outboxEventRepository.findByEventKey(any())).thenReturn(Optional.empty());
+            when(notificationRepository.save(any())).thenAnswer(invocation -> {
+                TeamRecruitmentNotification notification = invocation.getArgument(0);
+                ReflectionTestUtils.setField(
+                    notification,
+                    "id",
+                    notification.getApplication().getId() + 100
+                );
+                return notification;
+            });
+
+            processor.closeExpiredRecruitments();
+
+            assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
+            assertThat(pending.getStatus()).isEqualTo(REJECTED);
+            assertThat(pending.getDecisionReason()).isEqualTo("RECRUITMENT_CLOSED");
+            assertThat(accepted.getStatus()).isEqualTo(ACCEPTED);
+            assertThat(teamRoom.getStatus()).isEqualTo(READ_ONLY);
+            assertThat(directRoom.getStatus()).isEqualTo(READ_ONLY);
+            verify(applicationRepository).save(pending);
+            verify(chatRoomRepository).save(teamRoom);
+            verify(chatRoomRepository).save(directRoom);
+            verify(notificationRepository, org.mockito.Mockito.times(2)).save(any());
+            verify(outboxEventRepository, org.mockito.Mockito.times(2)).save(any());
+            ArgumentCaptor<TeamRecruitmentOutboxEvent> outboxCaptor =
+                ArgumentCaptor.forClass(TeamRecruitmentOutboxEvent.class);
+            verify(outboxEventRepository, org.mockito.Mockito.times(2)).save(outboxCaptor.capture());
+            assertThat(outboxCaptor.getAllValues())
+                .extracting(TeamRecruitmentOutboxEvent::getPayload)
+                .anySatisfy(payload -> assertThat(payload).contains("\"notification_id\":111"))
+                .anySatisfy(payload -> assertThat(payload).contains("\"notification_id\":112"));
+        }
+
+        @Test
+        void 이미_마감된_모집은_다시_처리하지_않는다() {
+            TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
+            TeamRecruitmentApplication pending = application(11, recruitment, PENDING);
+            stubCandidates(recruitment);
+            when(recruitmentRepository.findByIdWithLock(1)).thenReturn(Optional.of(recruitment));
+
+            processor.closeExpiredRecruitments();
+            clearInvocations(applicationRepository, chatRoomRepository, notificationRepository, outboxEventRepository);
+
+            processor.closeExpiredRecruitments();
+
+            assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
+            assertThat(pending.getStatus()).isEqualTo(PENDING);
+            verify(applicationRepository, never()).save(any());
+            verify(chatRoomRepository, never()).save(any());
+            verify(notificationRepository, never()).save(any());
+            verify(outboxEventRepository, never()).save(any());
+        }
+
+        @Test
+        void 승인된_지원자가_있는데_TEAM_채팅방이_없으면_내부_무결성_예외를_던진다() {
+            TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
+            TeamRecruitmentApplication accepted = application(12, recruitment, ACCEPTED);
+            stubCandidates(recruitment);
+            when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+                1,
+                List.of(PENDING),
+                Pageable.unpaged()
+            )).thenReturn(new PageImpl<>(List.of()));
+            when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+                1,
+                List.of(ACCEPTED),
+                Pageable.unpaged()
+            )).thenReturn(new PageImpl<>(List.of(accepted)));
+            when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
+                .thenReturn(Optional.empty());
+            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of());
+
+            IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> processor.closeExpiredRecruitments()
+            );
+
+            assertThat(exception).hasMessageContaining("TEAM 채팅방");
+            verify(notificationRepository, never()).save(any());
+            verify(outboxEventRepository, never()).save(any());
+        }
+
+        @Test
+        void 승인된_지원자가_없으면_TEAM_채팅방이_없어도_정상_마감한다() {
+            TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
+            stubCandidates(recruitment);
+            when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+                1,
+                List.of(PENDING),
+                Pageable.unpaged()
+            )).thenReturn(new PageImpl<>(List.of()));
+            when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+                1,
+                List.of(ACCEPTED),
+                Pageable.unpaged()
+            )).thenReturn(new PageImpl<>(List.of()));
+            when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
+                .thenReturn(Optional.empty());
+            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of());
+
+            processor.closeExpiredRecruitments();
+
+            assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
+            verify(notificationRepository, never()).save(any());
+            verify(outboxEventRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class SkipNonExpiredRecruitments {
+
+        @Test
+        void 오늘이_마감일이면_모집을_닫지_않는다() {
+            TeamRecruitment recruitment = recruitment(1, TODAY);
+            stubCandidates(recruitment);
+
+            processor.closeExpiredRecruitments();
+
+            assertThat(recruitment.getStatus()).isEqualTo(RECRUITING);
+            verify(applicationRepository, never()).findAllByRecruitment_IdAndStatusIn(any(), anyList(), any(Pageable.class));
+            verify(chatRoomRepository, never()).findAllByRecruitment_Id(any());
+        }
+    }
+
+    @Test
+    void DB에서_마감일_조건을_적용해_앞선_미만료_모집이_많아도_만료_모집을_조회한다() {
+        TeamRecruitment expiredRecruitment = recruitment(101, TODAY.minusDays(1));
+        stubCandidates(expiredRecruitment);
+
+        processor.closeExpiredRecruitments();
+
+        assertThat(expiredRecruitment.getStatus()).isEqualTo(CLOSED);
+        verify(recruitmentRepository).findAllByStatusAndDeadlineDateBefore(
+            eq(RECRUITING),
+            eq(TODAY),
+            any(Pageable.class)
+        );
+    }
+
+    private void stubCandidates(TeamRecruitment recruitment) {
+        when(recruitmentRepository.findAllByStatusAndDeadlineDateBefore(
+            eq(RECRUITING),
+            eq(TODAY),
+            any(Pageable.class)
+        ))
+            .thenReturn(new PageImpl<>(List.of(recruitment)));
+        when(recruitmentRepository.findByIdWithLock(recruitment.getId()))
+            .thenReturn(Optional.of(recruitment));
+    }
+
+    private void stubApplications(
+        TeamRecruitmentApplication pending,
+        TeamRecruitmentApplication accepted
+    ) {
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            1,
+            List.of(PENDING),
+            Pageable.unpaged()
+        )).thenReturn(new PageImpl<>(List.of(pending)));
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            1,
+            List.of(ACCEPTED),
+            Pageable.unpaged()
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+    }
+
+    private TeamRecruitment recruitment(Integer id, LocalDate deadlineDate) {
+        return TeamRecruitment.builder()
+            .id(id)
+            .author(UserFixture.id_설정_코인_유저(1))
+            .activityStartDate(TODAY.plusDays(1))
+            .activityEndDate(TODAY.plusDays(10))
+            .deadlineDate(deadlineDate)
+            .maxParticipants(5)
+            .currentParticipants(1)
+            .status(RECRUITING)
+            .description("모집 내용")
+            .build();
+    }
+
+    private TeamRecruitmentApplication application(
+        Integer id,
+        TeamRecruitment recruitment,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        return TeamRecruitmentApplication.builder()
+            .id(id)
+            .recruitment(recruitment)
+            .applicant(UserFixture.id_설정_코인_유저(id))
+            .motivation("지원 동기")
+            .availability("가능")
+            .status(status)
+            .profileSnapshot("{}")
+            .build();
+    }
+
+    private TeamRecruitmentChatRoom chatRoom(
+        Integer id,
+        TeamRecruitment recruitment,
+        in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType roomType,
+        in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus status
+    ) {
+        return TeamRecruitmentChatRoom.builder()
+            .id(id)
+            .recruitment(recruitment)
+            .roomScopeKey(roomType == TEAM ? "TEAM" : "APPLICATION:12")
+            .roomType(roomType)
+            .status(status)
+            .build();
+    }
+}


### PR DESCRIPTION
### 🔍 개요

- 모집 기한이 지난 팀원 모집글과 관련 상태를 자동으로 정리합니다.
- close #2340

---

### 🚀 주요 변경 내용

- KST 기준 마감 대상 모집글을 bounded batch로 조회
- 모집글 잠금 후 상태와 마감일 재검증
- 모집글 CLOSED, PENDING 지원서 REJECTED, 채팅방 READ_ONLY 처리
- 승인자와 거절 대상자의 inbox 및 outbox를 같은 트랜잭션에 저장
- 반복 실행 시 중복 처리를 방지하는 event key 적용

---

### 💬 참고 사항

- 선행 PR: #2348
- 트랜잭션 참고: [Spring Data JPA Transactionality](https://docs.spring.io/spring-data/jpa/reference/jpa/transactions.html)
- 검증: `TeamRecruitmentDeadlineCloseProcessorTest` 통과

---

### ✅ Checklist

- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Assignee 및 Labels 지정
- [x] 민감 정보 검토
