### PR TITLE
feat: 팀원 모집 채팅/알림 API Swagger 노출 및 응답 코드 명시

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
@@ -1,5 +1,16 @@
 package in.koreatech.koin.domain.teamrecruitment.controller;
 
+import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_USER_TYPE;
+import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_READ_ONLY;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -11,12 +22,20 @@ import in.koreatech.koin.domain.teamrecruitment.dto.ChatMessageResponse;
 import in.koreatech.koin.domain.teamrecruitment.dto.ChatRoomResponse;
 import in.koreatech.koin.domain.teamrecruitment.dto.CreateChatMessageRequest;
 import in.koreatech.koin.domain.teamrecruitment.dto.DirectChatRoomResponse;
+import in.koreatech.koin.global.code.ApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "3. 원지웅 - 채팅/알림", description = "팀원 모집 채팅 API")
+@Tag(name = "(Normal) Team Recruitment Chat: 팀원 모집 채팅", description = "팀원 모집 채팅 API")
 public interface TeamRecruitmentChatApi {
 
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_CHAT_NOT_FOUND,
+        TEAM_RECRUITMENT_CHAT_FORBIDDEN,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "팀 또는 개인 채팅방 정보 조회")
     ResponseEntity<ChatRoomResponse> getChatRoom(
             Integer userId,
@@ -24,6 +43,14 @@ public interface TeamRecruitmentChatApi {
             @PathVariable Integer chatRoomId
     );
 
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_NOT_FOUND,
+        TEAM_RECRUITMENT_APPLICATION_NOT_FOUND,
+        TEAM_RECRUITMENT_FORBIDDEN,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "지원자와 개인 채팅방 생성 또는 조회")
     ResponseEntity<DirectChatRoomResponse> getOrCreateDirectChatRoom(
             Integer userId,
@@ -31,6 +58,12 @@ public interface TeamRecruitmentChatApi {
             @PathVariable Integer applicationId
     );
 
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_CHAT_FORBIDDEN,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "채팅 메시지 조회 (Polling)")
     ResponseEntity<List<ChatMessageResponse>> getMessages(
             Integer userId,
@@ -41,6 +74,15 @@ public interface TeamRecruitmentChatApi {
             @RequestParam(defaultValue = "100") int limit
     );
 
+    @ApiResponseCodes({
+        OK,
+        INVALID_REQUEST_BODY,
+        TEAM_RECRUITMENT_CHAT_NOT_FOUND,
+        TEAM_RECRUITMENT_CHAT_FORBIDDEN,
+        TEAM_RECRUITMENT_CHAT_READ_ONLY,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "메시지 전송")
     ResponseEntity<ChatMessageResponse> createMessage(
             Integer userId,

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.controller;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_USER_TYPE;
+import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
 import static in.koreatech.koin.global.code.ApiResponseCode.OK;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
@@ -30,7 +31,7 @@ public interface TeamRecruitmentNotificationApi {
     );
 
     @ApiResponseCodes({
-        OK,
+        NO_CONTENT,
         TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
@@ -42,7 +43,7 @@ public interface TeamRecruitmentNotificationApi {
     );
 
     @ApiResponseCodes({
-        OK,
+        NO_CONTENT,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
     })
@@ -50,7 +51,7 @@ public interface TeamRecruitmentNotificationApi {
     ResponseEntity<Void> markAllRead(Integer userId);
 
     @ApiResponseCodes({
-        OK,
+        NO_CONTENT,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
     })

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
@@ -1,16 +1,27 @@
 package in.koreatech.koin.domain.teamrecruitment.controller;
 
+import static in.koreatech.koin.global.code.ApiResponseCode.FORBIDDEN_USER_TYPE;
+import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND;
+import static in.koreatech.koin.global.code.ApiResponseCode.UNAUTHORIZED_USER;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import in.koreatech.koin.domain.teamrecruitment.dto.TeamRecruitmentNotificationsResponse;
+import in.koreatech.koin.global.code.ApiResponseCodes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "팀원 모집 알림", description = "팀원 모집 알림 API")
+@Tag(name = "(Normal) Team Recruitment Notification: 팀원 모집 알림", description = "팀원 모집 알림 API")
 public interface TeamRecruitmentNotificationApi {
 
+    @ApiResponseCodes({
+        OK,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "팀원 모집 알림 목록 조회")
     ResponseEntity<TeamRecruitmentNotificationsResponse> getNotifications(
             Integer userId,
@@ -18,15 +29,31 @@ public interface TeamRecruitmentNotificationApi {
             @RequestParam(defaultValue = "10") int limit
     );
 
+    @ApiResponseCodes({
+        OK,
+        TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "알림 읽음 처리")
     ResponseEntity<Void> markAsRead(
             Integer userId,
             @PathVariable Integer notificationId
     );
 
+    @ApiResponseCodes({
+        OK,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "모든 알림 읽음 처리")
     ResponseEntity<Void> markAllRead(Integer userId);
 
+    @ApiResponseCodes({
+        OK,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
     @Operation(summary = "모든 알림 삭제")
     ResponseEntity<Void> deleteAll(Integer userId);
 }

--- a/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
@@ -60,6 +60,7 @@ public class SwaggerGroupConfig {
                 "in.koreatech.koin.domain.club",
                 "in.koreatech.koin.domain.callvan",
                 "in.koreatech.koin.domain.team",
+                "in.koreatech.koin.domain.teamrecruitment",
                 "in.koreatech.koin.domain.weather"
             });
     }


### PR DESCRIPTION
### 🔍 개요

* 채팅/알림 API(#2336)가 Swagger 문서에 노출되지 않던 문제를 해결합니다. 패키지가 `in.koreatech.koin.domain.teamrecruitment` 인데 `SwaggerGroupConfig` 에는 `in.koreatech.koin.domain.team` 만 등록되어 있어, springdoc 의 패키지 매칭(정확히 일치하거나 `접두사 + "."`)에 걸리지 않았습니다.
* 노출과 함께 응답 코드 목록과 태그명을 정리합니다.

- close #2361

---

### 🚀 주요 변경 내용

* `SwaggerGroupConfig.campusApi()` 에 `in.koreatech.koin.domain.teamrecruitment` 를 추가해 채팅 4개, 알림 4개 엔드포인트를 노출합니다.
* 두 Api 인터페이스에 `@ApiResponseCodes` 를 추가했습니다. #2359 에서 추가된 오류 코드 4개와 `UNAUTHORIZED_USER` / `FORBIDDEN_USER_TYPE` 이 문서에 나오지 않던 상태였습니다.
* 알림 API 세 곳(`markAsRead`, `markAllRead`, `deleteAll`)은 실제로 `204 No Content` 를 반환하므로 `NO_CONTENT` 로 적었습니다.
* `@Tag` 이름을 팀원 모집 도메인의 기존 규칙에 맞췄습니다.

| 변경 전 | 변경 후 |
| --- | --- |
| `3. 원지웅 - 채팅/알림` | `(Normal) Team Recruitment Chat: 팀원 모집 채팅` |
| `팀원 모집 알림` | `(Normal) Team Recruitment Notification: 팀원 모집 알림` |

---

### 💬 참고 사항

* 선행 PR: #2352, #2359
* 코드 변경은 없고 Swagger 노출 설정과 문서 애너테이션만 바뀝니다.

**로컬에서 앱을 띄워 실측한 결과입니다.**

| 확인 항목 | 결과 |
| --- | --- |
| 채팅/알림 8개 엔드포인트 노출 | 전부 노출 |
| Campus 그룹 경로 수 | 83 → 89 (신규 경로 6개와 일치) |
| 다른 그룹 영향 | User 75 / Admin 92, 변화 없음 |
| 응답 코드 | 구현이 실제 던지는 코드와 일치 |

* 응답 코드는 서비스 코드에서 실제로 던지는 것만 넣었습니다. 예를 들어 `GET .../{chatRoomId}/messages` 는 멤버 조회부터 시작해 `TEAM_RECRUITMENT_CHAT_NOT_FOUND` 를 던지지 않으므로 목록에 없습니다.
* 개인 채팅방 생성 API 는 외부 명세가 신규 생성 시 `201`, 승인 전 지원서·읽기 전용 모집에서 `409` 를 정의하지만 현재 구현은 항상 `200` 이고 해당 검증이 없습니다. 문서를 명세에 맞추면 실제 동작과 어긋나므로 이 PR 에서는 실제 동작인 `200` 으로 두었습니다. 구현 변경이 필요한 항목이라 별도 이슈로 정리했습니다.
* `GET /team-recruitments/notifications` 는 외부 명세에 400 이 있지만, 쿼리 파라미터 타입 오류에 대응하는 `ApiResponseCode` 가 없어 넣지 않았습니다.
* `POST /team-recruitments/notifications/{notificationId}/read` 는 구현이 404 를 던지는데 외부 명세에는 404 가 없습니다. 구현에 맞춰 404 를 넣었고, 명세 쪽 반영 여부는 확인이 필요합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨 (Swagger 설정과 문서 애너테이션 변경이라 해당 없음)
- [x] Reviewers / Assignees / Labels 지정 완료 (Reviewers: @taejinn, @dnjswldnd-3513)
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
