### PR TITLE
fix: 개인 채팅 CTA와 DIRECT 생성 조건을 동일 정책으로 정렬

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantDetail.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantDetail.java
@@ -31,7 +31,12 @@ public record ApplicantDetail(
     @Schema(description = "현재 사용자가 승인/거절할 수 있는지", example = "true", requiredMode = REQUIRED)
     Boolean canDecide,
 
-    @Schema(description = "개인 채팅을 시작할 수 있는지", example = "false", requiredMode = REQUIRED)
+    @Schema(
+        description = "기존 DIRECT 방이 있거나, 마감일이 지나지 않은 RECRUITING 상태이거나, "
+            + "정원 충족으로 마감되어 ACTIVE TEAM 방이 있을 때 개인 채팅을 시작할 수 있는지",
+        example = "false",
+        requiredMode = REQUIRED
+    )
     Boolean canOpenDirectChat
 ) {
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantSummary.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantSummary.java
@@ -28,7 +28,12 @@ public record ApplicantSummary(
     @Schema(description = "지원 상태", example = "PENDING", requiredMode = REQUIRED)
     TeamRecruitmentApplicationStatus status,
 
-    @Schema(description = "개인 채팅 시작 가능 여부", example = "false", requiredMode = REQUIRED)
+    @Schema(
+        description = "기존 DIRECT 방이 있거나, 마감일이 지나지 않은 RECRUITING 상태이거나, "
+            + "정원 충족으로 마감되어 ACTIVE TEAM 방이 있을 때 개인 채팅 시작 가능 여부",
+        example = "false",
+        requiredMode = REQUIRED
+    )
     Boolean canOpenDirectChat
 ) {
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicy.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicy.java
@@ -1,0 +1,42 @@
+package in.koreatech.koin.domain.team.recruitment.model;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public final class TeamRecruitmentDirectChatPolicy {
+
+    private TeamRecruitmentDirectChatPolicy() {
+    }
+
+    public static boolean canOpenDirectChat(
+        TeamRecruitmentApplicationStatus applicationStatus,
+        boolean hasExistingDirectChat,
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoom teamChatRoom,
+        LocalDate today
+    ) {
+        if (applicationStatus != ACCEPTED) {
+            return false;
+        }
+        if (hasExistingDirectChat) {
+            return true;
+        }
+        if (recruitment == null || recruitment.isDeleted()) {
+            return false;
+        }
+        Objects.requireNonNull(today, "today must not be null");
+        if (recruitment.isRecruiting()) {
+            return recruitment.getDeadlineDate() == null
+                || !today.isAfter(recruitment.getDeadlineDate());
+        }
+        return recruitment.getStatus() == CLOSED
+            && teamChatRoom != null
+            && teamChatRoom.getRoomType() == TEAM
+            && teamChatRoom.isActive();
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -31,6 +31,7 @@ import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentDirectChatPolicy;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
@@ -125,8 +126,10 @@ public class TeamRecruitmentApplicationQueryService {
             selectedStatuses,
             pageRequest(criteria, TeamRecruitmentApplicationSort.LATEST_DESC, false)
         );
+        LocalDate today = today();
+        AcceptedChatRooms acceptedChatRooms = findAcceptedChatRooms(applications.getContent());
         List<ApplicantSummary> content = applications.getContent().stream()
-            .map(this::toApplicantSummary)
+            .map(application -> toApplicantSummary(application, acceptedChatRooms, today))
             .toList();
         return new ApplicantListResponse(
             toApplicantRecruitment(recruitment),
@@ -156,6 +159,9 @@ public class TeamRecruitmentApplicationQueryService {
         boolean canDecide = application.getStatus() == PENDING
             && recruitment.getStatus() == RECRUITING
             && !isPastDeadline(recruitment);
+        LocalDate today = today();
+        boolean canOpenDirectChat = application.getStatus() == ACCEPTED
+            && canOpenDirectChat(application, findAcceptedChatRooms(List.of(application)), today);
         return new ApplicantDetail(
             application.getId(),
             application.getStatus(),
@@ -164,7 +170,7 @@ public class TeamRecruitmentApplicationQueryService {
             application.getAvailability(),
             toApplicationRole(application.getRole()),
             canDecide,
-            application.getStatus() == ACCEPTED
+            canOpenDirectChat
         );
     }
 
@@ -306,7 +312,11 @@ public class TeamRecruitmentApplicationQueryService {
         return new AcceptedChatRooms(teamRoomsByRecruitmentId, directRoomsByApplicationId);
     }
 
-    private ApplicantSummary toApplicantSummary(TeamRecruitmentApplication application) {
+    private ApplicantSummary toApplicantSummary(
+        TeamRecruitmentApplication application,
+        AcceptedChatRooms acceptedChatRooms,
+        LocalDate today
+    ) {
         ProfileSnapshot snapshot = readProfileSnapshot(application.getProfileSnapshot());
         return new ApplicantSummary(
             application.getId(),
@@ -315,8 +325,23 @@ public class TeamRecruitmentApplicationQueryService {
             snapshot.studentYear(),
             toApplicationRole(application.getRole()),
             application.getStatus(),
-            application.getStatus() == ACCEPTED
+            canOpenDirectChat(application, acceptedChatRooms, today)
         );
+    }
+
+    private boolean canOpenDirectChat(
+        TeamRecruitmentApplication application,
+        AcceptedChatRooms acceptedChatRooms,
+        LocalDate today
+    ) {
+        TeamRecruitment recruitment = application.getRecruitment();
+        boolean hasExistingDirectChat = application.getId() != null
+            && acceptedChatRooms.directRoomsByApplicationId().containsKey(application.getId());
+        TeamRecruitmentChatRoom teamChatRoom = recruitment.getId() == null
+            ? null
+            : acceptedChatRooms.teamRoomsByRecruitmentId().get(recruitment.getId());
+        return TeamRecruitmentDirectChatPolicy.canOpenDirectChat(
+            application.getStatus(), hasExistingDirectChat, recruitment, teamChatRoom, today);
     }
 
     private RecruitmentCard toRecruitmentCard(TeamRecruitment recruitment) {
@@ -407,6 +432,10 @@ public class TeamRecruitmentApplicationQueryService {
     private boolean isPastDeadline(TeamRecruitment recruitment) {
         return recruitment.getDeadlineDate() != null
             && LocalDate.now(clock.withZone(KST)).isAfter(recruitment.getDeadlineDate());
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(clock.withZone(KST));
     }
 
     private ProfileSnapshot readProfileSnapshot(String profileSnapshot) {

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
@@ -60,7 +60,12 @@ public interface TeamRecruitmentChatApi {
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
     })
-    @Operation(summary = "지원자와 개인 채팅방 생성 또는 조회")
+    @Operation(
+        summary = "지원자와 개인 채팅방 생성 또는 조회",
+        description = "ACCEPTED 지원서만 대상입니다. 기존 DIRECT 채팅방이 있으면 모집 상태와 관계없이 기존 방을 반환합니다. "
+            + "기존 방이 없을 때는 마감일이 지나지 않은 RECRUITING 상태이거나 "
+            + "정원 충족으로 마감되어 ACTIVE 상태인 TEAM 채팅방이 있는 경우에만 새 방을 생성합니다."
+    )
     ResponseEntity<DirectChatRoomResponse> getOrCreateDirectChatRoom(
             Integer userId,
             @PathVariable Integer recruitmentId,

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
@@ -1,10 +1,14 @@
 package in.koreatech.koin.domain.teamrecruitment.service;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +18,7 @@ import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplicatio
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMessage;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentDirectChatPolicy;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentNotification;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
@@ -46,6 +51,7 @@ import static in.koreatech.koin.global.code.ApiResponseCode.*;
 @Transactional(readOnly = true)
 public class TeamRecruitmentChatService {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
     private static final String AGGREGATE_TYPE = "TEAM_RECRUITMENT";
 
@@ -57,6 +63,7 @@ public class TeamRecruitmentChatService {
     private final TeamRecruitmentNotificationRepository notificationRepository;
     private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
+    private final Clock clock;
 
     public ChatRoomResponse getChatRoom(Integer userId, Integer recruitmentId, Integer chatRoomId) {
         TeamRecruitmentChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -113,31 +120,39 @@ public class TeamRecruitmentChatService {
             throw CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_ACCEPTED);
         }
 
-        if (!recruitment.isRecruiting()) {
+        User counterpartUser = application.getApplicant();
+        Optional<TeamRecruitmentChatRoom> existingDirectChatRoom = chatRoomRepository
+                .findByRecruitment_IdAndApplication_IdAndRoomType(
+                        recruitmentId, applicationId, TeamRecruitmentChatRoomType.DIRECT);
+        if (existingDirectChatRoom.isPresent()) {
+            return new DirectChatRoomCreationResult(
+                    DirectChatRoomResponse.of(existingDirectChatRoom.get(), counterpartUser), false);
+        }
+
+        TeamRecruitmentChatRoom teamChatRoom = chatRoomRepository
+                .findByRecruitment_IdAndRoomScopeKey(recruitmentId, TeamRecruitmentChatRoom.TEAM_ROOM_SCOPE_KEY)
+                .filter(room -> room.getRoomType() == TeamRecruitmentChatRoomType.TEAM)
+                .orElse(null);
+        LocalDate today = LocalDate.now(clock.withZone(KST));
+        if (!TeamRecruitmentDirectChatPolicy.canOpenDirectChat(
+                application.getStatus(), false, recruitment, teamChatRoom, today)) {
             throw CustomException.of(TEAM_RECRUITMENT_CLOSED);
         }
 
-        User counterpartUser = application.getApplicant();
+        TeamRecruitmentChatRoom chatRoom = TeamRecruitmentChatRoom.builder()
+                .recruitment(recruitment)
+                .roomScopeKey("DIRECT-" + applicationId)
+                .roomType(TeamRecruitmentChatRoomType.DIRECT)
+                .application(application)
+                .build();
+        chatRoom = chatRoomRepository.save(chatRoom);
 
-        return chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(
-                        recruitmentId, applicationId, TeamRecruitmentChatRoomType.DIRECT)
-                .map(existing -> new DirectChatRoomCreationResult(DirectChatRoomResponse.of(existing, counterpartUser), false))
-                .orElseGet(() -> {
-                    TeamRecruitmentChatRoom chatRoom = TeamRecruitmentChatRoom.builder()
-                            .recruitment(recruitment)
-                            .roomScopeKey("DIRECT-" + applicationId)
-                            .roomType(TeamRecruitmentChatRoomType.DIRECT)
-                            .application(application)
-                            .build();
-                    chatRoom = chatRoomRepository.save(chatRoom);
+        memberRepository.save(TeamRecruitmentChatMember.builder()
+                .chatRoom(chatRoom).user(recruitment.getAuthor()).build());
+        memberRepository.save(TeamRecruitmentChatMember.builder()
+                .chatRoom(chatRoom).user(counterpartUser).build());
 
-                    memberRepository.save(TeamRecruitmentChatMember.builder()
-                            .chatRoom(chatRoom).user(recruitment.getAuthor()).build());
-                    memberRepository.save(TeamRecruitmentChatMember.builder()
-                            .chatRoom(chatRoom).user(counterpartUser).build());
-
-                    return new DirectChatRoomCreationResult(DirectChatRoomResponse.of(chatRoom, counterpartUser), true);
-                });
+        return new DirectChatRoomCreationResult(DirectChatRoomResponse.of(chatRoom, counterpartUser), true);
     }
 
     @Transactional

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -5,6 +5,8 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
@@ -12,6 +14,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSta
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -160,6 +163,152 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.applications[0].recruitment.status").value("CLOSED"))
             .andExpect(jsonPath("$.applications[0].team_chat_available").value(true))
             .andExpect(jsonPath("$.applications[0].team_chat_room_id").value(teamRoom.getId()));
+    }
+
+    @Test
+    void 수동_마감된_ACCEPTED_지원서는_DIRECT_CTA와_생성_조건이_모두_닫힌다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(put("/team-recruitments/{id}/close", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applications[0].status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.applications[0].can_open_direct_chat").value(false));
+
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_CLOSED"));
+    }
+
+    @Test
+    void 정원충족으로_자동_마감된_ACCEPTED_지원서는_ACTIVE_TEAM_방이_있어_DIRECT를_생성할_수_있다() throws Exception {
+        RecruitmentContext lastSeatContext = saveRecruitmentAndTeamRoom("한 명 모집 개인 채팅", 1);
+        TeamRecruitment recruitment = lastSeatContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applications[0].status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.applications[0].can_open_direct_chat").value(true));
+
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.chat_room_id").isNumber())
+            .andExpect(jsonPath("$.room_type").value("DIRECT"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    @Test
+    void 마감일이_지난_RECRUITING_모집글은_스케줄러_전에도_DIRECT_CTA와_생성이_차단된다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+        expireRecruitment(recruitment);
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/team-recruitments/{recruitmentId}/applications", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applications[0].status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.applications[0].can_open_direct_chat").value(false));
+
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_CLOSED"));
+    }
+
+    @Test
+    void 마감일이_지난_RECRUITING_모집글의_기존_DIRECT_방은_계속_반환된다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+        mockMvc.perform(post(
+                "/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.room_type").value("DIRECT"));
+        entityManager.flush();
+        Integer directRoomId = chatRoomRepository
+            .findByRecruitment_IdAndApplication_IdAndRoomType(recruitment.getId(), application.getId(), DIRECT)
+            .orElseThrow()
+            .getId();
+        expireRecruitment(recruitment);
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.chat_room_id").value(directRoomId));
+
+        mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}",
+                recruitment.getId(), directRoomId)
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void 삭제된_모집글의_기존_DIRECT_방은_재요청과_조회가_가능하다() throws Exception {
+        TeamRecruitment recruitment = recruitmentContext.recruitment();
+        TeamRecruitmentApplication application = savePendingApplication(recruitment);
+
+        accept(recruitment, application, authorToken)
+            .andExpect(status().isNoContent());
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isCreated());
+
+        entityManager.flush();
+        entityManager.clear();
+        TeamRecruitmentChatRoom directRoom = chatRoomRepository
+            .findByRecruitment_IdAndApplication_IdAndRoomType(recruitment.getId(), application.getId(), DIRECT)
+            .orElseThrow();
+
+        mockMvc.perform(delete("/team-recruitments/{id}", recruitment.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isNoContent());
+
+        assertThat(chatRoomRepository.findById(directRoom.getId()).orElseThrow().getStatus())
+            .isEqualTo(READ_ONLY);
+
+        mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+                recruitment.getId(), application.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.chat_room_id").value(directRoom.getId()))
+            .andExpect(jsonPath("$.status").value("READ_ONLY"));
+
+        mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}",
+                recruitment.getId(), directRoom.getId())
+                .header("Authorization", "Bearer " + authorToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("READ_ONLY"));
     }
 
     @Test
@@ -449,6 +598,23 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
             .description("모집 내용")
             .status(RECRUITING)
             .build());
+    }
+
+    private void expireRecruitment(TeamRecruitment recruitment) {
+        recruitment.modify(
+            recruitment.getCategory(),
+            recruitment.getTitle(),
+            recruitment.getMeetingType(),
+            recruitment.getActivityStartDate(),
+            recruitment.getActivityEndDate(),
+            LocalDate.now(clock).minusDays(1),
+            recruitment.getRecruitmentType(),
+            recruitment.getMaxParticipants(),
+            recruitment.getDescription(),
+            recruitment.getRelatedUrl(),
+            recruitment.getQualification()
+        );
+        recruitmentRepository.save(recruitment);
     }
 
     private TeamRecruitmentApplication savePendingApplication(TeamRecruitment recruitment) {

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
@@ -1,0 +1,115 @@
+package in.koreatech.koin.unit.domain.team.recruitment.model;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentDirectChatPolicy;
+import in.koreatech.koin.unit.fixture.UserFixture;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class TeamRecruitmentDirectChatPolicyTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 28);
+
+    @Test
+    void 모집_중인_ACCEPTED_지원서는_TEAM_방이_없어도_DIRECT를_열수있다() {
+        assertThat(canOpen(ACCEPTED, false, recruitment(RECRUITING), null)).isTrue();
+    }
+
+    @Test
+    void 마감일이_지난_RECRUITING_모집글은_ACTIVE_TEAM_방이_있어도_DIRECT를_열수없다() {
+        TeamRecruitment recruitment = recruitment(RECRUITING, LocalDate.of(2026, 8, 27));
+
+        assertThat(canOpen(ACCEPTED, false, recruitment, teamRoom(recruitment, ACTIVE))).isFalse();
+    }
+
+    @Test
+    void 정원충족으로_마감된_ACCEPTED_지원서는_ACTIVE_TEAM_방이_있으면_DIRECT를_열수있다() {
+        TeamRecruitment recruitment = recruitment(CLOSED);
+
+        assertThat(canOpen(ACCEPTED, false, recruitment, teamRoom(recruitment, ACTIVE))).isTrue();
+    }
+
+    @Test
+    void 수동_기한_마감된_ACCEPTED_지원서는_READ_ONLY_TEAM_방이면_DIRECT를_열수없다() {
+        TeamRecruitment recruitment = recruitment(CLOSED);
+
+        assertThat(canOpen(ACCEPTED, false, recruitment, teamRoom(recruitment, READ_ONLY))).isFalse();
+    }
+
+    @Test
+    void 삭제된_모집글은_ACTIVE_TEAM_방이_남아도_신규_DIRECT를_열수없다() {
+        TeamRecruitment deleted = recruitment(CLOSED);
+        deleted.markDeleted(LocalDate.of(2026, 8, 28).atStartOfDay());
+
+        assertThat(canOpen(ACCEPTED, false, deleted, teamRoom(deleted, ACTIVE))).isFalse();
+    }
+
+    @Test
+    void 기존_DIRECT_방은_모집글_상태와_관계없이_열수있다() {
+        TeamRecruitment recruitment = recruitment(CLOSED);
+
+        assertThat(canOpen(ACCEPTED, true, recruitment, teamRoom(recruitment, READ_ONLY))).isTrue();
+    }
+
+    @Test
+    void ACCEPTED가_아니면_모집_중이어도_DIRECT를_열수없다() {
+        assertThat(canOpen(PENDING, false, recruitment(RECRUITING), null)).isFalse();
+    }
+
+    private boolean canOpen(
+        TeamRecruitmentApplicationStatus applicationStatus,
+        boolean hasExistingDirectChat,
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoom teamChatRoom
+    ) {
+        return TeamRecruitmentDirectChatPolicy.canOpenDirectChat(
+            applicationStatus, hasExistingDirectChat, recruitment, teamChatRoom, TODAY);
+    }
+
+    private TeamRecruitment recruitment(TeamRecruitmentStatus status) {
+        return recruitment(status, LocalDate.of(2026, 8, 31));
+    }
+
+    private TeamRecruitment recruitment(TeamRecruitmentStatus status, LocalDate deadlineDate) {
+        return TeamRecruitment.builder()
+            .id(10)
+            .author(UserFixture.id_설정_코인_유저(1))
+            .title("팀원 모집")
+            .activityStartDate(LocalDate.of(2026, 9, 1))
+            .activityEndDate(LocalDate.of(2026, 9, 30))
+            .deadlineDate(deadlineDate)
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .description("모집 내용")
+            .status(status)
+            .build();
+    }
+
+    private TeamRecruitmentChatRoom teamRoom(
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoomStatus status
+    ) {
+        return TeamRecruitmentChatRoom.builder()
+            .id(40)
+            .recruitment(recruitment)
+            .roomScopeKey("TEAM")
+            .roomType(TEAM)
+            .status(status)
+            .build();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -4,6 +4,7 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import in.koreatech.koin.domain.student.model.Student;
 import in.koreatech.koin.domain.student.repository.StudentRepository;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicantDetail;
 import in.koreatech.koin.domain.team.recruitment.dto.ApplicantListResponse;
 import in.koreatech.koin.domain.team.recruitment.dto.ApplicantSummary;
 import in.koreatech.koin.domain.team.recruitment.dto.MyApplication;
@@ -31,6 +33,8 @@ import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCard;
 import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentRole;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
@@ -477,6 +481,191 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     @Test
+    void 수동_마감된_모집글의_ACCEPTED_지원자는_기존방이_없으면_DIRECT_CTA가_닫힌다() {
+        TeamRecruitment recruitment = recruitment();
+        recruitment.close();
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of());
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(ACCEPTED),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(response.applications().get(0).canOpenDirectChat()).isFalse();
+    }
+
+    @Test
+    void 정원충족으로_자동_마감된_모집글은_ACTIVE_TEAM_방이_있으면_DIRECT_CTA가_열린다() {
+        TeamRecruitment recruitment = recruitment(1, 1, CLOSED);
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, ACTIVE)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of());
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(ACCEPTED),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(response.applications().get(0).canOpenDirectChat()).isTrue();
+    }
+
+    @Test
+    void 마감일이_지난_RECRUITING_모집글은_ACTIVE_TEAM_방이_있어도_DIRECT_CTA가_닫힌다() {
+        TeamRecruitment recruitment = recruitment(LocalDate.of(2026, 8, 27));
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, ACTIVE)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of());
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(ACCEPTED),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(response.applications().get(0).canOpenDirectChat()).isFalse();
+    }
+
+    @Test
+    void 마감된_모집글의_기존_DIRECT_방은_DIRECT_CTA를_계속_연다() {
+        TeamRecruitment recruitment = recruitment();
+        recruitment.close();
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+        TeamRecruitmentChatRoom existingDirect = TeamRecruitmentChatRoom.builder()
+            .id(DIRECT_ROOM_ID)
+            .recruitment(recruitment)
+            .roomScopeKey("DIRECT-20")
+            .roomType(DIRECT)
+            .application(accepted)
+            .status(READ_ONLY)
+            .build();
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(accepted)));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of(existingDirect));
+
+        ApplicantListResponse response = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(ACCEPTED),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(response.applications().get(0).canOpenDirectChat()).isTrue();
+    }
+
+    @Test
+    void 지원서_상세도_마감된_모집글에서_기존방이_없으면_DIRECT_CTA가_닫힌다() {
+        TeamRecruitment recruitment = recruitment();
+        recruitment.close();
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findById(20)).thenReturn(Optional.of(accepted));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of());
+
+        ApplicantDetail response = queryService.getApplicationDetail(RECRUITMENT_ID, 20, AUTHOR_ID);
+
+        assertThat(response.canOpenDirectChat()).isFalse();
+    }
+
+    @Test
+    void 지원서_상세도_마감일이_지난_RECRUITING_모집글은_ACTIVE_TEAM_방이_있어도_DIRECT_CTA가_닫힌다() {
+        TeamRecruitment recruitment = recruitment(LocalDate.of(2026, 8, 27));
+        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.findById(20)).thenReturn(Optional.of(accepted));
+        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
+            List.of(RECRUITMENT_ID),
+            "TEAM",
+            TEAM
+        )).thenReturn(List.of(teamRoom(recruitment, ACTIVE)));
+        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
+            .thenReturn(List.of());
+
+        ApplicantDetail response = queryService.getApplicationDetail(RECRUITMENT_ID, 20, AUTHOR_ID);
+
+        assertThat(response.canOpenDirectChat()).isFalse();
+    }
+
+    @Test
     void ACCEPTED인데_TEAM_room이_없으면_내부_무결성_예외가_발생한다() {
         TeamRecruitment recruitment = recruitment();
         TeamRecruitmentApplication accepted = application(22, recruitment, ACCEPTED);
@@ -557,12 +746,19 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     private TeamRecruitmentChatRoom teamRoom(TeamRecruitment recruitment) {
+        return teamRoom(recruitment, ACTIVE);
+    }
+
+    private TeamRecruitmentChatRoom teamRoom(
+        TeamRecruitment recruitment,
+        TeamRecruitmentChatRoomStatus status
+    ) {
         return TeamRecruitmentChatRoom.builder()
             .id(TEAM_ROOM_ID)
             .recruitment(recruitment)
             .roomScopeKey("TEAM")
             .roomType(TEAM)
-            .status(ACTIVE)
+            .status(status)
             .build();
     }
 
@@ -571,6 +767,23 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     private TeamRecruitment recruitment(LocalDate deadlineDate) {
+        return recruitment(5, 0, RECRUITING, deadlineDate);
+    }
+
+    private TeamRecruitment recruitment(
+        Integer maxParticipants,
+        Integer currentParticipants,
+        TeamRecruitmentStatus status
+    ) {
+        return recruitment(maxParticipants, currentParticipants, status, LocalDate.of(2026, 8, 31));
+    }
+
+    private TeamRecruitment recruitment(
+        Integer maxParticipants,
+        Integer currentParticipants,
+        TeamRecruitmentStatus status,
+        LocalDate deadlineDate
+    ) {
         return TeamRecruitment.builder()
             .id(RECRUITMENT_ID)
             .author(UserFixture.id_설정_코인_유저(1))
@@ -579,9 +792,10 @@ class TeamRecruitmentApplicationQueryServiceTest {
             .activityEndDate(LocalDate.of(2026, 9, 30))
             .deadlineDate(deadlineDate)
             .recruitmentType(GENERAL)
-            .maxParticipants(5)
-            .currentParticipants(0)
+            .maxParticipants(maxParticipants)
+            .currentParticipants(currentParticipants)
             .description("모집 내용")
+            .status(status)
             .build();
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -2,12 +2,18 @@ package in.koreatech.koin.unit.domain.teamrecruitment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +29,7 @@ import in.koreatech.koin.global.exception.CustomException;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
@@ -48,6 +55,9 @@ class TeamRecruitmentChatServiceTest {
     private static final Integer RECRUITMENT_ID = 10;
     private static final Integer CHAT_ROOM_ID = 20;
     private static final Integer APPLICATION_ID = 30;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-08-28T03:00:00Z"), KST);
 
     @Mock
     private TeamRecruitmentRepository recruitmentRepository;
@@ -73,8 +83,16 @@ class TeamRecruitmentChatServiceTest {
     @Mock
     private ObjectMapper objectMapper;
 
+    @Mock
+    private Clock clock;
+
     @InjectMocks
     private TeamRecruitmentChatService chatService;
+
+    @BeforeEach
+    void setUpClock() {
+        lenient().when(clock.withZone(KST)).thenReturn(FIXED_CLOCK);
+    }
 
     @Test
     void 존재하지_않는_채팅방_조회시_404를_반환한다() {
@@ -163,6 +181,7 @@ class TeamRecruitmentChatServiceTest {
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(recruitment.getAuthor()).thenReturn(author);
         when(application.getStatus()).thenReturn(TeamRecruitmentApplicationStatus.ACCEPTED);
+        when(recruitment.getStatus()).thenReturn(TeamRecruitmentStatus.CLOSED);
         when(recruitment.isRecruiting()).thenReturn(false);
 
         assertThatThrownBy(() -> chatService.getOrCreateDirectChatRoom(USER_ID, RECRUITMENT_ID, APPLICATION_ID))
@@ -203,7 +222,6 @@ class TeamRecruitmentChatServiceTest {
         when(application.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(application.getStatus()).thenReturn(TeamRecruitmentApplicationStatus.ACCEPTED);
-        when(recruitment.isRecruiting()).thenReturn(true);
         when(recruitment.getAuthor()).thenReturn(author);
         when(application.getApplicant()).thenReturn(counterpart);
         when(chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(


### PR DESCRIPTION
### 🔍 개요

* `can_open_direct_chat` 표시와 DIRECT 생성·조회 명령이 동일한 정책을 사용하도록 정렬합니다.

- close #2372

---

### 🚀 주요 변경 내용

* ACCEPTED 지원서의 기존 DIRECT 방은 모집이 `CLOSED` 또는 `DELETED`여도 `200`으로 반환하고 보존합니다.
* 신규 DIRECT는 마감일이 지나지 않은 `RECRUITING` 모집에서 허용합니다.
* 정원 충족 자동 마감 후 TEAM 방이 `ACTIVE`인 모집에서도 신규 DIRECT를 허용합니다.
* 수동 마감, 기한 마감, 삭제, TEAM `READ_ONLY` 상태의 신규 생성은 `409`로 처리합니다.
* 스케줄러 실행 전 deadline 경과 상태에도 CTA와 생성 명령이 같은 결과를 반환합니다.
* 현행 TEAM `ACTIVE/READ_ONLY` lifecycle을 마감 판단 기준으로 사용합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P2 협의 확정 정책이며 클라이언트 CTA 값과 POST 결과가 같은 기준으로 동작합니다.
  * 서버 정책 객체, Java API/DTO 설명, 조회·생성 서비스를 같은 기준으로 정렬합니다.
* **검증**
  * 수동 마감, 정원 충족, 기한 경과, 삭제 HTTP 시나리오와 정책·ChatService·ApplicationQueryService 테스트가 통과했습니다.
  * 전체 Gradle 테스트와 `git diff --check`가 통과했습니다.
* **반영 순서**
  * #2384 반영 후 rebase하여 `lock → 정책 검증 → 기존 방 반환 → 신규 생성` 순서를 결합합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)