### PR TITLE
fix: 로그인 ID 하이픈을 이모지로 오인하는 검증 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/validation/NotEmojiValidator.java
+++ b/src/main/java/in/koreatech/koin/global/validation/NotEmojiValidator.java
@@ -1,8 +1,5 @@
 package in.koreatech.koin.global.validation;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.springframework.stereotype.Component;
 
 import jakarta.validation.ConstraintValidator;
@@ -11,7 +8,7 @@ import jakarta.validation.ConstraintValidatorContext;
 @Component
 public class NotEmojiValidator implements ConstraintValidator<NotEmoji, String> {
 
-    private static final Pattern EMOJI_PATTERN = Pattern.compile("[\\uD83C-\\uDBFF\\uDC00-\\uDFFF]+");
+    private static final int EMOJI_VARIATION_SELECTOR = 0xFE0F;
 
     @Override
     public void initialize(NotEmoji constraintAnnotation) {
@@ -23,10 +20,14 @@ public class NotEmojiValidator implements ConstraintValidator<NotEmoji, String> 
         if (field == null) {
             return true;
         }
-        Matcher emojiMatcher = EMOJI_PATTERN.matcher(field);
-        if (emojiMatcher.find()) {
-            return false;
-        }
-        return true;
+        return field.codePoints().noneMatch(codePoint ->
+            Character.isSupplementaryCodePoint(codePoint)
+                || codePoint == EMOJI_VARIATION_SELECTOR
+                || isIsolatedSurrogate(codePoint)
+        );
+    }
+
+    private static boolean isIsolatedSurrogate(int codePoint) {
+        return codePoint >= Character.MIN_SURROGATE && codePoint <= Character.MAX_SURROGATE;
     }
 }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/UserApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/UserApiTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import in.koreatech.koin.acceptance.AcceptanceTest;
 import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
@@ -37,6 +38,9 @@ class UserApiTest extends AcceptanceTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -70,6 +74,37 @@ class UserApiTest extends AcceptanceTest {
                           "password" : "%s"
                         }
                         """.formatted(email, password))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("User-Agent", userFixture.맥북userAgent헤더())
+            )
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 하이픈이_포함된_아이디로_로그인한다() throws Exception {
+        String loginId = "user-1";
+        String password = "1234";
+        userRepository.save(User.builder()
+            .loginPw(passwordEncoder.encode(password))
+            .nickname("하이픈")
+            .name("하이픈사용자")
+            .phoneNumber("01098765432")
+            .userType(UserType.GENERAL)
+            .email("hyphen@koreatech.ac.kr")
+            .loginId(loginId)
+            .isAuthed(true)
+            .isDeleted(false)
+            .build()
+        );
+
+        mockMvc.perform(
+                post("/v2/users/login")
+                    .content("""
+                        {
+                          "login_id" : "%s",
+                          "login_pw" : "%s"
+                        }
+                        """.formatted(loginId, password))
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("User-Agent", userFixture.맥북userAgent헤더())
             )

--- a/src/test/java/in/koreatech/koin/global/validation/NotEmojiValidatorTest.java
+++ b/src/test/java/in/koreatech/koin/global/validation/NotEmojiValidatorTest.java
@@ -1,0 +1,52 @@
+package in.koreatech.koin.global.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NotEmojiValidatorTest {
+
+    private final NotEmojiValidator validator = new NotEmojiValidator();
+
+    @Test
+    void ASCII_하이픈을_허용한다() {
+        assertThat(validator.isValid("user-1", null)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"abc_d", "abc.d", "abc123"})
+    void 회원가입_아이디에_허용된_문자를_허용한다(String field) {
+        assertThat(validator.isValid(field, null)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"😀", "abc😀d", "🫠", "❤️", "1️⃣"})
+    void 실제_이모지를_거절한다(String field) {
+        assertThat(validator.isValid(field, null)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0xD83D, 0xDC00})
+    void 고립된_surrogate를_거절한다(int surrogate) {
+        String field = new String(new char[]{(char)surrogate});
+
+        assertThat(validator.isValid(field, null)).isFalse();
+    }
+
+    @Test
+    void variation_selector가_없는_기존_BMP_문자는_허용한다() {
+        assertThat(validator.isValid("☕", null)).isTrue();
+    }
+
+    @Test
+    void 빈_문자열은_허용한다() {
+        assertThat(validator.isValid("", null)).isTrue();
+    }
+
+    @Test
+    void null은_허용한다() {
+        assertThat(validator.isValid(null, null)).isTrue();
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 로그인 ID의 ASCII 하이픈(`-`)을 이모지로 잘못 판단해 정상 로그인을 차단하던 공용 validator 오류를 수정합니다.

- close #2370

---

### 🚀 주요 변경 내용

* 문자열 검사를 UTF-16 문자 범위 정규식에서 Unicode code point 검사로 교체했습니다.
* `user-1`, `_`, `.`, 영숫자를 정상 ID로 허용합니다.
* supplementary code point, variation selector, 고립 surrogate를 거절합니다.
* `/v2/users/login`에 하이픈 ID HTTP 회귀 테스트를 추가했습니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P1 인증 오류이며 클라이언트는 기존 로그인 요청 JSON을 그대로 사용합니다.
  * 가입 DTO의 `@NotBlank`와 ASCII 형식 검증 계약을 유지합니다.
* **검증**
  * validator 경계 테스트 14개와 로그인 HTTP 회귀 테스트 1개, 총 15개가 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input validation to consistently reject emoji characters, including multi-character emoji sequences and invalid surrogate characters.
  - Preserved support for permitted registration ID characters such as hyphens, underscores, periods, and alphanumeric characters.
  - Fixed authentication for general users with hyphenated login IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->