### PR TITLE
refactor: 팀원 모집 TEAM 채팅방 생성 로직 공용화

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
@@ -51,6 +51,8 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class TeamRecruitmentChatRoom extends BaseEntity {
 
+    public static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
@@ -98,6 +100,15 @@ public class TeamRecruitmentChatRoom extends BaseEntity {
         this.roomType = roomType;
         this.application = application;
         this.status = status == null ? TeamRecruitmentChatRoomStatus.ACTIVE : status;
+    }
+
+    public static TeamRecruitmentChatRoom createTeamRoom(TeamRecruitment recruitment) {
+        return TeamRecruitmentChatRoom.builder()
+            .recruitment(recruitment)
+            .roomScopeKey(TEAM_ROOM_SCOPE_KEY)
+            .roomType(TeamRecruitmentChatRoomType.TEAM)
+            .status(TeamRecruitmentChatRoomStatus.ACTIVE)
+            .build();
     }
 
     public void addMember(TeamRecruitmentChatMember member) {

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
@@ -9,6 +9,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNot
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_CLOSED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY;
 
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType;
@@ -55,8 +56,6 @@ public class TeamRecruitmentDeadlineCloseProcessor {
     private static final String RECRUITMENT_CLOSED_REASON = "RECRUITMENT_CLOSED";
     private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
     private static final String AGGREGATE_TYPE = "TEAM_RECRUITMENT";
-    private static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
-
     private final TeamRecruitmentRepository recruitmentRepository;
     private final TeamRecruitmentApplicationRepository applicationRepository;
     private final TeamRecruitmentChatRoomRepository chatRoomRepository;

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -5,6 +5,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
@@ -59,7 +60,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TeamRecruitmentApplicationQueryService {
 
-    private static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final List<TeamRecruitmentApplicationStatus> ALL_STATUSES = List.of(
         PENDING,

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationService.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.domain.team.recruitment.service;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.APPLICANT_MANAGEMENT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.CHAT_ROOM;
@@ -14,6 +13,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNot
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_CLOSED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_DUPLICATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_FINALIZED;
@@ -87,7 +87,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TeamRecruitmentApplicationService {
 
-    private static final String TEAM_ROOM_SCOPE_KEY = "TEAM";
     private static final String RECRUITMENT_CLOSED_REASON = "RECRUITMENT_CLOSED";
     private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
     private static final String AGGREGATE_TYPE = "TEAM_RECRUITMENT";
@@ -385,12 +384,7 @@ public class TeamRecruitmentApplicationService {
             return existing.get();
         }
 
-        TeamRecruitmentChatRoom created = TeamRecruitmentChatRoom.builder()
-            .recruitment(recruitment)
-            .roomScopeKey(TEAM_ROOM_SCOPE_KEY)
-            .roomType(TEAM)
-            .status(ACTIVE)
-            .build();
+        TeamRecruitmentChatRoom created = TeamRecruitmentChatRoom.createTeamRoom(recruitment);
         TeamRecruitmentChatRoom saved = chatRoomRepository.save(created);
         TeamRecruitmentChatRoom room = saved == null ? created : saved;
         addMemberIfAbsent(room, recruitment.getAuthor());

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentCommunicationModelTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentCommunicationModelTest.java
@@ -1,16 +1,34 @@
 package in.koreatech.koin.unit.domain.team.recruitment.model;
 
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMessage;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
 
 class TeamRecruitmentCommunicationModelTest {
+
+    @Test
+    void 팀_채팅방은_공용_규칙으로_생성한다() {
+        TeamRecruitment recruitment = TeamRecruitment.builder().build();
+
+        TeamRecruitmentChatRoom chatRoom = TeamRecruitmentChatRoom.createTeamRoom(recruitment);
+
+        assertThat(chatRoom.getRecruitment()).isSameAs(recruitment);
+        assertThat(chatRoom.getRoomScopeKey()).isEqualTo(TEAM_ROOM_SCOPE_KEY);
+        assertThat(chatRoom.getRoomType()).isEqualTo(TEAM);
+        assertThat(chatRoom.getStatus()).isEqualTo(ACTIVE);
+        assertThat(chatRoom.getApplication()).isNull();
+    }
 
     @Test
     void 마지막으로_읽은_메시지는_앞으로만_이동한다() {


### PR DESCRIPTION
### 🔍 개요

TEAM 채팅방 생성 규칙과 scope key를 공용화합니다.

- close #2353

### 🚀 주요 변경 내용

- TeamRecruitmentChatRoom에 TEAM_ROOM_SCOPE_KEY 추가
- TeamRecruitmentChatRoom.createTeamRoom 팩토리 추가
- 지원 승인 서비스의 TEAM 채팅방 생성 코드를 공용 팩토리로 변경
- 조회 서비스와 마감 처리기의 TEAM scope key를 공용 상수로 변경
- TEAM 채팅방 생성 규칙 단위 테스트 추가

### 💬 참고 사항

- API 요청 및 응답 구조는 변경되지 않습니다.
- 모집글 생성 구현에서는 공용 팩토리로 TEAM 채팅방을 생성한 뒤 작성자를 같은 트랜잭션에서 최초 멤버로 추가해야 합니다.

### ✅ Checklist (완료 조건)

- [x] 코드 스타일 가이드 준수
- [x] 관련 단위 테스트 통과
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized creation of team recruitment chat rooms with the correct team scope, room type, and active status.

* **Bug Fixes**
  * Improved consistency across team recruitment chat room creation and lookup operations.

* **Tests**
  * Added coverage verifying that team chat rooms are created with the expected settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->