### PR TITLE
feat: 팀원 모집 알림 개별 삭제 API 구현

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationApi.java
@@ -52,6 +52,22 @@ public interface TeamRecruitmentNotificationApi {
 
     @ApiResponseCodes({
         NO_CONTENT,
+        TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND,
+        UNAUTHORIZED_USER,
+        FORBIDDEN_USER_TYPE,
+    })
+    @Operation(summary = "알림 개별 삭제", description = """
+        ### 알림 개별 삭제
+        - 알림을 삭제 처리하여 목록에서 제외합니다.
+        - 본인에게 온 알림만 삭제할 수 있으며, 그 외에는 404를 반환합니다.
+        """)
+    ResponseEntity<Void> delete(
+            Integer userId,
+            @PathVariable Integer notificationId
+    );
+
+    @ApiResponseCodes({
+        NO_CONTENT,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
     })

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationController.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentNotificationController.java
@@ -47,6 +47,15 @@ public class TeamRecruitmentNotificationController implements TeamRecruitmentNot
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> delete(
+            @Auth(permit = {STUDENT}) Integer userId,
+            @PathVariable Integer notificationId
+    ) {
+        notificationService.delete(userId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
     @DeleteMapping
     public ResponseEntity<Void> deleteAll(@Auth(permit = {STUDENT}) Integer userId) {
         notificationService.deleteAll(userId);

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentNotificationService.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentNotificationService.java
@@ -57,6 +57,14 @@ public class TeamRecruitmentNotificationService {
     }
 
     @Transactional
+    public void delete(Integer userId, Integer notificationId) {
+        TeamRecruitmentNotification notification = notificationRepository
+                .findByIdAndRecipient_Id(notificationId, userId)
+                .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND));
+        notification.delete();
+    }
+
+    @Transactional
     public void markAllRead(Integer userId) {
         LocalDateTime now = LocalDateTime.now();
         List<TeamRecruitmentNotification> notifications =

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentNotificationServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentNotificationServiceTest.java
@@ -89,6 +89,28 @@ class TeamRecruitmentNotificationServiceTest {
     }
 
     @Test
+    void 개별_삭제시_해당_알림만_삭제한다() {
+        TeamRecruitmentNotification notification = mock(TeamRecruitmentNotification.class);
+        when(notificationRepository.findByIdAndRecipient_Id(NOTIFICATION_ID, USER_ID))
+                .thenReturn(Optional.of(notification));
+
+        notificationService.delete(USER_ID, NOTIFICATION_ID);
+
+        verify(notification).delete();
+    }
+
+    @Test
+    void 존재하지_않는_알림을_삭제하면_404를_반환한다() {
+        when(notificationRepository.findByIdAndRecipient_Id(NOTIFICATION_ID, USER_ID))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.delete(USER_ID, NOTIFICATION_ID))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ApiResponseCode.TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND));
+    }
+
+    @Test
     void 전체_삭제시_삭제되지_않은_알림을_모두_삭제한다() {
         TeamRecruitmentNotification n1 = mock(TeamRecruitmentNotification.class);
         TeamRecruitmentNotification n2 = mock(TeamRecruitmentNotification.class);


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집 알림에 개별 삭제 API 를 추가합니다. 기존에는 전체 삭제만 있어 알림을 하나씩 정리할 수단이 없었습니다.

- close #2362

---

### 🚀 주요 변경 내용

* `DELETE /team-recruitments/notifications/{notificationId}` 를 추가했습니다. 응답은 기존 개별 읽음 처리와 동일하게 `204 No Content` 입니다.
* 본인에게 온 알림만 삭제하도록 `findByIdAndRecipient_Id` 로 조회하고, 없으면 `TEAM_RECRUITMENT_NOTIFICATION_NOT_FOUND` (404) 를 반환합니다. 남의 알림 ID 를 넣어도 404 라 존재 여부가 드러나지 않습니다.
* 삭제는 기존 전체 삭제와 같은 소프트 삭제입니다. `is_deleted` 가 `true` 가 되어 목록 조회와 미읽음 수 집계에서 제외됩니다.

---

### 💬 참고 사항

* 선행 이슈: #2336 / 선행 PR: #2352, #2359, #2360
* 태진님 요청으로 추가하는 신규 엔드포인트입니다. 외부 명세에도 반영이 필요합니다.
* DB 변경, 마이그레이션, 신규 오류 코드가 없습니다. 엔티티의 `delete()` 와 `findByIdAndRecipient_Id` 가 이미 있어 그대로 사용합니다.
* 기존 전체 삭제(`DELETE /team-recruitments/notifications`)와 경로가 겹치지 않습니다.

**로컬에서 확인한 결과입니다.**

| 확인 항목 | 결과 |
| --- | --- |
| 단위 테스트 (정상 삭제 / 존재하지 않는 알림 404) | 통과 |
| Swagger 노출 | `DELETE /team-recruitments/notifications/{notificationId}` — 204, 404, 401, 403 |
| 미인증 실호출 | 401 |

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료 (Reviewers: @taejinn, @dnjswldnd-3513)
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
