### PR TITLE
feat: 팀원 모집 게시글 및 프로필 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
@@ -1,0 +1,229 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.CREATED;
+import static in.koreatech.koin.global.code.ApiResponseCode.ILLEGAL_ARGUMENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_USER_TYPE;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.NOT_FOUND_USER;
+import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED;
+import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import in.koreatech.koin.domain.team.recruitment.dto.CreateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.CreatedRecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.IdResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
+import in.koreatech.koin.global.code.ApiResponseCodes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Normal) Team Recruitment Articles: 팀원 모집글", description = "팀원 모집글을 관리한다")
+@RequestMapping("/team-recruitments")
+public interface TeamRecruitmentApi {
+
+    @ApiResponseCodes({
+        OK,
+        ILLEGAL_ARGUMENT,
+    })
+    @Operation(summary = "모집글 목록 조회", description = """
+        ### 모집글 목록 조회
+        - 비로그인 조회가 가능합니다.
+        - `keyword`는 모집글 제목, 역할명, 모집 카테고리 표시명, 진행 방식 표시명을
+          대소문자 구분 없이 부분 일치로 검색합니다. 본문은 검색 대상이 아닙니다.
+        - `status`는 ALL 전체, RECRUITING 모집 중, CLOSED 모집 마감입니다. 삭제된 모집글은 항상 제외됩니다.
+        - `categories`는 복수 지정이 가능하며, `meetingType`은 전체 조회 시 파라미터를 생략하셔야 합니다.
+        - `sort`는 LATEST_DESC 최신순, DEADLINE_ASC 마감 임박순입니다.
+        - `page`는 1보다 작으면 1로, 전체 페이지를 넘으면 마지막 페이지로 보정됩니다.
+        - `limit`은 1보다 작으면 1로, 50보다 크면 50으로 보정됩니다.
+        """)
+    @GetMapping
+    ResponseEntity<RecruitmentListResponse> getRecruitments(
+        @Parameter(description = "검색어. 제목, 역할명, 카테고리/진행 방식 표시명을 검색합니다.", example = "공모전")
+        @RequestParam(required = false) String keyword,
+        @Parameter(description = "모집 상태 필터", example = "ALL")
+        @RequestParam(required = false, defaultValue = "ALL") TeamRecruitmentStatusFilter status,
+        @Parameter(description = "모집 카테고리 필터. 복수 지정이 가능합니다.", example = "CONTEST")
+        @RequestParam(required = false) List<TeamRecruitmentCategory> categories,
+        @Parameter(description = "진행 방식 필터", example = "ONLINE")
+        @RequestParam(required = false) TeamRecruitmentMeetingType meetingType,
+        @Parameter(description = "정렬 방식", example = "LATEST_DESC")
+        @RequestParam(required = false, defaultValue = "LATEST_DESC") TeamRecruitmentSort sort,
+        @Parameter(description = "페이지", example = "1")
+        @RequestParam(required = false, defaultValue = "1") Integer page,
+        @Parameter(description = "페이지당 개수", example = "10")
+        @RequestParam(required = false, defaultValue = "10") Integer limit
+    );
+
+    @ApiResponseCodes({
+        CREATED,
+        TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
+        TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
+        TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME,
+        INVALID_START_DATE_AFTER_END_DATE,
+        INVALID_REQUEST_BODY,
+        NOT_FOUND_USER,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "모집글 작성", description = """
+        ### 모집글 작성
+        - `recruitment_type=ROLE_BASED`은 `roles`를 1~5개 보내며 전체 정원은 역할 정원의 합으로 계산됩니다.
+        - 전체 정원은 10명을 넘을 수 없습니다. 역할별 정원의 합도 같은 상한을 지켜야 합니다.
+        - 역할명은 앞뒤 공백을 제거해 저장하며, 대소문자와 악센트만 다른 이름도 중복으로 봅니다.
+        - `recruitment_type=GENERAL`은 `max_participants`를 보내고 `roles`는 빈 배열로 보내셔야 합니다.
+        - 지원 마감일은 활동 시작일 이하, 활동 시작일은 활동 종료일 이하여야 합니다.
+        - 모집글과 TEAM 채팅방을 같은 트랜잭션에서 생성하고 작성자를 최초 채팅방 멤버로 추가합니다.
+        - 별도의 팀 채팅방 생성 API는 없습니다.
+        - 생성된 모집글 id만 반환합니다.
+        """)
+    @PostMapping
+    ResponseEntity<IdResponse> createRecruitment(
+        @RequestBody @Valid CreateRecruitmentRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_NOT_FOUND,
+    })
+    @Operation(summary = "모집글 상세 조회", description = """
+        ### 모집글 상세 조회
+        - 비로그인 조회가 가능합니다.
+        - 로그인한 경우 `is_author`, `can_apply`, `apply_block_reason`, `application`,
+          `can_manage_applicants`, 팀 채팅방 정보를 함께 반환합니다.
+        - `d_day`는 지원 마감일 기준이며 마감일이 지나면 null입니다.
+        - 삭제된 모집글은 404를 반환합니다.
+        """)
+    @GetMapping("/{recruitmentId}")
+    ResponseEntity<RecruitmentDetail> getRecruitment(
+        @Parameter(description = "모집글 고유 식별자(recruitmentId)", example = "17") @PathVariable Integer recruitmentId,
+        @UserId Integer userId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        TEAM_RECRUITMENT_CLOSED,
+        TEAM_RECRUITMENT_ROLE_NOT_FOUND,
+        TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED,
+        TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
+        TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
+        TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME,
+        INVALID_START_DATE_AFTER_END_DATE,
+        INVALID_REQUEST_BODY,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "모집글 수정", description = """
+        ### 모집글 수정
+        - 작성자만 수정할 수 있습니다.
+        - 기존 역할은 `id`를 반드시 보내고 새 역할은 `id`를 생략하셔야 합니다.
+        - 지원자가 있는 역할은 삭제, 이름 변경, 정원 축소를 할 수 없습니다.
+        - 기존 역할의 표시 순서는 유지되며 새 역할이 비어 있는 순서를 채웁니다.
+        - 전체 정원은 10명을 넘을 수 없습니다.
+        - 역할명은 앞뒤 공백을 제거해 저장하며, 대소문자와 악센트만 다른 이름도 중복으로 봅니다.
+        - 정원을 이미 승인된 인원과 같게 줄이면 그 자리에서 마감됩니다.
+        - 마감된 모집글은 수정할 수 없습니다.
+        """)
+    @PutMapping("/{recruitmentId}")
+    ResponseEntity<RecruitmentDetail> updateRecruitment(
+        @Parameter(description = "모집글 고유 식별자(recruitmentId)", example = "17") @PathVariable Integer recruitmentId,
+        @RequestBody @Valid UpdateRecruitmentRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        NO_CONTENT,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "모집글 삭제", description = """
+        ### 모집글 삭제
+        - 작성자만 삭제할 수 있습니다.
+        - soft delete 로 처리하며 이미 삭제된 모집글에 다시 요청해도 204를 반환합니다.
+        """)
+    @DeleteMapping("/{recruitmentId}")
+    ResponseEntity<Void> deleteRecruitment(
+        @Parameter(description = "모집글 고유 식별자(recruitmentId)", example = "17") @PathVariable Integer recruitmentId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        NO_CONTENT,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "모집글 마감", description = """
+        ### 모집글 마감
+        - 작성자만 마감할 수 있습니다.
+        - 이미 마감된 모집글에 다시 요청해도 204를 반환합니다.
+        - 마감 후 재개는 지원하지 않습니다.
+        """)
+    @PutMapping("/{recruitmentId}/close")
+    ResponseEntity<Void> closeRecruitment(
+        @Parameter(description = "모집글 고유 식별자(recruitmentId)", example = "17") @PathVariable Integer recruitmentId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        ILLEGAL_ARGUMENT,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "내가 작성한 모집글 목록", description = """
+        ### 내가 작성한 모집글 목록
+        - 작성자 화면용으로 지원자 수, 모집 마감 가능 여부, 팀 채팅방 정보를 포함합니다.
+        - `applicant_count`는 대기 중과 승인된 지원자를 합산합니다.
+        - 삭제된 모집글은 제외됩니다.
+        """)
+    @GetMapping("/me/created")
+    ResponseEntity<CreatedRecruitmentListResponse> getMyCreatedRecruitments(
+        @Parameter(description = "모집 상태 필터", example = "ALL")
+        @RequestParam(required = false, defaultValue = "ALL") TeamRecruitmentStatusFilter status,
+        @Parameter(description = "정렬 방식", example = "LATEST_DESC")
+        @RequestParam(required = false, defaultValue = "LATEST_DESC") TeamRecruitmentSort sort,
+        @Parameter(description = "페이지", example = "1")
+        @RequestParam(required = false, defaultValue = "1") Integer page,
+        @Parameter(description = "페이지당 개수", example = "10")
+        @RequestParam(required = false, defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentController.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentController.java
@@ -1,0 +1,118 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.team.recruitment.dto.CreateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.CreatedRecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.IdResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentQueryService;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentService;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.auth.UserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/team-recruitments")
+public class TeamRecruitmentController implements TeamRecruitmentApi {
+
+    private final TeamRecruitmentService teamRecruitmentService;
+    private final TeamRecruitmentQueryService teamRecruitmentQueryService;
+
+    @GetMapping
+    public ResponseEntity<RecruitmentListResponse> getRecruitments(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false, defaultValue = "ALL") TeamRecruitmentStatusFilter status,
+        @RequestParam(required = false) List<TeamRecruitmentCategory> categories,
+        @RequestParam(required = false) TeamRecruitmentMeetingType meetingType,
+        @RequestParam(required = false, defaultValue = "LATEST_DESC") TeamRecruitmentSort sort,
+        @RequestParam(required = false, defaultValue = "1") Integer page,
+        @RequestParam(required = false, defaultValue = "10") Integer limit
+    ) {
+        RecruitmentListResponse response = teamRecruitmentQueryService.getRecruitments(
+            keyword, status, categories, meetingType, sort, page, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<IdResponse> createRecruitment(
+        @RequestBody @Valid CreateRecruitmentRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        IdResponse response = teamRecruitmentService.createRecruitment(studentId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{recruitmentId}")
+    public ResponseEntity<RecruitmentDetail> getRecruitment(
+        @PathVariable Integer recruitmentId,
+        @UserId Integer userId
+    ) {
+        RecruitmentDetail response = teamRecruitmentQueryService.getRecruitment(recruitmentId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{recruitmentId}")
+    public ResponseEntity<RecruitmentDetail> updateRecruitment(
+        @PathVariable Integer recruitmentId,
+        @RequestBody @Valid UpdateRecruitmentRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        teamRecruitmentService.updateRecruitment(studentId, recruitmentId, request);
+        RecruitmentDetail response = teamRecruitmentQueryService.getRecruitment(recruitmentId, studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{recruitmentId}")
+    public ResponseEntity<Void> deleteRecruitment(
+        @PathVariable Integer recruitmentId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        teamRecruitmentService.deleteRecruitment(studentId, recruitmentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{recruitmentId}/close")
+    public ResponseEntity<Void> closeRecruitment(
+        @PathVariable Integer recruitmentId,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        teamRecruitmentService.closeRecruitment(studentId, recruitmentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me/created")
+    public ResponseEntity<CreatedRecruitmentListResponse> getMyCreatedRecruitments(
+        @RequestParam(required = false, defaultValue = "ALL") TeamRecruitmentStatusFilter status,
+        @RequestParam(required = false, defaultValue = "LATEST_DESC") TeamRecruitmentSort sort,
+        @RequestParam(required = false, defaultValue = "1") Integer page,
+        @RequestParam(required = false, defaultValue = "10") Integer limit,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        CreatedRecruitmentListResponse response = teamRecruitmentQueryService.getMyCreatedRecruitments(
+            studentId, status, sort, page, limit);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentProfileApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentProfileApi.java
@@ -1,0 +1,76 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_USER_TYPE;
+import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.NOT_FOUND_USER;
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_PROFILE_NOT_FOUND;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileUpsertRequest;
+import in.koreatech.koin.global.auth.Auth;
+import in.koreatech.koin.global.code.ApiResponseCodes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Normal) Team Recruitment Profile: 팀원 모집 프로필", description = "팀원 모집 전용 프로필을 관리한다")
+@RequestMapping("/team-recruitment-profiles")
+public interface TeamRecruitmentProfileApi {
+
+    @ApiResponseCodes({
+        OK,
+        NOT_FOUND_USER,
+        TEAM_RECRUITMENT_PROFILE_NOT_FOUND,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "내 팀원 모집 프로필 조회", description = """
+        ### 내 팀원 모집 프로필 조회
+        - 현재 인증된 사용자의 팀원 모집 전용 프로필을 조회합니다.
+        - 학과/학부, 전공, 학번은 학적 정보에서 가져옵니다.
+        - 전공 구분이 없는 학부는 전공이 null입니다.
+        - 저장된 프로필이 없으면 404를 반환합니다.
+        """)
+    @GetMapping("/me")
+    ResponseEntity<TeamRecruitmentProfileResponse> getMyProfile(
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+
+    @ApiResponseCodes({
+        OK,
+        NOT_FOUND_USER,
+        TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED,
+        TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL,
+        INVALID_START_DATE_AFTER_END_DATE,
+        INVALID_REQUEST_BODY,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "팀원 모집 프로필 생성 또는 수정", description = """
+        ### 팀원 모집 프로필 생성 또는 수정
+        - 현재 인증된 사용자의 프로필을 저장합니다. 프로필이 없으면 생성하고, 있으면 수정합니다.
+        - 보유 기술과 활동 내역은 기존 목록을 전부 대체하며, 요청한 순서대로 저장됩니다.
+        - 활동 내역의 각 항목에 id를 보내지 않습니다.
+        - 활동 시작일과 종료일은 "yyyy-MM-dd" 형식입니다.
+        - 진행 중인 활동인 경우, 활동 종료일은 null로 요청하셔야 합니다.
+        - 진행 중인 활동이 아닌 경우, 활동 종료일은 필수이며 활동 시작일과 같거나 이후여야 합니다.
+        - 학과/학부, 전공, 학번 변경은 학적 정보 수정 API를 사용하셔야 합니다.
+        """)
+    @PutMapping("/me")
+    ResponseEntity<TeamRecruitmentProfileResponse> upsertMyProfile(
+        @RequestBody @Valid TeamRecruitmentProfileUpsertRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    );
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentProfileController.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentProfileController.java
@@ -1,0 +1,43 @@
+package in.koreatech.koin.domain.team.recruitment.controller;
+
+import static in.koreatech.koin.domain.user.model.UserType.STUDENT;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileUpsertRequest;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentProfileService;
+import in.koreatech.koin.global.auth.Auth;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/team-recruitment-profiles")
+public class TeamRecruitmentProfileController implements TeamRecruitmentProfileApi {
+
+    private final TeamRecruitmentProfileService teamRecruitmentProfileService;
+
+    @GetMapping("/me")
+    public ResponseEntity<TeamRecruitmentProfileResponse> getMyProfile(
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        TeamRecruitmentProfileResponse response = teamRecruitmentProfileService.getMyProfile(studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<TeamRecruitmentProfileResponse> upsertMyProfile(
+        @RequestBody @Valid TeamRecruitmentProfileUpsertRequest request,
+        @Auth(permit = {STUDENT}) Integer studentId
+    ) {
+        TeamRecruitmentProfileResponse response =
+            teamRecruitmentProfileService.upsertMyProfile(studentId, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
@@ -1,0 +1,122 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CreateRecruitmentRequest(
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 50)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일. 활동 시작일 이하여야 합니다.", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate deadlineDate,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "전체 모집 정원. GENERAL 모집만 사용하며 ROLE_BASED 모집은 역할 정원의 합으로 계산됩니다.",
+        example = "5", nullable = true, requiredMode = NOT_REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록. ROLE_BASED 모집은 1~5개이며 역할별 정원의 합은 최대 10명입니다. "
+        + "GENERAL 모집은 빈 배열입니다.", requiredMode = REQUIRED)
+    @NotNull
+    List<@NotNull @Valid RoleInput> roles,
+
+    @Schema(description = "모집 상세 설명", example = "공모전 팀원을 모집합니다.", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 1000)
+    String description,
+
+    @Schema(description = "관련 링크", example = "https://example.com", nullable = true, requiredMode = NOT_REQUIRED)
+    @Pattern(regexp = "^https://.*")
+    @Size(max = 2048)
+    String relatedUrl,
+
+    @Schema(description = "지원 자격", example = "기획 경험이 있는 분", nullable = true, requiredMode = NOT_REQUIRED)
+    @Size(min = 1, max = 500)
+    String qualification
+) {
+    public CreateRecruitmentRequest {
+        RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
+        RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
+        RecruitmentRequestValidator.validateDistinctRoleNames(
+            roles == null ? List.of() : roles.stream().map(RoleInput::name).toList());
+        RecruitmentRequestValidator.validateTotalCapacity(
+            recruitmentType == TeamRecruitmentType.ROLE_BASED && roles != null
+                ? roles.stream().mapToInt(RoleInput::maxParticipants).sum()
+                : (maxParticipants == null ? 0 : maxParticipants));
+    }
+
+    /**
+     * ROLE_BASED 모집의 전체 정원은 역할 정원의 합이다.
+     */
+    public int resolveMaxParticipants() {
+        if (recruitmentType == TeamRecruitmentType.ROLE_BASED) {
+            return roles.stream().mapToInt(RoleInput::maxParticipants).sum();
+        }
+        return maxParticipants;
+    }
+
+    public TeamRecruitment toEntity(User author) {
+        return TeamRecruitment.builder()
+            .author(author)
+            .category(category)
+            .title(title)
+            .meetingType(meetingType)
+            .activityStartDate(activityStartDate)
+            .activityEndDate(activityEndDate)
+            .deadlineDate(deadlineDate)
+            .recruitmentType(recruitmentType)
+            .maxParticipants(resolveMaxParticipants())
+            .currentParticipants(0)
+            .description(description)
+            .relatedUrl(relatedUrl)
+            .qualification(qualification)
+            .status(TeamRecruitmentStatus.RECRUITING)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitment.java
@@ -1,0 +1,102 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CreatedRecruitment(
+    @Schema(description = "모집글 ID", example = "17", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate deadlineDate,
+
+    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    Integer dDay,
+
+    @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)
+    TeamRecruitmentStatus status,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "승인된 전체 지원자 수", example = "2", requiredMode = REQUIRED)
+    Integer currentParticipants,
+
+    @Schema(description = "전체 모집 정원", example = "5", requiredMode = REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록", requiredMode = REQUIRED)
+    List<RecruitmentRole> roles,
+
+    @Schema(description = "지원자 수", example = "4", requiredMode = REQUIRED)
+    Integer applicantCount,
+
+    @Schema(description = "모집 마감 가능 여부", example = "true", requiredMode = REQUIRED)
+    Boolean canClose,
+
+    @Schema(description = "작성자 TEAM 방이 존재할 때 true이며 team_chat_room_id는 null이 아닙니다.",
+        example = "true", requiredMode = REQUIRED)
+    Boolean teamChatAvailable,
+
+    @Schema(description = "팀 채팅방 ID. team_chat_available=true일 때 non-null입니다.", example = "31",
+        nullable = true, requiredMode = REQUIRED)
+    Integer teamChatRoomId
+) {
+    public static CreatedRecruitment of(
+        RecruitmentCard card,
+        long applicantCount,
+        boolean canClose,
+        Integer teamChatRoomId
+    ) {
+        return new CreatedRecruitment(
+            card.id(),
+            card.category(),
+            card.title(),
+            card.meetingType(),
+            card.activityStartDate(),
+            card.activityEndDate(),
+            card.deadlineDate(),
+            card.dDay(),
+            card.status(),
+            card.recruitmentType(),
+            card.currentParticipants(),
+            card.maxParticipants(),
+            card.roles(),
+            (int) applicantCount,
+            canClose,
+            teamChatRoomId != null,
+            teamChatRoomId
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitmentListResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitmentListResponse.java
@@ -1,0 +1,45 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.common.model.Criteria;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CreatedRecruitmentListResponse(
+    @Schema(description = "내가 작성한 모집글 목록", requiredMode = REQUIRED)
+    List<CreatedRecruitment> recruitments,
+
+    @Schema(description = "전체 모집글 수", example = "1", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지의 모집글 수", example = "1", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "전체 페이지 수", example = "1", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+    public static CreatedRecruitmentListResponse of(
+        List<CreatedRecruitment> recruitments,
+        Page<?> pagedResult,
+        Criteria criteria
+    ) {
+        return new CreatedRecruitmentListResponse(
+            recruitments,
+            pagedResult.getTotalElements(),
+            recruitments.size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/IdResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/IdResponse.java
@@ -1,0 +1,15 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record IdResponse(
+    @Schema(description = "생성된 리소스 고유 식별자", example = "17", requiredMode = REQUIRED)
+    Integer id
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ProfileActivityInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ProfileActivityInput.java
@@ -1,0 +1,61 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.global.exception.CustomException;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record ProfileActivityInput(
+    @Schema(description = "활동명", example = "AI 공모전", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 50)
+    String title,
+
+    @Schema(description = "시작일", example = "2025-03-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate startedAt,
+
+    @Schema(description = "종료일. 진행 중인 활동이면 null이고, 그 외에는 시작일과 같거나 이후여야 합니다.", example = "2025-05-05",
+        nullable = true, requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate endedAt,
+
+    @Schema(description = "진행 중 여부", example = "false", requiredMode = REQUIRED)
+    @NotNull
+    Boolean isOngoing,
+
+    @Schema(description = "활동 설명", example = "기획 담당", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 500)
+    String description
+) {
+    public ProfileActivityInput {
+        if (TRUE.equals(isOngoing) && endedAt != null) {
+            throw CustomException.of(TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL);
+        }
+        if (FALSE.equals(isOngoing)) {
+            if (endedAt == null) {
+                throw CustomException.of(TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED);
+            }
+            if (startedAt != null && endedAt.isBefore(startedAt)) {
+                throw CustomException.of(INVALID_START_DATE_AFTER_END_DATE);
+            }
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCards.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCards.java
@@ -1,0 +1,68 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+
+/**
+ * 모집글 카드 응답 조립. 목록/상세/내가 작성한 목록이 공유한다.
+ */
+public final class RecruitmentCards {
+
+    private RecruitmentCards() {
+    }
+
+    public static RecruitmentCard of(TeamRecruitment recruitment, LocalDate today) {
+        boolean recruitmentClosed = isRecruitmentClosed(recruitment, today);
+        return new RecruitmentCard(
+            recruitment.getId(),
+            recruitment.getCategory(),
+            recruitment.getTitle(),
+            recruitment.getMeetingType(),
+            recruitment.getActivityStartDate(),
+            recruitment.getActivityEndDate(),
+            recruitment.getDeadlineDate(),
+            dDayOf(recruitment.getDeadlineDate(), today),
+            recruitment.getStatus(),
+            recruitment.getRecruitmentType(),
+            recruitment.getCurrentParticipants(),
+            recruitment.getMaxParticipants(),
+            recruitment.getRoles().stream()
+                .map(role -> roleOf(role, recruitmentClosed))
+                .toList()
+        );
+    }
+
+    /**
+     * 모집글이 마감되었거나 지원 마감일이 지나면 정원이 남은 역할도 마감으로 본다.
+     */
+    private static boolean isRecruitmentClosed(TeamRecruitment recruitment, LocalDate today) {
+        if (!recruitment.isRecruiting()) {
+            return true;
+        }
+        LocalDate deadline = recruitment.getDeadlineDate();
+        return deadline != null && today != null && today.isAfter(deadline);
+    }
+
+    /**
+     * 지원 마감일이 지나면 null 이다.
+     */
+    public static Integer dDayOf(LocalDate deadlineDate, LocalDate today) {
+        if (deadlineDate == null || today == null || today.isAfter(deadlineDate)) {
+            return null;
+        }
+        return (int) ChronoUnit.DAYS.between(today, deadlineDate);
+    }
+
+    public static RecruitmentRole roleOf(TeamRecruitmentRole role, boolean recruitmentClosed) {
+        return new RecruitmentRole(
+            role.getId(),
+            role.getName(),
+            role.getCurrentParticipants(),
+            role.getMaxParticipants(),
+            recruitmentClosed || role.isClosed()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
@@ -1,0 +1,112 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record RecruitmentDetail(
+    @Schema(description = "모집글 ID", example = "17", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate deadlineDate,
+
+    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    Integer dDay,
+
+    @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)
+    TeamRecruitmentStatus status,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "승인된 전체 지원자 수", example = "2", requiredMode = REQUIRED)
+    Integer currentParticipants,
+
+    @Schema(description = "전체 모집 정원", example = "5", requiredMode = REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록", requiredMode = REQUIRED)
+    List<RecruitmentRole> roles,
+
+    @Schema(description = "작성자 닉네임", example = "홍길동", requiredMode = REQUIRED)
+    String authorNickname,
+
+    @Schema(description = "모집 상세 설명", example = "공모전 팀원을 모집합니다.", requiredMode = REQUIRED)
+    String description,
+
+    @Schema(description = "관련 링크", example = "https://example.com", nullable = true, requiredMode = REQUIRED)
+    String relatedUrl,
+
+    @Schema(description = "지원 자격", example = "기획 경험이 있는 분", nullable = true, requiredMode = REQUIRED)
+    String qualification,
+
+    @Schema(description = "작성 일시(KST)", example = "2026-08-25 09:00:00", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    LocalDateTime createdAt,
+
+    @Schema(description = "조회자가 작성자인지 여부", example = "false", requiredMode = REQUIRED)
+    Boolean isAuthor,
+
+    @Schema(description = "지원 가능 여부", example = "true", requiredMode = REQUIRED)
+    Boolean canApply,
+
+    @Schema(description = "지원 불가 사유. 지원 가능하면 null입니다.", nullable = true, requiredMode = REQUIRED)
+    TeamRecruitmentApplyBlockReason applyBlockReason,
+
+    @Schema(description = "내 지원 정보. 미지원자는 null입니다.", nullable = true, requiredMode = REQUIRED)
+    AppliedApplication application,
+
+    @Schema(description = "지원자 관리 가능 여부", example = "false", requiredMode = REQUIRED)
+    Boolean canManageApplicants,
+
+    @Schema(description = "팀 채팅방 이용 가능 여부", example = "false", requiredMode = REQUIRED)
+    Boolean teamChatAvailable,
+
+    @Schema(description = "팀 채팅방 ID. 이용 가능할 때만 non-null입니다.", example = "31",
+        nullable = true, requiredMode = REQUIRED)
+    Integer teamChatRoomId
+) {
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record AppliedApplication(
+        @Schema(description = "지원서 ID", example = "51", requiredMode = REQUIRED)
+        Integer applicationId,
+
+        @Schema(description = "지원 상태", example = "PENDING", requiredMode = REQUIRED)
+        TeamRecruitmentApplicationStatus status
+    ) {
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentListResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentListResponse.java
@@ -1,0 +1,49 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record RecruitmentListResponse(
+    @Schema(description = "모집글 카드 목록", requiredMode = REQUIRED)
+    List<RecruitmentCard> recruitments,
+
+    @Schema(description = "전체 모집글 수", example = "20", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "현재 페이지의 모집글 수", example = "10", requiredMode = REQUIRED)
+    Integer currentCount,
+
+    @Schema(description = "전체 페이지 수", example = "2", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지", example = "1", requiredMode = REQUIRED)
+    Integer currentPage
+) {
+    public static RecruitmentListResponse of(
+        Page<TeamRecruitment> pagedResult,
+        Criteria criteria,
+        LocalDate today
+    ) {
+        return new RecruitmentListResponse(
+            pagedResult.getContent().stream()
+                .map(recruitment -> RecruitmentCards.of(recruitment, today))
+                .toList(),
+            pagedResult.getTotalElements(),
+            pagedResult.getContent().size(),
+            pagedResult.getTotalPages(),
+            criteria.getPage() + 1
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
@@ -1,0 +1,106 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
+
+import java.text.Normalizer;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import in.koreatech.koin.global.exception.CustomException;
+
+/**
+ * 모집글 작성/수정 요청이 공통으로 쓰는 검증. null 필드는 Bean Validation 이 처리하므로 여기서는 건너뛴다.
+ */
+final class RecruitmentRequestValidator {
+
+    static final int MAX_ROLE_COUNT = 5;
+    static final int MAX_GENERAL_PARTICIPANTS = 10;
+
+    // 전체 모집 정원 상한. team_recruitment.max_participants CHECK 도 1~10 이다.
+    static final int MAX_TOTAL_PARTICIPANTS = 10;
+
+    private RecruitmentRequestValidator() {
+    }
+
+    static void validatePeriod(LocalDate activityStartDate, LocalDate activityEndDate, LocalDate deadlineDate) {
+        if (activityStartDate == null) {
+            return;
+        }
+        if (activityEndDate != null && activityEndDate.isBefore(activityStartDate)) {
+            throw CustomException.of(INVALID_START_DATE_AFTER_END_DATE);
+        }
+        if (deadlineDate != null && deadlineDate.isAfter(activityStartDate)) {
+            throw CustomException.of(TEAM_RECRUITMENT_INVALID_DEADLINE_DATE);
+        }
+    }
+
+    /**
+     * 전체 모집 정원은 최대 10명이다.
+     * ROLE_BASED 는 역할 정원의 합이 전체 정원이 되므로 합계도 같은 상한을 지켜야 한다.
+     */
+    static void validateTotalCapacity(int totalCapacity) {
+        if (totalCapacity > MAX_TOTAL_PARTICIPANTS) {
+            throw CustomException.of(INVALID_REQUEST_BODY, "totalCapacity: " + totalCapacity);
+        }
+    }
+
+    /**
+     * 역할명은 앞뒤 공백을 제거한 형태를 정본으로 삼는다.
+     * utf8mb4_0900_ai_ci 는 NO PAD 라 DB 에서는 "PM" 과 "PM " 이 다르지만,
+     * 사용자에게는 구분되지 않는 이름이므로 저장 값 자체를 공백 없이 통일한다.
+     */
+    static String canonicalRoleName(String roleName) {
+        return roleName == null ? null : roleName.trim();
+    }
+
+    /**
+     * 역할명에는 (recruitment_id, name) unique 제약이 걸려 있고 collation 이 utf8mb4_0900_ai_ci 라
+     * 대소문자와 악센트를 무시한 채 같으면 중복으로 본다. 요청 단계에서 걸러 DB 오류를 막는다.
+     * 이름은 canonicalRoleName 으로 이미 공백이 제거된 상태로 들어온다.
+     */
+    static void validateDistinctRoleNames(List<String> roleNames) {
+        Set<String> normalized = new HashSet<>();
+        for (String roleName : roleNames) {
+            if (roleName != null && !normalized.add(normalizeRoleName(roleName))) {
+                throw CustomException.of(TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME, "roleName: " + roleName);
+            }
+        }
+    }
+
+    private static String normalizeRoleName(String roleName) {
+        String withoutMarks = Normalizer.normalize(roleName, Normalizer.Form.NFD)
+            .replaceAll("\\p{M}+", "");
+        return withoutMarks.toLowerCase(Locale.ROOT);
+    }
+
+    static void validateRoleComposition(
+        TeamRecruitmentType recruitmentType,
+        List<?> roles,
+        Integer maxParticipants
+    ) {
+        if (recruitmentType == null || roles == null) {
+            return;
+        }
+        if (recruitmentType == TeamRecruitmentType.ROLE_BASED) {
+            if (roles.isEmpty() || roles.size() > MAX_ROLE_COUNT) {
+                throw CustomException.of(TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+            }
+            return;
+        }
+        boolean invalidGeneral = !roles.isEmpty()
+            || maxParticipants == null
+            || maxParticipants < 1
+            || maxParticipants > MAX_GENERAL_PARTICIPANTS;
+        if (invalidGeneral) {
+            throw CustomException.of(TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RoleInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RoleInput.java
@@ -1,0 +1,31 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record RoleInput(
+    @Schema(description = "역할명. 앞뒤 공백은 제거되어 저장됩니다.", example = "PM", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 10)
+    String name,
+
+    @Schema(description = "역할 정원", example = "1", requiredMode = REQUIRED)
+    @NotNull
+    @Min(1)
+    @Max(10)
+    Integer maxParticipants
+) {
+    public RoleInput {
+        name = RecruitmentRequestValidator.canonicalRoleName(name);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/TeamRecruitmentProfileResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/TeamRecruitmentProfileResponse.java
@@ -1,0 +1,75 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.student.model.Major;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfile;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileActivity;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileSkill;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record TeamRecruitmentProfileResponse(
+    @Schema(description = "팀원 모집 전용 닉네임", example = "홍길동", requiredMode = REQUIRED)
+    String profileNickname,
+
+    @Schema(description = "학적 정보의 학과/학부", example = "컴퓨터공학부", requiredMode = REQUIRED)
+    String department,
+
+    @Schema(description = "학적 정보의 전공. 전공 구분이 없는 학부는 null입니다.", example = "null",
+        nullable = true, requiredMode = REQUIRED)
+    String major,
+
+    @Schema(description = "학적 정보의 학번", example = "2023100000", requiredMode = REQUIRED)
+    String studentNumber,
+
+    @Schema(description = "선호 역할", example = "기획", requiredMode = REQUIRED)
+    String preferredRole,
+
+    @Schema(description = "보유 기술", example = "[\"정보처리기사\"]", requiredMode = REQUIRED)
+    List<String> skills,
+
+    @Schema(description = "활동 내역", requiredMode = REQUIRED)
+    List<ProfileActivity> activities,
+
+    @Schema(description = "자기소개", example = "안녕하세요.", requiredMode = REQUIRED)
+    String selfIntroduction
+) {
+    public static TeamRecruitmentProfileResponse of(TeamRecruitmentProfile profile, Student student) {
+        return new TeamRecruitmentProfileResponse(
+            profile.getProfileNickname(),
+            student.getDepartment() == null ? null : student.getDepartment().getName(),
+            majorNameOf(student.getMajor()),
+            student.getStudentNumber(),
+            profile.getPreferredRole(),
+            profile.getSkills().stream()
+                .map(TeamRecruitmentProfileSkill::getSkill)
+                .toList(),
+            profile.getActivities().stream()
+                .map(TeamRecruitmentProfileResponse::activityOf)
+                .toList(),
+            profile.getSelfIntroduction()
+        );
+    }
+
+    private static String majorNameOf(Major major) {
+        return major == null ? null : major.getName();
+    }
+
+    private static ProfileActivity activityOf(TeamRecruitmentProfileActivity activity) {
+        return new ProfileActivity(
+            activity.getId(),
+            activity.getTitle(),
+            activity.getStartedAt(),
+            activity.getEndedAt(),
+            activity.getIsOngoing(),
+            activity.getDescription()
+        );
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/TeamRecruitmentProfileUpsertRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/TeamRecruitmentProfileUpsertRequest.java
@@ -1,0 +1,41 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record TeamRecruitmentProfileUpsertRequest(
+    @Schema(description = "팀원 모집 전용 닉네임", example = "홍길동", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 20)
+    String profileNickname,
+
+    @Schema(description = "선호 역할", example = "기획", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 20)
+    String preferredRole,
+
+    @Schema(description = "보유 기술. 기존 목록을 전부 대체합니다.", example = "[\"정보처리기사\"]", requiredMode = REQUIRED)
+    @NotNull
+    List<@NotBlank @Size(min = 1, max = 20) String> skills,
+
+    @Schema(description = "활동 내역. 기존 목록을 전부 대체하며 각 항목에 id를 보내지 않습니다.", requiredMode = REQUIRED)
+    @NotNull
+    List<@NotNull @Valid ProfileActivityInput> activities,
+
+    @Schema(description = "자기소개", example = "안녕하세요.", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 1000)
+    String selfIntroduction
+) {
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
@@ -1,0 +1,98 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record UpdateRecruitmentRequest(
+    @Schema(description = "모집 카테고리", example = "CONTEST", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentCategory category,
+
+    @Schema(description = "모집글 제목", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 50)
+    String title,
+
+    @Schema(description = "진행 방식", example = "ONLINE", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentMeetingType meetingType,
+
+    @Schema(description = "활동 시작일", example = "2026-09-07", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate activityStartDate,
+
+    @Schema(description = "활동 종료일", example = "2026-09-30", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate activityEndDate,
+
+    @Schema(description = "지원 마감일. 활동 시작일 이하여야 합니다.", example = "2026-09-03", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull
+    LocalDate deadlineDate,
+
+    @Schema(description = "모집 유형", example = "ROLE_BASED", requiredMode = REQUIRED)
+    @NotNull
+    TeamRecruitmentType recruitmentType,
+
+    @Schema(description = "전체 모집 정원. GENERAL 모집만 사용하며 ROLE_BASED 모집은 역할 정원의 합으로 계산됩니다.",
+        example = "5", nullable = true, requiredMode = NOT_REQUIRED)
+    Integer maxParticipants,
+
+    @Schema(description = "역할 목록. 기존 역할은 id를 반드시 보내고 새 역할은 id를 생략합니다. "
+        + "ROLE_BASED 모집은 1~5개이며 역할별 정원의 합은 최대 10명입니다. "
+        + "GENERAL 모집은 빈 배열입니다.", requiredMode = REQUIRED)
+    @NotNull
+    List<@NotNull @Valid UpdateRoleInput> roles,
+
+    @Schema(description = "모집 상세 설명", example = "공모전 팀원을 모집합니다.", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 1000)
+    String description,
+
+    @Schema(description = "관련 링크", example = "https://example.com", nullable = true, requiredMode = NOT_REQUIRED)
+    @Pattern(regexp = "^https://.*")
+    @Size(max = 2048)
+    String relatedUrl,
+
+    @Schema(description = "지원 자격", example = "기획 경험이 있는 분", nullable = true, requiredMode = NOT_REQUIRED)
+    @Size(min = 1, max = 500)
+    String qualification
+) {
+    public UpdateRecruitmentRequest {
+        RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
+        RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
+        RecruitmentRequestValidator.validateDistinctRoleNames(
+            roles == null ? List.of() : roles.stream().map(UpdateRoleInput::name).toList());
+        RecruitmentRequestValidator.validateTotalCapacity(
+            recruitmentType == TeamRecruitmentType.ROLE_BASED && roles != null
+                ? roles.stream().mapToInt(UpdateRoleInput::maxParticipants).sum()
+                : (maxParticipants == null ? 0 : maxParticipants));
+    }
+
+    public int resolveMaxParticipants() {
+        if (recruitmentType == TeamRecruitmentType.ROLE_BASED) {
+            return roles.stream().mapToInt(UpdateRoleInput::maxParticipants).sum();
+        }
+        return maxParticipants;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRoleInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRoleInput.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.domain.team.recruitment.dto;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record UpdateRoleInput(
+    @Schema(description = "기존 역할 ID. 새 역할은 생략합니다.", example = "1", requiredMode = NOT_REQUIRED)
+    Integer id,
+
+    @Schema(description = "역할명. 앞뒤 공백은 제거되어 저장됩니다.", example = "PM", requiredMode = REQUIRED)
+    @NotBlank
+    @Size(min = 1, max = 10)
+    String name,
+
+    @Schema(description = "역할 정원", example = "1", requiredMode = REQUIRED)
+    @NotNull
+    @Min(1)
+    @Max(10)
+    Integer maxParticipants
+) {
+    public UpdateRoleInput {
+        name = RecruitmentRequestValidator.canonicalRoleName(name);
+    }
+
+    public boolean isNew() {
+        return id == null;
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentApplyBlockReason.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentApplyBlockReason.java
@@ -1,0 +1,22 @@
+package in.koreatech.koin.domain.team.recruitment.enums;
+
+/**
+ * 지원 불가 사유. 여러 사유가 동시에 성립하면 선언 순서가 이른 값을 반환한다.
+ * <p>
+ * 순서는 클라이언트와 합의한 화면 안내 우선순위를 따른다.
+ * 지원 API 의 검증 순서와는 일부 다르므로, 이미 지원한 마감 글처럼 두 사유가 겹치는 경우
+ * 상세가 알려주는 사유와 실제 지원 시 오류 코드가 다를 수 있다.
+ */
+public enum TeamRecruitmentApplyBlockReason {
+    /**
+     * 상세 조회는 삭제된 모집글에 404 를 반환하므로 이 값은 상세 응답으로 나가지 않는다.
+     */
+    RECRUITMENT_DELETED,
+    LOGIN_REQUIRED,
+    OWN_RECRUITMENT,
+    ALREADY_APPLIED,
+    RECRUITMENT_CLOSED,
+    DEADLINE_PASSED,
+    ROLE_CLOSED,
+    PROFILE_REQUIRED
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentDisplayName.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentDisplayName.java
@@ -1,0 +1,62 @@
+package in.koreatech.koin.domain.team.recruitment.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 모집 카테고리와 진행 방식의 화면 표시명. keyword 검색이 표시명도 대상으로 하기 때문에 필요하다.
+ * <p>
+ * 표시명은 Swagger 의 enum 설명을 그대로 따른다. enum 자체에 표시명이 생기면 이 클래스는 없앨 수 있다.
+ */
+public final class TeamRecruitmentDisplayName {
+
+    private static final Map<TeamRecruitmentCategory, String> CATEGORY_NAMES = Map.of(
+        TeamRecruitmentCategory.CONTEST, "공모전",
+        TeamRecruitmentCategory.EXTERNAL_ACTIVITY, "대외활동",
+        TeamRecruitmentCategory.STUDY, "스터디",
+        TeamRecruitmentCategory.PROJECT, "프로젝트",
+        TeamRecruitmentCategory.OTHER, "기타"
+    );
+
+    private static final Map<TeamRecruitmentMeetingType, String> MEETING_TYPE_NAMES = Map.of(
+        TeamRecruitmentMeetingType.ONLINE, "온라인",
+        TeamRecruitmentMeetingType.OFFLINE, "오프라인",
+        TeamRecruitmentMeetingType.MIXED, "온/오프라인"
+    );
+
+    private TeamRecruitmentDisplayName() {
+    }
+
+    public static String of(TeamRecruitmentCategory category) {
+        return CATEGORY_NAMES.get(category);
+    }
+
+    public static String of(TeamRecruitmentMeetingType meetingType) {
+        return MEETING_TYPE_NAMES.get(meetingType);
+    }
+
+    /**
+     * 표시명에 검색어가 포함되는 카테고리를 찾는다.
+     * enum 영문 이름은 대상이 아니다. 예를 들어 "test" 로 CONTEST 가 걸리면 안 된다.
+     */
+    public static List<TeamRecruitmentCategory> categoriesMatching(String keyword) {
+        return Arrays.stream(TeamRecruitmentCategory.values())
+            .filter(category -> matches(keyword, of(category)))
+            .toList();
+    }
+
+    /**
+     * 표시명에 검색어가 포함되는 진행 방식을 찾는다.
+     * enum 영문 이름은 대상이 아니다. 예를 들어 "line" 으로 ONLINE 이 걸리면 안 된다.
+     */
+    public static List<TeamRecruitmentMeetingType> meetingTypesMatching(String keyword) {
+        return Arrays.stream(TeamRecruitmentMeetingType.values())
+            .filter(meetingType -> matches(keyword, of(meetingType)))
+            .toList();
+    }
+
+    private static boolean matches(String keyword, String displayName) {
+        return displayName.toLowerCase().contains(keyword.toLowerCase());
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentSort.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentSort.java
@@ -1,0 +1,6 @@
+package in.koreatech.koin.domain.team.recruitment.enums;
+
+public enum TeamRecruitmentSort {
+    LATEST_DESC,
+    DEADLINE_ASC
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentStatusFilter.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentStatusFilter.java
@@ -1,0 +1,20 @@
+package in.koreatech.koin.domain.team.recruitment.enums;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamRecruitmentStatusFilter {
+
+    ALL(List.of(TeamRecruitmentStatus.RECRUITING, TeamRecruitmentStatus.CLOSED)),
+    RECRUITING(List.of(TeamRecruitmentStatus.RECRUITING)),
+    CLOSED(List.of(TeamRecruitmentStatus.CLOSED));
+
+    /**
+     * 삭제된 모집글은 어떤 필터에서도 노출되지 않는다.
+     */
+    private final List<TeamRecruitmentStatus> statuses;
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/repository/TeamRecruitmentListQueryRepository.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/repository/TeamRecruitmentListQueryRepository.java
@@ -1,0 +1,180 @@
+package in.koreatech.koin.domain.team.recruitment.repository;
+
+import static in.koreatech.koin.domain.team.recruitment.model.QTeamRecruitment.teamRecruitment;
+import static in.koreatech.koin.domain.team.recruitment.model.QTeamRecruitmentRole.teamRecruitmentRole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentDisplayName;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 모집글 목록 조회. 필터 조합이 많아 QueryDSL 로 분리했다.
+ * 역할 목록을 함께 쓰기 때문에, 페이지 대상 id 를 먼저 뽑고 그 id 들만 fetch join 으로 다시 읽는다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class TeamRecruitmentListQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public long count(
+        String keyword,
+        TeamRecruitmentStatusFilter statusFilter,
+        List<TeamRecruitmentCategory> categories,
+        TeamRecruitmentMeetingType meetingType
+    ) {
+        Long total = queryFactory
+            .select(teamRecruitment.count())
+            .from(teamRecruitment)
+            .where(publicFilter(keyword, statusFilter, categories, meetingType))
+            .fetchOne();
+        return total == null ? 0L : total;
+    }
+
+    public List<TeamRecruitment> findAll(
+        String keyword,
+        TeamRecruitmentStatusFilter statusFilter,
+        List<TeamRecruitmentCategory> categories,
+        TeamRecruitmentMeetingType meetingType,
+        TeamRecruitmentSort sort,
+        Criteria criteria
+    ) {
+        return findByIdsInOrder(
+            pageIds(publicFilter(keyword, statusFilter, categories, meetingType), sort, criteria),
+            sort
+        );
+    }
+
+    public long countByAuthor(Integer authorId, TeamRecruitmentStatusFilter statusFilter) {
+        Long total = queryFactory
+            .select(teamRecruitment.count())
+            .from(teamRecruitment)
+            .where(authorFilter(authorId, statusFilter))
+            .fetchOne();
+        return total == null ? 0L : total;
+    }
+
+    public List<TeamRecruitment> findAllByAuthor(
+        Integer authorId,
+        TeamRecruitmentStatusFilter statusFilter,
+        TeamRecruitmentSort sort,
+        Criteria criteria
+    ) {
+        return findByIdsInOrder(pageIds(authorFilter(authorId, statusFilter), sort, criteria), sort);
+    }
+
+    private List<Integer> pageIds(BooleanBuilder filter, TeamRecruitmentSort sort, Criteria criteria) {
+        return queryFactory
+            .select(teamRecruitment.id)
+            .from(teamRecruitment)
+            .where(filter)
+            .orderBy(orderBy(sort))
+            .offset((long) criteria.getPage() * criteria.getLimit())
+            .limit(criteria.getLimit())
+            .fetch();
+    }
+
+    private List<TeamRecruitment> findByIdsInOrder(List<Integer> ids, TeamRecruitmentSort sort) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        return queryFactory
+            .selectFrom(teamRecruitment)
+            .leftJoin(teamRecruitment.roles).fetchJoin()
+            .where(teamRecruitment.id.in(ids))
+            .orderBy(orderBy(sort))
+            .distinct()
+            .fetch();
+    }
+
+    private BooleanBuilder publicFilter(
+        String keyword,
+        TeamRecruitmentStatusFilter statusFilter,
+        List<TeamRecruitmentCategory> categories,
+        TeamRecruitmentMeetingType meetingType
+    ) {
+        BooleanBuilder filter = new BooleanBuilder(teamRecruitment.status.in(statuses(statusFilter)));
+        String normalized = normalize(keyword);
+        if (normalized != null) {
+            filter.and(keywordFilter(normalized));
+        }
+        if (categories != null && !categories.isEmpty()) {
+            filter.and(teamRecruitment.category.in(categories.stream().filter(Objects::nonNull).toList()));
+        }
+        if (meetingType != null) {
+            filter.and(teamRecruitment.meetingType.eq(meetingType));
+        }
+        return filter;
+    }
+
+    /**
+     * 검색어는 모집글 제목, 역할명, 카테고리 표시명, 진행 방식 표시명을 대상으로 부분 일치 비교한다.
+     * 본문(description)은 대상이 아니다.
+     * 역할은 exists 로 확인해 조인 때문에 모집글이 중복되지 않게 한다.
+     */
+    private BooleanBuilder keywordFilter(String keyword) {
+        BooleanBuilder keywordFilter = new BooleanBuilder(teamRecruitment.title.containsIgnoreCase(keyword));
+        keywordFilter.or(JPAExpressions.selectOne()
+            .from(teamRecruitmentRole)
+            .where(teamRecruitmentRole.recruitment.id.eq(teamRecruitment.id)
+                .and(teamRecruitmentRole.name.containsIgnoreCase(keyword)))
+            .exists());
+
+        List<TeamRecruitmentCategory> categories = TeamRecruitmentDisplayName.categoriesMatching(keyword);
+        if (!categories.isEmpty()) {
+            keywordFilter.or(teamRecruitment.category.in(categories));
+        }
+        List<TeamRecruitmentMeetingType> meetingTypes = TeamRecruitmentDisplayName.meetingTypesMatching(keyword);
+        if (!meetingTypes.isEmpty()) {
+            keywordFilter.or(teamRecruitment.meetingType.in(meetingTypes));
+        }
+        return keywordFilter;
+    }
+
+    private BooleanBuilder authorFilter(Integer authorId, TeamRecruitmentStatusFilter statusFilter) {
+        return new BooleanBuilder(teamRecruitment.author.id.eq(authorId))
+            .and(teamRecruitment.status.in(statuses(statusFilter)));
+    }
+
+    private List<TeamRecruitmentStatus> statuses(TeamRecruitmentStatusFilter statusFilter) {
+        TeamRecruitmentStatusFilter resolved =
+            statusFilter == null ? TeamRecruitmentStatusFilter.ALL : statusFilter;
+        return resolved.getStatuses();
+    }
+
+    private OrderSpecifier<?>[] orderBy(TeamRecruitmentSort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        if (sort == TeamRecruitmentSort.DEADLINE_ASC) {
+            orders.add(teamRecruitment.deadlineDate.asc());
+            orders.add(teamRecruitment.id.asc());
+        } else {
+            orders.add(teamRecruitment.createdAt.desc());
+            orders.add(teamRecruitment.id.desc());
+        }
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+
+    private String normalize(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return keyword.trim();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentClosureService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentClosureService.java
@@ -1,0 +1,234 @@
+package in.koreatech.koin.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.CHAT_ROOM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.RECRUITMENT_DELETED;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 작성자의 수동 마감과 삭제에 따른 후속 처리.
+ * <p>
+ * 마감 자동 처리 스케줄러는 RECRUITING 이고 지원 마감일이 지난 모집글만 대상으로 하므로,
+ * 작성자가 직접 마감하거나 삭제한 모집글은 스케줄러가 다시 잡지 않는다.
+ * 그래서 동일한 후속 처리를 이 컴포넌트가 담당한다.
+ * <p>
+ * 알림과 Outbox 적재 방식은 TeamRecruitmentDeadlineCloseProcessor 와 같은 규약을 따른다.
+ * eventKey 가 같으면 건너뛰므로 스케줄러와 중복 적재되지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TeamRecruitmentClosureService {
+
+    private static final String RECRUITMENT_CLOSED_REASON = "RECRUITMENT_CLOSED";
+    private static final String RECRUITMENT_DELETED_REASON = "RECRUITMENT_DELETED";
+    private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
+    private static final String AGGREGATE_TYPE = "TEAM_RECRUITMENT";
+    private static final int MESSAGE_PREVIEW_MAX_LENGTH = 255;
+
+    private final TeamRecruitmentApplicationRepository applicationRepository;
+    private final TeamRecruitmentChatRoomRepository chatRoomRepository;
+    private final TeamRecruitmentNotificationRepository notificationRepository;
+    private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
+
+    /**
+     * 대기 중인 지원서를 거절하고, 모든 채팅방을 읽기 전용으로 바꾸고,
+     * 대기 중이던 지원자와 승인된 팀원에게 알림을 남긴다.
+     */
+    public void onClosed(TeamRecruitment recruitment) {
+        List<TeamRecruitmentApplication> pending = findApplications(recruitment.getId(), PENDING);
+        List<TeamRecruitmentApplication> accepted = findApplications(recruitment.getId(), ACCEPTED);
+
+        rejectAll(pending, RECRUITMENT_CLOSED_REASON);
+        markRoomsReadOnly(recruitment.getId());
+        notifyRejected(recruitment, pending, closedRejectedMessage(recruitment));
+        notifyAccepted(recruitment, accepted, RECRUITMENT_CLOSED, closedMessage(recruitment));
+    }
+
+    /**
+     * 삭제도 마감과 같은 후속 처리를 하되 거절 사유와 알림 문구를 삭제 기준으로 남긴다.
+     */
+    public void onDeleted(TeamRecruitment recruitment) {
+        List<TeamRecruitmentApplication> pending = findApplications(recruitment.getId(), PENDING);
+        List<TeamRecruitmentApplication> accepted = findApplications(recruitment.getId(), ACCEPTED);
+
+        rejectAll(pending, RECRUITMENT_DELETED_REASON);
+        markRoomsReadOnly(recruitment.getId());
+        notifyRejected(recruitment, pending, deletedRejectedMessage(recruitment));
+        notifyAccepted(recruitment, accepted, RECRUITMENT_DELETED, deletedMessage(recruitment));
+    }
+
+    /**
+     * 정원이 차서 자동 마감되는 경우. 기한 경과나 수동 마감과 달리 TEAM 채팅방은 ACTIVE 를 유지한다.
+     */
+    public void onCapacityFull(TeamRecruitment recruitment) {
+        List<TeamRecruitmentApplication> pending = findApplications(recruitment.getId(), PENDING);
+        List<TeamRecruitmentApplication> accepted = findApplications(recruitment.getId(), ACCEPTED);
+
+        rejectAll(pending, RECRUITMENT_CLOSED_REASON);
+        notifyRejected(recruitment, pending, closedRejectedMessage(recruitment));
+        notifyAccepted(recruitment, accepted, RECRUITMENT_CLOSED, closedMessage(recruitment));
+    }
+
+    private List<TeamRecruitmentApplication> findApplications(
+        Integer recruitmentId,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        Page<TeamRecruitmentApplication> page = applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            recruitmentId, List.of(status), Pageable.unpaged());
+        return page == null ? List.of() : page.getContent();
+    }
+
+    private void rejectAll(List<TeamRecruitmentApplication> applications, String reason) {
+        applications.forEach(application -> application.reject(reason));
+    }
+
+    private void markRoomsReadOnly(Integer recruitmentId) {
+        List<TeamRecruitmentChatRoom> chatRooms = chatRoomRepository.findAllByRecruitment_Id(recruitmentId);
+        if (chatRooms == null) {
+            return;
+        }
+        chatRooms.stream()
+            .filter(chatRoom -> chatRoom.getStatus() == ACTIVE)
+            .forEach(TeamRecruitmentChatRoom::markReadOnly);
+    }
+
+    private void notifyRejected(
+        TeamRecruitment recruitment,
+        List<TeamRecruitmentApplication> pending,
+        String messagePreview
+    ) {
+        for (TeamRecruitmentApplication application : pending) {
+            TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+                .recipient(application.getApplicant())
+                .type(APPLICATION_REJECTED)
+                .targetType(MY_APPLICATIONS)
+                .messagePreview(messagePreview)
+                .recruitment(recruitment)
+                .application(application)
+                .build();
+            saveNotificationAndOutbox(notification, eventKey(application.getId(), APPLICATION_REJECTED),
+                application.getId(), null);
+        }
+    }
+
+    private void notifyAccepted(
+        TeamRecruitment recruitment,
+        List<TeamRecruitmentApplication> accepted,
+        TeamRecruitmentNotificationType type,
+        String messagePreview
+    ) {
+        if (accepted.isEmpty()) {
+            return;
+        }
+        TeamRecruitmentChatRoom teamRoom = chatRoomRepository
+            .findByRecruitment_IdAndRoomScopeKey(recruitment.getId(), TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY)
+            .orElse(null);
+        for (TeamRecruitmentApplication application : accepted) {
+            TeamRecruitmentNotification notification = TeamRecruitmentNotification.builder()
+                .recipient(application.getApplicant())
+                .type(type)
+                .targetType(teamRoom == null ? MY_APPLICATIONS : CHAT_ROOM)
+                .messagePreview(messagePreview)
+                .recruitment(recruitment)
+                .application(application)
+                .chatRoom(teamRoom)
+                .build();
+            saveNotificationAndOutbox(notification, eventKey(application.getId(), type),
+                application.getId(), teamRoom == null ? null : teamRoom.getId());
+        }
+    }
+
+    private void saveNotificationAndOutbox(
+        TeamRecruitmentNotification notification,
+        String eventKey,
+        Integer applicationId,
+        Integer chatRoomId
+    ) {
+        if (outboxEventRepository.findByEventKey(eventKey).isPresent()) {
+            return;
+        }
+        TeamRecruitmentNotification saved = notificationRepository.save(notification);
+        if (saved == null) {
+            saved = notification;
+        }
+        outboxEventRepository.save(TeamRecruitmentOutboxEvent.builder()
+            .eventKey(eventKey)
+            .eventType(OUTBOX_EVENT_TYPE)
+            .aggregateType(AGGREGATE_TYPE)
+            .aggregateId(notification.getRecruitment().getId())
+            .payload(payload(saved, applicationId, chatRoomId))
+            .status(TeamRecruitmentOutboxEventStatus.PENDING)
+            .build());
+    }
+
+    private String payload(TeamRecruitmentNotification notification, Integer applicationId, Integer chatRoomId) {
+        Integer recipientId = notification.getRecipient() == null ? null : notification.getRecipient().getId();
+        return "{"
+            + "\"type\":\"" + notification.getType().name() + "\","
+            + "\"target_type\":\"" + notification.getTargetType().name() + "\","
+            + "\"recipient_id\":" + jsonNumber(recipientId) + ","
+            + "\"recruitment_id\":" + jsonNumber(notification.getRecruitment().getId()) + ","
+            + "\"application_id\":" + jsonNumber(applicationId) + ","
+            + "\"chat_room_id\":" + jsonNumber(chatRoomId) + ","
+            + "\"notification_id\":" + jsonNumber(notification.getId())
+            + "}";
+    }
+
+    private String eventKey(Integer applicationId, TeamRecruitmentNotificationType type) {
+        return "team-recruitment:application:" + applicationId + ":" + type.name();
+    }
+
+    private String jsonNumber(Integer value) {
+        return value == null ? "null" : value.toString();
+    }
+
+    private String closedRejectedMessage(TeamRecruitment recruitment) {
+        return truncate("지원하신 " + title(recruitment) + " 모집이 마감되어 지원이 거절되었어요.");
+    }
+
+    private String deletedRejectedMessage(TeamRecruitment recruitment) {
+        return truncate("지원하신 " + title(recruitment) + " 모집이 삭제되어 지원이 취소되었어요.");
+    }
+
+    private String closedMessage(TeamRecruitment recruitment) {
+        return truncate(title(recruitment) + " 모집이 마감되었어요.");
+    }
+
+    private String deletedMessage(TeamRecruitment recruitment) {
+        return truncate(title(recruitment) + " 모집이 삭제되었어요.");
+    }
+
+    private String title(TeamRecruitment recruitment) {
+        return recruitment.getTitle() == null ? "팀원 모집" : recruitment.getTitle();
+    }
+
+    private String truncate(String message) {
+        return message.length() <= MESSAGE_PREVIEW_MAX_LENGTH
+            ? message
+            : message.substring(0, MESSAGE_PREVIEW_MAX_LENGTH);
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentProfileService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentProfileService.java
@@ -1,0 +1,109 @@
+package in.koreatech.koin.domain.team.recruitment.service;
+
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_PROFILE_NOT_FOUND;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.team.recruitment.dto.ProfileActivityInput;
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.TeamRecruitmentProfileUpsertRequest;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfile;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileActivity;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileSkill;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamRecruitmentProfileService {
+
+    // display_order 는 CHECK 제약이 1 이상을 요구한다.
+    private static final int FIRST_DISPLAY_ORDER = 1;
+
+    private final TeamRecruitmentProfileRepository teamRecruitmentProfileRepository;
+    private final StudentRepository studentRepository;
+    private final EntityManager entityManager;
+
+    public TeamRecruitmentProfileResponse getMyProfile(Integer userId) {
+        TeamRecruitmentProfile profile = teamRecruitmentProfileRepository.findByUser_Id(userId)
+            .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_PROFILE_NOT_FOUND, "userId: " + userId));
+        return TeamRecruitmentProfileResponse.of(profile, studentRepository.getById(userId));
+    }
+
+    @Transactional
+    public TeamRecruitmentProfileResponse upsertMyProfile(
+        Integer userId,
+        TeamRecruitmentProfileUpsertRequest request
+    ) {
+        Student student = studentRepository.getById(userId);
+        TeamRecruitmentProfile profile = teamRecruitmentProfileRepository.findByUser_Id(userId)
+            .orElseGet(() -> createProfile(student, request));
+        profile.replace(request.profileNickname(), request.preferredRole(), request.selfIntroduction());
+        replaceSkillsAndActivities(profile, request);
+        entityManager.flush();
+        return TeamRecruitmentProfileResponse.of(profile, student);
+    }
+
+    private TeamRecruitmentProfile createProfile(Student student, TeamRecruitmentProfileUpsertRequest request) {
+        return teamRecruitmentProfileRepository.save(
+            TeamRecruitmentProfile.builder()
+                .user(student.getUser())
+                .profileNickname(request.profileNickname())
+                .preferredRole(request.preferredRole())
+                .selfIntroduction(request.selfIntroduction())
+                .build()
+        );
+    }
+
+    /**
+     * 기술과 활동 내역은 (profile_user_id, display_order)에 unique 제약이 있다.
+     * 기존 행을 지우기 전에 새 행이 insert 되면 제약을 위반하므로,
+     * 목록을 비운 뒤 flush 해서 delete 를 먼저 내보낸다.
+     */
+    private void replaceSkillsAndActivities(
+        TeamRecruitmentProfile profile,
+        TeamRecruitmentProfileUpsertRequest request
+    ) {
+        profile.replaceSkills(List.of());
+        profile.replaceActivities(List.of());
+        entityManager.flush();
+
+        profile.replaceSkills(toSkills(request.skills()));
+        profile.replaceActivities(toActivities(request.activities()));
+    }
+
+    private List<TeamRecruitmentProfileSkill> toSkills(List<String> skills) {
+        return IntStream.range(0, skills.size())
+            .mapToObj(index -> TeamRecruitmentProfileSkill.builder()
+                .skill(skills.get(index))
+                .displayOrder(index + FIRST_DISPLAY_ORDER)
+                .build())
+            .toList();
+    }
+
+    private List<TeamRecruitmentProfileActivity> toActivities(List<ProfileActivityInput> activities) {
+        return IntStream.range(0, activities.size())
+            .mapToObj(index -> toActivity(activities.get(index), index + FIRST_DISPLAY_ORDER))
+            .toList();
+    }
+
+    private TeamRecruitmentProfileActivity toActivity(ProfileActivityInput input, int displayOrder) {
+        return TeamRecruitmentProfileActivity.builder()
+            .title(input.title())
+            .startedAt(input.startedAt())
+            .endedAt(input.endedAt())
+            .isOngoing(input.isOngoing())
+            .description(input.description())
+            .displayOrder(displayOrder)
+            .build();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentQueryService.java
@@ -1,0 +1,223 @@
+package in.koreatech.koin.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.ALREADY_APPLIED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.DEADLINE_PASSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.LOGIN_REQUIRED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.OWN_RECRUITMENT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.PROFILE_REQUIRED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.RECRUITMENT_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.RECRUITMENT_DELETED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.ROLE_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.team.recruitment.dto.CreatedRecruitment;
+import in.koreatech.koin.domain.team.recruitment.dto.CreatedRecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCard;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCards;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentDetail;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentListResponse;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentListQueryRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamRecruitmentQueryService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final TeamRecruitmentRepository teamRecruitmentRepository;
+    private final TeamRecruitmentListQueryRepository listQueryRepository;
+    private final TeamRecruitmentApplicationRepository applicationRepository;
+    private final TeamRecruitmentProfileRepository profileRepository;
+    private final TeamRecruitmentChatRoomRepository chatRoomRepository;
+    private final Clock clock;
+
+    public RecruitmentListResponse getRecruitments(
+        String keyword,
+        TeamRecruitmentStatusFilter statusFilter,
+        List<TeamRecruitmentCategory> categories,
+        TeamRecruitmentMeetingType meetingType,
+        TeamRecruitmentSort sort,
+        Integer page,
+        Integer limit
+    ) {
+        long total = listQueryRepository.count(keyword, statusFilter, categories, meetingType);
+        Criteria criteria = Criteria.of(page, limit, (int) total);
+        List<TeamRecruitment> recruitments =
+            listQueryRepository.findAll(keyword, statusFilter, categories, meetingType, sort, criteria);
+        return RecruitmentListResponse.of(pageOf(recruitments, criteria, total), criteria, today());
+    }
+
+    public CreatedRecruitmentListResponse getMyCreatedRecruitments(
+        Integer userId,
+        TeamRecruitmentStatusFilter statusFilter,
+        TeamRecruitmentSort sort,
+        Integer page,
+        Integer limit
+    ) {
+        long total = listQueryRepository.countByAuthor(userId, statusFilter);
+        Criteria criteria = Criteria.of(page, limit, (int) total);
+        List<TeamRecruitment> recruitments = listQueryRepository.findAllByAuthor(userId, statusFilter, sort, criteria);
+
+        LocalDate today = today();
+        List<CreatedRecruitment> created = recruitments.stream()
+            .map(recruitment -> CreatedRecruitment.of(
+                RecruitmentCards.of(recruitment, today),
+                applicantCountOf(recruitment),
+                recruitment.isRecruiting(),
+                teamChatRoomIdOf(recruitment.getId())
+            ))
+            .toList();
+        return CreatedRecruitmentListResponse.of(created, pageOf(recruitments, criteria, total), criteria);
+    }
+
+    public RecruitmentDetail getRecruitment(Integer recruitmentId, Integer userId) {
+        TeamRecruitment recruitment = teamRecruitmentRepository.findById(recruitmentId)
+            .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_NOT_FOUND, "recruitmentId: " + recruitmentId));
+        if (recruitment.isDeleted()) {
+            throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND, "recruitmentId: " + recruitmentId);
+        }
+        return toDetail(recruitment, userId);
+    }
+
+    private RecruitmentDetail toDetail(TeamRecruitment recruitment, Integer userId) {
+        RecruitmentCard card = RecruitmentCards.of(recruitment, today());
+        boolean isAuthor = userId != null && recruitment.getAuthor().getId().equals(userId);
+        Optional<TeamRecruitmentApplication> myApplication = userId == null
+            ? Optional.empty()
+            : applicationRepository.findByRecruitment_IdAndApplicant_Id(recruitment.getId(), userId);
+
+        TeamRecruitmentApplyBlockReason blockReason = applyBlockReasonOf(recruitment, userId, isAuthor, myApplication);
+        boolean accepted = myApplication
+            .map(application -> application.getStatus() == ACCEPTED)
+            .orElse(false);
+        Integer teamChatRoomId = (isAuthor || accepted) ? teamChatRoomIdOf(recruitment.getId()) : null;
+
+        return new RecruitmentDetail(
+            card.id(),
+            card.category(),
+            card.title(),
+            card.meetingType(),
+            card.activityStartDate(),
+            card.activityEndDate(),
+            card.deadlineDate(),
+            card.dDay(),
+            card.status(),
+            card.recruitmentType(),
+            card.currentParticipants(),
+            card.maxParticipants(),
+            card.roles(),
+            recruitment.getAuthor().getNickname(),
+            recruitment.getDescription(),
+            recruitment.getRelatedUrl(),
+            recruitment.getQualification(),
+            recruitment.getCreatedAt(),
+            isAuthor,
+            blockReason == null,
+            blockReason,
+            myApplication
+                .map(application -> new RecruitmentDetail.AppliedApplication(
+                    application.getId(), application.getStatus()))
+                .orElse(null),
+            isAuthor,
+            teamChatRoomId != null,
+            teamChatRoomId
+        );
+    }
+
+    /**
+     * 여러 사유가 동시에 성립하면 선언 순서가 이른 값을 반환한다. 지원 가능하면 null 이다.
+     * 순서는 클라이언트와 합의한 화면 안내 우선순위를 따른다.
+     */
+    private TeamRecruitmentApplyBlockReason applyBlockReasonOf(
+        TeamRecruitment recruitment,
+        Integer userId,
+        boolean isAuthor,
+        Optional<TeamRecruitmentApplication> myApplication
+    ) {
+        if (recruitment.isDeleted()) {
+            return RECRUITMENT_DELETED;
+        }
+        if (userId == null) {
+            return LOGIN_REQUIRED;
+        }
+        if (isAuthor) {
+            return OWN_RECRUITMENT;
+        }
+        if (myApplication.isPresent()) {
+            return ALREADY_APPLIED;
+        }
+        if (!recruitment.isRecruiting()) {
+            return RECRUITMENT_CLOSED;
+        }
+        if (today().isAfter(recruitment.getDeadlineDate())) {
+            return DEADLINE_PASSED;
+        }
+        if (isFullyClosed(recruitment)) {
+            return ROLE_CLOSED;
+        }
+        if (!profileRepository.existsByUser_Id(userId)) {
+            return PROFILE_REQUIRED;
+        }
+        return null;
+    }
+
+    /**
+     * 역할 구분 모집은 모든 역할이 마감되면, 역할 구분이 없는 모집은 전체 정원이 차면 지원할 수 없다.
+     */
+    private boolean isFullyClosed(TeamRecruitment recruitment) {
+        List<TeamRecruitmentRole> roles = recruitment.getRoles();
+        if (roles.isEmpty()) {
+            return recruitment.getCurrentParticipants() >= recruitment.getMaxParticipants();
+        }
+        return roles.stream().allMatch(TeamRecruitmentRole::isClosed);
+    }
+
+    private long applicantCountOf(TeamRecruitment recruitment) {
+        return applicationRepository.countByRecruitment_IdAndStatusIn(recruitment.getId(), List.of(PENDING, ACCEPTED));
+    }
+
+    private Integer teamChatRoomIdOf(Integer recruitmentId) {
+        return chatRoomRepository
+            .findByRecruitment_IdAndRoomScopeKey(recruitmentId, TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY)
+            .map(TeamRecruitmentChatRoom::getId)
+            .orElse(null);
+    }
+
+    private PageImpl<TeamRecruitment> pageOf(List<TeamRecruitment> content, Criteria criteria, long total) {
+        return new PageImpl<>(content, PageRequest.of(criteria.getPage(), criteria.getLimit()), total);
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(clock.withZone(KST));
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
@@ -1,0 +1,344 @@
+package in.koreatech.koin.domain.team.recruitment.service;
+
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import in.koreatech.koin.domain.team.recruitment.dto.CreateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.IdResponse;
+import in.koreatech.koin.domain.team.recruitment.dto.RoleInput;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRoleInput;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamRecruitmentService {
+
+    // display_order 는 CHECK 제약이 1 이상을 요구한다.
+    private static final int FIRST_DISPLAY_ORDER = 1;
+
+    // display_order 는 CHECK 제약이 1~5 만 허용한다.
+    private static final int MAX_DISPLAY_ORDER = 5;
+
+    // (recruitment_id, name) unique 제약을 피하기 위한 임시 이름. name 컬럼은 10자까지다.
+    private static final String TEMPORARY_NAME_PREFIX = "#";
+    private static final int MAX_ROLE_NAME_LENGTH = 10;
+
+    // 예약 이름은 기존 역할 5개와 요청 이름 5개를 합쳐 최대 10개다.
+    private static final int TEMPORARY_NAME_CANDIDATES = 32;
+
+    private final TeamRecruitmentRepository teamRecruitmentRepository;
+    private final TeamRecruitmentApplicationRepository applicationRepository;
+    private final TeamRecruitmentChatRoomRepository chatRoomRepository;
+    private final TeamRecruitmentChatMemberRepository chatMemberRepository;
+    private final UserRepository userRepository;
+    private final TeamRecruitmentClosureService closureService;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    /**
+     * 모집글과 TEAM 채팅방, 작성자 멤버를 같은 트랜잭션에서 생성한다.
+     */
+    @Transactional
+    public IdResponse createRecruitment(Integer userId, CreateRecruitmentRequest request) {
+        User author = userRepository.getById(userId);
+        TeamRecruitment recruitment = request.toEntity(author);
+        addRoles(recruitment, request.roles());
+
+        TeamRecruitment saved = teamRecruitmentRepository.save(recruitment);
+        createTeamChatRoom(saved, author);
+        return new IdResponse(saved.getId());
+    }
+
+    @Transactional
+    public void updateRecruitment(Integer userId, Integer recruitmentId, UpdateRecruitmentRequest request) {
+        TeamRecruitment recruitment = getModifiableRecruitment(userId, recruitmentId);
+        if (!recruitment.isRecruiting()) {
+            throw CustomException.of(TEAM_RECRUITMENT_CLOSED);
+        }
+
+        validateTypeChange(recruitment, request);
+        validateMaxParticipants(recruitment, request.resolveMaxParticipants());
+        replaceRoles(recruitment, request.roles());
+        recruitment.modify(
+            request.category(),
+            request.title(),
+            request.meetingType(),
+            request.activityStartDate(),
+            request.activityEndDate(),
+            request.deadlineDate(),
+            request.recruitmentType(),
+            request.resolveMaxParticipants(),
+            request.description(),
+            request.relatedUrl(),
+            request.qualification()
+        );
+        closeIfCapacityFull(recruitment);
+    }
+
+    /**
+     * 정원을 줄여 이미 승인된 인원과 같아지면 그 자리에서 마감된다.
+     * 정원 충족 자동 마감이므로 TEAM 채팅방은 ACTIVE 를 유지한다.
+     */
+    private void closeIfCapacityFull(TeamRecruitment recruitment) {
+        if (recruitment.getCurrentParticipants() < recruitment.getMaxParticipants()) {
+            return;
+        }
+        recruitment.close();
+        entityManager.flush();
+        closureService.onCapacityFull(recruitment);
+    }
+
+    /**
+     * soft delete 이며 이미 삭제된 모집글에 대한 재요청도 성공으로 처리한다.
+     */
+    @Transactional
+    public void deleteRecruitment(Integer userId, Integer recruitmentId) {
+        TeamRecruitment recruitment = getOwnedRecruitment(userId, recruitmentId);
+        if (recruitment.isDeleted()) {
+            return;
+        }
+        recruitment.markDeleted(LocalDateTime.now(clock));
+        closureService.onDeleted(recruitment);
+    }
+
+    /**
+     * 이미 마감된 모집글에 대한 재요청도 성공으로 처리한다.
+     */
+    @Transactional
+    public void closeRecruitment(Integer userId, Integer recruitmentId) {
+        TeamRecruitment recruitment = getModifiableRecruitment(userId, recruitmentId);
+        if (!recruitment.isRecruiting()) {
+            return;
+        }
+        recruitment.close();
+        closureService.onClosed(recruitment);
+    }
+
+    /**
+     * 지원자가 이미 있으면 모집 유형을 바꿀 수 없다.
+     * GENERAL 지원서는 역할이 없고 ROLE_BASED 지원서는 역할이 필수여서 전환하면 기존 지원서가 규칙을 어긴다.
+     */
+    private void validateTypeChange(TeamRecruitment recruitment, UpdateRecruitmentRequest request) {
+        if (recruitment.getRecruitmentType() == request.recruitmentType()) {
+            return;
+        }
+        if (applicationCountOf(recruitment) > 0) {
+            throw CustomException.of(TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED,
+                "recruitmentId: " + recruitment.getId());
+        }
+    }
+
+    /**
+     * 승인된 인원보다 적은 정원으로는 수정할 수 없다.
+     */
+    private void validateMaxParticipants(TeamRecruitment recruitment, int maxParticipants) {
+        if (maxParticipants < recruitment.getCurrentParticipants()) {
+            throw CustomException.of(TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED,
+                "recruitmentId: " + recruitment.getId());
+        }
+    }
+
+    /**
+     * 거절된 지원서도 모집글에 남아 role_id 규칙을 어기게 되므로 모든 상태를 센다.
+     */
+    private long applicationCountOf(TeamRecruitment recruitment) {
+        return applicationRepository.countByRecruitment_IdAndStatusIn(
+            recruitment.getId(), List.of(TeamRecruitmentApplicationStatus.values()));
+    }
+
+    private TeamRecruitment getOwnedRecruitment(Integer userId, Integer recruitmentId) {
+        TeamRecruitment recruitment = teamRecruitmentRepository.findByIdWithLock(recruitmentId)
+            .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_NOT_FOUND, "recruitmentId: " + recruitmentId));
+        if (!recruitment.getAuthor().getId().equals(userId)) {
+            throw CustomException.of(TEAM_RECRUITMENT_FORBIDDEN, "recruitmentId: " + recruitmentId);
+        }
+        return recruitment;
+    }
+
+    private TeamRecruitment getModifiableRecruitment(Integer userId, Integer recruitmentId) {
+        TeamRecruitment recruitment = getOwnedRecruitment(userId, recruitmentId);
+        if (recruitment.isDeleted()) {
+            throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND, "recruitmentId: " + recruitmentId);
+        }
+        return recruitment;
+    }
+
+    private void addRoles(TeamRecruitment recruitment, List<RoleInput> roles) {
+        IntStream.range(0, roles.size())
+            .forEach(index -> recruitment.addRole(TeamRecruitmentRole.builder()
+                .name(roles.get(index).name())
+                .maxParticipants(roles.get(index).maxParticipants())
+                .currentParticipants(0)
+                .displayOrder(index + FIRST_DISPLAY_ORDER)
+                .build()));
+    }
+
+    /**
+     * 지원자가 있는 역할은 삭제, 이름 변경, 정원 축소를 할 수 없다.
+     * 기존 역할은 id 로 갱신하고 id 가 없는 항목은 새 역할로 추가한다.
+     * <p>
+     * display_order 에는 (recruitment_id, display_order) unique 제약과 BETWEEN 1 AND 5 CHECK 가 함께 걸려 있다.
+     * 슬롯이 1~5 로 한정되어 있어 기존 역할의 순서를 서로 맞바꿀 임시 자리가 없으므로,
+     * 기존 역할은 자신의 순서를 유지하고 새 역할만 비어 있는 슬롯을 채운다.
+     * 삭제로 비는 슬롯을 새 역할이 쓸 수 있도록 삭제를 먼저 flush 한다.
+     * <p>
+     * 이름에도 (recruitment_id, name) unique 제약이 있어 두 역할의 이름을 서로 맞바꾸면
+     * 중간 update 에서 충돌한다. 그래서 이름이 바뀌는 역할을 먼저 임시 이름으로 옮기고
+     * flush 한 뒤 최종 이름을 부여한다.
+     */
+    private void replaceRoles(TeamRecruitment recruitment, List<UpdateRoleInput> requestedRoles) {
+        Map<Integer, TeamRecruitmentRole> existing = recruitment.getRoles().stream()
+            .collect(Collectors.toMap(TeamRecruitmentRole::getId, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<Integer> usedOrders = new HashSet<>();
+        List<UpdateRoleInput> newRoles = new ArrayList<>();
+        Map<TeamRecruitmentRole, UpdateRoleInput> renamed = new LinkedHashMap<>();
+        for (UpdateRoleInput requested : requestedRoles) {
+            if (requested.isNew()) {
+                newRoles.add(requested);
+                continue;
+            }
+            TeamRecruitmentRole role = existing.remove(requested.id());
+            if (role == null) {
+                throw CustomException.of(TEAM_RECRUITMENT_ROLE_NOT_FOUND, "roleId: " + requested.id());
+            }
+            validateRoleModifiable(role, requested);
+            usedOrders.add(role.getDisplayOrder());
+            if (role.getName().equals(requested.name())) {
+                role.modify(requested.name(), requested.maxParticipants(), role.getDisplayOrder());
+            } else {
+                renamed.put(role, requested);
+            }
+        }
+
+        existing.values().forEach(this::validateRoleRemovable);
+        existing.values().forEach(recruitment::removeRole);
+        moveRenamedToTemporaryNames(renamed, recruitment, requestedRoles);
+        entityManager.flush();
+
+        renamed.forEach((role, requested) ->
+            role.modify(requested.name(), requested.maxParticipants(), role.getDisplayOrder()));
+        for (UpdateRoleInput requested : newRoles) {
+            recruitment.addRole(TeamRecruitmentRole.builder()
+                .name(requested.name())
+                .maxParticipants(requested.maxParticipants())
+                .currentParticipants(0)
+                .displayOrder(nextFreeDisplayOrder(usedOrders))
+                .build());
+        }
+    }
+
+    /**
+     * 이름이 바뀌는 역할을 다른 어떤 이름과도 겹치지 않는 임시 이름으로 옮긴다.
+     */
+    private void moveRenamedToTemporaryNames(
+        Map<TeamRecruitmentRole, UpdateRoleInput> renamed,
+        TeamRecruitment recruitment,
+        List<UpdateRoleInput> requestedRoles
+    ) {
+        if (renamed.isEmpty()) {
+            return;
+        }
+        Set<String> reserved = new HashSet<>();
+        recruitment.getRoles().forEach(role -> reserved.add(role.getName()));
+        requestedRoles.forEach(requested -> reserved.add(requested.name()));
+        for (TeamRecruitmentRole role : renamed.keySet()) {
+            role.modify(temporaryName(reserved), role.getMaxParticipants(), role.getDisplayOrder());
+        }
+    }
+
+    /**
+     * 역할 이름에 쓸 수 있는 문자에 제한이 없으므로 "#0" 같은 이름도 사용자가 쓸 수 있다.
+     * 예약된 이름은 기존 역할과 요청 이름을 합쳐 최대 10개라, 후보를 그보다 넉넉히 두면 항상 빈 자리가 있다.
+     * 후보는 잘림이 일어나지 않는 길이로만 만든다.
+     */
+    private String temporaryName(Set<String> reserved) {
+        for (int candidate = 0; candidate < TEMPORARY_NAME_CANDIDATES; candidate++) {
+            String name = TEMPORARY_NAME_PREFIX + candidate;
+            if (name.length() <= MAX_ROLE_NAME_LENGTH && reserved.add(name)) {
+                return name;
+            }
+        }
+        throw CustomException.of(TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+    }
+
+    private int nextFreeDisplayOrder(Set<Integer> usedOrders) {
+        for (int order = FIRST_DISPLAY_ORDER; order <= MAX_DISPLAY_ORDER; order++) {
+            if (usedOrders.add(order)) {
+                return order;
+            }
+        }
+        throw CustomException.of(TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+    }
+
+    private void validateRoleModifiable(TeamRecruitmentRole role, UpdateRoleInput requested) {
+        boolean renamed = !role.getName().equals(requested.name());
+        boolean capacityReduced = requested.maxParticipants() < role.getMaxParticipants();
+        if ((renamed || capacityReduced) && hasApplicants(role)) {
+            throw CustomException.of(TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED, "roleId: " + role.getId());
+        }
+    }
+
+    private void validateRoleRemovable(TeamRecruitmentRole role) {
+        if (hasApplicants(role)) {
+            throw CustomException.of(TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED, "roleId: " + role.getId());
+        }
+    }
+
+    /**
+     * 거절된 지원서도 역할을 계속 참조하고 role_id FK 가 ON DELETE RESTRICT 이므로
+     * 한 번이라도 지원서가 생긴 역할은 삭제, 이름 변경, 정원 축소를 막는다.
+     */
+    private boolean hasApplicants(TeamRecruitmentRole role) {
+        return Arrays.stream(TeamRecruitmentApplicationStatus.values())
+            .anyMatch(status -> applicationRepository.countByRole_IdAndStatus(role.getId(), status) > 0);
+    }
+
+    private void createTeamChatRoom(TeamRecruitment recruitment, User author) {
+        TeamRecruitmentChatRoom room = chatRoomRepository.save(TeamRecruitmentChatRoom.createTeamRoom(recruitment));
+        TeamRecruitmentChatMember member = TeamRecruitmentChatMember.builder()
+            .chatRoom(room)
+            .user(author)
+            .build();
+        room.addMember(member);
+        chatMemberRepository.save(member);
+    }
+}

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -92,6 +92,11 @@ public enum ApiResponseCode {
     CALLVAN_POST_AUTHOR(HttpStatus.BAD_REQUEST, "콜벤 게시글 작성자는 나갈 수 없습니다"),
     CALLVAN_REPORT_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 신고할 수 없습니다."),
     CALLVAN_REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 콜벤 신고입니다."),
+    TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "진행 중인 활동이 아닌 경우, 활동 종료일은 필수입니다."),
+    TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL(HttpStatus.BAD_REQUEST, "진행 중인 활동인 경우, 활동 종료일은 입력하면 안 됩니다."),
+    TEAM_RECRUITMENT_INVALID_DEADLINE_DATE(HttpStatus.BAD_REQUEST, "지원 마감일은 활동 시작일 이하여야 합니다."),
+    TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION(HttpStatus.BAD_REQUEST, "모집 유형에 맞지 않는 역할 또는 정원 구성입니다."),
+    TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME(HttpStatus.BAD_REQUEST, "역할명은 중복될 수 없습니다."),
 
     /**
      * 401 Unauthorized (인증 필요)
@@ -150,6 +155,7 @@ public enum ApiResponseCode {
     TEAM_RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "팀원 모집글이 존재하지 않습니다."),
     TEAM_RECRUITMENT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "팀원 모집 프로필이 존재하지 않습니다."),
     TEAM_RECRUITMENT_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "팀원 모집 지원서가 존재하지 않습니다."),
+    TEAM_RECRUITMENT_ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모집글의 역할이 존재하지 않습니다."),
 
     /**
      * 409 CONFLICT (중복 혹은 충돌)
@@ -175,6 +181,9 @@ public enum ApiResponseCode {
     TEAM_RECRUITMENT_PROFILE_REQUIRED(HttpStatus.CONFLICT, "팀원 모집 프로필 작성이 필요합니다."),
     TEAM_RECRUITMENT_APPLICATION_DUPLICATE(HttpStatus.CONFLICT, "이미 지원한 팀원 모집글입니다."),
     TEAM_RECRUITMENT_APPLICATION_FINALIZED(HttpStatus.CONFLICT, "이미 처리된 팀원 모집 지원서입니다."),
+    TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED(HttpStatus.CONFLICT, "지원자가 있는 역할은 삭제, 이름 변경, 정원 축소를 할 수 없습니다."),
+    TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED(HttpStatus.CONFLICT, "승인된 인원보다 적은 정원으로 수정할 수 없습니다."),
+    TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED(HttpStatus.CONFLICT, "지원자가 있으면 모집 유형을 변경할 수 없습니다."),
 
     /**
      * 429 Too Many Requests (요청량 초과)

--- a/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
@@ -59,6 +59,7 @@ public class SwaggerGroupConfig {
                 "in.koreatech.koin.domain.banner",
                 "in.koreatech.koin.domain.club",
                 "in.koreatech.koin.domain.callvan",
+                "in.koreatech.koin.domain.team",
                 "in.koreatech.koin.domain.weather"
             });
     }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -1,0 +1,440 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRoleRepository;
+
+/**
+ * 담당 API 의 요청/응답 계약과 인증, 권한을 확인한다.
+ */
+class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private TeamRecruitmentRoleRepository roleRepository;
+
+    @Autowired
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private TeamRecruitmentChatMemberRepository chatMemberRepository;
+
+    private Student author;
+    private Student otherStudent;
+    private String authorToken;
+    private String otherToken;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        author = userFixture.준호_학생(department, null);
+        otherStudent = userFixture.성빈_학생(department);
+        authorToken = userFixture.getToken(author.getUser());
+        otherToken = userFixture.getToken(otherStudent.getUser());
+    }
+
+    private String roleBasedBody(String roles) {
+        return """
+            {
+              "category": "CONTEST",
+              "title": "AI 아이디어 공모전 팀원 모집",
+              "meeting_type": "ONLINE",
+              "activity_start_date": "%s",
+              "activity_end_date": "%s",
+              "deadline_date": "%s",
+              "recruitment_type": "ROLE_BASED",
+              "roles": [%s],
+              "description": "공모전 팀원을 모집합니다.",
+              "related_url": "https://example.com",
+              "qualification": "기획 경험이 있는 분"
+            }
+            """.formatted(
+            LocalDate.now(clock).plusDays(10),
+            LocalDate.now(clock).plusDays(20),
+            LocalDate.now(clock).plusDays(3),
+            roles);
+    }
+
+    private String generalBody(int maxParticipants) {
+        return """
+            {
+              "category": "STUDY",
+              "title": "알고리즘 스터디",
+              "meeting_type": "ONLINE",
+              "activity_start_date": "%s",
+              "activity_end_date": "%s",
+              "deadline_date": "%s",
+              "recruitment_type": "GENERAL",
+              "max_participants": %d,
+              "roles": [],
+              "description": "스터디원을 모집합니다.",
+              "related_url": null,
+              "qualification": null
+            }
+            """.formatted(
+            LocalDate.now(clock).plusDays(10),
+            LocalDate.now(clock).plusDays(20),
+            LocalDate.now(clock).plusDays(3),
+            maxParticipants);
+    }
+
+    private TeamRecruitment saveRecruitment(Student writer, String title) {
+        return recruitmentRepository.save(TeamRecruitment.builder()
+            .author(writer.getUser())
+            .category(PROJECT)
+            .title(title)
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(10))
+            .activityEndDate(LocalDate.now(clock).plusDays(20))
+            .deadlineDate(LocalDate.now(clock).plusDays(3))
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(RECRUITING)
+            .build());
+    }
+
+    @Nested
+    @DisplayName("POST /team-recruitments")
+    class CreateRecruitment {
+
+        @Test
+        @DisplayName("ROLE_BASED 모집글과 TEAM 채팅방, 작성자 멤버가 함께 생성된다")
+        void createsRoleBasedRecruitmentWithTeamRoom() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(roleBasedBody("""
+                        {"name": "PM", "max_participants": 1},
+                        {"name": "Backend", "max_participants": 2}
+                        """)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists());
+
+            TeamRecruitment saved = recruitmentRepository
+                .findAllByAuthor_Id(author.getUser().getId(), org.springframework.data.domain.Pageable.unpaged())
+                .getContent().get(0);
+            assertThat(saved.getMaxParticipants()).isEqualTo(3);
+            assertThat(roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(saved.getId()))
+                .extracting(role -> role.getDisplayOrder())
+                .containsExactly(1, 2);
+            assertThat(chatRoomRepository.findAllByRecruitment_Id(saved.getId())).hasSize(1);
+            Integer teamRoomId = chatRoomRepository.findAllByRecruitment_Id(saved.getId()).get(0).getId();
+            assertThat(chatMemberRepository.existsByChatRoom_IdAndUser_Id(teamRoomId, author.getUser().getId()))
+                .isTrue();
+        }
+
+        @Test
+        @DisplayName("GENERAL 모집글을 생성한다")
+        void createsGeneralRecruitment() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("미인증 요청은 401 이다")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("역할 정원의 합이 10을 넘으면 400 이다")
+        void totalCapacityOverLimit() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(roleBasedBody("""
+                        {"name": "Backend", "max_participants": 6},
+                        {"name": "Frontend", "max_participants": 6}
+                        """)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST_BODY"));
+        }
+
+        @Test
+        @DisplayName("역할명이 대소문자만 달라도 400 이다")
+        void duplicateRoleName() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(roleBasedBody("""
+                        {"name": "PM", "max_participants": 1},
+                        {"name": "pm", "max_participants": 1}
+                        """)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME"));
+        }
+
+        @Test
+        @DisplayName("지원 마감일이 활동 시작일보다 이후면 400 이다")
+        void deadlineAfterActivityStart() throws Exception {
+            String body = """
+                {
+                  "category": "STUDY",
+                  "title": "잘못된 기간",
+                  "meeting_type": "ONLINE",
+                  "activity_start_date": "%s",
+                  "activity_end_date": "%s",
+                  "deadline_date": "%s",
+                  "recruitment_type": "GENERAL",
+                  "max_participants": 3,
+                  "roles": [],
+                  "description": "설명",
+                  "related_url": null,
+                  "qualification": null
+                }
+                """.formatted(
+                LocalDate.now(clock).plusDays(10),
+                LocalDate.now(clock).plusDays(20),
+                LocalDate.now(clock).plusDays(11));
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_INVALID_DEADLINE_DATE"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /team-recruitments")
+    class GetRecruitments {
+
+        @Test
+        @DisplayName("비로그인으로 목록을 조회하고 페이지네이션 필드를 받는다")
+        void listsWithoutLogin() throws Exception {
+            saveRecruitment(author, "첫 번째");
+            saveRecruitment(author, "두 번째");
+
+            mockMvc.perform(get("/team-recruitments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_count").value(2))
+                .andExpect(jsonPath("$.current_count").value(2))
+                .andExpect(jsonPath("$.total_page").value(1))
+                .andExpect(jsonPath("$.current_page").value(1))
+                .andExpect(jsonPath("$.recruitments[0].d_day").exists())
+                .andExpect(jsonPath("$.recruitments[0].status").value("RECRUITING"));
+        }
+
+        @Test
+        @DisplayName("limit 은 50 을 넘지 않도록 보정된다")
+        void clampsLimit() throws Exception {
+            saveRecruitment(author, "하나");
+
+            mockMvc.perform(get("/team-recruitments").param("limit", "100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_count").value(1));
+        }
+
+        @Test
+        @DisplayName("잘못된 정렬 값은 400 ILLEGAL_ARGUMENT 이다")
+        void invalidSort() throws Exception {
+            mockMvc.perform(get("/team-recruitments").param("sort", "UNKNOWN"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+        }
+
+        @Test
+        @DisplayName("잘못된 상태, 카테고리, 진행 방식 값도 400 ILLEGAL_ARGUMENT 이다")
+        void invalidEnumParameters() throws Exception {
+            for (String parameter : new String[] {"status", "categories", "meetingType"}) {
+                mockMvc.perform(get("/team-recruitments").param(parameter, "UNKNOWN"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+            }
+        }
+
+        @Test
+        @DisplayName("enum 영문 이름으로는 검색되지 않는다")
+        void doesNotSearchEnumName() throws Exception {
+            saveRecruitment(author, "가나다");
+
+            mockMvc.perform(get("/team-recruitments").param("keyword", "test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_count").value(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /team-recruitments/{recruitmentId}")
+    class GetRecruitment {
+
+        @Test
+        @DisplayName("비로그인 조회는 사용자별 필드가 비어 있다")
+        void anonymousDetail() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "상세");
+
+            mockMvc.perform(get("/team-recruitments/{id}", recruitment.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.is_author").value(false))
+                .andExpect(jsonPath("$.can_apply").value(false))
+                .andExpect(jsonPath("$.apply_block_reason").value("LOGIN_REQUIRED"))
+                .andExpect(jsonPath("$.application").doesNotExist())
+                .andExpect(jsonPath("$.team_chat_available").value(false));
+        }
+
+        @Test
+        @DisplayName("작성자 조회는 관리 권한과 팀 채팅방 정보를 받는다")
+        void authorDetail() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isCreated());
+            TeamRecruitment saved = recruitmentRepository
+                .findAllByAuthor_Id(author.getUser().getId(), org.springframework.data.domain.Pageable.unpaged())
+                .getContent().get(0);
+
+            mockMvc.perform(get("/team-recruitments/{id}", saved.getId())
+                    .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.is_author").value(true))
+                .andExpect(jsonPath("$.can_manage_applicants").value(true))
+                .andExpect(jsonPath("$.apply_block_reason").value("OWN_RECRUITMENT"))
+                .andExpect(jsonPath("$.team_chat_available").value(true))
+                .andExpect(jsonPath("$.team_chat_room_id").isNumber());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 모집글은 404 이다")
+        void notFound() throws Exception {
+            mockMvc.perform(get("/team-recruitments/{id}", 999999))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /team-recruitments/me/created")
+    class GetMyCreated {
+
+        @Test
+        @DisplayName("내가 작성한 모집글만 작성자 화면 필드와 함께 반환한다")
+        void listsOnlyMine() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isCreated());
+            saveRecruitment(otherStudent, "남의 글");
+
+            mockMvc.perform(get("/team-recruitments/me/created")
+                    .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total_count").value(1))
+                .andExpect(jsonPath("$.recruitments[0].applicant_count").value(0))
+                .andExpect(jsonPath("$.recruitments[0].can_close").value(true))
+                .andExpect(jsonPath("$.recruitments[0].team_chat_available").value(true))
+                .andExpect(jsonPath("$.recruitments[0].team_chat_room_id").isNumber());
+        }
+
+        @Test
+        @DisplayName("미인증 요청은 401 이다")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(get("/team-recruitments/me/created"))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("잘못된 정렬 값은 400 ILLEGAL_ARGUMENT 이다")
+        void invalidSort() throws Exception {
+            mockMvc.perform(get("/team-recruitments/me/created")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .param("sort", "UNKNOWN"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("ILLEGAL_ARGUMENT"));
+        }
+    }
+
+    @Nested
+    @DisplayName("작성자만 가능한 요청")
+    class AuthorOnly {
+
+        @Test
+        @DisplayName("타인은 수정할 수 없다")
+        void otherCannotUpdate() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "내 글");
+
+            mockMvc.perform(put("/team-recruitments/{id}", recruitment.getId())
+                    .header("Authorization", "Bearer " + otherToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_FORBIDDEN"));
+        }
+
+        @Test
+        @DisplayName("타인은 삭제할 수 없다")
+        void otherCannotDelete() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "내 글");
+
+            mockMvc.perform(delete("/team-recruitments/{id}", recruitment.getId())
+                    .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("타인은 마감할 수 없다")
+        void otherCannotClose() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "내 글");
+
+            mockMvc.perform(put("/team-recruitments/{id}/close", recruitment.getId())
+                    .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("미인증 삭제 요청은 401 이다")
+        void unauthenticatedDelete() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "내 글");
+
+            mockMvc.perform(delete("/team-recruitments/{id}", recruitment.getId()))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
@@ -1,0 +1,354 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.DELETED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.ROLE_BASED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfile;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRoleRepository;
+
+/**
+ * 모집글 마감/삭제 후속 처리와 역할 수정 시 DB 제약을 실제 DB 로 검증한다.
+ * 단위 테스트는 EntityManager 를 mock 하므로 unique/FK 위반을 잡지 못한다.
+ */
+class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private TeamRecruitmentRoleRepository roleRepository;
+
+    @Autowired
+    private TeamRecruitmentProfileRepository profileRepository;
+
+    @Autowired
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Autowired
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private TeamRecruitmentChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private TeamRecruitmentNotificationRepository notificationRepository;
+
+    private static final String PROFILE_SNAPSHOT = """
+        {
+          "nickname": "지원자",
+          "department": "컴퓨터공학부",
+          "student_year": 2023,
+          "preferred_role": "백엔드",
+          "skills": [],
+          "activities": [],
+          "self_introduction": "소개"
+        }
+        """;
+
+    private Student author;
+    private Student applicant;
+    private String authorToken;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        author = userFixture.준호_학생(department, null);
+        applicant = userFixture.성빈_학생(department);
+        authorToken = userFixture.getToken(author.getUser());
+        profileRepository.save(TeamRecruitmentProfile.builder()
+            .user(applicant.getUser())
+            .profileNickname("지원자")
+            .preferredRole("백엔드")
+            .selfIntroduction("소개")
+            .build());
+    }
+
+    @Test
+    @DisplayName("수동 마감하면 대기 지원서가 거절되고 채팅방이 READ_ONLY 로 바뀌며 알림이 남는다")
+    void 수동_마감_후속_처리() throws Exception {
+        TeamRecruitment recruitment = saveGeneralRecruitment("수동 마감", 3, 0);
+        TeamRecruitmentChatRoom teamRoom = saveTeamRoom(recruitment);
+        TeamRecruitmentApplication application = saveApplication(recruitment, null, PENDING);
+
+        mockMvc.perform(put("/team-recruitments/{id}/close", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNoContent());
+
+        assertThat(recruitmentRepository.findById(recruitment.getId()).orElseThrow().getStatus())
+            .isEqualTo(CLOSED);
+        assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
+            .isEqualTo(REJECTED);
+        assertThat(chatRoomRepository.findById(teamRoom.getId()).orElseThrow().getStatus())
+            .isEqualTo(READ_ONLY);
+        assertThat(notificationRepository.findAllByRecipient_IdAndIsDeletedFalse(applicant.getUser().getId()))
+            .extracting(TeamRecruitmentNotification::getType)
+            .contains(APPLICATION_REJECTED);
+    }
+
+    @Test
+    @DisplayName("삭제하면 대기 지원서가 취소되고 삭제 문구로 알림이 남는다")
+    void 삭제_후속_처리() throws Exception {
+        TeamRecruitment recruitment = saveGeneralRecruitment("삭제", 3, 0);
+        TeamRecruitmentChatRoom teamRoom = saveTeamRoom(recruitment);
+        TeamRecruitmentApplication application = saveApplication(recruitment, null, PENDING);
+
+        mockMvc.perform(delete("/team-recruitments/{id}", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNoContent());
+
+        assertThat(recruitmentRepository.findById(recruitment.getId()).orElseThrow().getStatus())
+            .isEqualTo(DELETED);
+        assertThat(applicationRepository.findById(application.getId()).orElseThrow().getDecisionReason())
+            .isEqualTo("RECRUITMENT_DELETED");
+        assertThat(chatRoomRepository.findById(teamRoom.getId()).orElseThrow().getStatus())
+            .isEqualTo(READ_ONLY);
+        assertThat(notificationRepository.findAllByRecipient_IdAndIsDeletedFalse(applicant.getUser().getId()))
+            .extracting(TeamRecruitmentNotification::getMessagePreview)
+            .anyMatch(message -> message.contains("삭제되어"));
+    }
+
+    @Test
+    @DisplayName("정원을 승인 인원과 같게 줄이면 마감되지만 TEAM 채팅방은 ACTIVE 를 유지한다")
+    void 정원_충족_자동_마감() throws Exception {
+        TeamRecruitment recruitment = saveGeneralRecruitment("정원 충족", 3, 1);
+        TeamRecruitmentChatRoom teamRoom = saveTeamRoom(recruitment);
+        saveApplication(recruitment, null, ACCEPTED);
+
+        mockMvc.perform(put("/team-recruitments/{id}", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(generalBody(1)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("CLOSED"));
+
+        assertThat(chatRoomRepository.findById(teamRoom.getId()).orElseThrow().getStatus())
+            .isEqualTo(ACTIVE);
+    }
+
+    @Test
+    @DisplayName("두 역할의 이름을 서로 맞바꿔도 unique 제약을 위반하지 않는다")
+    void 역할_이름_교환() throws Exception {
+        TeamRecruitment recruitment = saveRoleBasedRecruitment();
+        List<TeamRecruitmentRole> roles =
+            roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(recruitment.getId());
+        Integer first = roles.get(0).getId();
+        Integer second = roles.get(1).getId();
+
+        mockMvc.perform(put("/team-recruitments/{id}", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(roleBasedBody("""
+                    {"id": %d, "name": "Backend", "max_participants": 1},
+                    {"id": %d, "name": "PM", "max_participants": 2}
+                    """.formatted(first, second))))
+            .andExpect(status().isOk());
+
+        assertThat(roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(recruitment.getId()))
+            .extracting(TeamRecruitmentRole::getId, TeamRecruitmentRole::getName)
+            .containsExactly(
+                tuple(first, "Backend"),
+                tuple(second, "PM"));
+    }
+
+    @Test
+    @DisplayName("거절된 지원서만 남은 역할도 삭제할 수 없다")
+    void 거절된_지원서가_있는_역할_삭제_차단() throws Exception {
+        TeamRecruitment recruitment = saveRoleBasedRecruitment();
+        List<TeamRecruitmentRole> roles =
+            roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(recruitment.getId());
+        TeamRecruitmentRole target = roles.get(0);
+        saveApplication(recruitment, target, REJECTED);
+
+        mockMvc.perform(put("/team-recruitments/{id}", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(roleBasedBody("""
+                    {"id": %d, "name": "PM", "max_participants": 2}
+                    """.formatted(roles.get(1).getId()))))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED"));
+
+        assertThat(roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(recruitment.getId()))
+            .hasSize(2);
+    }
+
+    @Test
+    @DisplayName("마감된 모집글은 정원이 남은 역할도 is_closed 가 true 이다")
+    void 마감된_모집글의_역할은_닫힌다() throws Exception {
+        TeamRecruitment recruitment = saveRoleBasedRecruitment();
+
+        mockMvc.perform(put("/team-recruitments/{id}/close", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/team-recruitments/{id}", recruitment.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("CLOSED"))
+            .andExpect(jsonPath("$.roles[0].is_closed").value(true))
+            .andExpect(jsonPath("$.roles[1].is_closed").value(true));
+    }
+
+    private TeamRecruitment saveGeneralRecruitment(String title, int maxParticipants, int currentParticipants) {
+        return recruitmentRepository.save(TeamRecruitment.builder()
+            .author(author.getUser())
+            .category(PROJECT)
+            .title(title)
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(2))
+            .activityEndDate(LocalDate.now(clock).plusDays(10))
+            .deadlineDate(LocalDate.now(clock).plusDays(1))
+            .recruitmentType(GENERAL)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(currentParticipants)
+            .description("모집 내용")
+            .status(RECRUITING)
+            .build());
+    }
+
+    private TeamRecruitment saveRoleBasedRecruitment() {
+        TeamRecruitment recruitment = TeamRecruitment.builder()
+            .author(author.getUser())
+            .category(PROJECT)
+            .title("역할 모집")
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(2))
+            .activityEndDate(LocalDate.now(clock).plusDays(10))
+            .deadlineDate(LocalDate.now(clock).plusDays(1))
+            .recruitmentType(ROLE_BASED)
+            .maxParticipants(3)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(RECRUITING)
+            .build();
+        recruitment.addRole(TeamRecruitmentRole.builder()
+            .name("PM").maxParticipants(1).currentParticipants(0).displayOrder(1).build());
+        recruitment.addRole(TeamRecruitmentRole.builder()
+            .name("Backend").maxParticipants(2).currentParticipants(0).displayOrder(2).build());
+        return recruitmentRepository.save(recruitment);
+    }
+
+    private TeamRecruitmentChatRoom saveTeamRoom(TeamRecruitment recruitment) {
+        TeamRecruitmentChatRoom teamRoom =
+            chatRoomRepository.save(TeamRecruitmentChatRoom.createTeamRoom(recruitment));
+        chatMemberRepository.save(TeamRecruitmentChatMember.builder()
+            .chatRoom(teamRoom)
+            .user(author.getUser())
+            .build());
+        return teamRoom;
+    }
+
+    private TeamRecruitmentApplication saveApplication(
+        TeamRecruitment recruitment,
+        TeamRecruitmentRole role,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        return applicationRepository.save(TeamRecruitmentApplication.builder()
+            .recruitment(recruitment)
+            .applicant(applicant.getUser())
+            .role(role)
+            .motivation("지원 동기")
+            .availability("월수금")
+            .status(status)
+            .profileSnapshot(PROFILE_SNAPSHOT)
+            .snapshotVersion(1)
+            .build());
+    }
+
+    private String generalBody(int maxParticipants) {
+        return """
+            {
+              "category": "PROJECT",
+              "title": "수정된 제목",
+              "meeting_type": "ONLINE",
+              "activity_start_date": "%s",
+              "activity_end_date": "%s",
+              "deadline_date": "%s",
+              "recruitment_type": "GENERAL",
+              "max_participants": %d,
+              "roles": [],
+              "description": "수정한 내용",
+              "related_url": null,
+              "qualification": null
+            }
+            """.formatted(
+            LocalDate.now(clock).plusDays(2),
+            LocalDate.now(clock).plusDays(10),
+            LocalDate.now(clock).plusDays(1),
+            maxParticipants);
+    }
+
+    private String roleBasedBody(String roles) {
+        return """
+            {
+              "category": "PROJECT",
+              "title": "수정된 제목",
+              "meeting_type": "ONLINE",
+              "activity_start_date": "%s",
+              "activity_end_date": "%s",
+              "deadline_date": "%s",
+              "recruitment_type": "ROLE_BASED",
+              "roles": [%s],
+              "description": "수정한 내용",
+              "related_url": null,
+              "qualification": null
+            }
+            """.formatted(
+            LocalDate.now(clock).plusDays(2),
+            LocalDate.now(clock).plusDays(10),
+            LocalDate.now(clock).plusDays(1),
+            roles);
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentProfileApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentProfileApiTest.java
@@ -1,0 +1,298 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileActivity;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentProfileSkill;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileActivityRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileSkillRepository;
+
+/**
+ * 팀원 모집 프로필 API 의 요청/응답 계약과 upsert 동작을 확인한다.
+ */
+class TeamRecruitmentProfileApiTest extends AcceptanceTest {
+
+    private static final String URL = "/team-recruitment-profiles/me";
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private TeamRecruitmentProfileRepository profileRepository;
+
+    @Autowired
+    private TeamRecruitmentProfileSkillRepository skillRepository;
+
+    @Autowired
+    private TeamRecruitmentProfileActivityRepository activityRepository;
+
+    private Student student;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        student = userFixture.준호_학생(department, null);
+        token = userFixture.getToken(student.getUser());
+    }
+
+    private static final String UPSERT_BODY = """
+        {
+          "profile_nickname": "홍길동",
+          "preferred_role": "기획",
+          "skills": ["정보처리기사", "SQLD", "피그마"],
+          "activities": [
+            {
+              "title": "AI 공모전",
+              "started_at": "2025-03-03",
+              "ended_at": "2025-05-05",
+              "is_ongoing": false,
+              "description": "기획 담당"
+            },
+            {
+              "title": "교내 동아리",
+              "started_at": "2025-06-01",
+              "ended_at": null,
+              "is_ongoing": true,
+              "description": "진행 중"
+            }
+          ],
+          "self_introduction": "안녕하세요."
+        }
+        """;
+
+    private static final String UPDATED_BODY = """
+        {
+          "profile_nickname": "수정된닉",
+          "preferred_role": "백엔드",
+          "skills": ["Java"],
+          "activities": [
+            {
+              "title": "오픈소스",
+              "started_at": "2026-01-01",
+              "ended_at": "2026-02-01",
+              "is_ongoing": false,
+              "description": "기여"
+            }
+          ],
+          "self_introduction": "수정했습니다."
+        }
+        """;
+
+    private static String activityBody(String endedAt, boolean isOngoing) {
+        return """
+            {
+              "profile_nickname": "홍길동",
+              "preferred_role": "기획",
+              "skills": [],
+              "activities": [
+                {
+                  "title": "활동",
+                  "started_at": "2025-03-03",
+                  "ended_at": %s,
+                  "is_ongoing": %s,
+                  "description": "설명"
+                }
+              ],
+              "self_introduction": "소개"
+            }
+            """.formatted(endedAt, isOngoing);
+    }
+
+    @Nested
+    @DisplayName("GET /team-recruitment-profiles/me")
+    class GetProfile {
+
+        @Test
+        @DisplayName("프로필이 없으면 404 이다")
+        void notFoundWhenAbsent() throws Exception {
+            mockMvc.perform(get(URL).header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_PROFILE_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("미인증 요청은 401 이다")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(get(URL)).andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("저장한 프로필을 학적 정보와 함께 반환한다")
+        void returnsProfileWithAcademicInfo() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(UPSERT_BODY))
+                .andExpect(status().isOk());
+
+            mockMvc.perform(get(URL).header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile_nickname").value("홍길동"))
+                .andExpect(jsonPath("$.department").value("컴퓨터공학부"))
+                .andExpect(jsonPath("$.student_number").value(student.getStudentNumber()))
+                .andExpect(jsonPath("$.preferred_role").value("기획"))
+                .andExpect(jsonPath("$.skills.length()").value(3))
+                .andExpect(jsonPath("$.activities.length()").value(2))
+                .andExpect(jsonPath("$.self_introduction").value("안녕하세요."));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /team-recruitment-profiles/me")
+    class UpsertProfile {
+
+        @Test
+        @DisplayName("프로필을 생성하고 활동 id 를 채워서 반환한다")
+        void createsProfile() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(UPSERT_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activities[0].id").isNumber())
+                .andExpect(jsonPath("$.activities[0].title").value("AI 공모전"))
+                .andExpect(jsonPath("$.activities[0].is_ongoing").value(false))
+                .andExpect(jsonPath("$.activities[1].ended_at").doesNotExist())
+                .andExpect(jsonPath("$.activities[1].is_ongoing").value(true));
+
+            Integer userId = student.getUser().getId();
+            assertThat(skillRepository.findAllByProfile_UserIdOrderByDisplayOrderAsc(userId))
+                .extracting(TeamRecruitmentProfileSkill::getDisplayOrder)
+                .containsExactly(1, 2, 3);
+            assertThat(activityRepository.findAllByProfile_UserIdOrderByDisplayOrderAsc(userId))
+                .extracting(TeamRecruitmentProfileActivity::getDisplayOrder)
+                .containsExactly(1, 2);
+        }
+
+        @Test
+        @DisplayName("재요청은 기술과 활동을 전부 대체한다")
+        void replacesSkillsAndActivities() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(UPSERT_BODY))
+                .andExpect(status().isOk());
+
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(UPDATED_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile_nickname").value("수정된닉"))
+                .andExpect(jsonPath("$.skills.length()").value(1))
+                .andExpect(jsonPath("$.activities.length()").value(1));
+
+            Integer userId = student.getUser().getId();
+            assertThat(profileRepository.findByUser_Id(userId)).isPresent();
+            assertThat(skillRepository.findAllByProfile_UserIdOrderByDisplayOrderAsc(userId)).hasSize(1);
+            assertThat(activityRepository.findAllByProfile_UserIdOrderByDisplayOrderAsc(userId)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("같은 요청을 반복해도 성공한다")
+        void isIdempotent() throws Exception {
+            for (int attempt = 0; attempt < 2; attempt++) {
+                mockMvc.perform(put(URL)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATED_BODY))
+                    .andExpect(status().isOk());
+            }
+        }
+
+        @Test
+        @DisplayName("미인증 요청은 401 이다")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(put(URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(UPSERT_BODY))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("진행 중이 아닌 활동에 종료일이 없으면 400 이다")
+        void endDateRequired() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityBody("null", false)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED"));
+        }
+
+        @Test
+        @DisplayName("진행 중인 활동에 종료일이 있으면 400 이다")
+        void endDateMustBeNull() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityBody("\"2025-05-05\"", true)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL"));
+        }
+
+        @Test
+        @DisplayName("하루짜리 활동은 종료일이 시작일과 같아도 저장된다")
+        void allowsSingleDayActivity() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityBody("\"2025-03-03\"", false)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activities[0].ended_at").value("2025-03-03"));
+        }
+
+        @Test
+        @DisplayName("종료일이 시작일보다 이전이면 400 이다")
+        void endDateBeforeStartDate() throws Exception {
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityBody("\"2025-03-02\"", false)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_START_DATE_AFTER_END_DATE"));
+        }
+
+        @Test
+        @DisplayName("닉네임이 20자를 넘으면 400 이다")
+        void nicknameTooLong() throws Exception {
+            String body = """
+                {
+                  "profile_nickname": "%s",
+                  "preferred_role": "기획",
+                  "skills": [],
+                  "activities": [],
+                  "self_introduction": "소개"
+                }
+                """.formatted("가".repeat(21));
+
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/repository/TeamRecruitmentListQueryRepositoryTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/repository/TeamRecruitmentListQueryRepositoryTest.java
@@ -1,0 +1,422 @@
+package in.koreatech.koin.acceptance.repository;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.CONTEST;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.STUDY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.OFFLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort.DEADLINE_ASC;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort.LATEST_DESC;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.DELETED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter.ALL;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.ROLE_BASED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.common.model.Criteria;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatusFilter;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentListQueryRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+
+/**
+ * 모집글 목록 조회 QueryDSL 검증. 필터 조합과 정렬, 페이지 경계, 삭제 제외를 실제 DB 로 확인한다.
+ */
+class TeamRecruitmentListQueryRepositoryTest extends AcceptanceTest {
+
+    @Autowired
+    private TeamRecruitmentListQueryRepository listQueryRepository;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    private Student author;
+    private Student otherAuthor;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        author = userFixture.준호_학생(department, null);
+        otherAuthor = userFixture.성빈_학생(department);
+    }
+
+    private TeamRecruitment save(
+        Student writer,
+        String title,
+        TeamRecruitmentCategory category,
+        TeamRecruitmentMeetingType meetingType,
+        TeamRecruitmentStatus status,
+        LocalDate deadline
+    ) {
+        return recruitmentRepository.save(TeamRecruitment.builder()
+            .author(writer.getUser())
+            .category(category)
+            .title(title)
+            .meetingType(meetingType)
+            .activityStartDate(LocalDate.now(clock).plusDays(10))
+            .activityEndDate(LocalDate.now(clock).plusDays(20))
+            .deadlineDate(deadline)
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(status)
+            .deletedAt(status == DELETED ? LocalDateTime.now(clock) : null)
+            .build());
+    }
+
+    private TeamRecruitment save(String title, TeamRecruitmentCategory category) {
+        return save(author, title, category, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+    }
+
+    private TeamRecruitment saveWithRoles(String title, String... roleNames) {
+        TeamRecruitment recruitment = TeamRecruitment.builder()
+            .author(author.getUser())
+            .category(PROJECT)
+            .title(title)
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(10))
+            .activityEndDate(LocalDate.now(clock).plusDays(20))
+            .deadlineDate(LocalDate.now(clock).plusDays(3))
+            .recruitmentType(ROLE_BASED)
+            .maxParticipants(roleNames.length)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(RECRUITING)
+            .build();
+        for (int index = 0; index < roleNames.length; index++) {
+            recruitment.addRole(TeamRecruitmentRole.builder()
+                .name(roleNames[index])
+                .maxParticipants(1)
+                .currentParticipants(0)
+                .displayOrder(index + 1)
+                .build());
+        }
+        return recruitmentRepository.save(recruitment);
+    }
+
+    private List<String> titlesOf(List<TeamRecruitment> recruitments) {
+        return recruitments.stream().map(TeamRecruitment::getTitle).toList();
+    }
+
+    private List<TeamRecruitment> findAll(
+        String keyword,
+        TeamRecruitmentStatusFilter statusFilter,
+        List<TeamRecruitmentCategory> categories,
+        TeamRecruitmentMeetingType meetingType,
+        in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSort sort,
+        int page,
+        int limit
+    ) {
+        long total = listQueryRepository.count(keyword, statusFilter, categories, meetingType);
+        Criteria criteria = Criteria.of(page, limit, (int) total);
+        return listQueryRepository.findAll(keyword, statusFilter, categories, meetingType, sort, criteria);
+    }
+
+    @Nested
+    @DisplayName("keyword 검색")
+    class KeywordSearch {
+
+        @Test
+        @DisplayName("제목에 포함된 검색어로 찾는다")
+        void searchesByTitle() {
+            save("AI 공모전 팀원 모집", CONTEST);
+            save("알고리즘 스터디", STUDY);
+
+            List<TeamRecruitment> found = findAll("공모전", ALL, null, null, LATEST_DESC, 1, 10);
+
+            assertThat(titlesOf(found)).containsExactly("AI 공모전 팀원 모집");
+        }
+
+        @Test
+        @DisplayName("검색어는 대소문자를 구분하지 않는다")
+        void searchesCaseInsensitively() {
+            save("Backend Study", STUDY);
+
+            assertThat(findAll("backend", ALL, null, null, LATEST_DESC, 1, 10)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("본문은 검색 대상이 아니다")
+        void doesNotSearchDescription() {
+            save("제목에는 없음", STUDY);
+
+            assertThat(findAll("모집 내용", ALL, null, null, LATEST_DESC, 1, 10)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("카테고리 표시명으로 찾는다")
+        void searchesByCategoryDisplayName() {
+            save("이름에 없음", STUDY);
+            save("여기도 없음", CONTEST);
+
+            assertThat(titlesOf(findAll("스터디", ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("이름에 없음");
+        }
+
+        @Test
+        @DisplayName("진행 방식 표시명으로 찾는다")
+        void searchesByMeetingTypeDisplayName() {
+            save(author, "온라인 글", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "대면 글", PROJECT, OFFLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+
+            assertThat(titlesOf(findAll("오프라인", ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("대면 글");
+        }
+
+        @Test
+        @DisplayName("역할명으로 찾고 모집글이 중복되지 않는다")
+        void searchesByRoleName() {
+            TeamRecruitment withRoles = saveWithRoles("역할 있는 글", "Backend", "Frontend");
+            save("역할 없는 글", STUDY);
+
+            List<TeamRecruitment> found = findAll("backend", ALL, null, null, LATEST_DESC, 1, 10);
+
+            assertThat(titlesOf(found)).containsExactly("역할 있는 글");
+            assertThat(found.get(0).getId()).isEqualTo(withRoles.getId());
+            assertThat(listQueryRepository.count("backend", ALL, null, null)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("여러 역할명이 검색어를 포함해도 모집글은 한 번만 나온다")
+        void doesNotDuplicateWhenSeveralRolesMatch() {
+            saveWithRoles("중복 확인", "PM Back", "Sub Back");
+
+            assertThat(findAll("back", ALL, null, null, LATEST_DESC, 1, 10)).hasSize(1);
+            assertThat(listQueryRepository.count("back", ALL, null, null)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("카테고리 enum 영문 이름은 검색 대상이 아니다")
+        void doesNotSearchCategoryEnumName() {
+            save("가나다", CONTEST);
+
+            assertThat(findAll("test", ALL, null, null, LATEST_DESC, 1, 10)).isEmpty();
+            assertThat(findAll("contest", ALL, null, null, LATEST_DESC, 1, 10)).isEmpty();
+            assertThat(listQueryRepository.count("test", ALL, null, null)).isZero();
+        }
+
+        @Test
+        @DisplayName("진행 방식 enum 영문 이름은 검색 대상이 아니다")
+        void doesNotSearchMeetingTypeEnumName() {
+            save(author, "가나다", CONTEST, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+
+            assertThat(findAll("line", ALL, null, null, LATEST_DESC, 1, 10)).isEmpty();
+            assertThat(findAll("online", ALL, null, null, LATEST_DESC, 1, 10)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("표시명 검색은 여전히 동작한다")
+        void stillSearchesDisplayName() {
+            save("가나다", CONTEST);
+
+            assertThat(titlesOf(findAll("공모전", ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("가나다");
+            assertThat(titlesOf(findAll("온라인", ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("가나다");
+        }
+
+        @Test
+        @DisplayName("검색어가 공백이면 필터로 쓰지 않는다")
+        void blankKeywordIsIgnored() {
+            save("첫 번째", STUDY);
+            save("두 번째", STUDY);
+
+            assertThat(findAll("   ", ALL, null, null, LATEST_DESC, 1, 10)).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("필터 조합")
+    class Filters {
+
+        @Test
+        @DisplayName("카테고리를 복수로 지정할 수 있다")
+        void filtersByCategories() {
+            save("공모전", CONTEST);
+            save("스터디", STUDY);
+            save("프로젝트", PROJECT);
+
+            List<TeamRecruitment> found =
+                findAll(null, ALL, List.of(CONTEST, PROJECT), null, LATEST_DESC, 1, 10);
+
+            assertThat(titlesOf(found)).containsExactlyInAnyOrder("공모전", "프로젝트");
+        }
+
+        @Test
+        @DisplayName("진행 방식으로 걸러낸다")
+        void filtersByMeetingType() {
+            save(author, "온라인", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "오프라인", STUDY, OFFLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+
+            assertThat(titlesOf(findAll(null, ALL, null, OFFLINE, LATEST_DESC, 1, 10)))
+                .containsExactly("오프라인");
+        }
+
+        @Test
+        @DisplayName("모집 상태로 걸러낸다")
+        void filtersByStatus() {
+            save(author, "모집중", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "마감", STUDY, ONLINE, CLOSED, LocalDate.now(clock).plusDays(3));
+
+            assertThat(titlesOf(findAll(null, TeamRecruitmentStatusFilter.RECRUITING, null, null,
+                LATEST_DESC, 1, 10))).containsExactly("모집중");
+            assertThat(titlesOf(findAll(null, TeamRecruitmentStatusFilter.CLOSED, null, null,
+                LATEST_DESC, 1, 10))).containsExactly("마감");
+            assertThat(findAll(null, ALL, null, null, LATEST_DESC, 1, 10)).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("검색어와 카테고리, 진행 방식을 함께 적용한다")
+        void combinesFilters() {
+            save(author, "AI 공모전", CONTEST, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "AI 공모전 오프라인", CONTEST, OFFLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "AI 스터디", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+
+            assertThat(titlesOf(findAll("AI", ALL, List.of(CONTEST), ONLINE, LATEST_DESC, 1, 10)))
+                .containsExactly("AI 공모전");
+        }
+
+        @Test
+        @DisplayName("삭제된 모집글은 어떤 필터에서도 제외된다")
+        void excludesDeleted() {
+            save(author, "살아있음", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "삭제됨", STUDY, ONLINE, DELETED, LocalDate.now(clock).plusDays(3));
+
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("살아있음");
+            assertThat(listQueryRepository.count(null, ALL, null, null)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("정렬")
+    class Sorting {
+
+        @Test
+        @DisplayName("LATEST_DESC 는 최근에 생성된 모집글이 먼저다")
+        void sortsByLatest() {
+            save("첫 번째", STUDY);
+            save("두 번째", STUDY);
+            save("세 번째", STUDY);
+
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 1, 10)))
+                .containsExactly("세 번째", "두 번째", "첫 번째");
+        }
+
+        @Test
+        @DisplayName("DEADLINE_ASC 는 마감이 임박한 모집글이 먼저다")
+        void sortsByDeadline() {
+            save(author, "늦은 마감", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(9));
+            save(author, "빠른 마감", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(1));
+            save(author, "중간 마감", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(5));
+
+            assertThat(titlesOf(findAll(null, ALL, null, null, DEADLINE_ASC, 1, 10)))
+                .containsExactly("빠른 마감", "중간 마감", "늦은 마감");
+        }
+    }
+
+    @Nested
+    @DisplayName("페이지 경계")
+    class Paging {
+
+        @BeforeEach
+        void saveFive() {
+            for (int index = 1; index <= 5; index++) {
+                save("모집글" + index, STUDY);
+            }
+        }
+
+        @Test
+        @DisplayName("첫 페이지는 limit 만큼 반환한다")
+        void firstPage() {
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 1, 2)))
+                .containsExactly("모집글5", "모집글4");
+        }
+
+        @Test
+        @DisplayName("마지막 페이지는 남은 개수만 반환한다")
+        void lastPage() {
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 3, 2)))
+                .containsExactly("모집글1");
+        }
+
+        @Test
+        @DisplayName("전체 페이지를 넘는 page 는 마지막 페이지로 보정된다")
+        void pageBeyondLastIsClamped() {
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 99, 2)))
+                .containsExactly("모집글1");
+        }
+
+        @Test
+        @DisplayName("1보다 작은 page 는 첫 페이지로 보정된다")
+        void pageBelowOneIsClamped() {
+            assertThat(titlesOf(findAll(null, ALL, null, null, LATEST_DESC, 0, 2)))
+                .containsExactly("모집글5", "모집글4");
+        }
+
+        @Test
+        @DisplayName("count 는 필터를 적용한 전체 개수를 반환한다")
+        void countAppliesFilter() {
+            assertThat(listQueryRepository.count(null, ALL, null, null)).isEqualTo(5);
+            assertThat(listQueryRepository.count("모집글1", ALL, null, null)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("작성자별 조회")
+    class ByAuthor {
+
+        @Test
+        @DisplayName("작성자의 모집글만 반환한다")
+        void filtersByAuthor() {
+            save(author, "내 글", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(otherAuthor, "남의 글", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+
+            Integer authorId = author.getUser().getId();
+            long total = listQueryRepository.countByAuthor(authorId, ALL);
+            Criteria criteria = Criteria.of(1, 10, (int) total);
+
+            assertThat(total).isEqualTo(1);
+            assertThat(titlesOf(listQueryRepository.findAllByAuthor(authorId, ALL, LATEST_DESC, criteria)))
+                .containsExactly("내 글");
+        }
+
+        @Test
+        @DisplayName("작성자별 조회에서도 삭제된 모집글은 제외된다")
+        void excludesDeletedForAuthor() {
+            save(author, "살아있음", STUDY, ONLINE, RECRUITING, LocalDate.now(clock).plusDays(3));
+            save(author, "삭제됨", STUDY, ONLINE, DELETED, LocalDate.now(clock).plusDays(3));
+
+            assertThat(listQueryRepository.countByAuthor(author.getUser().getId(), ALL)).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
@@ -1,0 +1,253 @@
+package in.koreatech.koin.unit.domain.team.recruitment.dto;
+
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.team.recruitment.dto.CreateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.RoleInput;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import in.koreatech.koin.global.exception.CustomException;
+
+class CreateRecruitmentRequestTest {
+
+    private static final LocalDate DEADLINE = LocalDate.of(2026, 9, 3);
+    private static final LocalDate ACTIVITY_START = LocalDate.of(2026, 9, 7);
+    private static final LocalDate ACTIVITY_END = LocalDate.of(2026, 9, 30);
+
+    private static CreateRecruitmentRequest create(
+        TeamRecruitmentType recruitmentType,
+        Integer maxParticipants,
+        List<RoleInput> roles,
+        LocalDate activityStartDate,
+        LocalDate activityEndDate,
+        LocalDate deadlineDate
+    ) {
+        return new CreateRecruitmentRequest(
+            TeamRecruitmentCategory.CONTEST,
+            "AI 아이디어 공모전 팀원 모집",
+            TeamRecruitmentMeetingType.ONLINE,
+            activityStartDate,
+            activityEndDate,
+            deadlineDate,
+            recruitmentType,
+            maxParticipants,
+            roles,
+            "공모전 팀원을 모집합니다.",
+            null,
+            null
+        );
+    }
+
+    private static CreateRecruitmentRequest roleBased(List<RoleInput> roles) {
+        return create(TeamRecruitmentType.ROLE_BASED, null, roles, ACTIVITY_START, ACTIVITY_END, DEADLINE);
+    }
+
+    private static CreateRecruitmentRequest general(Integer maxParticipants, List<RoleInput> roles) {
+        return create(TeamRecruitmentType.GENERAL, maxParticipants, roles, ACTIVITY_START, ACTIVITY_END, DEADLINE);
+    }
+
+    @Nested
+    @DisplayName("역할 구성 검증")
+    class RoleComposition {
+
+        @Test
+        @DisplayName("ROLE_BASED 모집의 전체 정원은 역할 정원의 합이다")
+        void roleBasedMaxParticipantsIsSumOfRoles() {
+            CreateRecruitmentRequest request = roleBased(List.of(
+                new RoleInput("PM", 1),
+                new RoleInput("프론트엔드", 2)
+            ));
+
+            assertThat(request.resolveMaxParticipants()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("GENERAL 모집의 전체 정원은 요청값을 그대로 사용한다")
+        void generalMaxParticipantsIsRequestValue() {
+            assertThat(general(5, List.of()).resolveMaxParticipants()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("ROLE_BASED 모집은 역할이 5개까지 허용된다")
+        void roleBasedAllowsFiveRoles() {
+            List<RoleInput> roles = IntStream.rangeClosed(1, 5)
+                .mapToObj(index -> new RoleInput("역할" + index, 1))
+                .toList();
+
+            assertThatCode(() -> roleBased(roles)).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("ROLE_BASED 모집에 역할이 없으면 예외가 발생한다")
+        void roleBasedRequiresAtLeastOneRole() {
+            assertThatThrownBy(() -> roleBased(List.of()))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+
+        @Test
+        @DisplayName("ROLE_BASED 모집의 역할이 5개를 넘으면 예외가 발생한다")
+        void roleBasedRejectsMoreThanFiveRoles() {
+            List<RoleInput> roles = IntStream.rangeClosed(1, 6)
+                .mapToObj(index -> new RoleInput("역할" + index, 1))
+                .toList();
+
+            assertThatThrownBy(() -> roleBased(roles))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+
+        @Test
+        @DisplayName("GENERAL 모집에 역할이 있으면 예외가 발생한다")
+        void generalRejectsRoles() {
+            assertThatThrownBy(() -> general(5, List.of(new RoleInput("PM", 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+
+        @Test
+        @DisplayName("GENERAL 모집에 전체 정원이 없으면 예외가 발생한다")
+        void generalRequiresMaxParticipants() {
+            assertThatThrownBy(() -> general(null, List.of()))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+
+        @Test
+        @DisplayName("GENERAL 모집의 전체 정원이 10을 넘으면 예외가 발생한다")
+        void generalRejectsMaxParticipantsOverLimit() {
+            assertThatThrownBy(() -> general(11, List.of()))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 정원과 역할명 중복 검증")
+    class CapacityAndDuplicateNames {
+
+        @Test
+        @DisplayName("역할 정원의 합이 10이면 통과한다")
+        void allowsTotalCapacityOfTen() {
+            assertThatCode(() -> roleBased(List.of(
+                new RoleInput("Backend", 5),
+                new RoleInput("Frontend", 5))))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("역할 정원의 합이 10을 넘으면 예외가 발생한다")
+        void rejectsTotalCapacityOverTen() {
+            assertThatThrownBy(() -> roleBased(List.of(
+                new RoleInput("Backend", 6),
+                new RoleInput("Frontend", 6))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_REQUEST_BODY);
+        }
+
+        @Test
+        @DisplayName("역할명이 같으면 예외가 발생한다")
+        void rejectsDuplicateRoleNames() {
+            assertThatThrownBy(() -> roleBased(List.of(
+                new RoleInput("PM", 1),
+                new RoleInput("PM", 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+        }
+
+        @Test
+        @DisplayName("역할명이 대소문자만 다르면 DB collation 기준으로 중복이다")
+        void rejectsRoleNamesDifferingOnlyByCase() {
+            assertThatThrownBy(() -> roleBased(List.of(
+                new RoleInput("PM", 1),
+                new RoleInput("pm", 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+        }
+
+        @Test
+        @DisplayName("역할명의 앞뒤 공백은 제거되어 저장된다")
+        void trimsRoleName() {
+            CreateRecruitmentRequest request = roleBased(List.of(new RoleInput("  PM  ", 1)));
+
+            assertThat(request.roles().get(0).name()).isEqualTo("PM");
+        }
+
+        @Test
+        @DisplayName("앞뒤 공백만 다른 역할명은 중복이다")
+        void rejectsRoleNamesDifferingOnlyBySurroundingSpace() {
+            assertThatThrownBy(() -> roleBased(List.of(
+                new RoleInput("PM", 1),
+                new RoleInput("PM ", 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+        }
+
+        @Test
+        @DisplayName("역할명이 악센트만 다르면 DB collation 기준으로 중복이다")
+        void rejectsRoleNamesDifferingOnlyByAccent() {
+            assertThatThrownBy(() -> roleBased(List.of(
+                new RoleInput("Cafe", 1),
+                new RoleInput("Café", 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+        }
+    }
+
+    @Nested
+    @DisplayName("기간 검증")
+    class Period {
+
+        private static final List<RoleInput> ROLES = List.of(new RoleInput("PM", 1));
+
+        @Test
+        @DisplayName("지원 마감일이 활동 시작일과 같아도 된다")
+        void deadlineCanEqualActivityStartDate() {
+            assertThatCode(() -> create(
+                TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_END, ACTIVITY_START))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("활동 시작일과 종료일이 같아도 된다")
+        void activityStartCanEqualActivityEnd() {
+            assertThatCode(() -> create(
+                TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_START, DEADLINE))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("지원 마감일이 활동 시작일보다 이후이면 예외가 발생한다")
+        void deadlineAfterActivityStartDateFails() {
+            assertThatThrownBy(() -> create(
+                TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_END, ACTIVITY_START.plusDays(1)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_DEADLINE_DATE);
+        }
+
+        @Test
+        @DisplayName("활동 종료일이 활동 시작일보다 이전이면 예외가 발생한다")
+        void activityEndBeforeActivityStartFails() {
+            assertThatThrownBy(() -> create(
+                TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_START.minusDays(1), DEADLINE))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_START_DATE_AFTER_END_DATE);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/ProfileActivityInputTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/ProfileActivityInputTest.java
@@ -1,0 +1,81 @@
+package in.koreatech.koin.unit.domain.team.recruitment.dto;
+
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.team.recruitment.dto.ProfileActivityInput;
+import in.koreatech.koin.global.exception.CustomException;
+
+class ProfileActivityInputTest {
+
+    private static final LocalDate STARTED_AT = LocalDate.of(2025, 3, 3);
+    private static final LocalDate ENDED_AT = LocalDate.of(2025, 5, 5);
+
+    private static ProfileActivityInput create(LocalDate endedAt, Boolean isOngoing) {
+        return new ProfileActivityInput("AI 공모전", STARTED_AT, endedAt, isOngoing, "기획 담당");
+    }
+
+    @Nested
+    @DisplayName("활동 기간 검증 성공")
+    class ValidateSuccess {
+
+        @Test
+        @DisplayName("진행 중인 활동은 종료일이 없어도 된다")
+        void ongoingActivityWithoutEndDate() {
+            assertThatCode(() -> create(null, true))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("종료된 활동은 종료일이 시작일보다 이후이면 된다")
+        void endedActivityWithEndDateAfterStartDate() {
+            assertThatCode(() -> create(ENDED_AT, false))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("하루짜리 활동은 종료일이 시작일과 같아도 된다")
+        void endedActivityWithEndDateEqualToStartDate() {
+            assertThatCode(() -> create(STARTED_AT, false))
+                .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("활동 기간 검증 실패")
+    class ValidateFail {
+
+        @Test
+        @DisplayName("진행 중인 활동에 종료일을 보내면 예외가 발생한다")
+        void ongoingActivityWithEndDate() {
+            assertThatThrownBy(() -> create(ENDED_AT, true))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL);
+        }
+
+        @Test
+        @DisplayName("종료된 활동에 종료일이 없으면 예외가 발생한다")
+        void endedActivityWithoutEndDate() {
+            assertThatThrownBy(() -> create(null, false))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("종료일이 시작일보다 이전이면 예외가 발생한다")
+        void endedActivityWithEndDateBeforeStartDate() {
+            assertThatThrownBy(() -> create(STARTED_AT.minusDays(1), false))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_START_DATE_AFTER_END_DATE);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/RecruitmentCardsTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/RecruitmentCardsTest.java
@@ -1,0 +1,34 @@
+package in.koreatech.koin.unit.domain.team.recruitment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCards;
+
+@DisplayName("D-day 계산")
+class RecruitmentCardsTest {
+
+    private static final LocalDate DEADLINE = LocalDate.of(2026, 9, 3);
+
+    @Test
+    @DisplayName("마감일까지 남은 일수를 반환한다")
+    void returnsDaysUntilDeadline() {
+        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE.minusDays(8))).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("마감일 당일은 0을 반환한다")
+    void returnsZeroOnDeadline() {
+        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE)).isZero();
+    }
+
+    @Test
+    @DisplayName("마감일이 지나면 null을 반환한다")
+    void returnsNullAfterDeadline() {
+        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE.plusDays(1))).isNull();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentQueryServiceTest.java
@@ -1,0 +1,423 @@
+package in.koreatech.koin.unit.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.ALREADY_APPLIED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.DEADLINE_PASSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.LOGIN_REQUIRED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.OWN_RECRUITMENT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.PROFILE_REQUIRED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.RECRUITMENT_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplyBlockReason.ROLE_CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.ROLE_BASED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentDetail;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentListQueryRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentProfileRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentQueryService;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.unit.fixture.UserFixture;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentQueryServiceTest {
+
+    private static final Integer AUTHOR_ID = 1;
+    private static final Integer VIEWER_ID = 2;
+    private static final Integer RECRUITMENT_ID = 17;
+    private static final Integer ROLE_ID = 4;
+    private static final Integer TEAM_ROOM_ID = 31;
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 30);
+
+    @InjectMocks
+    private TeamRecruitmentQueryService teamRecruitmentQueryService;
+
+    @Mock
+    private TeamRecruitmentRepository teamRecruitmentRepository;
+
+    @Mock
+    private TeamRecruitmentListQueryRepository listQueryRepository;
+
+    @Mock
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Mock
+    private TeamRecruitmentProfileRepository profileRepository;
+
+    @Mock
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-08-30T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private TeamRecruitment recruitment;
+
+    @BeforeEach
+    void setUp() {
+        recruitment = recruitment(ROLE_BASED, 3, 0, TODAY.plusDays(3));
+    }
+
+    private TeamRecruitment recruitment(
+        in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType type,
+        int maxParticipants,
+        int currentParticipants,
+        LocalDate deadline
+    ) {
+        User author = UserFixture.id_설정_코인_유저(AUTHOR_ID);
+        TeamRecruitment created = TeamRecruitment.builder()
+            .author(author)
+            .category(TeamRecruitmentCategory.CONTEST)
+            .title("AI 아이디어 공모전 팀원 모집")
+            .meetingType(TeamRecruitmentMeetingType.ONLINE)
+            .activityStartDate(TODAY.plusDays(10))
+            .activityEndDate(TODAY.plusDays(20))
+            .deadlineDate(deadline)
+            .recruitmentType(type)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(currentParticipants)
+            .description("공모전 팀원을 모집합니다.")
+            .build();
+        ReflectionTestUtils.setField(created, "id", RECRUITMENT_ID);
+        if (type == ROLE_BASED) {
+            created.addRole(role(ROLE_ID, 3, 0));
+        }
+        return created;
+    }
+
+    private static TeamRecruitmentRole role(Integer id, int maxParticipants, int currentParticipants) {
+        TeamRecruitmentRole role = TeamRecruitmentRole.builder()
+            .name("PM")
+            .maxParticipants(maxParticipants)
+            .currentParticipants(currentParticipants)
+            .displayOrder(1)
+            .build();
+        ReflectionTestUtils.setField(role, "id", id);
+        return role;
+    }
+
+    private void givenFound() {
+        when(teamRecruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+    }
+
+    private void givenHasProfile(boolean hasProfile) {
+        lenient().when(profileRepository.existsByUser_Id(anyInt())).thenReturn(hasProfile);
+    }
+
+    private void givenNoApplication() {
+        lenient().when(applicationRepository.findByRecruitment_IdAndApplicant_Id(anyInt(), anyInt()))
+            .thenReturn(Optional.empty());
+    }
+
+    private void givenApplication(TeamRecruitmentApplicationStatus status) {
+        TeamRecruitmentApplication application = TeamRecruitmentApplication.builder()
+            .recruitment(recruitment)
+            .applicant(UserFixture.id_설정_코인_유저(VIEWER_ID))
+            .motivation("지원 동기")
+            .availability("월수금")
+            .status(status)
+            .profileSnapshot("{}")
+            .snapshotVersion(1)
+            .build();
+        ReflectionTestUtils.setField(application, "id", 51);
+        lenient().when(applicationRepository.findByRecruitment_IdAndApplicant_Id(anyInt(), anyInt()))
+            .thenReturn(Optional.of(application));
+    }
+
+    private void givenTeamRoom() {
+        TeamRecruitmentChatRoom teamRoom = TeamRecruitmentChatRoom.createTeamRoom(recruitment);
+        ReflectionTestUtils.setField(teamRoom, "id", TEAM_ROOM_ID);
+        lenient().when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(anyInt(), anyString()))
+            .thenReturn(Optional.of(teamRoom));
+    }
+
+    private RecruitmentDetail detail(Integer userId) {
+        return teamRecruitmentQueryService.getRecruitment(RECRUITMENT_ID, userId);
+    }
+
+    @Nested
+    @DisplayName("지원 불가 사유")
+    class ApplyBlockReason {
+
+        @Test
+        @DisplayName("비로그인 조회는 LOGIN_REQUIRED 이다")
+        void loginRequired() {
+            givenFound();
+
+            RecruitmentDetail response = detail(null);
+
+            assertThat(response.applyBlockReason()).isEqualTo(LOGIN_REQUIRED);
+            assertThat(response.canApply()).isFalse();
+        }
+
+        @Test
+        @DisplayName("작성자 조회는 OWN_RECRUITMENT 이다")
+        void ownRecruitment() {
+            givenFound();
+            givenNoApplication();
+
+            assertThat(detail(AUTHOR_ID).applyBlockReason()).isEqualTo(OWN_RECRUITMENT);
+        }
+
+        @Test
+        @DisplayName("마감된 모집글은 RECRUITMENT_CLOSED 이다")
+        void recruitmentClosed() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFound();
+            givenNoApplication();
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(RECRUITMENT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("지원 마감일이 지나면 DEADLINE_PASSED 이다")
+        void deadlinePassed() {
+            recruitment = recruitment(ROLE_BASED, 3, 0, TODAY.minusDays(1));
+            givenFound();
+            givenNoApplication();
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(DEADLINE_PASSED);
+        }
+
+        @Test
+        @DisplayName("이미 지원했으면 ALREADY_APPLIED 이다")
+        void alreadyApplied() {
+            givenFound();
+            givenApplication(PENDING);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ALREADY_APPLIED);
+        }
+
+        @Test
+        @DisplayName("프로필이 없으면 PROFILE_REQUIRED 이다")
+        void profileRequired() {
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(false);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(PROFILE_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("모든 역할이 마감되면 ROLE_CLOSED 이다")
+        void roleClosed() {
+            recruitment.getRoles().clear();
+            recruitment.addRole(role(ROLE_ID, 1, 1));
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(true);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ROLE_CLOSED);
+        }
+
+        @Test
+        @DisplayName("역할 구분이 없는 모집은 전체 정원이 차면 ROLE_CLOSED 이다")
+        void generalCapacityFull() {
+            recruitment = recruitment(GENERAL, 2, 2, TODAY.plusDays(3));
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(true);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ROLE_CLOSED);
+        }
+
+        @Test
+        @DisplayName("지원 가능하면 사유가 null 이고 can_apply 가 true 이다")
+        void canApply() {
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(true);
+
+            RecruitmentDetail response = detail(VIEWER_ID);
+
+            assertThat(response.applyBlockReason()).isNull();
+            assertThat(response.canApply()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("사유 우선순위는 합의된 화면 안내 순서를 따른다")
+    class ReasonPriority {
+
+        @Test
+        @DisplayName("비로그인 작성자 조회는 LOGIN_REQUIRED 가 먼저다")
+        void loginBeforeOwn() {
+            givenFound();
+
+            assertThat(detail(null).applyBlockReason()).isEqualTo(LOGIN_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("작성자가 마감한 글을 봐도 OWN_RECRUITMENT 가 먼저다")
+        void ownBeforeClosed() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFound();
+            givenNoApplication();
+
+            assertThat(detail(AUTHOR_ID).applyBlockReason()).isEqualTo(OWN_RECRUITMENT);
+        }
+
+        @Test
+        @DisplayName("이미 지원한 마감 글은 ALREADY_APPLIED 가 먼저다")
+        void alreadyAppliedBeforeClosed() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFound();
+            givenApplication(PENDING);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ALREADY_APPLIED);
+        }
+
+        @Test
+        @DisplayName("이미 지원했고 마감일이 지났어도 ALREADY_APPLIED 가 먼저다")
+        void alreadyAppliedBeforeDeadline() {
+            recruitment = recruitment(ROLE_BASED, 3, 0, TODAY.minusDays(1));
+            givenFound();
+            givenApplication(PENDING);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ALREADY_APPLIED);
+        }
+
+        @Test
+        @DisplayName("마감된 글에서 마감일도 지났으면 RECRUITMENT_CLOSED 가 먼저다")
+        void closedBeforeDeadline() {
+            recruitment = recruitment(ROLE_BASED, 3, 0, TODAY.minusDays(1));
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFound();
+            givenNoApplication();
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(RECRUITMENT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("프로필이 없고 역할이 마감됐으면 ROLE_CLOSED 가 먼저다")
+        void roleClosedBeforeProfile() {
+            recruitment.getRoles().clear();
+            recruitment.addRole(role(ROLE_ID, 1, 1));
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(false);
+
+            assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(ROLE_CLOSED);
+        }
+    }
+
+    @Nested
+    @DisplayName("팀 채팅방 정보")
+    class TeamChatRoom {
+
+        @Test
+        @DisplayName("작성자는 팀 채팅방 정보를 받는다")
+        void authorReceivesTeamRoom() {
+            givenFound();
+            givenNoApplication();
+            givenTeamRoom();
+
+            RecruitmentDetail response = detail(AUTHOR_ID);
+
+            assertThat(response.isAuthor()).isTrue();
+            assertThat(response.canManageApplicants()).isTrue();
+            assertThat(response.teamChatAvailable()).isTrue();
+            assertThat(response.teamChatRoomId()).isEqualTo(TEAM_ROOM_ID);
+        }
+
+        @Test
+        @DisplayName("승인된 지원자는 팀 채팅방 정보를 받는다")
+        void acceptedApplicantReceivesTeamRoom() {
+            givenFound();
+            givenApplication(ACCEPTED);
+            givenTeamRoom();
+
+            RecruitmentDetail response = detail(VIEWER_ID);
+
+            assertThat(response.teamChatAvailable()).isTrue();
+            assertThat(response.teamChatRoomId()).isEqualTo(TEAM_ROOM_ID);
+            assertThat(response.application().status()).isEqualTo(ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("대기 중인 지원자는 팀 채팅방 정보를 받지 못한다")
+        void pendingApplicantHasNoTeamRoom() {
+            givenFound();
+            givenApplication(PENDING);
+
+            RecruitmentDetail response = detail(VIEWER_ID);
+
+            assertThat(response.teamChatAvailable()).isFalse();
+            assertThat(response.teamChatRoomId()).isNull();
+        }
+
+        @Test
+        @DisplayName("비로그인 조회는 팀 채팅방 정보를 받지 못한다")
+        void anonymousHasNoTeamRoom() {
+            givenFound();
+
+            RecruitmentDetail response = detail(null);
+
+            assertThat(response.teamChatAvailable()).isFalse();
+            assertThat(response.teamChatRoomId()).isNull();
+            assertThat(response.application()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("상세 조회 실패")
+    class DetailFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 모집글은 404 이다")
+        void notFound() {
+            when(teamRecruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> detail(VIEWER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("삭제된 모집글은 404 이므로 RECRUITMENT_DELETED 사유는 노출되지 않는다")
+        void deletedRecruitmentReturnsNotFound() {
+            recruitment.markDeleted(java.time.LocalDateTime.of(2026, 8, 30, 0, 0));
+            givenFound();
+
+            assertThatThrownBy(() -> detail(VIEWER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentServiceTest.java
@@ -1,0 +1,521 @@
+package in.koreatech.koin.unit.domain.team.recruitment.service;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.DELETED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.ROLE_BASED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRecruitmentRequest;
+import in.koreatech.koin.domain.team.recruitment.dto.UpdateRoleInput;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentClosureService;
+import in.koreatech.koin.domain.team.recruitment.service.TeamRecruitmentService;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.exception.CustomException;
+import in.koreatech.koin.unit.fixture.UserFixture;
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentServiceTest {
+
+    private static final Integer AUTHOR_ID = 1;
+    private static final Integer OTHER_USER_ID = 2;
+    private static final Integer RECRUITMENT_ID = 17;
+    private static final Integer ROLE_ID = 4;
+    private static final LocalDate DEADLINE = LocalDate.of(2026, 9, 3);
+    private static final LocalDate ACTIVITY_START = LocalDate.of(2026, 9, 7);
+    private static final LocalDate ACTIVITY_END = LocalDate.of(2026, 9, 30);
+
+    @InjectMocks
+    private TeamRecruitmentService teamRecruitmentService;
+
+    @Mock
+    private TeamRecruitmentRepository teamRecruitmentRepository;
+
+    @Mock
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Mock
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private TeamRecruitmentChatMemberRepository chatMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TeamRecruitmentClosureService closureService;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-08-30T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private TeamRecruitment recruitment;
+
+    @BeforeEach
+    void setUp() {
+        User author = UserFixture.id_설정_코인_유저(AUTHOR_ID);
+        recruitment = TeamRecruitment.builder()
+            .author(author)
+            .category(TeamRecruitmentCategory.CONTEST)
+            .title("AI 아이디어 공모전 팀원 모집")
+            .meetingType(TeamRecruitmentMeetingType.ONLINE)
+            .activityStartDate(ACTIVITY_START)
+            .activityEndDate(ACTIVITY_END)
+            .deadlineDate(DEADLINE)
+            .recruitmentType(ROLE_BASED)
+            .maxParticipants(3)
+            .currentParticipants(0)
+            .description("공모전 팀원을 모집합니다.")
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", RECRUITMENT_ID);
+        recruitment.addRole(role(ROLE_ID, "PM", 3, 1));
+    }
+
+    private static TeamRecruitmentRole role(Integer id, String name, int maxParticipants, int displayOrder) {
+        TeamRecruitmentRole role = TeamRecruitmentRole.builder()
+            .name(name)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(0)
+            .displayOrder(displayOrder)
+            .build();
+        ReflectionTestUtils.setField(role, "id", id);
+        return role;
+    }
+
+    private static UpdateRecruitmentRequest request(
+        TeamRecruitmentType recruitmentType,
+        Integer maxParticipants,
+        List<UpdateRoleInput> roles
+    ) {
+        return new UpdateRecruitmentRequest(
+            TeamRecruitmentCategory.CONTEST,
+            "수정된 제목",
+            TeamRecruitmentMeetingType.MIXED,
+            ACTIVITY_START,
+            ACTIVITY_END,
+            DEADLINE,
+            recruitmentType,
+            maxParticipants,
+            roles,
+            "수정했습니다.",
+            null,
+            null
+        );
+    }
+
+    private void givenFoundRecruitment() {
+        when(teamRecruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+    }
+
+    private void givenNoApplicants() {
+        lenient().when(applicationRepository.countByRecruitment_IdAndStatusIn(anyInt(), any())).thenReturn(0L);
+        lenient().when(applicationRepository.countByRole_IdAndStatus(anyInt(), any())).thenReturn(0L);
+    }
+
+    @Nested
+    @DisplayName("소유권 검증")
+    class Ownership {
+
+        @Test
+        @DisplayName("작성자가 아니면 수정할 수 없다")
+        void otherUserCannotUpdate() {
+            givenFoundRecruitment();
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                OTHER_USER_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(ROLE_ID, "PM", 3)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 삭제할 수 없다")
+        void otherUserCannotDelete() {
+            givenFoundRecruitment();
+
+            assertThatThrownBy(() -> teamRecruitmentService.deleteRecruitment(OTHER_USER_ID, RECRUITMENT_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 마감할 수 없다")
+        void otherUserCannotClose() {
+            givenFoundRecruitment();
+
+            assertThatThrownBy(() -> teamRecruitmentService.closeRecruitment(OTHER_USER_ID, RECRUITMENT_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 모집글은 404이다")
+        void notFoundRecruitment() {
+            when(teamRecruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> teamRecruitmentService.closeRecruitment(AUTHOR_ID, RECRUITMENT_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("마감과 삭제")
+    class CloseAndDelete {
+
+        @Test
+        @DisplayName("마감하면 상태가 CLOSED 가 된다")
+        void closeChangesStatus() {
+            givenFoundRecruitment();
+
+            teamRecruitmentService.closeRecruitment(AUTHOR_ID, RECRUITMENT_ID);
+
+            assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
+            verify(closureService).onClosed(recruitment);
+        }
+
+        @Test
+        @DisplayName("이미 마감된 모집글에 다시 요청해도 예외가 발생하지 않는다")
+        void closeIsIdempotent() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFoundRecruitment();
+
+            assertThatCode(() -> teamRecruitmentService.closeRecruitment(AUTHOR_ID, RECRUITMENT_ID))
+                .doesNotThrowAnyException();
+            verify(closureService, never()).onClosed(any());
+        }
+
+        @Test
+        @DisplayName("삭제하면 상태가 DELETED 이고 삭제 시각이 기록된다")
+        void deleteMarksDeleted() {
+            givenFoundRecruitment();
+
+            teamRecruitmentService.deleteRecruitment(AUTHOR_ID, RECRUITMENT_ID);
+
+            assertThat(recruitment.getStatus()).isEqualTo(DELETED);
+            assertThat(recruitment.getDeletedAt()).isNotNull();
+            verify(closureService).onDeleted(recruitment);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 모집글에 다시 요청해도 예외가 발생하지 않는다")
+        void deleteIsIdempotent() {
+            recruitment.markDeleted(LocalDateTime.of(2026, 8, 30, 0, 0));
+            givenFoundRecruitment();
+
+            assertThatCode(() -> teamRecruitmentService.deleteRecruitment(AUTHOR_ID, RECRUITMENT_ID))
+                .doesNotThrowAnyException();
+            verify(closureService, never()).onDeleted(any());
+        }
+
+        @Test
+        @DisplayName("마감된 모집글은 수정할 수 없다")
+        void closedRecruitmentCannotBeUpdated() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFoundRecruitment();
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(ROLE_ID, "PM", 3)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_CLOSED);
+        }
+    }
+
+    @Nested
+    @DisplayName("정원과 모집 유형 수정 제약")
+    class CapacityAndType {
+
+        @Test
+        @DisplayName("승인된 인원보다 적은 정원으로 수정하면 예외가 발생한다")
+        void cannotShrinkBelowAcceptedCount() {
+            ReflectionTestUtils.setField(recruitment, "currentParticipants", 3);
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 1, List.of())))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED);
+        }
+
+        @Test
+        @DisplayName("지원자가 있으면 모집 유형을 변경할 수 없다")
+        void cannotChangeTypeWithApplicants() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRecruitment_IdAndStatusIn(anyInt(), any())).thenReturn(1L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of())))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("거절된 지원서만 있어도 모집 유형을 변경할 수 없다")
+        void cannotChangeTypeWithRejectedApplication() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRecruitment_IdAndStatusIn(anyInt(), any())).thenReturn(1L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of())))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("모집 유형 검증은 거절을 포함한 모든 상태를 센다")
+        void typeChangeCountsEveryStatus() {
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of()));
+
+            verify(applicationRepository).countByRecruitment_IdAndStatusIn(
+                RECRUITMENT_ID, List.of(TeamRecruitmentApplicationStatus.values()));
+        }
+
+        @Test
+        @DisplayName("지원자가 없으면 모집 유형을 변경할 수 있다")
+        void canChangeTypeWithoutApplicants() {
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of()));
+
+            assertThat(recruitment.getRecruitmentType()).isEqualTo(GENERAL);
+            assertThat(recruitment.getMaxParticipants()).isEqualTo(5);
+            assertThat(recruitment.getRoles()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("정원 충족 자동 마감")
+    class CapacityAutoClose {
+
+        @Test
+        @DisplayName("정원을 승인 인원과 같게 줄이면 그 자리에서 마감된다")
+        void closesWhenCapacityBecomesFull() {
+            ReflectionTestUtils.setField(recruitment, "currentParticipants", 1);
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 1, List.of()));
+
+            assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
+            verify(closureService).onCapacityFull(recruitment);
+            verify(closureService, never()).onClosed(any());
+        }
+
+        @Test
+        @DisplayName("정원이 남아 있으면 마감되지 않는다")
+        void staysRecruitingWhenCapacityRemains() {
+            ReflectionTestUtils.setField(recruitment, "currentParticipants", 1);
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of()));
+
+            assertThat(recruitment.isRecruiting()).isTrue();
+            verify(closureService, never()).onCapacityFull(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("역할 수정 제약")
+    class RoleUpdate {
+
+        @Test
+        @DisplayName("해당 모집글의 역할이 아니면 404이다")
+        void unknownRoleId() {
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(999, "PM", 3)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ROLE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("지원자가 있는 역할은 이름을 바꿀 수 없다")
+        void cannotRenameRoleWithApplicants() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRole_IdAndStatus(anyInt(), any())).thenReturn(1L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(ROLE_ID, "이름바꿈", 3)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("지원자가 있는 역할은 정원을 줄일 수 없다")
+        void cannotShrinkRoleWithApplicants() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRole_IdAndStatus(anyInt(), any())).thenReturn(1L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(ROLE_ID, "PM", 2)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("역할 정원을 늘릴 때는 지원자 조회 없이 통과한다")
+        void canGrowRoleWithApplicants() {
+            givenFoundRecruitment();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(ROLE_ID, "PM", 5))));
+
+            assertThat(recruitment.getRoles().get(0).getMaxParticipants()).isEqualTo(5);
+            assertThat(recruitment.getMaxParticipants()).isEqualTo(5);
+            verify(applicationRepository, never()).countByRole_IdAndStatus(anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("거절된 지원서만 있는 역할도 삭제할 수 없다")
+        void cannotRemoveRoleWithRejectedApplication() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRole_IdAndStatus(anyInt(), any()))
+                .thenAnswer(invocation -> invocation.getArgument(1) == REJECTED ? 1L : 0L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(null, "새 역할", 2)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("지원자가 있는 역할은 삭제할 수 없다")
+        void cannotRemoveRoleWithApplicants() {
+            givenFoundRecruitment();
+            when(applicationRepository.countByRole_IdAndStatus(anyInt(), any())).thenReturn(1L);
+
+            assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
+                AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                    new UpdateRoleInput(null, "새 역할", 2)))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED);
+        }
+
+        @Test
+        @DisplayName("기존 역할의 순서는 요청 순서와 무관하게 유지되고 새 역할은 빈 슬롯을 받는다")
+        void keepsExistingDisplayOrderAndFillsFreeSlot() {
+            recruitment.addRole(role(5, "프론트엔드", 2, 2));
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(5, "프론트엔드", 2),
+                new UpdateRoleInput(ROLE_ID, "PM", 3),
+                new UpdateRoleInput(null, "디자이너", 1)
+            )));
+
+            assertThat(recruitment.getRoles())
+                .extracting(TeamRecruitmentRole::getName, TeamRecruitmentRole::getDisplayOrder)
+                .containsExactlyInAnyOrder(
+                    tuple("PM", 1),
+                    tuple("프론트엔드", 2),
+                    tuple("디자이너", 3)
+                );
+            verify(entityManager).flush();
+        }
+
+        @Test
+        @DisplayName("역할 이름이 임시 이름 후보와 겹쳐도 이름 교환이 성공한다")
+        void renamesEvenWhenTemporaryNameCandidatesAreTaken() {
+            recruitment.getRoles().clear();
+            recruitment.addRole(role(ROLE_ID, "#0", 1, 1));
+            recruitment.addRole(role(5, "#1", 2, 2));
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(ROLE_ID, "#1", 1),
+                new UpdateRoleInput(5, "#0", 2)
+            )));
+
+            assertThat(recruitment.getRoles())
+                .extracting(TeamRecruitmentRole::getId, TeamRecruitmentRole::getName)
+                .containsExactlyInAnyOrder(tuple(ROLE_ID, "#1"), tuple(5, "#0"));
+        }
+
+        @Test
+        @DisplayName("삭제로 비는 슬롯을 새 역할이 재사용한다")
+        void reusesFreedDisplayOrder() {
+            recruitment.addRole(role(5, "프론트엔드", 2, 2));
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(ROLE_ID, "PM", 3),
+                new UpdateRoleInput(null, "디자이너", 1)
+            )));
+
+            assertThat(recruitment.getRoles())
+                .extracting(TeamRecruitmentRole::getName, TeamRecruitmentRole::getDisplayOrder)
+                .containsExactlyInAnyOrder(
+                    tuple("PM", 1),
+                    tuple("디자이너", 2)
+                );
+            verify(chatRoomRepository, never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집 게시글 CRUD/목록/마감 7개와 팀원 모집 전용 프로필 조회/저장 2개를 구현합니다.

- close #2351

---

### 🚀 주요 변경 내용

* 모집글 목록 조회: `keyword`, `categories`, `meetingType`, `status` 필터와 `LATEST_DESC`/`DEADLINE_ASC` 정렬을 QueryDSL 조회 클래스로 구현했습니다. `keyword` 는 제목, 역할명, 카테고리/진행 방식 표시명을 대소문자 구분 없이 부분 일치로 검색하며 본문은 대상이 아닙니다.
* 모집글 작성: `ROLE_BASED`/`GENERAL` 분기와 함께 TEAM 채팅방, 작성자 멤버를 같은 트랜잭션에서 생성합니다.
* 모집글 상세 조회: 비로그인 조회를 지원하고, 로그인 시 `is_author`, `can_apply`, `apply_block_reason`, `application`, `can_manage_applicants`, 팀 채팅방 정보를 계산합니다.
* 모집글 수정: 역할을 `id` 기준으로 갱신하며, 지원자가 있는 역할의 삭제/이름 변경/정원 축소를 차단합니다. 정원을 승인 인원과 같게 줄이면 그 자리에서 마감합니다.
* 모집글 삭제/마감: soft delete 와 멱등 처리, 대기 지원서 거절, 채팅방 `READ_ONLY` 전환, 알림 및 Outbox 적재까지 처리합니다.
* 내가 작성한 모집글 목록: `applicant_count`, `can_close`, 팀 채팅방 정보를 포함합니다.
* 프로필 조회/저장: 사용자당 1개 upsert 이며 `skills`, `activities` 는 요청 순서대로 전체 대체합니다.
* `SwaggerGroupConfig` 에 `in.koreatech.koin.domain.team` 을 등록했습니다. 등록 전에는 팀원 모집 API 가 Swagger 문서에 노출되지 않았습니다.

---

### 💬 참고 사항

* 선행 PR: #2346, #2347, #2348
* 검증: `./gradlew clean test` 성공 (클래스 239개 / 테스트 1022개 / 실패 0)
* 단위 테스트 외에 실제 DB 통합 테스트를 포함했습니다. `EntityManager` 를 mock 하는 단위 테스트로는 unique/FK 제약 위반을 잡을 수 없어, 마감/삭제 후속 처리와 역할 `display_order`/`name` unique, 지원서 `role_id` FK 를 실제 MySQL 로 검증했습니다.
* 공유 파일 수정은 `ApiResponseCode` 오류 코드 추가와 `SwaggerGroupConfig` 한 줄 등록뿐입니다.

**Swagger 보완이 필요한 항목입니다.** 구현은 아래 규칙을 따르지만 외부 Swagger 에는 아직 없습니다.

| 항목 | 구현 동작 |
| --- | --- |
| 전체 모집 정원 | `ROLE_BASED` 는 역할 정원의 합이며 최대 10명입니다. 초과 시 400 `INVALID_REQUEST_BODY` 입니다. `team_recruitment.max_participants` CHECK 가 1~10 이라 초과하면 DB 오류가 나므로 요청 단계에서 막았습니다. |
| 역할명 | 앞뒤 공백을 제거해 저장합니다. collation 이 `utf8mb4_0900_ai_ci` 라 대소문자와 악센트만 다른 이름도 중복으로 보고 400 `TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME` 을 반환합니다. |
| `keyword` 검색 범위 | 제목, 역할명, 카테고리 표시명, 진행 방식 표시명입니다. 본문은 제외입니다. |
| `team_chat_available` | 작성자와 승인된 지원자 모두 `true` 입니다. Swagger 필드 설명은 승인된 지원자만 언급하고 있습니다. |
| 수정 시 역할 순서 | 요청 배열 순서로 재정렬하지 않고 기존 역할의 순서를 유지합니다. `display_order` 에 unique 와 `BETWEEN 1 AND 5` CHECK 가 함께 걸려 있어 5개가 꽉 찬 상태의 순환 재배치가 불가능합니다. 재정렬이 필요하면 스키마 변경이 선행되어야 합니다. |

* `apply_block_reason` 우선순위는 협의된 화면 안내 순서(`LOGIN_REQUIRED`, `OWN_RECRUITMENT`, `ALREADY_APPLIED`, `RECRUITMENT_CLOSED`, `DEADLINE_PASSED`, `ROLE_CLOSED`, `PROFILE_REQUIRED`)를 따릅니다. 지원 API 의 검증 순서와는 일부 달라, 이미 지원한 마감 글처럼 두 사유가 겹치면 상세가 알려주는 사유와 실제 지원 시 오류 코드가 다를 수 있습니다.
* `RECRUITMENT_DELETED` 는 상세 조회가 삭제된 모집글에 404 를 반환하므로 실제 응답으로 나가지 않습니다.
* 채팅/알림 API(#2336)는 패키지가 `domain/teamrecruitment` 라 이번에 등록한 `domain.team` 에 포함되지 않아 Swagger 문서에 노출되지 않습니다. 담당자와 이야기한 뒤 별도로 처리할 예정이라 이 PR 에는 포함하지 않았습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료 (Reviewers: @taejinn, @dnjswldnd-3513)
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team recruitment posts with creation, editing, deletion, closing, and detail views.
  * Added keyword search, status/category/meeting-type filters, sorting, and pagination.
  * Added “My recruitments” management views for authors.
  * Added student recruitment profiles with skills, activities, and self-introduction.
  * Added applicant eligibility details, role availability, team chat access, and status indicators.
* **Validation**
  * Added validation for dates, participant capacity, recruitment types, and duplicate roles.
* **Bug Fixes**
  * Improved handling of applications, notifications, and chat rooms when recruitments close or are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->