### PR TITLE
fix: 팀원 모집 조회 응답의 d_day 계산 계약을 공통화

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
@@ -126,7 +126,8 @@ public interface TeamRecruitmentApi {
         - 비로그인 조회가 가능합니다.
         - 로그인한 경우 `is_author`, `can_apply`, `apply_block_reason`, `application`,
           `can_manage_applicants`, 팀 채팅방 정보를 함께 반환합니다.
-        - `d_day`는 지원 마감일 기준이며 마감일이 지나면 null입니다.
+        - `d_day`는 KST 기준 현재 날짜와 지원 마감일의 차이입니다.
+        - 유효 모집 상태가 `RECRUITING`이고 마감일이 오늘 또는 미래일 때만 반환하며, `CLOSED`/`DELETED`, null 마감일 또는 마감일 경과 시 `null`입니다.
         - 삭제된 모집글은 404를 반환합니다.
         """)
     @GetMapping("/{recruitmentId}")

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicantRecruitment.java
@@ -41,7 +41,8 @@ public record ApplicantRecruitment(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate deadlineDate,
 
-    @Schema(description = "D-day", example = "8", nullable = true, requiredMode = REQUIRED)
+    @Schema(description = "D-day. 모집 상태가 RECRUITING이고 마감일이 오늘 또는 미래일 때만 반환되며, CLOSED/DELETED, null 마감일 또는 마감일 경과 시 null입니다.",
+        example = "8", nullable = true, requiredMode = REQUIRED)
     Integer dDay,
 
     @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitment.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreatedRecruitment.java
@@ -41,7 +41,8 @@ public record CreatedRecruitment(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate deadlineDate,
 
-    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    @Schema(description = "D-day. 모집 상태가 RECRUITING이고 마감일이 오늘 또는 미래일 때만 반환되며, CLOSED/DELETED, null 마감일 또는 마감일 경과 시 null입니다.",
+        example = "8", nullable = true, requiredMode = REQUIRED)
     Integer dDay,
 
     @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCard.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCard.java
@@ -41,7 +41,8 @@ public record RecruitmentCard(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate deadlineDate,
 
-    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    @Schema(description = "D-day. 모집 상태가 RECRUITING이고 마감일이 오늘 또는 미래일 때만 반환되며, CLOSED/DELETED, null 마감일 또는 마감일 경과 시 null입니다.",
+        example = "8", nullable = true, requiredMode = REQUIRED)
     Integer dDay,
 
     @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCards.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentCards.java
@@ -3,6 +3,7 @@ package in.koreatech.koin.domain.team.recruitment.dto;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentRole;
 
@@ -24,7 +25,7 @@ public final class RecruitmentCards {
             recruitment.getActivityStartDate(),
             recruitment.getActivityEndDate(),
             recruitment.getDeadlineDate(),
-            dDayOf(recruitment.getDeadlineDate(), today),
+            dDayOf(recruitment.getStatus(), recruitment.getDeadlineDate(), today),
             recruitment.getStatus(),
             recruitment.getRecruitmentType(),
             recruitment.getCurrentParticipants(),
@@ -47,10 +48,17 @@ public final class RecruitmentCards {
     }
 
     /**
-     * 지원 마감일이 지나면 null 이다.
+     * 모집 상태가 RECRUITING이고 지원 마감일이 지나지 않았을 때만 D-day를 반환한다.
      */
-    public static Integer dDayOf(LocalDate deadlineDate, LocalDate today) {
-        if (deadlineDate == null || today == null || today.isAfter(deadlineDate)) {
+    public static Integer dDayOf(
+        TeamRecruitmentStatus status,
+        LocalDate deadlineDate,
+        LocalDate today
+    ) {
+        if (status != TeamRecruitmentStatus.RECRUITING
+            || deadlineDate == null
+            || today == null
+            || today.isAfter(deadlineDate)) {
             return null;
         }
         return (int) ChronoUnit.DAYS.between(today, deadlineDate);

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
@@ -44,7 +44,8 @@ public record RecruitmentDetail(
     @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate deadlineDate,
 
-    @Schema(description = "D-day, 모집 마감 후 null", example = "8", nullable = true, requiredMode = REQUIRED)
+    @Schema(description = "D-day. 모집 상태가 RECRUITING이고 마감일이 오늘 또는 미래일 때만 반환되며, CLOSED/DELETED, null 마감일 또는 마감일 경과 시 null입니다.",
+        example = "8", nullable = true, requiredMode = REQUIRED)
     Integer dDay,
 
     @Schema(description = "모집 상태", example = "RECRUITING", requiredMode = REQUIRED)

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentApplicationQueryService.java
@@ -23,6 +23,7 @@ import in.koreatech.koin.domain.team.recruitment.dto.MyApplication;
 import in.koreatech.koin.domain.team.recruitment.dto.MyApplicationListResponse;
 import in.koreatech.koin.domain.team.recruitment.dto.ProfileSnapshot;
 import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCard;
+import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentCards;
 import in.koreatech.koin.domain.team.recruitment.dto.RecruitmentRole;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationSort;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
@@ -41,7 +42,6 @@ import in.koreatech.koin.global.exception.custom.KoinIllegalStateException;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -92,8 +92,9 @@ public class TeamRecruitmentApplicationQueryService {
             pageRequest(criteria, sort, true)
         );
         AcceptedChatRooms acceptedChatRooms = findAcceptedChatRooms(applications.getContent());
+        LocalDate today = today();
         List<MyApplication> content = applications.getContent().stream()
-            .map(application -> toMyApplication(application, acceptedChatRooms))
+            .map(application -> toMyApplication(application, acceptedChatRooms, today))
             .toList();
         return new MyApplicationListResponse(
             content,
@@ -132,7 +133,7 @@ public class TeamRecruitmentApplicationQueryService {
             .map(application -> toApplicantSummary(application, acceptedChatRooms, today))
             .toList();
         return new ApplicantListResponse(
-            toApplicantRecruitment(recruitment),
+            toApplicantRecruitment(recruitment, today),
             content,
             totalCount,
             content.size(),
@@ -156,10 +157,10 @@ public class TeamRecruitmentApplicationQueryService {
             .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_APPLICATION_NOT_FOUND));
         validateApplicationBelongsToRecruitment(application, recruitmentId);
 
+        LocalDate today = today();
         boolean canDecide = application.getStatus() == PENDING
             && recruitment.getStatus() == RECRUITING
-            && !isPastDeadline(recruitment);
-        LocalDate today = today();
+            && !isPastDeadline(recruitment, today);
         boolean canOpenDirectChat = application.getStatus() == ACCEPTED
             && canOpenDirectChat(application, findAcceptedChatRooms(List.of(application)), today);
         return new ApplicantDetail(
@@ -237,7 +238,8 @@ public class TeamRecruitmentApplicationQueryService {
 
     private MyApplication toMyApplication(
         TeamRecruitmentApplication application,
-        AcceptedChatRooms acceptedChatRooms
+        AcceptedChatRooms acceptedChatRooms,
+        LocalDate today
     ) {
         TeamRecruitment recruitment = application.getRecruitment();
         boolean accepted = application.getStatus() == ACCEPTED;
@@ -258,7 +260,7 @@ public class TeamRecruitmentApplicationQueryService {
             accepted && teamRoom != null ? teamRoom.getId() : null,
             directRoom == null ? null : directRoom.getId(),
             toApplicationRole(application.getRole()),
-            toRecruitmentCard(recruitment)
+            toRecruitmentCard(recruitment, today)
         );
     }
 
@@ -344,7 +346,8 @@ public class TeamRecruitmentApplicationQueryService {
             application.getStatus(), hasExistingDirectChat, recruitment, teamChatRoom, today);
     }
 
-    private RecruitmentCard toRecruitmentCard(TeamRecruitment recruitment) {
+    private RecruitmentCard toRecruitmentCard(TeamRecruitment recruitment, LocalDate today) {
+        TeamRecruitmentStatus status = effectiveStatus(recruitment, today);
         return new RecruitmentCard(
             recruitment.getId(),
             recruitment.getCategory(),
@@ -353,17 +356,18 @@ public class TeamRecruitmentApplicationQueryService {
             recruitment.getActivityStartDate(),
             recruitment.getActivityEndDate(),
             recruitment.getDeadlineDate(),
-            dDay(recruitment),
-            effectiveStatus(recruitment),
+            RecruitmentCards.dDayOf(status, recruitment.getDeadlineDate(), today),
+            status,
             recruitment.getRecruitmentType(),
             recruitment.getCurrentParticipants(),
             recruitment.getMaxParticipants(),
-            toRecruitmentRoles(recruitment)
+            toRecruitmentRoles(recruitment, today)
         );
     }
 
-    private ApplicantRecruitment toApplicantRecruitment(TeamRecruitment recruitment) {
+    private ApplicantRecruitment toApplicantRecruitment(TeamRecruitment recruitment, LocalDate today) {
         Optional<TeamRecruitmentChatRoom> teamRoom = findTeamRoom(recruitment.getId());
+        TeamRecruitmentStatus status = effectiveStatus(recruitment, today);
         return new ApplicantRecruitment(
             recruitment.getId(),
             recruitment.getCategory(),
@@ -372,22 +376,22 @@ public class TeamRecruitmentApplicationQueryService {
             recruitment.getActivityStartDate(),
             recruitment.getActivityEndDate(),
             recruitment.getDeadlineDate(),
-            dDay(recruitment),
-            effectiveStatus(recruitment),
+            RecruitmentCards.dDayOf(status, recruitment.getDeadlineDate(), today),
+            status,
             recruitment.getRecruitmentType(),
             recruitment.getCurrentParticipants(),
             recruitment.getMaxParticipants(),
-            toRecruitmentRoles(recruitment),
+            toRecruitmentRoles(recruitment, today),
             teamRoom.isPresent(),
             teamRoom.map(TeamRecruitmentChatRoom::getId).orElse(null)
         );
     }
 
-    private List<RecruitmentRole> toRecruitmentRoles(TeamRecruitment recruitment) {
+    private List<RecruitmentRole> toRecruitmentRoles(TeamRecruitment recruitment, LocalDate today) {
         if (recruitment.getRoles() == null) {
             return List.of();
         }
-        boolean recruitmentClosed = recruitment.getStatus() != RECRUITING || isPastDeadline(recruitment);
+        boolean recruitmentClosed = recruitment.getStatus() != RECRUITING || isPastDeadline(recruitment, today);
         return recruitment.getRoles().stream()
             .map(role -> new RecruitmentRole(
                 role.getId(),
@@ -399,8 +403,8 @@ public class TeamRecruitmentApplicationQueryService {
             .toList();
     }
 
-    private TeamRecruitmentStatus effectiveStatus(TeamRecruitment recruitment) {
-        if (recruitment.getStatus() == RECRUITING && isPastDeadline(recruitment)) {
+    private TeamRecruitmentStatus effectiveStatus(TeamRecruitment recruitment, LocalDate today) {
+        if (recruitment.getStatus() == RECRUITING && isPastDeadline(recruitment, today)) {
             return TeamRecruitmentStatus.CLOSED;
         }
         return recruitment.getStatus();
@@ -418,20 +422,9 @@ public class TeamRecruitmentApplicationQueryService {
             .filter(room -> room.getRoomType() == TeamRecruitmentChatRoomType.TEAM);
     }
 
-    private Integer dDay(TeamRecruitment recruitment) {
-        if (recruitment.getStatus() != RECRUITING || recruitment.getDeadlineDate() == null) {
-            return null;
-        }
-        LocalDate today = LocalDate.now(clock.withZone(KST));
-        if (today.isAfter(recruitment.getDeadlineDate())) {
-            return null;
-        }
-        return Math.toIntExact(ChronoUnit.DAYS.between(today, recruitment.getDeadlineDate()));
-    }
-
-    private boolean isPastDeadline(TeamRecruitment recruitment) {
+    private boolean isPastDeadline(TeamRecruitment recruitment, LocalDate today) {
         return recruitment.getDeadlineDate() != null
-            && LocalDate.now(clock.withZone(KST)).isAfter(recruitment.getDeadlineDate());
+            && today.isAfter(recruitment.getDeadlineDate());
     }
 
     private LocalDate today() {

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentQueryService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentQueryService.java
@@ -106,17 +106,24 @@ public class TeamRecruitmentQueryService {
         if (recruitment.isDeleted()) {
             throw CustomException.of(TEAM_RECRUITMENT_NOT_FOUND, "recruitmentId: " + recruitmentId);
         }
-        return toDetail(recruitment, userId);
+        LocalDate today = today();
+        return toDetail(recruitment, userId, today);
     }
 
-    private RecruitmentDetail toDetail(TeamRecruitment recruitment, Integer userId) {
-        RecruitmentCard card = RecruitmentCards.of(recruitment, today());
+    private RecruitmentDetail toDetail(TeamRecruitment recruitment, Integer userId, LocalDate today) {
+        RecruitmentCard card = RecruitmentCards.of(recruitment, today);
         boolean isAuthor = userId != null && recruitment.getAuthor().getId().equals(userId);
         Optional<TeamRecruitmentApplication> myApplication = userId == null
             ? Optional.empty()
             : applicationRepository.findByRecruitment_IdAndApplicant_Id(recruitment.getId(), userId);
 
-        TeamRecruitmentApplyBlockReason blockReason = applyBlockReasonOf(recruitment, userId, isAuthor, myApplication);
+        TeamRecruitmentApplyBlockReason blockReason = applyBlockReasonOf(
+            recruitment,
+            userId,
+            isAuthor,
+            myApplication,
+            today
+        );
         boolean accepted = myApplication
             .map(application -> application.getStatus() == ACCEPTED)
             .orElse(false);
@@ -162,7 +169,8 @@ public class TeamRecruitmentQueryService {
         TeamRecruitment recruitment,
         Integer userId,
         boolean isAuthor,
-        Optional<TeamRecruitmentApplication> myApplication
+        Optional<TeamRecruitmentApplication> myApplication,
+        LocalDate today
     ) {
         if (recruitment.isDeleted()) {
             return RECRUITMENT_DELETED;
@@ -179,7 +187,7 @@ public class TeamRecruitmentQueryService {
         if (!recruitment.isRecruiting()) {
             return RECRUITMENT_CLOSED;
         }
-        if (today().isAfter(recruitment.getDeadlineDate())) {
+        if (today.isAfter(recruitment.getDeadlineDate())) {
             return DEADLINE_PASSED;
         }
         if (isFullyClosed(recruitment)) {

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.acceptance.domain;
 
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -372,6 +373,19 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
                 .andExpect(jsonPath("$.apply_block_reason").value("LOGIN_REQUIRED"))
                 .andExpect(jsonPath("$.application").doesNotExist())
                 .andExpect(jsonPath("$.team_chat_available").value(false));
+        }
+
+        @Test
+        @DisplayName("CLOSED 모집글은 미래 마감일이어도 d_day가 없다")
+        void closedFutureDeadlineHasNoDday() throws Exception {
+            TeamRecruitment recruitment = saveRecruitment(author, "마감된 상세");
+            recruitment.close();
+            entityManager.flush();
+
+            mockMvc.perform(get("/team-recruitments/{id}", recruitment.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(CLOSED.name()))
+                .andExpect(jsonPath("$.d_day").doesNotExist());
         }
 
         @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/RecruitmentCardsTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/RecruitmentCardsTest.java
@@ -1,5 +1,8 @@
 package in.koreatech.koin.unit.domain.team.recruitment.dto;
 
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.DELETED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -17,18 +20,36 @@ class RecruitmentCardsTest {
     @Test
     @DisplayName("마감일까지 남은 일수를 반환한다")
     void returnsDaysUntilDeadline() {
-        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE.minusDays(8))).isEqualTo(8);
+        assertThat(RecruitmentCards.dDayOf(RECRUITING, DEADLINE, DEADLINE.minusDays(8))).isEqualTo(8);
     }
 
     @Test
     @DisplayName("마감일 당일은 0을 반환한다")
     void returnsZeroOnDeadline() {
-        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE)).isZero();
+        assertThat(RecruitmentCards.dDayOf(RECRUITING, DEADLINE, DEADLINE)).isZero();
     }
 
     @Test
     @DisplayName("마감일이 지나면 null을 반환한다")
     void returnsNullAfterDeadline() {
-        assertThat(RecruitmentCards.dDayOf(DEADLINE, DEADLINE.plusDays(1))).isNull();
+        assertThat(RecruitmentCards.dDayOf(RECRUITING, DEADLINE, DEADLINE.plusDays(1))).isNull();
+    }
+
+    @Test
+    @DisplayName("마감 상태가 CLOSED이면 미래 마감일이어도 null을 반환한다")
+    void returnsNullForClosedRecruitment() {
+        assertThat(RecruitmentCards.dDayOf(CLOSED, DEADLINE, DEADLINE.minusDays(8))).isNull();
+    }
+
+    @Test
+    @DisplayName("마감 상태가 DELETED이면 미래 마감일이어도 null을 반환한다")
+    void returnsNullForDeletedRecruitment() {
+        assertThat(RecruitmentCards.dDayOf(DELETED, DEADLINE, DEADLINE.minusDays(8))).isNull();
+    }
+
+    @Test
+    @DisplayName("마감일이 null이면 모집 중이어도 null을 반환한다")
+    void returnsNullForNullDeadline() {
+        assertThat(RecruitmentCards.dDayOf(RECRUITING, null, DEADLINE.minusDays(8))).isNull();
     }
 }

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -286,6 +286,56 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     @Test
+    void CLOSED_모집글은_미래_마감일이어도_두_목록에서_dDay가_null이다() {
+        TeamRecruitment recruitment = recruitment();
+        recruitment.close();
+        TeamRecruitmentApplication application = applicationWithSnapshot(20, recruitment, PENDING);
+
+        when(studentRepository.getById(APPLICANT_ID)).thenReturn(null);
+        when(applicationRepository.countByApplicant_IdAndStatusIn(eq(APPLICANT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByApplicant_IdAndStatusIn(
+            eq(APPLICANT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+
+        MyApplicationListResponse myResponse = queryService.getMyApplications(
+            List.of(PENDING),
+            TeamRecruitmentApplicationSort.LATEST_DESC,
+            1,
+            10,
+            APPLICANT_ID
+        );
+
+        assertThat(myResponse.applications().get(0).recruitment().status()).isEqualTo(CLOSED);
+        assertThat(myResponse.applications().get(0).recruitment().dDay()).isNull();
+
+        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
+            .thenReturn(1L);
+        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
+            eq(RECRUITMENT_ID),
+            any(),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(application)));
+        when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(RECRUITMENT_ID, "TEAM"))
+            .thenReturn(Optional.empty());
+
+        ApplicantListResponse authorResponse = queryService.getApplications(
+            RECRUITMENT_ID,
+            List.of(PENDING),
+            1,
+            10,
+            AUTHOR_ID
+        );
+
+        assertThat(authorResponse.recruitment().status()).isEqualTo(CLOSED);
+        assertThat(authorResponse.recruitment().dDay()).isNull();
+    }
+
+    @Test
     void 역할_하나가_정원에_도달해도_마감_전_모집글은_RECRUITING이고_해당_역할만_닫힌다() {
         TeamRecruitment recruitment = recruitment();
         recruitment.addRole(role(50, "백엔드", 1, 1, 1));

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentQueryServiceTest.java
@@ -18,7 +18,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -64,6 +67,7 @@ class TeamRecruitmentQueryServiceTest {
     private static final Integer RECRUITMENT_ID = 17;
     private static final Integer ROLE_ID = 4;
     private static final Integer TEAM_ROOM_ID = 31;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final LocalDate TODAY = LocalDate.of(2026, 8, 30);
 
     @InjectMocks
@@ -216,6 +220,41 @@ class TeamRecruitmentQueryServiceTest {
             givenNoApplication();
 
             assertThat(detail(VIEWER_ID).applyBlockReason()).isEqualTo(RECRUITMENT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("마감 상태이면 미래 마감일이어도 d_day는 null 이다")
+        void dDayIsNullForClosedRecruitmentWithFutureDeadline() {
+            ReflectionTestUtils.setField(recruitment, "status", CLOSED);
+            givenFound();
+
+            assertThat(detail(VIEWER_ID).dDay()).isNull();
+        }
+
+        @Test
+        @DisplayName("상세 응답은 카드와 지원 가능 여부 계산에 같은 KST 기준일을 사용한다")
+        void detailUsesOneKstDateForCardAndApplyEligibility() {
+            recruitment = recruitment(ROLE_BASED, 3, 0, TODAY);
+            givenFound();
+            givenNoApplication();
+            givenHasProfile(true);
+
+            Clock beforeMidnight = Clock.fixed(
+                Instant.parse("2026-08-30T14:59:00Z"),
+                KST
+            );
+            Clock afterMidnight = Clock.fixed(
+                Instant.parse("2026-08-30T15:01:00Z"),
+                KST
+            );
+            doReturn(beforeMidnight, afterMidnight).when(clock).withZone(KST);
+
+            RecruitmentDetail response = detail(VIEWER_ID);
+
+            assertThat(response.dDay()).isZero();
+            assertThat(response.applyBlockReason()).isNull();
+            assertThat(response.canApply()).isTrue();
+            verify(clock, times(1)).withZone(KST);
         }
 
         @Test


### PR DESCRIPTION
### 🔍 개요

* 모든 팀원 모집 조회 응답이 동일한 상태 기반 `d_day` 규칙을 사용하도록 정렬합니다.

- close #2375

---

### 🚀 주요 변경 내용

* 유효 상태가 `RECRUITING`일 때 KST 기준 남은 일수를 반환합니다.
* 지원 마감 당일은 `0`을 반환합니다.
* 마감일 경과, `CLOSED`, `DELETED`, 마감일 없음은 `null`을 반환합니다.
* 목록, 상세, 내 작성, 내 지원, 지원자 목록이 공통 계산 함수를 사용합니다.
* 한 응답에서 KST 기준 날짜를 한 번 캡처해 자정 경계 값을 일치시킵니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P2 조회 계약 오류이며 기존 필드와 날짜 직렬화 형식을 유지합니다.
  * 조회 응답 계산과 Java API/DTO 설명을 동일한 상태 규칙으로 정렬합니다.
* **검증**
  * D-day 공통 계산, QueryService 자정 경계, `CLOSED`와 미래 마감일 조합의 HTTP 응답을 확인했습니다.
  * 관련 acceptance 테스트와 `git diff --check`가 통과했습니다.
* **반영 순서**
  * #2385 반영 후 rebase하여 CTA 정책과 D-day 계산을 함께 보존합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)