### PR TITLE
fix: 팀원 모집글 연속 작성의 중복 side effect 방지

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
@@ -9,6 +9,7 @@ import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_A
 import static in.koreatech.koin.global.code.ApiResponseCode.NOT_FOUND_USER;
 import static in.koreatech.koin.global.code.ApiResponseCode.NO_CONTENT;
 import static in.koreatech.koin.global.code.ApiResponseCode.OK;
+import static in.koreatech.koin.global.code.ApiResponseCode.REQUEST_TOO_FAST;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
@@ -96,6 +97,7 @@ public interface TeamRecruitmentApi {
         NOT_FOUND_USER,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
+        REQUEST_TOO_FAST,
     })
     @Operation(summary = "모집글 작성", description = """
         ### 모집글 작성
@@ -109,6 +111,7 @@ public interface TeamRecruitmentApi {
         - 지원 마감일은 활동 시작일 이하, 활동 시작일은 활동 종료일 이하여야 합니다.
         - 모집글과 TEAM 채팅방을 같은 트랜잭션에서 생성하고 작성자를 최초 채팅방 멤버로 추가합니다.
         - 별도의 팀 채팅방 생성 API는 없습니다.
+        - 같은 사용자가 동일한 요청을 300ms 안에 반복하면 두 번째 요청은 `409 REQUEST_TOO_FAST`를 반환합니다.
         - 생성된 모집글 id만 반환합니다.
         """)
     @PostMapping

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentService.java
@@ -43,6 +43,7 @@ import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatR
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
 import in.koreatech.koin.domain.user.model.User;
 import in.koreatech.koin.domain.user.repository.UserRepository;
+import in.koreatech.koin.global.duplicate.DuplicateGuard;
 import in.koreatech.koin.global.exception.CustomException;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -78,6 +79,10 @@ public class TeamRecruitmentService {
      * 모집글과 TEAM 채팅방, 작성자 멤버를 같은 트랜잭션에서 생성한다.
      */
     @Transactional
+    @DuplicateGuard(
+        key = "'team-recruitment:create:' + #userId + ':' + #request.toString()",
+        timeoutSeconds = 300
+    )
     public IdResponse createRecruitment(Integer userId, CreateRecruitmentRequest request) {
         User author = userRepository.getById(userId);
         TeamRecruitment recruitment = request.toEntity(author);

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -206,6 +206,73 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
         }
 
         @Test
+        @DisplayName("같은 사용자의 동일한 모집글 생성 요청이 연속되면 두 번째 요청은 409이고 side effect는 한 번만 발생한다")
+        void rejectsImmediateDuplicateRequestWithoutDuplicateSideEffects() throws Exception {
+            String body = generalBody(5);
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isCreated());
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("REQUEST_TOO_FAST"));
+
+            entityManager.flush();
+            entityManager.clear();
+            assertThat(recruitmentGraphRowCounts()).containsExactly(1L, 0L, 1L, 1L);
+        }
+
+        @Test
+        @DisplayName("같은 사용자의 서로 다른 모집글 생성 요청은 연속되어도 허용한다")
+        void allowsImmediateRequestWithDifferentPayload() throws Exception {
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(4)))
+                .andExpect(status().isCreated());
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(generalBody(5)))
+                .andExpect(status().isCreated());
+
+            entityManager.flush();
+            entityManager.clear();
+            assertThat(recruitmentGraphRowCounts()).containsExactly(2L, 0L, 2L, 2L);
+        }
+
+        @Test
+        @DisplayName("동일한 모집글 생성 요청도 300ms가 지나면 허용한다")
+        void allowsSameRequestAfterDuplicateGuardWindow() throws Exception {
+            String body = generalBody(5);
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isCreated());
+
+            Thread.sleep(350);
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                .andExpect(status().isCreated());
+
+            entityManager.flush();
+            entityManager.clear();
+            assertThat(recruitmentGraphRowCounts()).containsExactly(2L, 0L, 2L, 2L);
+        }
+
+        @Test
         @DisplayName("미인증 요청은 401 이다")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/team-recruitments")


### PR DESCRIPTION
### 🔍 개요

* 같은 사용자가 동일한 모집글 생성 요청을 짧은 시간 안에 반복할 때 모집글과 TEAM 방의 중복 생성을 차단합니다.

- close #2376

---

### 🚀 주요 변경 내용

* 기존 KOIN `DuplicateGuard`를 사용자 ID와 동일 request payload 기준으로 적용합니다.
* 동일 요청을 300ms 안에 반복하면 두 번째 요청에 `409 REQUEST_TOO_FAST`를 반환합니다.
* payload가 다르거나 300ms가 지난 요청은 정상 처리합니다.
* Redis 장애는 기존 `DuplicateGuard` 공통 정책과 동일한 fail-closed `500`으로 처리합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P2 운영 안전장치이며 클라이언트는 기존 요청 payload만으로 호출합니다.
  * 생성 service의 중복 side effect 경계를 보강합니다.
* **검증**
  * 동일 payload 연속 요청의 side effect 1회, 서로 다른 payload 허용, 350ms 경과 요청 허용을 확인했습니다.
  * 관련 테스트와 `git diff --check`가 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)