### PR TITLE
fix: DIRECT 채팅방 생성을 동시성 안전한 get-or-create로 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
@@ -94,11 +94,12 @@ public class TeamRecruitmentChatService {
 
     @Transactional
     public DirectChatRoomCreationResult getOrCreateDirectChatRoom(Integer userId, Integer recruitmentId, Integer applicationId) {
-        TeamRecruitmentApplication application = applicationRepository.findById(applicationId)
-                .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND));
-
-        TeamRecruitment recruitment = recruitmentRepository.findById(recruitmentId)
+        TeamRecruitment recruitment = recruitmentRepository.findByIdWithLock(recruitmentId)
                 .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_NOT_FOUND));
+
+        TeamRecruitmentApplication application = applicationRepository
+                .findByIdAndRecruitmentIdWithLock(applicationId, recruitmentId)
+                .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND));
 
         if (!application.getRecruitment().getId().equals(recruitmentId)) {
             throw CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND);

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDirectChatConcurrencyTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDirectChatConcurrencyTest.java
@@ -1,0 +1,224 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.fixture.DepartmentAcceptanceFixture;
+import in.koreatech.koin.acceptance.fixture.UserAcceptanceFixture;
+import in.koreatech.koin.domain.student.model.Department;
+import in.koreatech.koin.domain.student.model.Student;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+
+@Import(TeamRecruitmentDirectChatConcurrencyTest.DirectRoomSaveBarrier.class)
+class TeamRecruitmentDirectChatConcurrencyTest extends AcceptanceTest {
+
+    private static final int CONCURRENT_REQUEST_COUNT = 8;
+
+    @Autowired
+    private UserAcceptanceFixture userFixture;
+
+    @Autowired
+    private DepartmentAcceptanceFixture departmentFixture;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Autowired
+    private DirectRoomSaveBarrier directRoomSaveBarrier;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private TeamRecruitment recruitment;
+    private TeamRecruitmentApplication application;
+    private String authorToken;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        Department department = departmentFixture.컴퓨터공학부();
+        Student author = userFixture.준호_학생(department, null);
+        Student applicant = userFixture.성빈_학생(department);
+        authorToken = userFixture.getToken(author.getUser());
+
+        recruitment = recruitmentRepository.save(TeamRecruitment.builder()
+            .author(author.getUser())
+            .category(PROJECT)
+            .title("동시성 테스트 모집글")
+            .meetingType(ONLINE)
+            .activityStartDate(LocalDate.now(clock).plusDays(2))
+            .activityEndDate(LocalDate.now(clock).plusDays(10))
+            .deadlineDate(LocalDate.now(clock).plusDays(1))
+            .recruitmentType(GENERAL)
+            .maxParticipants(2)
+            .currentParticipants(1)
+            .description("동일한 지원서로 DIRECT 채팅방을 동시에 생성한다.")
+            .status(RECRUITING)
+            .build());
+        application = applicationRepository.save(TeamRecruitmentApplication.builder()
+            .recruitment(recruitment)
+            .applicant(applicant.getUser())
+            .motivation("지원 동기")
+            .availability("월수금 20시 이후")
+            .status(ACCEPTED)
+            .profileSnapshot("{}")
+            .snapshotVersion(1)
+            .build());
+    }
+
+    @Test
+    void 동일한_지원서의_DIRECT_채팅방_생성_요청_2건은_하나의_방으로_수렴한다() throws Exception {
+        assertConcurrentGetOrCreate(2);
+    }
+
+    @Test
+    void 동일한_지원서의_DIRECT_채팅방_생성_요청_N건은_하나의_방으로_수렴한다() throws Exception {
+        assertConcurrentGetOrCreate(CONCURRENT_REQUEST_COUNT);
+    }
+
+    private void assertConcurrentGetOrCreate(int requestCount) throws Exception {
+        directRoomSaveBarrier.expectInsertions(requestCount);
+
+        entityManager.flush();
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        List<MvcResult> results = performConcurrentRequests(requestCount);
+        List<Integer> statuses = results.stream()
+            .map(result -> result.getResponse().getStatus())
+            .toList();
+        List<Integer> chatRoomIds = new ArrayList<>();
+        for (MvcResult result : results) {
+            JsonNode response = objectMapper.readTree(result.getResponse().getContentAsString());
+            chatRoomIds.add(response.path("chat_room_id").asInt());
+        }
+
+        assertThat(statuses).containsOnly(200, 201);
+        assertThat(statuses).containsExactlyInAnyOrderElementsOf(expectedStatuses(requestCount));
+        assertThat(chatRoomIds).doesNotContain(0).allMatch(chatRoomIds.get(0)::equals);
+
+        Integer chatRoomCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*)
+            FROM team_recruitment_chat_room
+            WHERE recruitment_id = ?
+              AND application_id = ?
+              AND room_type = 'DIRECT'
+            """, Integer.class, recruitment.getId(), application.getId());
+        Integer memberCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*)
+            FROM team_recruitment_chat_member
+            WHERE chat_room_id = ?
+            """, Integer.class, chatRoomIds.get(0));
+
+        assertThat(chatRoomCount).isOne();
+        assertThat(memberCount).isEqualTo(2);
+    }
+
+    private List<MvcResult> performConcurrentRequests(int requestCount) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch ready = new CountDownLatch(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<MvcResult>> futures = new ArrayList<>();
+            for (int i = 0; i < requestCount; i++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(5, SECONDS)) {
+                        throw new IllegalStateException("동시 요청 시작 대기 시간이 초과되었습니다.");
+                    }
+                    return mockMvc.perform(post(
+                            "/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                            recruitment.getId(), application.getId())
+                        .header("Authorization", "Bearer " + authorToken))
+                        .andReturn();
+                }));
+            }
+            assertThat(ready.await(5, SECONDS)).isTrue();
+            start.countDown();
+
+            List<MvcResult> results = new ArrayList<>();
+            for (Future<MvcResult> future : futures) {
+                results.add(future.get(15, SECONDS));
+            }
+            return results;
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, SECONDS)).isTrue();
+        }
+    }
+
+    private List<Integer> expectedStatuses(int requestCount) {
+        List<Integer> statuses = new ArrayList<>();
+        statuses.add(201);
+        for (int i = 1; i < requestCount; i++) {
+            statuses.add(200);
+        }
+        return statuses;
+    }
+
+    @Aspect
+    static class DirectRoomSaveBarrier {
+
+        private final AtomicReference<CountDownLatch> insertions =
+            new AtomicReference<>(new CountDownLatch(0));
+
+        void expectInsertions(int requestCount) {
+            insertions.set(new CountDownLatch(requestCount));
+        }
+
+        @Around("bean(teamRecruitmentChatRoomRepository) && execution(* save(..)) && args(chatRoom)")
+        Object awaitConcurrentInsertions(
+            ProceedingJoinPoint joinPoint,
+            TeamRecruitmentChatRoom chatRoom
+        ) throws Throwable {
+            if (chatRoom.getRoomType() == DIRECT) {
+                CountDownLatch latch = insertions.get();
+                latch.countDown();
+                // 수정 전에는 모든 요청이 insert까지 도달하고, 수정 후에는 최초 요청만 도달한다.
+                latch.await(1, SECONDS);
+            }
+            return joinPoint.proceed();
+        }
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.unit.domain.teamrecruitment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +11,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -117,8 +119,10 @@ class TeamRecruitmentChatServiceTest {
     void 지원서가_다른_모집글_소속이면_404를_반환한다() {
         TeamRecruitmentApplication application = mock(TeamRecruitmentApplication.class);
         TeamRecruitment wrongRecruitment = mock(TeamRecruitment.class);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(mock(TeamRecruitment.class)));
+        when(recruitmentRepository.findByIdWithLock(RECRUITMENT_ID))
+                .thenReturn(Optional.of(mock(TeamRecruitment.class)));
+        when(applicationRepository.findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID))
+                .thenReturn(Optional.of(application));
         when(application.getRecruitment()).thenReturn(wrongRecruitment);
         when(wrongRecruitment.getId()).thenReturn(99);
 
@@ -133,8 +137,9 @@ class TeamRecruitmentChatServiceTest {
         User author = UserFixture.id_설정_코인_유저(USER_ID);
         TeamRecruitmentApplication application = mock(TeamRecruitmentApplication.class);
         TeamRecruitment recruitment = mock(TeamRecruitment.class);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(recruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID))
+                .thenReturn(Optional.of(application));
         when(application.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(recruitment.getAuthor()).thenReturn(author);
@@ -151,8 +156,9 @@ class TeamRecruitmentChatServiceTest {
         User author = UserFixture.id_설정_코인_유저(USER_ID);
         TeamRecruitmentApplication application = mock(TeamRecruitmentApplication.class);
         TeamRecruitment recruitment = mock(TeamRecruitment.class);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(recruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID))
+                .thenReturn(Optional.of(application));
         when(application.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(recruitment.getAuthor()).thenReturn(author);
@@ -170,8 +176,9 @@ class TeamRecruitmentChatServiceTest {
         User otherAuthor = UserFixture.id_설정_코인_유저(OTHER_USER_ID);
         TeamRecruitmentApplication application = mock(TeamRecruitmentApplication.class);
         TeamRecruitment recruitment = mock(TeamRecruitment.class);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(recruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID))
+                .thenReturn(Optional.of(application));
         when(application.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(recruitment.getAuthor()).thenReturn(otherAuthor);
@@ -190,8 +197,9 @@ class TeamRecruitmentChatServiceTest {
         TeamRecruitment recruitment = mock(TeamRecruitment.class);
         TeamRecruitmentChatRoom existingRoom = mock(TeamRecruitmentChatRoom.class);
 
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(recruitmentRepository.findByIdWithLock(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID))
+                .thenReturn(Optional.of(application));
         when(application.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(application.getStatus()).thenReturn(TeamRecruitmentApplicationStatus.ACCEPTED);
@@ -210,6 +218,13 @@ class TeamRecruitmentChatServiceTest {
         assertThat(result.isNew()).isFalse();
         assertThat(result.response().chatRoomId()).isEqualTo(CHAT_ROOM_ID);
         assertThat(result.response().roomName()).isEqualTo(counterpart.getNickname());
+
+        InOrder lockOrder = inOrder(recruitmentRepository, applicationRepository, chatRoomRepository);
+        lockOrder.verify(recruitmentRepository).findByIdWithLock(RECRUITMENT_ID);
+        lockOrder.verify(applicationRepository)
+                .findByIdAndRecruitmentIdWithLock(APPLICATION_ID, RECRUITMENT_ID);
+        lockOrder.verify(chatRoomRepository).findByRecruitment_IdAndApplication_IdAndRoomType(
+                RECRUITMENT_ID, APPLICATION_ID, TeamRecruitmentChatRoomType.DIRECT);
     }
 
     @Test


### PR DESCRIPTION
### 🔍 개요

* 같은 모집글·지원서에 대한 DIRECT 채팅방 생성 요청이 동시에 들어와도 방 하나를 반환하도록 get-or-create 경계를 보강합니다.

- close #2371

---

### 🚀 주요 변경 내용

* 모집글과 지원서를 pessimistic lock으로 조회합니다.
* lock 획득 후 기존 DIRECT 방을 다시 조회합니다.
* 최초 요청은 방을 생성해 `201`을 반환하고 후속 동시 요청은 같은 방을 조회해 `200`을 반환합니다.
* 최종 상태를 DIRECT 방 1개와 멤버 2명으로 유지합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P1 서비스 동시성 오류이며 요청·응답 JSON 계약은 그대로 유지합니다.
  * 서버 transaction과 MySQL 동시성 경계를 보강합니다.
* **검증**
  * 실제 MySQL의 2개 및 N개 동시 요청을 포함한 관련 테스트 17개가 통과했습니다.
* **반영 순서**
  * 이 PR을 먼저 반영한 뒤 #2385와 #2386을 rebase하여 lock을 보존합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple requests create the same team recruitment direct chat room concurrently.
  * Prevented duplicate direct chat rooms from being created during simultaneous requests.

* **Tests**
  * Added coverage for concurrent direct chat room creation.
  * Expanded service tests to verify locking and operation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->