### PR TITLE
feat: 팀원 모집 알림 Outbox Worker 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxLeaseService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxLeaseService.java
@@ -1,0 +1,114 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TeamRecruitmentOutboxLeaseService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
+    private final TeamRecruitmentOutboxProperties properties;
+    private final Clock clock;
+
+    @Transactional
+    public List<OutboxClaim> claim(String workerId, int requestedLimit) {
+        if (requestedLimit <= 0) {
+            return List.of();
+        }
+        int limit = Math.min(requestedLimit, properties.getBoundedBatchSize());
+        int maxAttempts = properties.getBoundedMaxAttempts();
+        LocalDateTime now = now();
+        List<TeamRecruitmentOutboxEvent> events = outboxEventRepository.findClaimableForUpdate(
+            now,
+            limit,
+            maxAttempts
+        );
+        if (events == null || events.isEmpty()) {
+            return List.of();
+        }
+
+        LocalDateTime lockedUntil = now.plusSeconds(properties.getBoundedLeaseSeconds());
+        List<OutboxClaim> claims = new ArrayList<>(events.size());
+        for (TeamRecruitmentOutboxEvent event : events) {
+            if (event.getAttemptCount() >= maxAttempts) {
+                event.markTerminalFailure("MAX_ATTEMPTS_EXCEEDED", maxAttempts);
+                continue;
+            }
+            event.markProcessing(workerId, lockedUntil);
+            claims.add(new OutboxClaim(event.getId(), event.getEventKey(), event.getPayload()));
+        }
+        return claims;
+    }
+
+    @Transactional
+    public boolean complete(Integer eventId, String workerId) {
+        return outboxEventRepository.findByIdWithLock(eventId)
+            .filter(event -> event.isProcessingBy(workerId))
+            .map(event -> {
+                event.markPublished(now());
+                return true;
+            })
+            .orElse(false);
+    }
+
+    @Transactional
+    public boolean fail(
+        Integer eventId,
+        String workerId,
+        String reason,
+        boolean retryable
+    ) {
+        return outboxEventRepository.findByIdWithLock(eventId)
+            .filter(event -> event.isProcessingBy(workerId))
+            .map(event -> {
+                LocalDateTime now = now();
+                String safeReason = sanitize(reason);
+                if (!retryable || event.getAttemptCount() >= properties.getBoundedMaxAttempts()) {
+                    event.markTerminalFailure(safeReason, properties.getBoundedMaxAttempts());
+                    return true;
+                }
+
+                event.markFailed(safeReason, now.plusSeconds(resolveBackoffSeconds(event.getAttemptCount())));
+                return true;
+            })
+            .orElse(false);
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(clock.withZone(KST));
+    }
+
+    private long resolveBackoffSeconds(int attemptCount) {
+        long base = properties.getBoundedRetryBackoffSeconds();
+        long max = properties.getBoundedMaxRetryBackoffSeconds();
+        int exponent = Math.max(0, Math.min(attemptCount - 1, 30));
+        long multiplier = 1L << exponent;
+        if (base > max / multiplier) {
+            return max;
+        }
+        return Math.min(max, base * multiplier);
+    }
+
+    private String sanitize(String reason) {
+        if (reason == null || reason.isBlank()) {
+            return "UNKNOWN_FAILURE";
+        }
+        return reason.length() <= 500 ? reason : reason.substring(0, 500);
+    }
+
+    public record OutboxClaim(Integer id, String eventKey, String payload) {
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxProperties.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxProperties.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "team-recruitment.outbox")
+public class TeamRecruitmentOutboxProperties {
+
+    private boolean enabled;
+    private long fixedDelayMs = 10_000L;
+    private int batchSize = 20;
+    private int maxAttempts = 5;
+    private int leaseSeconds = 120;
+    private int retryBackoffSeconds = 30;
+    private int maxRetryBackoffSeconds = 3_600;
+
+    public int getBoundedBatchSize() {
+        return Math.min(Math.max(batchSize, 1), 100);
+    }
+
+    public int getBoundedMaxAttempts() {
+        return Math.min(Math.max(maxAttempts, 1), 100);
+    }
+
+    public int getBoundedLeaseSeconds() {
+        return Math.min(Math.max(leaseSeconds, 1), 86_400);
+    }
+
+    public int getBoundedRetryBackoffSeconds() {
+        return Math.min(Math.max(retryBackoffSeconds, 1), 86_400);
+    }
+
+    public int getBoundedMaxRetryBackoffSeconds() {
+        return Math.max(
+            getBoundedRetryBackoffSeconds(),
+            Math.min(Math.max(maxRetryBackoffSeconds, 1), 86_400)
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxScheduler.java
@@ -1,0 +1,30 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    prefix = "team-recruitment.outbox",
+    name = "enabled",
+    havingValue = "true"
+)
+public class TeamRecruitmentOutboxScheduler {
+
+    private final TeamRecruitmentOutboxWorker worker;
+
+    @Scheduled(fixedDelayString = "${team-recruitment.outbox.fixed-delay-ms:10000}")
+    public void publishTeamRecruitmentOutbox() {
+        try {
+            worker.processBatch();
+        } catch (Exception exception) {
+            log.error("팀원 모집 outbox 스케줄러 처리 중 오류가 발생했습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorker.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorker.java
@@ -1,0 +1,348 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.NEW_APPLICATION;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.NEW_CHAT_MESSAGE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_DELETED;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.infrastructure.fcm.FcmClient;
+import in.koreatech.koin.infrastructure.fcm.FcmSendRequest;
+import in.koreatech.koin.infrastructure.fcm.FcmSendResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamRecruitmentOutboxWorker {
+
+    private static final Set<TeamRecruitmentNotificationType> SUPPORTED_TYPES = Set.of(
+        NEW_APPLICATION,
+        APPLICATION_ACCEPTED,
+        APPLICATION_REJECTED,
+        RECRUITMENT_CLOSED,
+        RECRUITMENT_DELETED,
+        NEW_CHAT_MESSAGE
+    );
+    private static final Set<String> PERMANENT_FCM_CODES = Set.of(
+        "INVALID_ARGUMENT",
+        "UNREGISTERED",
+        "SENDER_ID_MISMATCH",
+        "THIRD_PARTY_AUTH_ERROR"
+    );
+
+    private final TeamRecruitmentOutboxLeaseService leaseService;
+    private final TeamRecruitmentOutboxProperties properties;
+    private final TeamRecruitmentNotificationRepository notificationRepository;
+    private final TeamRecruitmentRepository recruitmentRepository;
+    private final UserRepository userRepository;
+    private final FcmClient fcmClient;
+    private final ObjectMapper objectMapper;
+
+    public void processBatch() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        String workerId = UUID.randomUUID().toString();
+        List<TeamRecruitmentOutboxLeaseService.OutboxClaim> claims;
+        try {
+            claims = leaseService.claim(workerId, properties.getBoundedBatchSize());
+        } catch (Exception exception) {
+            log.error("팀원 모집 outbox claim 중 오류가 발생했습니다.", exception);
+            return;
+        }
+
+        for (TeamRecruitmentOutboxLeaseService.OutboxClaim claim : claims) {
+            publish(claim, workerId);
+        }
+    }
+
+    private void publish(TeamRecruitmentOutboxLeaseService.OutboxClaim claim, String workerId) {
+        try {
+            JsonNode payload = objectMapper.readTree(claim.payload());
+            OutboxPayload outboxPayload = OutboxPayload.from(payload);
+            if (!SUPPORTED_TYPES.contains(outboxPayload.type())) {
+                fail(claim, workerId, "UNSUPPORTED_EVENT_TYPE", false);
+                return;
+            }
+
+            Optional<TeamRecruitmentNotification> inbox = findInbox(outboxPayload);
+            if (inbox.isPresent() && Boolean.TRUE.equals(inbox.get().getIsDeleted())) {
+                complete(claim, workerId);
+                return;
+            }
+            if (outboxPayload.notificationId() != null && inbox.isEmpty()) {
+                throw new InvalidPayloadException("NOTIFICATION_NOT_FOUND");
+            }
+            TeamRecruitment recruitment = inbox
+                .map(TeamRecruitmentNotification::getRecruitment)
+                .orElseGet(() -> recruitmentRepository.findById(outboxPayload.recruitmentId()).orElse(null));
+            if (recruitment == null) {
+                throw new InvalidPayloadException("RECRUITMENT_NOT_FOUND");
+            }
+
+            User recipient = userRepository.findById(outboxPayload.recipientId()).orElse(null);
+            if (recipient == null) {
+                throw new InvalidPayloadException("RECIPIENT_NOT_FOUND");
+            }
+            if (!StringUtils.hasText(recipient.getDeviceToken())) {
+                fail(claim, workerId, "NO_DEVICE_TOKEN", false);
+                return;
+            }
+
+            String recruitmentTitle = recruitment.getTitle() == null
+                ? "팀원 모집"
+                : recruitment.getTitle();
+            String title = text(payload, "title").orElse(recruitmentTitle);
+            String content = text(payload, "content")
+                .or(() -> text(payload, "message_preview"))
+                .or(() -> inbox.map(TeamRecruitmentNotification::getMessagePreview))
+                .orElseGet(() -> fallbackContent(outboxPayload.type(), recruitmentTitle));
+
+            FcmSendRequest request = FcmSendRequest.of(
+                recipient.getDeviceToken(),
+                title,
+                content,
+                null,
+                null,
+                null,
+                outboxPayload.type().name().toLowerCase(Locale.ROOT)
+            );
+            List<FcmSendResponse> responses = fcmClient.sendMessages(List.of(request));
+            FcmSendResponse response = responses == null || responses.isEmpty()
+                ? FcmSendResponse.failed("EMPTY_RESPONSE", null)
+                : responses.get(0);
+            if (response != null && response.success()) {
+                complete(claim, workerId);
+                return;
+            }
+
+            String reason = response == null
+                ? "EMPTY_RESPONSE"
+                : firstText(response.errorCode(), response.messagingErrorCode(), "FCM_SEND_FAILED");
+            fail(claim, workerId, reason, isRetryable(response));
+        } catch (JsonProcessingException | InvalidPayloadException exception) {
+            fail(claim, workerId, exception.getMessage(), false);
+        } catch (Exception exception) {
+            fail(claim, workerId, exceptionSummary(exception), true);
+        }
+    }
+
+    private Optional<TeamRecruitmentNotification> findInbox(OutboxPayload payload) {
+        if (payload.notificationId() != null) {
+            Optional<TeamRecruitmentNotification> notification = notificationRepository
+                .findByIdForOutbox(payload.notificationId());
+            if (notification == null || notification.isEmpty()) {
+                return Optional.empty();
+            }
+            if (!matchesPayload(notification.get(), payload)) {
+                throw new InvalidPayloadException("NOTIFICATION_TARGET_MISMATCH");
+            }
+            return notification;
+        }
+
+        List<TeamRecruitmentNotification> notifications = notificationRepository.findForOutbox(
+            payload.recipientId(),
+            payload.type(),
+            payload.targetType(),
+            payload.recruitmentId(),
+            payload.applicationId(),
+            payload.chatRoomId()
+        );
+        if (notifications == null || notifications.isEmpty()) {
+            return Optional.empty();
+        }
+        if (notifications.size() != 1) {
+            throw new InvalidPayloadException("AMBIGUOUS_NOTIFICATION_TARGET");
+        }
+        return Optional.of(notifications.get(0));
+    }
+
+    private boolean matchesPayload(TeamRecruitmentNotification notification, OutboxPayload payload) {
+        Integer notificationRecipientId = notification.getRecipient() == null
+            ? null
+            : notification.getRecipient().getId();
+        Integer notificationRecruitmentId = notification.getRecruitment() == null
+            ? null
+            : notification.getRecruitment().getId();
+        Integer notificationApplicationId = notification.getApplication() == null
+            ? null
+            : notification.getApplication().getId();
+        Integer notificationChatRoomId = notification.getChatRoom() == null
+            ? null
+            : notification.getChatRoom().getId();
+        return Objects.equals(notificationRecipientId, payload.recipientId())
+            && notification.getType() == payload.type()
+            && notification.getTargetType() == payload.targetType()
+            && Objects.equals(notificationRecruitmentId, payload.recruitmentId())
+            && Objects.equals(notificationApplicationId, payload.applicationId())
+            && Objects.equals(notificationChatRoomId, payload.chatRoomId());
+    }
+
+    private String fallbackContent(TeamRecruitmentNotificationType type, String recruitmentTitle) {
+        return switch (type) {
+            case NEW_APPLICATION -> recruitmentTitle + "에 새로운 지원자가 있어요.";
+            case APPLICATION_ACCEPTED -> recruitmentTitle + " 지원이 승인되었어요.";
+            case APPLICATION_REJECTED -> recruitmentTitle + " 지원이 거절되었어요.";
+            case RECRUITMENT_CLOSED -> recruitmentTitle + " 모집이 마감되었어요.";
+            case RECRUITMENT_DELETED -> recruitmentTitle + " 모집글이 삭제되었어요.";
+            case NEW_CHAT_MESSAGE -> recruitmentTitle + " 새 메시지가 도착했어요.";
+            default -> throw new InvalidPayloadException("UNSUPPORTED_EVENT_TYPE");
+        };
+    }
+
+    private Optional<String> text(JsonNode payload, String field) {
+        JsonNode value = payload.get(field);
+        return value != null && value.isTextual() && StringUtils.hasText(value.asText())
+            ? Optional.of(value.asText())
+            : Optional.empty();
+    }
+
+    private boolean isRetryable(FcmSendResponse response) {
+        if (response == null) {
+            return true;
+        }
+        String errorCode = response.errorCode() == null
+            ? ""
+            : response.errorCode().toUpperCase(Locale.ROOT);
+        String messagingErrorCode = response.messagingErrorCode() == null
+            ? ""
+            : response.messagingErrorCode().toUpperCase(Locale.ROOT);
+        return !PERMANENT_FCM_CODES.stream().anyMatch(code ->
+            errorCode.contains(code) || messagingErrorCode.contains(code)
+        );
+    }
+
+    private void complete(TeamRecruitmentOutboxLeaseService.OutboxClaim claim, String workerId) {
+        if (!leaseService.complete(claim.id(), workerId)) {
+            log.warn(
+                "팀원 모집 outbox complete 소유권이 없습니다. eventId={}, workerId={}",
+                claim.id(),
+                workerId
+            );
+        }
+    }
+
+    private void fail(
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim,
+        String workerId,
+        String reason,
+        boolean retryable
+    ) {
+        if (!leaseService.fail(claim.id(), workerId, reason, retryable)) {
+            log.warn(
+                "팀원 모집 outbox fail 소유권이 없습니다. eventId={}, workerId={}",
+                claim.id(),
+                workerId
+            );
+        }
+    }
+
+    private String firstText(String first, String second, String fallback) {
+        if (StringUtils.hasText(first)) {
+            return first;
+        }
+        if (StringUtils.hasText(second)) {
+            return second;
+        }
+        return fallback;
+    }
+
+    private String exceptionSummary(Exception exception) {
+        String message = exception.getMessage();
+        return firstText(message, exception.getClass().getSimpleName(), "FCM_SEND_FAILED");
+    }
+
+    private record OutboxPayload(
+        TeamRecruitmentNotificationType type,
+        TeamRecruitmentNotificationTargetType targetType,
+        Integer recipientId,
+        Integer recruitmentId,
+        Integer applicationId,
+        Integer chatRoomId,
+        Integer notificationId
+    ) {
+        static OutboxPayload from(JsonNode payload) {
+            TeamRecruitmentNotificationType type = enumValue(
+                payload,
+                "type",
+                TeamRecruitmentNotificationType.class
+            );
+            TeamRecruitmentNotificationTargetType targetType = enumValue(
+                payload,
+                "target_type",
+                TeamRecruitmentNotificationTargetType.class
+            );
+            Integer recipientId = integer(payload, "recipient_id");
+            Integer recruitmentId = integer(payload, "recruitment_id");
+            Integer notificationId = integer(payload, "notification_id");
+            if (recipientId == null || recruitmentId == null) {
+                throw new InvalidPayloadException("MISSING_NOTIFICATION_TARGET");
+            }
+            return new OutboxPayload(
+                type,
+                targetType,
+                recipientId,
+                recruitmentId,
+                integer(payload, "application_id"),
+                integer(payload, "chat_room_id"),
+                notificationId
+            );
+        }
+
+        private static Integer integer(JsonNode payload, String field) {
+            JsonNode value = payload.get(field);
+            if (value == null || value.isNull()) {
+                return null;
+            }
+            if (!value.canConvertToInt() || !value.isIntegralNumber()) {
+                throw new InvalidPayloadException("INVALID_" + field.toUpperCase(Locale.ROOT));
+            }
+            return value.intValue();
+        }
+
+        private static <E extends Enum<E>> E enumValue(JsonNode payload, String field, Class<E> type) {
+            String value = payload.path(field).asText(null);
+            if (!StringUtils.hasText(value)) {
+                throw new InvalidPayloadException("MISSING_" + field.toUpperCase(Locale.ROOT));
+            }
+            try {
+                return Enum.valueOf(type, value);
+            } catch (IllegalArgumentException exception) {
+                throw new InvalidPayloadException("INVALID_" + field.toUpperCase(Locale.ROOT));
+            }
+        }
+    }
+
+    private static final class InvalidPayloadException extends RuntimeException {
+
+        private InvalidPayloadException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorker.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorker.java
@@ -131,7 +131,10 @@ public class TeamRecruitmentOutboxWorker {
                 null,
                 null,
                 null,
-                outboxPayload.type().name().toLowerCase(Locale.ROOT)
+                outboxPayload.type().name().toLowerCase(Locale.ROOT),
+                outboxPayload.notificationId() == null
+                    ? null
+                    : outboxPayload.notificationId().toString()
             );
             List<FcmSendResponse> responses = fcmClient.sendMessages(List.of(request));
             FcmSendResponse response = responses == null || responses.isEmpty()

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -142,13 +142,19 @@ public class FcmClient {
                     .setImage(imageUrl)
                     .build()
             )
-            .putAllCustomData(
-                Map.of(
-                    "type", type,
-                    "schemeUri", schemeUri
-                )
-            )
+            .putAllCustomData(appleCustomData(type, schemeUri))
             .build();
+    }
+
+    private Map<String, Object> appleCustomData(String type, String schemeUri) {
+        Map<String, Object> customData = new HashMap<>();
+        if (type != null) {
+            customData.put("type", type);
+        }
+        if (schemeUri != null) {
+            customData.put("schemeUri", schemeUri);
+        }
+        return customData;
     }
 
     private AndroidConfig generateAndroidConfig(
@@ -162,7 +168,9 @@ public class FcmClient {
         androidNotificationV2.put("title", title != null ? title : "");
         androidNotificationV2.put("content", content != null ? content : "");
         androidNotificationV2.put("imageUrl", imageUrl != null ? imageUrl : "");
-        androidNotificationV2.put("url", "koin://" + (schemeUri != null ? schemeUri : ""));
+        if (schemeUri != null) {
+            androidNotificationV2.put("url", "koin://" + schemeUri);
+        }
         androidNotificationV2.put("type", type != null ? type : "");
 
         return AndroidConfig.builder()

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmClient.java
@@ -48,8 +48,12 @@ public class FcmClient {
         try {
             log.info("call FcmClient sendMessage: title: {}, content: {}", title, content);
 
-            ApnsConfig apnsConfig = generateAppleConfig(title, content, imageUrl, path, type, schemeUri);
-            AndroidConfig androidConfig = generateAndroidConfig(title, content, imageUrl, schemeUri, type);
+            ApnsConfig apnsConfig = generateAppleConfig(
+                title, content, imageUrl, path, type, schemeUri, null
+            );
+            AndroidConfig androidConfig = generateAndroidConfig(
+                title, content, imageUrl, schemeUri, type, null
+            );
 
             Message message = Message.builder()
                 .setToken(targetDeviceToken)
@@ -77,14 +81,16 @@ public class FcmClient {
                         request.imageUrl(),
                         request.path(),
                         request.type(),
-                        request.schemeUri()
+                        request.schemeUri(),
+                        request.notificationId()
                     ))
                     .setAndroidConfig(generateAndroidConfig(
                         request.title(),
                         request.content(),
                         request.imageUrl(),
                         request.schemeUri(),
-                        request.type()
+                        request.type(),
+                        request.notificationId()
                     ))
                     .build()
                 )
@@ -121,7 +127,8 @@ public class FcmClient {
         String imageUrl,
         MobileAppPath path,
         String type,
-        String schemeUri
+        String schemeUri,
+        String notificationId
     ) {
         return ApnsConfig.builder()
             .setAps(
@@ -142,12 +149,19 @@ public class FcmClient {
                     .setImage(imageUrl)
                     .build()
             )
-            .putAllCustomData(appleCustomData(type, schemeUri))
+            .putAllCustomData(appleCustomData(type, schemeUri, notificationId))
             .build();
     }
 
-    private Map<String, Object> appleCustomData(String type, String schemeUri) {
+    private Map<String, Object> appleCustomData(
+        String type,
+        String schemeUri,
+        String notificationId
+    ) {
         Map<String, Object> customData = new HashMap<>();
+        if (notificationId != null) {
+            customData.put("notification_id", notificationId);
+        }
         if (type != null) {
             customData.put("type", type);
         }
@@ -162,9 +176,13 @@ public class FcmClient {
         String content,
         String imageUrl,
         String schemeUri,
-        String type
+        String type,
+        String notificationId
     ) {
         Map<String, String> androidNotificationV2 = new HashMap<>();
+        if (notificationId != null) {
+            androidNotificationV2.put("notification_id", notificationId);
+        }
         androidNotificationV2.put("title", title != null ? title : "");
         androidNotificationV2.put("content", content != null ? content : "");
         androidNotificationV2.put("imageUrl", imageUrl != null ? imageUrl : "");

--- a/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
+++ b/src/main/java/in/koreatech/koin/infrastructure/fcm/FcmSendRequest.java
@@ -9,8 +9,21 @@ public record FcmSendRequest(
     String imageUrl,
     MobileAppPath path,
     String schemeUri,
-    String type
+    String type,
+    String notificationId
 ) {
+    public FcmSendRequest(
+        String targetDeviceToken,
+        String title,
+        String content,
+        String imageUrl,
+        MobileAppPath path,
+        String schemeUri,
+        String type
+    ) {
+        this(targetDeviceToken, title, content, imageUrl, path, schemeUri, type, null);
+    }
+
     public static FcmSendRequest of(
         String targetDeviceToken,
         String title,
@@ -27,7 +40,30 @@ public record FcmSendRequest(
             imageUrl,
             path,
             schemeUri,
-            type
+            type,
+            null
+        );
+    }
+
+    public static FcmSendRequest of(
+        String targetDeviceToken,
+        String title,
+        String content,
+        String imageUrl,
+        MobileAppPath path,
+        String schemeUri,
+        String type,
+        String notificationId
+    ) {
+        return new FcmSendRequest(
+            targetDeviceToken,
+            title,
+            content,
+            imageUrl,
+            path,
+            schemeUri,
+            type,
+            notificationId
         );
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -80,3 +80,7 @@ address:
 toss-payment:
   secret-key: test_sk
   api-base-url: https://api.tosspayments.com/v1/payments
+
+team-recruitment:
+  outbox:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,6 +151,16 @@ article:
     allowed-content-url-prefixes: ${ARTICLE_AI_SUMMARY_ALLOWED_CONTENT_URL_PREFIXES:https://*.koreatech.in/,https://*.koreatech.ac.kr/}
     allowed-document-url-prefixes: ${ARTICLE_AI_SUMMARY_ALLOWED_DOCUMENT_URL_PREFIXES:https://*.koreatech.in/,https://*.koreatech.ac.kr/}
 
+team-recruitment:
+  outbox:
+    enabled: ${TEAM_RECRUITMENT_OUTBOX_ENABLED:true}
+    fixed-delay-ms: ${TEAM_RECRUITMENT_OUTBOX_FIXED_DELAY_MS:10000}
+    batch-size: ${TEAM_RECRUITMENT_OUTBOX_BATCH_SIZE:20}
+    max-attempts: ${TEAM_RECRUITMENT_OUTBOX_MAX_ATTEMPTS:5}
+    lease-seconds: ${TEAM_RECRUITMENT_OUTBOX_LEASE_SECONDS:120}
+    retry-backoff-seconds: ${TEAM_RECRUITMENT_OUTBOX_RETRY_BACKOFF_SECONDS:30}
+    max-retry-backoff-seconds: ${TEAM_RECRUITMENT_OUTBOX_MAX_RETRY_BACKOFF_SECONDS:3600}
+
 management:
   endpoint:
     health:

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxLeaseServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxLeaseServiceTest.java
@@ -1,0 +1,129 @@
+package in.koreatech.koin.unit.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus.FAILED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus.PUBLISHED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus.PROCESSING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentOutboxLeaseService;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentOutboxProperties;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentOutboxLeaseServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 28, 12, 0);
+
+    @Mock
+    private TeamRecruitmentOutboxEventRepository outboxEventRepository;
+
+    @Spy
+    private TeamRecruitmentOutboxProperties properties = new TeamRecruitmentOutboxProperties();
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TeamRecruitmentOutboxLeaseService leaseService;
+
+    @BeforeEach
+    void setUp() {
+        properties.setBatchSize(10);
+        properties.setMaxAttempts(3);
+        properties.setLeaseSeconds(120);
+        properties.setRetryBackoffSeconds(30);
+        properties.setMaxRetryBackoffSeconds(300);
+        lenient().when(clock.withZone(KST)).thenReturn(Clock.fixed(Instant.parse("2026-08-28T03:00:00Z"), KST));
+    }
+
+    @Test
+    void claim은_만료_행을_worker와_lease로_점유하고_attempt를_증가시킨다() {
+        TeamRecruitmentOutboxEvent event = event();
+        when(outboxEventRepository.findClaimableForUpdate(any(), any(Integer.class), any(Integer.class)))
+            .thenReturn(List.of(event));
+
+        List<TeamRecruitmentOutboxLeaseService.OutboxClaim> claims = leaseService.claim("worker-1", 10);
+
+        assertThat(claims).hasSize(1);
+        assertThat(event.getStatus()).isEqualTo(PROCESSING);
+        assertThat(event.getWorkerId()).isEqualTo("worker-1");
+        assertThat(event.getAttemptCount()).isEqualTo(1);
+        assertThat(event.getLockedUntil()).isEqualTo(NOW.plusSeconds(120));
+    }
+
+    @Test
+    void complete와_fail은_현재_worker만_상태를_변경한다() {
+        TeamRecruitmentOutboxEvent event = event();
+        event.markProcessing("worker-1", NOW.plusSeconds(120));
+        when(outboxEventRepository.findByIdWithLock(1)).thenReturn(Optional.of(event));
+
+        assertThat(leaseService.complete(1, "worker-2")).isFalse();
+        assertThat(event.getStatus()).isEqualTo(PROCESSING);
+        assertThat(leaseService.complete(1, "worker-1")).isTrue();
+        assertThat(event.getStatus()).isEqualTo(PUBLISHED);
+        assertThat(event.getLockedUntil()).isNull();
+
+        event.markProcessing("worker-1", NOW.plusSeconds(120));
+        assertThat(leaseService.fail(1, "worker-2", "INTERNAL", true)).isFalse();
+        assertThat(event.getStatus()).isEqualTo(PROCESSING);
+    }
+
+    @Test
+    void transient_failure은_backoff으로_재시도하고_permanent_failure은_terminal_failed가_된다() {
+        TeamRecruitmentOutboxEvent event = event();
+        event.markProcessing("worker-1", NOW.plusSeconds(120));
+        when(outboxEventRepository.findByIdWithLock(1)).thenReturn(Optional.of(event));
+
+        assertThat(leaseService.fail(1, "worker-1", "INTERNAL", true)).isTrue();
+        assertThat(event.getStatus()).isEqualTo(FAILED);
+        assertThat(event.getNextAttemptAt()).isEqualTo(NOW.plusSeconds(30));
+        assertThat(event.getWorkerId()).isNull();
+
+        event.markProcessing("worker-1", NOW.plusSeconds(120));
+        assertThat(leaseService.fail(1, "worker-1", "NO_DEVICE_TOKEN", false)).isTrue();
+        assertThat(event.getStatus()).isEqualTo(FAILED);
+        assertThat(event.getAttemptCount()).isEqualTo(3);
+        assertThat(event.getNextAttemptAt()).isNull();
+    }
+
+    @Test
+    void publishedAt은_주입된_시간을_요구한다() {
+        TeamRecruitmentOutboxEvent event = event();
+        event.markProcessing("worker-1", NOW.plusSeconds(120));
+
+        event.markPublished(NOW);
+
+        assertThat(event.getPublishedAt()).isEqualTo(NOW);
+    }
+
+    private TeamRecruitmentOutboxEvent event() {
+        return TeamRecruitmentOutboxEvent.builder()
+            .id(1)
+            .eventKey("event-key")
+            .eventType("TEAM_RECRUITMENT_NOTIFICATION")
+            .aggregateType("TEAM_RECRUITMENT")
+            .aggregateId(10)
+            .payload("{}")
+            .build();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorkerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorkerTest.java
@@ -119,6 +119,7 @@ class TeamRecruitmentOutboxWorkerTest {
         assertThat(request.path()).isNull();
         assertThat(request.schemeUri()).isNull();
         assertThat(request.type()).isEqualTo("application_rejected");
+        assertThat(request.notificationId()).isNull();
         verify(leaseService).complete(eq(EVENT_ID), anyString());
     }
 
@@ -152,7 +153,9 @@ class TeamRecruitmentOutboxWorkerTest {
         verify(notificationRepository, never()).findForOutbox(
             any(), any(), any(), any(), any(), any()
         );
-        verify(fcmClient).sendMessages(anyList());
+        ArgumentCaptor<List<FcmSendRequest>> requestCaptor = ArgumentCaptor.forClass(List.class);
+        verify(fcmClient).sendMessages(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().get(0).notificationId()).isEqualTo("90");
         verify(leaseService).complete(eq(EVENT_ID), anyString());
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorkerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentOutboxWorkerTest.java
@@ -1,0 +1,378 @@
+package in.koreatech.koin.unit.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentOutboxLeaseService;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentOutboxProperties;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentOutboxWorker;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.infrastructure.fcm.FcmClient;
+import in.koreatech.koin.infrastructure.fcm.FcmSendRequest;
+import in.koreatech.koin.infrastructure.fcm.FcmSendResponse;
+import in.koreatech.koin.unit.fixture.UserFixture;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentOutboxWorkerTest {
+
+    private static final Integer EVENT_ID = 1;
+    private static final Integer RECIPIENT_ID = 2;
+    private static final Integer RECRUITMENT_ID = 10;
+
+    @Mock
+    private TeamRecruitmentOutboxLeaseService leaseService;
+
+    @Spy
+    private TeamRecruitmentOutboxProperties properties = new TeamRecruitmentOutboxProperties();
+
+    @Mock
+    private TeamRecruitmentNotificationRepository notificationRepository;
+
+    @Mock
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FcmClient fcmClient;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private TeamRecruitmentOutboxWorker worker;
+
+    @BeforeEach
+    void enableWorker() {
+        properties.setEnabled(true);
+        properties.setBatchSize(10);
+    }
+
+    @Test
+    void 기존_payload로_inbox_내용을_사용해_synchronous_FCM을_호출하고_완료한다() {
+        User recipient = UserFixture.id_설정_코인_유저(RECIPIENT_ID);
+        recipient.permitNotification("device-token");
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+            .recipient(recipient)
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("모집 지원이 거절되었어요.")
+            .recruitment(recruitment)
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,\"chat_room_id\":null}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findForOutbox(
+            RECIPIENT_ID,
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            RECRUITMENT_ID,
+            20,
+            null
+        )).thenReturn(List.of(notification));
+        when(userRepository.findById(RECIPIENT_ID)).thenReturn(Optional.of(recipient));
+        when(fcmClient.sendMessages(anyList())).thenReturn(List.of(FcmSendResponse.succeeded()));
+
+        worker.processBatch();
+
+        ArgumentCaptor<List<FcmSendRequest>> requestCaptor = ArgumentCaptor.forClass(List.class);
+        verify(fcmClient).sendMessages(requestCaptor.capture());
+        FcmSendRequest request = requestCaptor.getValue().get(0);
+        assertThat(request.targetDeviceToken()).isEqualTo("device-token");
+        assertThat(request.title()).isEqualTo("팀원 모집");
+        assertThat(request.content()).isEqualTo("모집 지원이 거절되었어요.");
+        assertThat(request.path()).isNull();
+        assertThat(request.schemeUri()).isNull();
+        assertThat(request.type()).isEqualTo("application_rejected");
+        verify(leaseService).complete(eq(EVENT_ID), anyString());
+    }
+
+    @Test
+    void notification_id가_있는_payload는_정확한_inbox를_조회한다() {
+        User recipient = UserFixture.id_설정_코인_유저(RECIPIENT_ID);
+        recipient.permitNotification("device-token");
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+            .id(90)
+            .recipient(recipient)
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("정확한 알림")
+            .recruitment(recruitment)
+            .application(TeamRecruitmentApplication.builder().id(20).recruitment(recruitment).build())
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,"
+                + "\"chat_room_id\":null,\"notification_id\":90}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findByIdForOutbox(90)).thenReturn(Optional.of(notification));
+        when(userRepository.findById(RECIPIENT_ID)).thenReturn(Optional.of(recipient));
+        when(fcmClient.sendMessages(anyList())).thenReturn(List.of(FcmSendResponse.succeeded()));
+
+        worker.processBatch();
+
+        verify(notificationRepository).findByIdForOutbox(90);
+        verify(notificationRepository, never()).findForOutbox(
+            any(), any(), any(), any(), any(), any()
+        );
+        verify(fcmClient).sendMessages(anyList());
+        verify(leaseService).complete(eq(EVENT_ID), anyString());
+    }
+
+    @Test
+    void 삭제된_inbox_이벤트는_FCM없이_완료한다() {
+        TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+            .id(90)
+            .recipient(UserFixture.id_설정_코인_유저(RECIPIENT_ID))
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("삭제된 알림")
+            .recruitment(recruitment())
+            .application(TeamRecruitmentApplication.builder().id(20).recruitment(recruitment()).build())
+            .isDeleted(true)
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,"
+                + "\"chat_room_id\":null,\"notification_id\":90}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findByIdForOutbox(90)).thenReturn(Optional.of(notification));
+
+        worker.processBatch();
+
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(userRepository, never()).findById(any());
+        verify(leaseService).complete(eq(EVENT_ID), anyString());
+        verify(leaseService, never()).fail(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    void notification_id가_있는_payload와_inbox_식별자가_다르면_전송하지_않고_실패한다() {
+        TeamRecruitment recruitment = recruitment();
+        TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+            .id(90)
+            .recipient(UserFixture.id_설정_코인_유저(3))
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("다른 수신자")
+            .recruitment(recruitment)
+            .application(TeamRecruitmentApplication.builder().id(20).recruitment(recruitment).build())
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,"
+                + "\"chat_room_id\":null,\"notification_id\":90}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findByIdForOutbox(90)).thenReturn(Optional.of(notification));
+
+        worker.processBatch();
+
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(leaseService).fail(
+            eq(EVENT_ID),
+            anyString(),
+            eq("NOTIFICATION_TARGET_MISMATCH"),
+            eq(false)
+        );
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void notification_id가_없는_삭제된_legacy_inbox도_전송하지_않고_완료한다() {
+        TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+            .recipient(UserFixture.id_설정_코인_유저(RECIPIENT_ID))
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("삭제된 legacy 알림")
+            .recruitment(recruitment())
+            .isDeleted(true)
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,\"chat_room_id\":null}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findForOutbox(
+            RECIPIENT_ID,
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            RECRUITMENT_ID,
+            20,
+            null
+        )).thenReturn(List.of(notification));
+
+        worker.processBatch();
+
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(leaseService).complete(eq(EVENT_ID), anyString());
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void notification_id가_없는_legacy_payload가_복수_inbox와_일치하면_전송하지_않고_실패한다() {
+        TeamRecruitmentNotification first = TeamRecruitmentNotification.builder()
+            .recipient(UserFixture.id_설정_코인_유저(RECIPIENT_ID))
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("첫 번째")
+            .recruitment(recruitment())
+            .build();
+        TeamRecruitmentNotification second = TeamRecruitmentNotification.builder()
+            .recipient(UserFixture.id_설정_코인_유저(RECIPIENT_ID))
+            .type(APPLICATION_REJECTED)
+            .targetType(MY_APPLICATIONS)
+            .messagePreview("두 번째")
+            .recruitment(recruitment())
+            .build();
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,\"chat_room_id\":null}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findForOutbox(
+            RECIPIENT_ID,
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            RECRUITMENT_ID,
+            20,
+            null
+        )).thenReturn(List.of(first, second));
+
+        worker.processBatch();
+
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(leaseService).fail(
+            eq(EVENT_ID),
+            anyString(),
+            eq("AMBIGUOUS_NOTIFICATION_TARGET"),
+            eq(false)
+        );
+        verify(recruitmentRepository, never()).findById(any());
+    }
+
+    @Test
+    void notification_id가_있는_payload의_inbox가_없으면_legacy로_대체하지_않는다() {
+        TeamRecruitmentOutboxLeaseService.OutboxClaim claim = claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,"
+                + "\"chat_room_id\":null,\"notification_id\":90}"
+        );
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim));
+        when(notificationRepository.findByIdForOutbox(90)).thenReturn(Optional.empty());
+
+        worker.processBatch();
+
+        verify(notificationRepository, never()).findForOutbox(
+            any(), any(), any(), any(), any(), any()
+        );
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(leaseService).fail(
+            eq(EVENT_ID),
+            anyString(),
+            eq("NOTIFICATION_NOT_FOUND"),
+            eq(false)
+        );
+    }
+
+    @Test
+    void device_token이_없는_사용자는_FCM을_호출하지_않고_terminal_failed로_처리한다() {
+        User recipient = UserFixture.id_설정_코인_유저(RECIPIENT_ID);
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,\"chat_room_id\":null}"
+        )));
+        when(notificationRepository.findForOutbox(
+            RECIPIENT_ID,
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            RECRUITMENT_ID,
+            20,
+            null
+        )).thenReturn(List.of());
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment()));
+        when(userRepository.findById(RECIPIENT_ID)).thenReturn(Optional.of(recipient));
+
+        worker.processBatch();
+
+        verify(fcmClient, never()).sendMessages(anyList());
+        verify(leaseService).fail(any(), any(), org.mockito.ArgumentMatchers.eq("NO_DEVICE_TOKEN"), org.mockito.ArgumentMatchers.eq(false));
+    }
+
+    @Test
+    void FCM_UNREGISTERED는_재시도하지_않는다() {
+        User recipient = UserFixture.id_설정_코인_유저(RECIPIENT_ID);
+        recipient.permitNotification("device-token");
+        when(leaseService.claim(any(), any(Integer.class))).thenReturn(List.of(claim(
+            "{\"type\":\"APPLICATION_REJECTED\",\"target_type\":\"MY_APPLICATIONS\","
+                + "\"recipient_id\":2,\"recruitment_id\":10,\"application_id\":20,\"chat_room_id\":null}"
+        )));
+        when(notificationRepository.findForOutbox(
+            RECIPIENT_ID,
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            RECRUITMENT_ID,
+            20,
+            null
+        )).thenReturn(List.of());
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment()));
+        when(userRepository.findById(RECIPIENT_ID)).thenReturn(Optional.of(recipient));
+        when(fcmClient.sendMessages(anyList()))
+            .thenReturn(List.of(FcmSendResponse.failed("INVALID_ARGUMENT", "UNREGISTERED")));
+
+        worker.processBatch();
+
+        verify(leaseService).fail(any(), any(), org.mockito.ArgumentMatchers.eq("INVALID_ARGUMENT"), org.mockito.ArgumentMatchers.eq(false));
+    }
+
+    private TeamRecruitmentOutboxLeaseService.OutboxClaim claim(String payload) {
+        return new TeamRecruitmentOutboxLeaseService.OutboxClaim(EVENT_ID, "event-key", payload);
+    }
+
+    private TeamRecruitment recruitment() {
+        return TeamRecruitment.builder()
+            .id(RECRUITMENT_ID)
+            .author(UserFixture.id_설정_코인_유저(1))
+            .title("팀원 모집")
+            .description("모집 내용")
+            .build();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/infrastructure/fcm/FcmClientTest.java
+++ b/src/test/java/in/koreatech/koin/unit/infrastructure/fcm/FcmClientTest.java
@@ -1,0 +1,84 @@
+package in.koreatech.koin.unit.infrastructure.fcm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+
+import in.koreatech.koin.infrastructure.fcm.FcmClient;
+
+class FcmClientTest {
+
+    private final FcmClient fcmClient = new FcmClient();
+
+    @Test
+    void notification_id를_Android와_APNs_custom_data에_문자열로_추가한다() {
+        AndroidConfig androidConfig = ReflectionTestUtils.invokeMethod(
+            fcmClient,
+            "generateAndroidConfig",
+            "제목",
+            "내용",
+            null,
+            null,
+            "application_accepted",
+            "90"
+        );
+        ApnsConfig apnsConfig = ReflectionTestUtils.invokeMethod(
+            fcmClient,
+            "generateAppleConfig",
+            "제목",
+            "내용",
+            null,
+            null,
+            "application_accepted",
+            null,
+            "90"
+        );
+
+        assertThat(data(androidConfig)).containsEntry("notification_id", "90");
+        assertThat(payload(apnsConfig)).containsEntry("notification_id", "90");
+    }
+
+    @Test
+    void notification_id가_없으면_custom_data에_추가하지_않는다() {
+        AndroidConfig androidConfig = ReflectionTestUtils.invokeMethod(
+            fcmClient,
+            "generateAndroidConfig",
+            "제목",
+            "내용",
+            null,
+            null,
+            "application_rejected",
+            null
+        );
+        ApnsConfig apnsConfig = ReflectionTestUtils.invokeMethod(
+            fcmClient,
+            "generateAppleConfig",
+            "제목",
+            "내용",
+            null,
+            null,
+            "application_rejected",
+            null,
+            null
+        );
+
+        assertThat(data(androidConfig)).doesNotContainKey("notification_id");
+        assertThat(payload(apnsConfig)).doesNotContainKey("notification_id");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> data(AndroidConfig config) {
+        return (Map<String, String>)ReflectionTestUtils.getField(config, "data");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> payload(ApnsConfig config) {
+        return (Map<String, Object>)ReflectionTestUtils.getField(config, "payload");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -115,3 +115,7 @@ address:
 toss-payment:
   secret-key: test_sk
   api-base-url: https://api.tosspayments.com/v1/payments
+
+team-recruitment:
+  outbox:
+    enabled: false


### PR DESCRIPTION
### 🔍 개요

- 팀원 모집 Outbox 이벤트를 lease 기반으로 점유하고 FCM으로 발송합니다.
- close #2341

---

### 🚀 주요 변경 내용

- `FOR UPDATE SKIP LOCKED` 기반 bounded batch claim 구현
- worker별 lease 소유권과 complete 및 fail 상태 전이 적용
- 팀원 모집 알림 6종과 삭제된 inbox 발송 억제 처리
- FCM 일시 오류 backoff 재시도와 영구 오류 terminal 처리
- 운영, 로컬, 테스트 환경별 Outbox 활성화 설정 추가
- nullable deep link를 허용하는 FCM payload 처리

---

### 💬 참고 사항

- 선행 PR: #2349
- 설계 참고: [AWS Transactional Outbox](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html)
- 검증: Outbox lease 및 worker 테스트 통과
- 전체 검증: `./gradlew clean test --no-daemon --no-build-cache --max-workers=1` — 855 tests, 0 failures, 0 errors, 3 skipped

---

### ✅ Checklist

- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Assignee 및 Labels 지정
- [x] 민감 정보 검토
