### PR TITLE
fix: 팀원 모집 게시글 명세 반영 및 요청 검증 보강

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
@@ -10,13 +10,14 @@ import static in.koreatech.koin.global.code.ApiResponseCode.NOT_FOUND_USER;
 import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
 import static in.koreatech.koin.global.code.ApiResponseCode.OK;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED;
 import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
 
 import java.util.List;
@@ -90,7 +91,6 @@ public interface TeamRecruitmentApi {
         CREATED,
         TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
         TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
-        TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME,
         INVALID_START_DATE_AFTER_END_DATE,
         INVALID_REQUEST_BODY,
         NOT_FOUND_USER,
@@ -139,9 +139,10 @@ public interface TeamRecruitmentApi {
         TEAM_RECRUITMENT_CLOSED,
         TEAM_RECRUITMENT_ROLE_NOT_FOUND,
         TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED,
+        TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED,
+        TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED,
         TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
         TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
-        TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME,
         INVALID_START_DATE_AFTER_END_DATE,
         INVALID_REQUEST_BODY,
         UNAUTHORIZED_USER,
@@ -152,7 +153,7 @@ public interface TeamRecruitmentApi {
         - 작성자만 수정할 수 있습니다.
         - 기존 역할은 `id`를 반드시 보내고 새 역할은 `id`를 생략하셔야 합니다.
         - 지원자가 있는 역할은 삭제, 이름 변경, 정원 축소를 할 수 없습니다.
-        - 기존 역할의 표시 순서는 유지되며 새 역할이 비어 있는 순서를 채웁니다.
+        - 기존 역할의 표시 순서는 유지되며, 새 역할은 기존 역할 뒤에 요청 배열 순서대로 추가됩니다.
         - 전체 정원은 10명을 넘을 수 없습니다.
         - 역할명은 앞뒤 공백을 제거해 저장하며, 대소문자와 악센트만 다른 이름도 중복으로 봅니다.
         - 정원을 이미 승인된 인원과 같게 줄이면 그 자리에서 마감됩니다.

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
@@ -83,12 +83,13 @@ public record CreateRecruitmentRequest(
     public CreateRecruitmentRequest {
         RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
         RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
-        RecruitmentRequestValidator.validateDistinctRoleNames(
-            roles == null ? List.of() : roles.stream().map(RoleInput::name).toList());
-        RecruitmentRequestValidator.validateTotalCapacity(
-            recruitmentType == TeamRecruitmentType.ROLE_BASED && roles != null
-                ? roles.stream().mapToInt(RoleInput::maxParticipants).sum()
-                : (maxParticipants == null ? 0 : maxParticipants));
+        if (RecruitmentRequestValidator.isCompleteRoleList(roles, RoleInput::isComplete)) {
+            RecruitmentRequestValidator.validateDistinctRoleNames(roles.stream().map(RoleInput::name).toList());
+            RecruitmentRequestValidator.validateTotalCapacity(
+                recruitmentType == TeamRecruitmentType.ROLE_BASED
+                    ? roles.stream().mapToInt(RoleInput::maxParticipants).sum()
+                    : (maxParticipants == null ? 0 : maxParticipants));
+        }
     }
 
     /**

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.team.recruitment.dto;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
 
@@ -12,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
 import in.koreatech.koin.global.exception.CustomException;
@@ -70,7 +70,7 @@ final class RecruitmentRequestValidator {
         Set<String> normalized = new HashSet<>();
         for (String roleName : roleNames) {
             if (roleName != null && !normalized.add(normalizeRoleName(roleName))) {
-                throw CustomException.of(TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME, "roleName: " + roleName);
+                throw CustomException.of(INVALID_REQUEST_BODY, "duplicated roleName: " + roleName);
             }
         }
     }
@@ -79,6 +79,15 @@ final class RecruitmentRequestValidator {
         String withoutMarks = Normalizer.normalize(roleName, Normalizer.Form.NFD)
             .replaceAll("\\p{M}+", "");
         return withoutMarks.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * 압축 생성자는 Bean Validation 보다 먼저 실행되므로, 역할 목록에 null 이 섞여 있거나
+     * 필수 값이 비어 있으면 교차 검증에서 NullPointerException 이 날 수 있다.
+     * 그런 요청은 Bean Validation 이 400 으로 처리하므로 교차 검증을 건너뛴다.
+     */
+    static <T> boolean isCompleteRoleList(List<T> roles, Predicate<T> complete) {
+        return roles != null && roles.stream().allMatch(role -> role != null && complete.test(role));
     }
 
     static void validateRoleComposition(

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RoleInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RoleInput.java
@@ -28,4 +28,12 @@ public record RoleInput(
     public RoleInput {
         name = RecruitmentRequestValidator.canonicalRoleName(name);
     }
+
+    /**
+     * 교차 검증에 필요한 값이 모두 들어왔는지 확인한다.
+     * 비어 있으면 Bean Validation 이 400 을 반환하므로 교차 검증은 건너뛴다.
+     */
+    boolean isComplete() {
+        return name != null && maxParticipants != null;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
@@ -81,12 +81,13 @@ public record UpdateRecruitmentRequest(
     public UpdateRecruitmentRequest {
         RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
         RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
-        RecruitmentRequestValidator.validateDistinctRoleNames(
-            roles == null ? List.of() : roles.stream().map(UpdateRoleInput::name).toList());
-        RecruitmentRequestValidator.validateTotalCapacity(
-            recruitmentType == TeamRecruitmentType.ROLE_BASED && roles != null
-                ? roles.stream().mapToInt(UpdateRoleInput::maxParticipants).sum()
-                : (maxParticipants == null ? 0 : maxParticipants));
+        if (RecruitmentRequestValidator.isCompleteRoleList(roles, UpdateRoleInput::isComplete)) {
+            RecruitmentRequestValidator.validateDistinctRoleNames(roles.stream().map(UpdateRoleInput::name).toList());
+            RecruitmentRequestValidator.validateTotalCapacity(
+                recruitmentType == TeamRecruitmentType.ROLE_BASED
+                    ? roles.stream().mapToInt(UpdateRoleInput::maxParticipants).sum()
+                    : (maxParticipants == null ? 0 : maxParticipants));
+        }
     }
 
     public int resolveMaxParticipants() {

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRoleInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRoleInput.java
@@ -36,4 +36,12 @@ public record UpdateRoleInput(
     public boolean isNew() {
         return id == null;
     }
+
+    /**
+     * 교차 검증에 필요한 값이 모두 들어왔는지 확인한다.
+     * 비어 있으면 Bean Validation 이 400 을 반환하므로 교차 검증은 건너뛴다.
+     */
+    boolean isComplete() {
+        return name != null && maxParticipants != null;
+    }
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
@@ -261,7 +261,7 @@ public class TeamRecruitmentService {
                 .name(requested.name())
                 .maxParticipants(requested.maxParticipants())
                 .currentParticipants(0)
-                .displayOrder(nextFreeDisplayOrder(usedOrders))
+                .displayOrder(nextDisplayOrder(usedOrders))
                 .build());
         }
     }
@@ -300,7 +300,16 @@ public class TeamRecruitmentService {
         throw CustomException.of(TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION);
     }
 
-    private int nextFreeDisplayOrder(Set<Integer> usedOrders) {
+    /**
+     * 새 역할은 기존 역할 뒤에 요청 배열 순서대로 붙인다.
+     * display_order 는 1~5 만 허용하므로 뒤에 자리가 없으면 앞쪽 빈 슬롯을 쓴다.
+     * 앞쪽 슬롯은 이전 요청에서 낮은 순서의 역할이 삭제된 경우에만 비어 있다.
+     */
+    private int nextDisplayOrder(Set<Integer> usedOrders) {
+        int afterExisting = usedOrders.stream().mapToInt(Integer::intValue).max().orElse(0) + 1;
+        if (afterExisting <= MAX_DISPLAY_ORDER && usedOrders.add(afterExisting)) {
+            return afterExisting;
+        }
         for (int order = FIRST_DISPLAY_ORDER; order <= MAX_DISPLAY_ORDER; order++) {
             if (usedOrders.add(order)) {
                 return order;

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -96,7 +96,6 @@ public enum ApiResponseCode {
     TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL(HttpStatus.BAD_REQUEST, "진행 중인 활동인 경우, 활동 종료일은 입력하면 안 됩니다."),
     TEAM_RECRUITMENT_INVALID_DEADLINE_DATE(HttpStatus.BAD_REQUEST, "지원 마감일은 활동 시작일 이하여야 합니다."),
     TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION(HttpStatus.BAD_REQUEST, "모집 유형에 맞지 않는 역할 또는 정원 구성입니다."),
-    TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME(HttpStatus.BAD_REQUEST, "역할명은 중복될 수 없습니다."),
 
     /**
      * 401 Unauthorized (인증 필요)

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -206,7 +206,7 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
                         {"name": "pm", "max_participants": 1}
                         """)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME"));
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST_BODY"));
         }
 
         @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.unit.domain.team.recruitment.dto;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -168,7 +167,7 @@ class CreateRecruitmentRequestTest {
                 new RoleInput("PM", 1),
                 new RoleInput("PM", 1))))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_REQUEST_BODY);
         }
 
         @Test
@@ -178,7 +177,7 @@ class CreateRecruitmentRequestTest {
                 new RoleInput("PM", 1),
                 new RoleInput("pm", 1))))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_REQUEST_BODY);
         }
 
         @Test
@@ -196,7 +195,7 @@ class CreateRecruitmentRequestTest {
                 new RoleInput("PM", 1),
                 new RoleInput("PM ", 1))))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_REQUEST_BODY);
         }
 
         @Test
@@ -206,7 +205,7 @@ class CreateRecruitmentRequestTest {
                 new RoleInput("Cafe", 1),
                 new RoleInput("Café", 1))))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME);
+                .hasFieldOrPropertyWithValue("errorCode", INVALID_REQUEST_BODY);
         }
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentServiceTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -306,7 +308,8 @@ class TeamRecruitmentServiceTest {
         @DisplayName("거절된 지원서만 있어도 모집 유형을 변경할 수 없다")
         void cannotChangeTypeWithRejectedApplication() {
             givenFoundRecruitment();
-            when(applicationRepository.countByRecruitment_IdAndStatusIn(anyInt(), any())).thenReturn(1L);
+            when(applicationRepository.countByRecruitment_IdAndStatusIn(
+                eq(RECRUITMENT_ID), argThat(statuses -> statuses.contains(REJECTED)))).thenReturn(1L);
 
             assertThatThrownBy(() -> teamRecruitmentService.updateRecruitment(
                 AUTHOR_ID, RECRUITMENT_ID, request(GENERAL, 5, List.of())))
@@ -495,6 +498,51 @@ class TeamRecruitmentServiceTest {
             assertThat(recruitment.getRoles())
                 .extracting(TeamRecruitmentRole::getId, TeamRecruitmentRole::getName)
                 .containsExactlyInAnyOrder(tuple(ROLE_ID, "#1"), tuple(5, "#0"));
+        }
+
+        @Test
+        @DisplayName("낮은 순서의 역할이 삭제되어도 새 역할은 기존 역할 뒤에 붙는다")
+        void appendsNewRoleAfterExistingRoles() {
+            recruitment.getRoles().clear();
+            recruitment.addRole(role(ROLE_ID, "A", 1, 1));
+            recruitment.addRole(role(5, "B", 1, 2));
+            recruitment.addRole(role(6, "C", 1, 3));
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(5, "B", 1),
+                new UpdateRoleInput(6, "C", 1),
+                new UpdateRoleInput(null, "D", 1)
+            )));
+
+            assertThat(recruitment.getRoles())
+                .extracting(TeamRecruitmentRole::getName, TeamRecruitmentRole::getDisplayOrder)
+                .containsExactlyInAnyOrder(tuple("B", 2), tuple("C", 3), tuple("D", 4));
+        }
+
+        @Test
+        @DisplayName("뒤에 자리가 없으면 앞쪽 빈 슬롯을 쓴다")
+        void fallsBackToFreeSlotWhenNoRoomAfter() {
+            recruitment.getRoles().clear();
+            recruitment.addRole(role(ROLE_ID, "B", 1, 2));
+            recruitment.addRole(role(5, "C", 1, 3));
+            recruitment.addRole(role(6, "D", 1, 4));
+            recruitment.addRole(role(7, "E", 1, 5));
+            givenFoundRecruitment();
+            givenNoApplicants();
+
+            teamRecruitmentService.updateRecruitment(AUTHOR_ID, RECRUITMENT_ID, request(ROLE_BASED, null, List.of(
+                new UpdateRoleInput(ROLE_ID, "B", 1),
+                new UpdateRoleInput(5, "C", 1),
+                new UpdateRoleInput(6, "D", 1),
+                new UpdateRoleInput(7, "E", 1),
+                new UpdateRoleInput(null, "F", 1)
+            )));
+
+            assertThat(recruitment.getRoles())
+                .extracting(TeamRecruitmentRole::getName, TeamRecruitmentRole::getDisplayOrder)
+                .contains(tuple("F", 1));
         }
 
         @Test


### PR DESCRIPTION
### 🔍 개요

* #2355 머지 이후 갱신된 Swagger 명세와 어긋나는 부분을 맞추고, 잘못된 역할 요청이 서버 예외로 처리되던 경로를 보강합니다.

- close #2356

---

### 🚀 주요 변경 내용

* 역할명 중복 응답을 명세대로 `400 INVALID_REQUEST_BODY` 로 맞추고 전용 오류 코드 `TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME` 을 제거했습니다.
* 새 역할을 기존 역할 뒤에 요청 배열 순서대로 배치합니다. 기존에는 빈 슬롯 중 가장 작은 번호를 써서, 낮은 순서의 역할이 삭제되면 새 역할이 목록 맨 앞에 왔습니다.
* record 압축 생성자는 Bean Validation 보다 먼저 실행되므로, 역할 목록에 `null` 이 섞이거나 `name`, `max_participants` 가 비면 교차 검증에서 `NullPointerException` 이 발생했습니다. 값이 모두 들어온 경우에만 교차 검증하도록 바꿨습니다.
* 모집글 수정 API 의 `@ApiResponseCodes` 에 실제로 반환하는 409 두 개를 추가했습니다.
* 거절된 지원서만으로 모집 유형 변경이 차단되는지 실제로 검증하도록 단위 테스트 스텁을 좁혔습니다.

---

### 💬 참고 사항

* 선행 PR: #2355
* 검증: `./gradlew clean test --no-build-cache` 성공

**실행으로 확인한 변경 전후입니다.**

| 요청 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 역할명 `["PM", "pm"]` | 400 `TEAM_RECRUITMENT_DUPLICATE_ROLE_NAME` | 400 `INVALID_REQUEST_BODY` |
| 역할 A(1) B(2) C(3) 에서 A 삭제 후 D 추가 | `D(1), B(2), C(3)` | `B(2), C(3), D(4)` |
| `roles: [null]` | 400 `NOT_READABLE_HTTP_MESSAGE` (NPE 를 Jackson 이 감싼 결과) | 400 `INVALID_REQUEST_BODY` |
| `max_participants` 누락 | 400 `NOT_READABLE_HTTP_MESSAGE` | 400 `INVALID_REQUEST_BODY` |

* `display_order` 는 `(recruitment_id, display_order)` unique 와 `BETWEEN 1 AND 5` CHECK 가 함께 걸려 있어, 기존 역할이 2~5 를 차지한 상태에서는 새 역할을 뒤에 붙일 수 없습니다. 이 경우에만 앞쪽 빈 슬롯을 사용하며, 명세와 다르게 동작하는 유일한 경로입니다. 이 동작을 명세에 명시할지 확인 부탁드립니다.
* NPE 경로는 Jackson 이 예외를 감싸 결과적으로 400 이 나가고 있었지만, 로그에 `NullPointerException` 이 남고 record 를 직접 생성하는 경로에서는 그대로 터지므로 검증으로 대체했습니다.
* 채팅/알림 API(#2336)의 Swagger 노출은 담당자와 논의한 뒤 별도로 처리할 예정이라 이 PR 에는 포함하지 않았습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료 (Reviewers: @taejinn, @dnjswldnd-3513)
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Recruitment updates now place newly added roles after existing roles in request order.
  - Incomplete role details receive standard request-validation errors.
  - Duplicate role names now return the standard invalid-request error.
  - Recruitment update responses now clearly report capacity-limit and recruitment-type change restrictions.

- **Bug Fixes**
  - Improved validation handling for incomplete role entries.
  - Added safeguards for role display ordering when existing roles are removed or no later slots are available.

- **Tests**
  - Expanded coverage for validation errors and role-ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->