### PR TITLE
fix: 중복 JSON 키 요청의 500 오류 방지

### DIFF
--- a/src/main/java/in/koreatech/koin/global/config/WebConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/WebConfig.java
@@ -1,9 +1,15 @@
 package in.koreatech.koin.global.config;
 
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.List;
+import java.util.ListIterator;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -86,5 +92,31 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/static/**")
             .addResourceLocations("classpath:/static/");
+    }
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        ListIterator<HttpMessageConverter<?>> iterator = converters.listIterator();
+        while (iterator.hasNext()) {
+            HttpMessageConverter<?> converter = iterator.next();
+            if (!(converter instanceof MappingJackson2HttpMessageConverter jacksonConverter)) {
+                continue;
+            }
+            if (converter.getClass() != MappingJackson2HttpMessageConverter.class) {
+                throw new IllegalStateException(
+                    "Unsupported MappingJackson2HttpMessageConverter subclass: "
+                        + converter.getClass().getName()
+                );
+            }
+
+            ObjectMapper strictObjectMapper = jacksonConverter.getObjectMapper().copy();
+            strictObjectMapper.enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION.mappedFeature());
+
+            MappingJackson2HttpMessageConverter strictConverter =
+                new MappingJackson2HttpMessageConverter(strictObjectMapper);
+            strictConverter.setSupportedMediaTypes(jacksonConverter.getSupportedMediaTypes());
+            strictConverter.setDefaultCharset(jacksonConverter.getDefaultCharset());
+            iterator.set(strictConverter);
+        }
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import in.koreatech.koin.acceptance.AcceptanceTest;
 import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
@@ -90,6 +92,36 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
             LocalDate.now(clock).plusDays(20),
             LocalDate.now(clock).plusDays(3),
             roles);
+    }
+
+    private ResultActions createRoleBasedRecruitment(String roles) throws Exception {
+        return mockMvc.perform(post("/team-recruitments")
+            .header("Authorization", "Bearer " + authorToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(roleBasedBody(roles)));
+    }
+
+    private void assertNotReadableHttpMessage(ResultActions result) throws Exception {
+        result.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("NOT_READABLE_HTTP_MESSAGE"));
+    }
+
+    private List<Long> recruitmentGraphRowCounts() {
+        return List.of(
+            entityManager.createQuery("select count(recruitment) from TeamRecruitment recruitment", Long.class)
+                .getSingleResult(),
+            entityManager.createQuery("select count(role) from TeamRecruitmentRole role", Long.class)
+                .getSingleResult(),
+            entityManager.createQuery("select count(chatRoom) from TeamRecruitmentChatRoom chatRoom", Long.class)
+                .getSingleResult(),
+            entityManager.createQuery("select count(chatMember) from TeamRecruitmentChatMember chatMember", Long.class)
+                .getSingleResult());
+    }
+
+    private void assertRecruitmentGraphUnchanged(List<Long> before) {
+        entityManager.flush();
+        entityManager.clear();
+        assertThat(recruitmentGraphRowCounts()).containsExactlyElementsOf(before);
     }
 
     private String generalBody(int maxParticipants) {
@@ -207,6 +239,30 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
                         """)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST_BODY"));
+        }
+
+        @Test
+        @DisplayName("역할 객체의 name 키가 max_participants 앞에서 중복되면 400 이다")
+        void duplicateRoleNameKeyBeforeMaxParticipantsOnCreate() throws Exception {
+            List<Long> before = recruitmentGraphRowCounts();
+
+            assertNotReadableHttpMessage(createRoleBasedRecruitment("""
+                {"name": "Backend", "name": "Backend2", "max_participants": 1}
+                """));
+
+            assertRecruitmentGraphUnchanged(before);
+        }
+
+        @Test
+        @DisplayName("역할 객체의 name 키가 max_participants 뒤에서 중복되면 400 이다")
+        void duplicateRoleNameKeyAfterMaxParticipantsOnCreate() throws Exception {
+            List<Long> before = recruitmentGraphRowCounts();
+
+            assertNotReadableHttpMessage(createRoleBasedRecruitment("""
+                {"name": "Backend", "max_participants": 1, "name": "Backend2"}
+                """));
+
+            assertRecruitmentGraphUnchanged(before);
         }
 
         @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import in.koreatech.koin.acceptance.AcceptanceTest;
 import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
@@ -201,6 +202,50 @@ class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
             .containsExactly(
                 tuple(first, "Backend"),
                 tuple(second, "PM"));
+    }
+
+    @Test
+    @DisplayName("수정 시 역할 객체의 name 키가 max_participants 앞에서 중복되면 400 이고 기존 값은 유지된다")
+    void duplicateRoleNameKeyBeforeMaxParticipantsOnUpdate() throws Exception {
+        TeamRecruitment recruitment = saveRoleBasedRecruitment();
+        entityManager.flush();
+        String titleBefore = recruitment.getTitle();
+        List<RoleSnapshot> rolesBefore = roleSnapshots(recruitment.getId());
+        Integer roleId = rolesBefore.get(0).id();
+        RoleSnapshot retainedRole = rolesBefore.get(1);
+
+        assertNotReadableHttpMessage(updateRoleBasedRecruitment(recruitment, """
+            {"id": %d, "name": "PM", "name": "PM2", "max_participants": 1},
+            {"id": %d, "name": "%s", "max_participants": %d}
+            """.formatted(
+            roleId,
+            retainedRole.id(),
+            retainedRole.name(),
+            retainedRole.maxParticipants())));
+
+        assertRecruitmentUnchanged(recruitment.getId(), titleBefore, rolesBefore);
+    }
+
+    @Test
+    @DisplayName("수정 시 역할 객체의 name 키가 max_participants 뒤에서 중복되면 400 이고 기존 값은 유지된다")
+    void duplicateRoleNameKeyAfterMaxParticipantsOnUpdate() throws Exception {
+        TeamRecruitment recruitment = saveRoleBasedRecruitment();
+        entityManager.flush();
+        String titleBefore = recruitment.getTitle();
+        List<RoleSnapshot> rolesBefore = roleSnapshots(recruitment.getId());
+        Integer roleId = rolesBefore.get(0).id();
+        RoleSnapshot retainedRole = rolesBefore.get(1);
+
+        assertNotReadableHttpMessage(updateRoleBasedRecruitment(recruitment, """
+            {"id": %d, "name": "PM", "max_participants": 1, "name": "PM2"},
+            {"id": %d, "name": "%s", "max_participants": %d}
+            """.formatted(
+            roleId,
+            retainedRole.id(),
+            retainedRole.name(),
+            retainedRole.maxParticipants())));
+
+        assertRecruitmentUnchanged(recruitment.getId(), titleBefore, rolesBefore);
     }
 
     @Test
@@ -427,5 +472,50 @@ class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
             LocalDate.now(clock).plusDays(10),
             LocalDate.now(clock).plusDays(1),
             roles);
+    }
+
+    private ResultActions updateRoleBasedRecruitment(TeamRecruitment recruitment, String roles) throws Exception {
+        return mockMvc.perform(put("/team-recruitments/{id}", recruitment.getId())
+            .header("Authorization", "Bearer " + authorToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(roleBasedBody(roles)));
+    }
+
+    private void assertNotReadableHttpMessage(ResultActions result) throws Exception {
+        result.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("NOT_READABLE_HTTP_MESSAGE"));
+    }
+
+    private List<RoleSnapshot> roleSnapshots(Integer recruitmentId) {
+        return roleRepository.findAllByRecruitment_IdOrderByDisplayOrderAsc(recruitmentId).stream()
+            .map(role -> new RoleSnapshot(
+                role.getId(),
+                role.getName(),
+                role.getMaxParticipants(),
+                role.getCurrentParticipants(),
+                role.getDisplayOrder()))
+            .toList();
+    }
+
+    private void assertRecruitmentUnchanged(
+        Integer recruitmentId,
+        String titleBefore,
+        List<RoleSnapshot> rolesBefore
+    ) {
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(recruitmentRepository.findById(recruitmentId).orElseThrow().getTitle())
+            .isEqualTo(titleBefore);
+        assertThat(roleSnapshots(recruitmentId)).containsExactlyElementsOf(rolesBefore);
+    }
+
+    private record RoleSnapshot(
+        Integer id,
+        String name,
+        Integer maxParticipants,
+        Integer currentParticipants,
+        Integer displayOrder
+    ) {
     }
 }

--- a/src/test/java/in/koreatech/koin/global/config/WebConfigTest.java
+++ b/src/test/java/in/koreatech/koin/global/config/WebConfigTest.java
@@ -1,0 +1,163 @@
+package in.koreatech.koin.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import in.koreatech.koin.admin.abtest.useragent.UserAgentArgumentResolver;
+import in.koreatech.koin.global.auth.AuthArgumentResolver;
+import in.koreatech.koin.global.auth.ExtractAuthenticationInterceptor;
+import in.koreatech.koin.global.auth.UserIdArgumentResolver;
+import in.koreatech.koin.global.host.ServerURLArgumentResolver;
+import in.koreatech.koin.global.host.ServerURLInterceptor;
+import in.koreatech.koin.global.ipaddress.IpAddressArgumentResolver;
+import in.koreatech.koin.global.ipaddress.IpAddressInterceptor;
+
+@ExtendWith(MockitoExtension.class)
+class WebConfigTest {
+
+    private static final String DUPLICATE_JSON = "{\"name\":\"first\",\"name\":\"last\"}";
+    private static final TypeReference<Map<String, String>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    @Mock
+    private ExtractAuthenticationInterceptor extractAuthenticationInterceptor;
+
+    @Mock
+    private IpAddressArgumentResolver ipAddressArgumentResolver;
+
+    @Mock
+    private ServerURLInterceptor serverURLInterceptor;
+
+    @Mock
+    private AuthArgumentResolver authArgumentResolver;
+
+    @Mock
+    private IpAddressInterceptor ipAddressInterceptor;
+
+    @Mock
+    private ServerURLArgumentResolver serverURLArgumentResolver;
+
+    @Mock
+    private UserIdArgumentResolver userIdArgumentResolver;
+
+    @Mock
+    private UserAgentArgumentResolver userAgentArgumentResolver;
+
+    @Mock
+    private CorsProperties corsProperties;
+
+    @InjectMocks
+    private WebConfig webConfig;
+
+    @Test
+    void replacesJacksonConvertersWithStrictCopiesWithoutMutatingSharedConverters() throws Exception {
+        ObjectMapper firstMapper = mapperWithMarker("first-marker");
+        ObjectMapper secondMapper = mapperWithMarker("second-marker");
+        MappingJackson2HttpMessageConverter firstConverter =
+            jacksonConverter(firstMapper, StandardCharsets.ISO_8859_1, "application/vnd.first+json");
+        MappingJackson2HttpMessageConverter secondConverter =
+            jacksonConverter(secondMapper, StandardCharsets.UTF_16, "application/vnd.second+json");
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setMessageConverters(List.of(firstConverter, secondConverter));
+
+        HttpMessageConverter<?> nonJacksonConverter = new StringHttpMessageConverter();
+        HttpMessageConverter<?> anotherNonJacksonConverter = new StringHttpMessageConverter();
+        List<HttpMessageConverter<?>> mvcConverters = new ArrayList<>();
+        mvcConverters.add(nonJacksonConverter);
+        mvcConverters.add(firstConverter);
+        mvcConverters.add(anotherNonJacksonConverter);
+        mvcConverters.add(secondConverter);
+
+        webConfig.extendMessageConverters(mvcConverters);
+
+        assertThat(mvcConverters).hasSize(4);
+        assertThat(mvcConverters.get(0)).isSameAs(nonJacksonConverter);
+        assertThat(mvcConverters.get(2)).isSameAs(anotherNonJacksonConverter);
+        assertThat(mvcConverters.get(1)).isNotSameAs(firstConverter);
+        assertThat(mvcConverters.get(3)).isNotSameAs(secondConverter);
+
+        MappingJackson2HttpMessageConverter firstReplacement =
+            (MappingJackson2HttpMessageConverter) mvcConverters.get(1);
+        MappingJackson2HttpMessageConverter secondReplacement =
+            (MappingJackson2HttpMessageConverter) mvcConverters.get(3);
+        assertThat(firstReplacement.getObjectMapper()
+            .isEnabled(StreamReadFeature.STRICT_DUPLICATE_DETECTION.mappedFeature())).isTrue();
+        assertThat(secondReplacement.getObjectMapper()
+            .isEnabled(StreamReadFeature.STRICT_DUPLICATE_DETECTION.mappedFeature())).isTrue();
+        assertThat(firstReplacement.getObjectMapper()).isNotSameAs(firstMapper);
+        assertThat(secondReplacement.getObjectMapper()).isNotSameAs(secondMapper);
+        assertThat(firstReplacement.getObjectMapper().getRegisteredModuleIds()).contains("first-marker");
+        assertThat(secondReplacement.getObjectMapper().getRegisteredModuleIds()).contains("second-marker");
+        assertThat(firstReplacement.getSupportedMediaTypes())
+            .containsExactlyElementsOf(firstConverter.getSupportedMediaTypes());
+        assertThat(secondReplacement.getSupportedMediaTypes())
+            .containsExactlyElementsOf(secondConverter.getSupportedMediaTypes());
+        assertThat(firstReplacement.getDefaultCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+        assertThat(secondReplacement.getDefaultCharset()).isEqualTo(StandardCharsets.UTF_16);
+
+        assertThat(restTemplate.getMessageConverters()).containsExactly(firstConverter, secondConverter);
+        assertThat(restTemplate.getMessageConverters().get(0)).isSameAs(firstConverter);
+        assertThat(restTemplate.getMessageConverters().get(1)).isSameAs(secondConverter);
+        assertThat(firstMapper.isEnabled(StreamReadFeature.STRICT_DUPLICATE_DETECTION.mappedFeature())).isFalse();
+        assertThat(secondMapper.isEnabled(StreamReadFeature.STRICT_DUPLICATE_DETECTION.mappedFeature())).isFalse();
+        assertThat(firstMapper.readValue(DUPLICATE_JSON, MAP_TYPE)).containsEntry("name", "last");
+        assertThat(secondMapper.readValue(DUPLICATE_JSON, MAP_TYPE)).containsEntry("name", "last");
+        assertThatThrownBy(() -> firstReplacement.getObjectMapper().readValue(DUPLICATE_JSON, MAP_TYPE))
+            .isInstanceOf(JsonParseException.class);
+        assertThatThrownBy(() -> secondReplacement.getObjectMapper().readValue(DUPLICATE_JSON, MAP_TYPE))
+            .isInstanceOf(JsonParseException.class);
+    }
+
+    @Test
+    void rejectsJacksonConverterSubclasses() {
+        MappingJackson2HttpMessageConverter subclassConverter = new CustomJacksonHttpMessageConverter();
+        List<HttpMessageConverter<?>> converters = new ArrayList<>();
+        converters.add(subclassConverter);
+
+        assertThatThrownBy(() -> webConfig.extendMessageConverters(converters))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(CustomJacksonHttpMessageConverter.class.getName());
+    }
+
+    private ObjectMapper mapperWithMarker(String markerName) {
+        return new ObjectMapper().registerModule(new SimpleModule(markerName));
+    }
+
+    private MappingJackson2HttpMessageConverter jacksonConverter(
+        ObjectMapper objectMapper,
+        java.nio.charset.Charset defaultCharset,
+        String customMediaType
+    ) {
+        MappingJackson2HttpMessageConverter converter =
+            new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaType.valueOf(customMediaType)));
+        converter.setDefaultCharset(defaultCharset);
+        return converter;
+    }
+
+    private static class CustomJacksonHttpMessageConverter extends MappingJackson2HttpMessageConverter {
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 중복 JSON 키가 포함된 모집글 요청이 필드 순서에 따라 마지막 값으로 처리되거나 500 오류를 반환하던 문제를 수정합니다.
* Spring MVC 요청 파서에서 중복 키를 일관되게 거부하고 기존 `NOT_READABLE_HTTP_MESSAGE` 400 응답 경로를 사용합니다.

- close #2368

---

### 🚀 주요 변경 내용

* MVC Jackson converter를 strict duplicate detection이 활성화된 복사본으로 같은 위치에서 교체했습니다.
* Boot `HttpMessageConverters`와 `RestTemplate`이 공유하는 원본 converter 및 `ObjectMapper`는 변경하지 않습니다.
* converter 순서, supported media types, default charset, Jackson module 구성을 보존하고 예상하지 못한 subclass는 fail-fast 처리합니다.
* POST/PUT 각각 두 가지 중복 키 순서를 400으로 처리하고 DB 상태가 바뀌지 않는 회귀 테스트를 추가했습니다.

---

### 💬 참고 사항

* 변경 전 재현 결과는 키 순서에 따라 POST 201/500, PUT 200/500이었습니다.
* 변경 후 네 경우 모두 400 `NOT_READABLE_HTTP_MESSAGE`를 반환합니다.
* multipart 내부 JSON part 및 별도 custom JSON converter는 현재 적용 범위에 포함하지 않습니다.
* `./gradlew test --no-daemon` 전체 테스트를 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate JSON keys are now rejected with a clear 400 error instead of being silently accepted.
  * Invalid recruitment creation or updates no longer modify existing recruitment, role, chat room, or member data.

* **Tests**
  * Added coverage for duplicate keys in different JSON positions.
  * Added validation for preserving existing request and response conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->