### PR TITLE
docs: 팀원 모집 Java Swagger와 공개 API 계약 동기화

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicationRole.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ApplicationRole.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
+@Schema(description = "지원자가 선택한 역할")
 public record ApplicationRole(
     @Schema(description = "역할 ID", example = "1", requiredMode = REQUIRED)
     Integer id,

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentDetail.java
@@ -85,7 +85,9 @@ public record RecruitmentDetail(
     @Schema(description = "지원 가능 여부", example = "true", requiredMode = REQUIRED)
     Boolean canApply,
 
-    @Schema(description = "지원 불가 사유. 지원 가능하면 null입니다.", nullable = true, requiredMode = REQUIRED)
+    @Schema(description = "지원 불가 사유. 지원 가능하면 null입니다. 여러 사유가 겹치면 "
+        + "LOGIN_REQUIRED > OWN_RECRUITMENT > ALREADY_APPLIED > RECRUITMENT_CLOSED > DEADLINE_PASSED > "
+        + "ROLE_CLOSED > PROFILE_REQUIRED 순으로 반환합니다.", nullable = true, requiredMode = REQUIRED)
     TeamRecruitmentApplyBlockReason applyBlockReason,
 
     @Schema(description = "내 지원 정보. 미지원자는 null입니다.", nullable = true, requiredMode = REQUIRED)
@@ -102,6 +104,7 @@ public record RecruitmentDetail(
     Integer teamChatRoomId
 ) {
     @JsonNaming(SnakeCaseStrategy.class)
+    @Schema(description = "현재 사용자의 지원 정보")
     public record AppliedApplication(
         @Schema(description = "지원서 ID", example = "51", requiredMode = REQUIRED)
         Integer applicationId,

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
@@ -85,9 +85,12 @@ public interface TeamRecruitmentChatApi {
             Integer userId,
             @PathVariable Integer recruitmentId,
             @PathVariable Integer chatRoomId,
-            @Parameter(schema = @Schema(minimum = "1")) @RequestParam(required = false) Integer afterMessageId,
-            @Parameter(schema = @Schema(minimum = "1")) @RequestParam(required = false) Integer beforeMessageId,
-            @Parameter(schema = @Schema(minimum = "1", maximum = "200")) @RequestParam(defaultValue = "100") int limit
+            @Parameter(schema = @Schema(minimum = "1"))
+            @RequestParam(name = "afterMessageId", required = false) Integer afterMessageId,
+            @Parameter(schema = @Schema(minimum = "1"))
+            @RequestParam(name = "beforeMessageId", required = false) Integer beforeMessageId,
+            @Parameter(schema = @Schema(minimum = "1", maximum = "200"))
+            @RequestParam(name = "limit", defaultValue = "100") int limit
     );
 
     @ApiResponseCodes({

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatController.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatController.java
@@ -56,9 +56,9 @@ public class TeamRecruitmentChatController implements TeamRecruitmentChatApi {
             @Auth(permit = {STUDENT}) Integer userId,
             @PathVariable Integer recruitmentId,
             @PathVariable Integer chatRoomId,
-            @RequestParam(required = false) Integer afterMessageId,
-            @RequestParam(required = false) Integer beforeMessageId,
-            @RequestParam(defaultValue = "100") int limit
+            @RequestParam(name = "afterMessageId", required = false) Integer afterMessageId,
+            @RequestParam(name = "beforeMessageId", required = false) Integer beforeMessageId,
+            @RequestParam(name = "limit", defaultValue = "100") int limit
     ) {
         return ResponseEntity.ok(chatService.getMessages(userId, recruitmentId, chatRoomId, afterMessageId, beforeMessageId, limit));
     }

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatMessageResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatMessageResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 
@@ -11,25 +12,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record ChatMessageResponse(
-        @Schema(description = "메시지 ID", example = "901")
+        @Schema(description = "메시지 ID", example = "901", requiredMode = REQUIRED)
         Integer messageId,
 
-        @Schema(description = "발신자 유저 ID", example = "22")
+        @Schema(description = "발신자 유저 ID", example = "22", requiredMode = REQUIRED)
         Integer userId,
 
-        @Schema(description = "발신자 닉네임", example = "김철수")
+        @Schema(description = "발신자 닉네임", example = "김철수", requiredMode = REQUIRED)
         String userNickname,
 
-        @Schema(description = "메시지 내용 (is_image=true이면 file_url)", example = "안녕하세요!")
+        @Schema(description = "메시지 내용 (is_image=true이면 file_url)", example = "안녕하세요!", requiredMode = REQUIRED)
         String content,
 
-        @Schema(description = "메시지 전송 시각 (KST LocalDateTime)", example = "2026-08-26T11:20:30.123456")
+        @Schema(description = "메시지 전송 시각 (KST LocalDateTime, ISO-8601)",
+                example = "2026-08-26T11:20:30.123456", format = "date-time", requiredMode = REQUIRED)
         LocalDateTime timestamp,
 
-        @Schema(description = "이미지 메시지 여부", example = "false")
+        @Schema(description = "이미지 메시지 여부", example = "false", requiredMode = REQUIRED)
         Boolean isImage,
 
-        @Schema(description = "아직 읽지 않은 다른 멤버 수", example = "2")
+        @Schema(description = "아직 읽지 않은 다른 멤버 수", example = "2", requiredMode = REQUIRED)
         int unreadCount
 ) {
     public static ChatMessageResponse of(TeamRecruitmentChatMessage message, int unreadCount) {

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatRoomResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatRoomResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -9,38 +10,42 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record ChatRoomResponse(
-        @Schema(description = "채팅방 ID", example = "31")
+        @Schema(description = "채팅방 ID", example = "31", requiredMode = REQUIRED)
         Integer chatRoomId,
 
-        @Schema(description = "채팅방 이름", example = "AI 아이디어 공모전 팀원 모집")
+        @Schema(description = "채팅방 이름", example = "AI 아이디어 공모전 팀원 모집", requiredMode = REQUIRED)
         String roomName,
 
-        @Schema(description = "채팅방 타입", example = "TEAM")
+        @Schema(description = "채팅방 타입", example = "TEAM", requiredMode = REQUIRED)
         String roomType,
 
-        @Schema(description = "채팅방 상태", example = "ACTIVE")
+        @Schema(description = "채팅방 상태", example = "ACTIVE", requiredMode = REQUIRED)
         String status,
 
         @Schema(
                 description = "현재 채팅방 멤버 수. TEAM은 작성자와 승인된 지원자를 포함하고, DIRECT는 항상 2",
-                example = "3"
+                example = "3",
+                requiredMode = REQUIRED
         )
         int memberCount,
 
         @Schema(
                 description = "최대 채팅방 멤버 수. TEAM은 모집 정원에 작성자 1명을 더한 값이고, DIRECT는 항상 2",
-                example = "6"
+                example = "6",
+                requiredMode = REQUIRED
         )
         int maxMemberCount,
 
-        @Schema(description = "상대방 정보 (DIRECT만 non-null)")
+        @Schema(description = "상대방 정보. TEAM은 null이고 DIRECT는 상대방 정보를 반환합니다.", nullable = true,
+                requiredMode = REQUIRED)
         Counterpart counterpart
 ) {
+    @Schema(description = "상대방 정보")
     public record Counterpart(
-            @Schema(description = "상대방 유저 ID", example = "22")
+            @Schema(description = "상대방 유저 ID", example = "22", requiredMode = REQUIRED)
             Integer id,
 
-            @Schema(description = "상대방 닉네임", example = "김철수")
+            @Schema(description = "상대방 닉네임", example = "김철수", requiredMode = REQUIRED)
             String nickname
     ) {}
 

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/CreateChatMessageRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/CreateChatMessageRequest.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -10,11 +11,11 @@ import jakarta.validation.constraints.NotNull;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record CreateChatMessageRequest(
-        @Schema(description = "메시지 내용 (is_image=true이면 file_url)", example = "안녕하세요!")
+        @Schema(description = "메시지 내용 (is_image=true이면 file_url)", example = "안녕하세요!", requiredMode = REQUIRED)
         @NotBlank
         String content,
 
-        @Schema(description = "이미지 메시지 여부", example = "false")
+        @Schema(description = "이미지 메시지 여부", example = "false", requiredMode = REQUIRED)
         @NotNull
         Boolean isImage
 ) {

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -10,26 +11,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record DirectChatRoomResponse(
-        @Schema(description = "채팅방 ID", example = "71")
+        @Schema(description = "채팅방 ID", example = "71", requiredMode = REQUIRED)
         Integer chatRoomId,
 
-        @Schema(description = "상대방 닉네임", example = "김철수")
+        @Schema(description = "상대방 닉네임", example = "김철수", requiredMode = REQUIRED)
         String roomName,
 
-        @Schema(description = "채팅방 타입", example = "DIRECT")
+        @Schema(description = "채팅방 타입", example = "DIRECT", requiredMode = REQUIRED)
         String roomType,
 
-        @Schema(description = "채팅방 상태", example = "ACTIVE")
+        @Schema(description = "채팅방 상태", example = "ACTIVE", requiredMode = REQUIRED)
         String status,
 
-        @Schema(description = "상대방 정보")
+        @Schema(description = "상대방 정보", requiredMode = REQUIRED)
         Counterpart counterpart
 ) {
     public record Counterpart(
-            @Schema(description = "상대방 유저 ID", example = "22")
+            @Schema(description = "상대방 유저 ID", example = "22", requiredMode = REQUIRED)
             Integer id,
 
-            @Schema(description = "상대방 닉네임", example = "김철수")
+            @Schema(description = "상대방 닉네임", example = "김철수", requiredMode = REQUIRED)
             String nickname
     ) {}
 

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentNotificationResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentNotificationResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.LocalDateTime;
 
@@ -11,34 +12,38 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record TeamRecruitmentNotificationResponse(
-        @Schema(description = "알림 ID", example = "101")
+        @Schema(description = "알림 ID", example = "101", requiredMode = REQUIRED)
         Integer id,
 
-        @Schema(description = "알림 타입", example = "NEW_APPLICATION")
+        @Schema(description = "알림 타입", example = "NEW_APPLICATION", requiredMode = REQUIRED)
         String type,
 
-        @Schema(description = "이동 대상 타입", example = "APPLICANT_MANAGEMENT")
+        @Schema(description = "이동 대상 타입", example = "APPLICANT_MANAGEMENT", requiredMode = REQUIRED)
         String targetType,
 
-        @Schema(description = "모집글 ID", example = "17")
+        @Schema(description = "모집글 ID", example = "17", requiredMode = REQUIRED)
         Integer recruitmentId,
 
-        @Schema(description = "지원서 ID", example = "51")
+        @Schema(description = "지원서 ID. 지원서와 관련 없는 알림은 null입니다.", example = "51", nullable = true,
+                requiredMode = REQUIRED)
         Integer applicationId,
 
-        @Schema(description = "채팅방 ID", example = "31")
+        @Schema(description = "채팅방 ID. 채팅방과 관련 없는 알림은 null입니다.", example = "31", nullable = true,
+                requiredMode = REQUIRED)
         Integer chatRoomId,
 
-        @Schema(description = "발신자 닉네임 (NEW_CHAT_MESSAGE 전용)", example = "홍길동")
+        @Schema(description = "발신자 닉네임. NEW_CHAT_MESSAGE가 아니면 null입니다.", example = "홍길동",
+                nullable = true, requiredMode = REQUIRED)
         String senderNickname,
 
-        @Schema(description = "메시지 미리보기", example = "새로운 지원자가 있어요.")
+        @Schema(description = "메시지 미리보기", example = "새로운 지원자가 있어요.", requiredMode = REQUIRED)
         String messagePreview,
 
-        @Schema(description = "읽음 여부", example = "false")
+        @Schema(description = "읽음 여부", example = "false", requiredMode = REQUIRED)
         Boolean isRead,
 
-        @Schema(description = "생성 일시")
+        @Schema(description = "생성 일시 (KST LocalDateTime, ISO-8601)",
+                example = "2026-08-26T11:20:30.123456", format = "date-time", requiredMode = REQUIRED)
         LocalDateTime createdAt
 ) {
     public static TeamRecruitmentNotificationResponse from(TeamRecruitmentNotification notification) {

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentNotificationsResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentNotificationsResponse.java
@@ -1,6 +1,7 @@
 package in.koreatech.koin.domain.teamrecruitment.dto;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
 
@@ -10,22 +11,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record TeamRecruitmentNotificationsResponse(
-        @Schema(description = "알림 목록")
+        @Schema(description = "알림 목록", requiredMode = REQUIRED)
         List<TeamRecruitmentNotificationResponse> notifications,
 
-        @Schema(description = "전체 미읽음 알림 수", example = "3")
+        @Schema(description = "전체 미읽음 알림 수", example = "3", requiredMode = REQUIRED)
         long unreadCount,
 
-        @Schema(description = "전체 알림 수", example = "24")
+        @Schema(description = "전체 알림 수", example = "24", requiredMode = REQUIRED)
         long totalCount,
 
-        @Schema(description = "현재 페이지 알림 수", example = "10")
+        @Schema(description = "현재 페이지 알림 수", example = "10", requiredMode = REQUIRED)
         int currentCount,
 
-        @Schema(description = "전체 페이지 수", example = "3")
+        @Schema(description = "전체 페이지 수", example = "3", requiredMode = REQUIRED)
         int totalPage,
 
-        @Schema(description = "현재 페이지 (1부터 시작)", example = "1")
+        @Schema(description = "현재 페이지 (1부터 시작)", example = "1", requiredMode = REQUIRED)
         int currentPage
 ) {
 }

--- a/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/SwaggerGroupConfig.java
@@ -46,9 +46,9 @@ public class SwaggerGroupConfig {
 
     @Bean
     public GroupedOpenApi campusApi() {
-        return createGroupedOpenApi(
-            "3. Campus API",
-            new String[] {
+        return GroupedOpenApi.builder()
+            .group("3. Campus API")
+            .packagesToScan(
                 "in.koreatech.koin.domain.bus",
                 "in.koreatech.koin.domain.community.article",
                 "in.koreatech.koin.domain.community.keyword",
@@ -62,7 +62,10 @@ public class SwaggerGroupConfig {
                 "in.koreatech.koin.domain.team",
                 "in.koreatech.koin.domain.teamrecruitment",
                 "in.koreatech.koin.domain.weather"
-            });
+            )
+            .addOperationCustomizer(customizer)
+            .addOpenApiCustomizer(new TeamRecruitmentOpenApiCustomizer())
+            .build();
     }
 
     @Bean

--- a/src/main/java/in/koreatech/koin/global/config/TeamRecruitmentOpenApiCustomizer.java
+++ b/src/main/java/in/koreatech/koin/global/config/TeamRecruitmentOpenApiCustomizer.java
@@ -1,0 +1,120 @@
+package in.koreatech.koin.global.config;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
+
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+
+public class TeamRecruitmentOpenApiCustomizer implements OpenApiCustomizer {
+
+    private static final String ISO_LOCAL_DATE_TIME_PATTERN =
+        "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?$";
+    private static final String SPACE_LOCAL_DATE_TIME_PATTERN =
+        "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$";
+
+    private static final List<NullableReference> NULLABLE_REFERENCES = List.of(
+        new NullableReference("ChatRoomResponse", "counterpart"),
+        new NullableReference("ApplicationCreatedResponse", "role"),
+        new NullableReference("ApplicantDetail", "role"),
+        new NullableReference("ApplicantSummary", "role"),
+        new NullableReference("MyApplication", "role"),
+        new NullableReference("RecruitmentDetail", "apply_block_reason"),
+        new NullableReference("RecruitmentDetail", "application")
+    );
+
+    @Override
+    public void customise(OpenAPI openApi) {
+        if (openApi.getComponents() == null || openApi.getComponents().getSchemas() == null) {
+            return;
+        }
+        Map<String, Schema> schemas = openApi.getComponents().getSchemas();
+        NULLABLE_REFERENCES.forEach(reference -> makeNullable(schemas, reference));
+        configureDateTime(
+            schemas,
+            "TeamRecruitmentNotificationResponse",
+            "created_at",
+            ISO_LOCAL_DATE_TIME_PATTERN
+        );
+        configureDateTime(schemas, "ApplicationCreatedResponse", "created_at", SPACE_LOCAL_DATE_TIME_PATTERN);
+        configureDateTime(schemas, "RecruitmentDetail", "created_at", SPACE_LOCAL_DATE_TIME_PATTERN);
+        configureChatMessageTimestamp(openApi, schemas);
+    }
+
+    private void makeNullable(Map<String, Schema> schemas, NullableReference reference) {
+        Schema<?> property = propertyOf(schemas, reference.schemaName(), reference.propertyName());
+        if (property == null) {
+            return;
+        }
+        Schema<?> source = property;
+        if (property.get$ref() != null && !property.get$ref().isBlank()) {
+            String schemaName = property.get$ref().substring(property.get$ref().lastIndexOf('/') + 1);
+            source = schemas.get(schemaName);
+        }
+        if (source == null) {
+            return;
+        }
+        Schema<?> nullableSchema = Json.mapper().convertValue(source, Schema.class);
+        nullableSchema.setNullable(true);
+        if (property.getDescription() != null) {
+            nullableSchema.setDescription(property.getDescription());
+        }
+        Schema<?> owner = schemas.get(reference.schemaName());
+        owner.addProperty(reference.propertyName(), nullableSchema);
+    }
+
+    private void configureChatMessageTimestamp(OpenAPI openApi, Map<String, Schema> schemas) {
+        if (openApi.getPaths() == null) {
+            return;
+        }
+        PathItem path = openApi.getPaths()
+            .get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages");
+        if (path == null || path.getPost() == null) {
+            return;
+        }
+        ApiResponse ok = path.getPost().getResponses().get("200");
+        if (ok == null || ok.getContent() == null || ok.getContent().isEmpty()) {
+            return;
+        }
+        MediaType mediaType = ok.getContent().get("application/json");
+        if (mediaType == null) {
+            mediaType = ok.getContent().values().iterator().next();
+        }
+        Schema<?> response = mediaType.getSchema();
+        if (response == null || response.get$ref() == null) {
+            return;
+        }
+        String schemaName = response.get$ref().substring(response.get$ref().lastIndexOf('/') + 1);
+        configureDateTime(schemas, schemaName, "timestamp", ISO_LOCAL_DATE_TIME_PATTERN);
+    }
+
+    private void configureDateTime(
+        Map<String, Schema> schemas,
+        String schemaName,
+        String propertyName,
+        String pattern
+    ) {
+        Schema<?> dateTime = propertyOf(schemas, schemaName, propertyName);
+        if (dateTime == null) {
+            return;
+        }
+        dateTime.setFormat(null);
+        dateTime.setPattern(pattern);
+    }
+
+    private Schema<?> propertyOf(Map<String, Schema> schemas, String schemaName, String propertyName) {
+        Schema<?> schema = schemas.get(schemaName);
+        return schema == null || schema.getProperties() == null
+            ? null
+            : (Schema<?>)schema.getProperties().get(propertyName);
+    }
+
+    private record NullableReference(String schemaName, String propertyName) {
+    }
+}

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
@@ -1,0 +1,309 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.domain.team.recruitment.dto.ApplicationCreatedResponse;
+import in.koreatech.koin.domain.teamrecruitment.dto.ChatMessageResponse;
+import in.koreatech.koin.domain.teamrecruitment.dto.ChatRoomResponse;
+import in.koreatech.koin.domain.teamrecruitment.dto.TeamRecruitmentNotificationResponse;
+
+class TeamRecruitmentOpenApiContractTest extends AcceptanceTest {
+
+    private static final String ISO_LOCAL_DATE_TIME_PATTERN =
+        "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?$";
+    private static final String SPACE_LOCAL_DATE_TIME_PATTERN =
+        "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$";
+
+    private static final String APPLY_BLOCK_REASON_PRIORITY = "LOGIN_REQUIRED > OWN_RECRUITMENT > "
+        + "ALREADY_APPLIED > RECRUITMENT_CLOSED > DEADLINE_PASSED > ROLE_CLOSED > PROFILE_REQUIRED";
+
+    private static final Set<String> HTTP_METHODS = Set.of("get", "post", "put", "patch", "delete");
+
+    private static final Set<String> TEAM_RECRUITMENT_OPERATIONS = Set.of(
+        "GET /team-recruitments",
+        "POST /team-recruitments",
+        "GET /team-recruitments/{recruitmentId}",
+        "PUT /team-recruitments/{recruitmentId}",
+        "DELETE /team-recruitments/{recruitmentId}",
+        "PUT /team-recruitments/{recruitmentId}/close",
+        "GET /team-recruitments/me/created",
+        "POST /team-recruitments/{recruitmentId}/applications",
+        "GET /team-recruitments/me/applications",
+        "GET /team-recruitments/{recruitmentId}/applications",
+        "GET /team-recruitments/{recruitmentId}/applications/{applicationId}",
+        "PUT /team-recruitments/{recruitmentId}/applications/{applicationId}/status",
+        "GET /team-recruitment-profiles/me",
+        "PUT /team-recruitment-profiles/me",
+        "GET /chatroom/team-recruitment/{recruitmentId}/{chatRoomId}",
+        "POST /chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
+        "GET /chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages",
+        "POST /chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages",
+        "GET /team-recruitments/notifications",
+        "POST /team-recruitments/notifications/{notificationId}/read",
+        "POST /team-recruitments/notifications/mark-all-read",
+        "DELETE /team-recruitments/notifications/{notificationId}",
+        "DELETE /team-recruitments/notifications"
+    );
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void teamRecruitmentContractMatchesRuntime() throws Exception {
+        JsonNode openApi = openApi("/v3/api-docs/3.%20Campus%20API");
+
+        assertThat(openApi.path("openapi").asText()).isEqualTo("3.0.3");
+        assertThat(teamRecruitmentOperations(openApi)).containsExactlyInAnyOrderElementsOf(
+            TEAM_RECRUITMENT_OPERATIONS
+        );
+
+        JsonNode chatRoom = schema(openApi, "ChatRoomResponse");
+        assertRequired(chatRoom, "chat_room_id", "room_name", "room_type", "status", "member_count",
+            "max_member_count", "counterpart");
+        assertNullable(chatRoom, "counterpart");
+        assertInlineObject(chatRoom, "counterpart", "id", "nickname");
+
+        assertRequiredNullable(schema(openApi, "ApplicationCreatedResponse"), "role");
+        assertInlineObject(schema(openApi, "ApplicationCreatedResponse"), "role", "id", "name");
+        assertRequiredNullable(schema(openApi, "ApplicantDetail"), "role");
+        assertRequiredNullable(schema(openApi, "ApplicantSummary"), "role");
+        assertRequiredNullable(schema(openApi, "MyApplication"), "role");
+
+        JsonNode directChatRoom = schema(openApi, "DirectChatRoomResponse");
+        assertRequired(directChatRoom, "chat_room_id", "room_name", "room_type", "status", "counterpart");
+        assertNonNullableObject(openApi, directChatRoom, "counterpart", "id", "nickname");
+
+        JsonNode chatMessage = responseSchema(openApi,
+            "/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages", "post", "200");
+        assertRequired(chatMessage, "message_id", "user_id", "user_nickname", "content", "timestamp",
+            "is_image", "unread_count");
+        assertRequired(schema(openApi, "CreateChatMessageRequest"), "content", "is_image");
+
+        JsonNode notification = schema(openApi, "TeamRecruitmentNotificationResponse");
+        assertRequired(notification, "id", "type", "target_type", "recruitment_id", "application_id",
+            "chat_room_id", "sender_nickname", "message_preview", "is_read", "created_at");
+        assertNullable(notification, "application_id");
+        assertNullable(notification, "chat_room_id");
+        assertNullable(notification, "sender_nickname");
+        assertDateTime(notification, "created_at", ISO_LOCAL_DATE_TIME_PATTERN);
+        assertRequired(schema(openApi, "TeamRecruitmentNotificationsResponse"), "notifications", "unread_count",
+            "total_count", "current_count", "total_page", "current_page");
+
+        assertDateTime(chatMessage, "timestamp", ISO_LOCAL_DATE_TIME_PATTERN);
+        assertDateTime(schema(openApi, "ApplicationCreatedResponse"), "created_at",
+            SPACE_LOCAL_DATE_TIME_PATTERN);
+        assertDateTime(schema(openApi, "RecruitmentDetail"), "created_at",
+            SPACE_LOCAL_DATE_TIME_PATTERN);
+        assertRequiredNullable(schema(openApi, "RecruitmentCard"), "d_day");
+        assertRequiredNullable(schema(openApi, "RecruitmentDetail"), "d_day");
+        assertRequiredNullable(schema(openApi, "CreatedRecruitment"), "d_day");
+        assertRequiredNullable(schema(openApi, "ApplicantRecruitment"), "d_day");
+
+        assertQueryParameterNames(openApi);
+
+        String blockReasonDescription = schema(openApi, "RecruitmentDetail")
+            .path("properties")
+            .path("apply_block_reason")
+            .path("description")
+            .asText();
+        assertThat(blockReasonDescription).contains(APPLY_BLOCK_REASON_PRIORITY);
+        assertInlineEnum(schema(openApi, "RecruitmentDetail"), "apply_block_reason",
+            "RECRUITMENT_DELETED", "LOGIN_REQUIRED", "OWN_RECRUITMENT", "ALREADY_APPLIED",
+            "RECRUITMENT_CLOSED", "DEADLINE_PASSED", "ROLE_CLOSED", "PROFILE_REQUIRED");
+        assertRequiredNullable(schema(openApi, "RecruitmentDetail"), "application");
+        assertInlineObject(schema(openApi, "RecruitmentDetail"), "application", "application_id", "status");
+    }
+
+    @Test
+    void teamRecruitmentCustomizerIsLimitedToCampusGroup() throws Exception {
+        JsonNode defaultOpenApi = openApi("/v3/api-docs");
+        JsonNode counterpart = schema(defaultOpenApi, "ChatRoomResponse")
+            .path("properties")
+            .path("counterpart");
+
+        assertThat(counterpart.path("$ref").asText()).startsWith("#/components/schemas/");
+        assertThat(counterpart.has("allOf")).isFalse();
+    }
+
+    @Test
+    void teamRecruitmentDtosMatchRuntimeJson() {
+        LocalDateTime timestamp = LocalDateTime.of(2026, 8, 26, 11, 20, 30, 123_456_000);
+
+        JsonNode application = objectMapper.valueToTree(
+            new ApplicationCreatedResponse(51, 17, PENDING, null, timestamp));
+        JsonNode chatRoom = objectMapper.valueToTree(
+            new ChatRoomResponse(31, "팀 채팅방", "TEAM", "ACTIVE", 1, 2, null));
+        JsonNode notification = objectMapper.valueToTree(new TeamRecruitmentNotificationResponse(
+            101, "NEW_APPLICATION", "APPLICANT_MANAGEMENT", 17, null, null, null,
+            "새로운 지원자가 있어요.", false, timestamp));
+        JsonNode message = objectMapper.valueToTree(
+            new ChatMessageResponse(901, 22, "김철수", "안녕하세요!", timestamp, false, 0));
+
+        assertThat(application.path("role").isNull()).isTrue();
+        assertThat(application.path("created_at").asText()).isEqualTo("2026-08-26 11:20:30");
+        assertThat(chatRoom.path("counterpart").isNull()).isTrue();
+        assertThat(notification.path("application_id").isNull()).isTrue();
+        assertThat(notification.path("chat_room_id").isNull()).isTrue();
+        assertThat(notification.path("sender_nickname").isNull()).isTrue();
+        assertThat(notification.path("created_at").asText()).isEqualTo("2026-08-26T11:20:30.123456");
+        assertThat(message.path("timestamp").asText()).isEqualTo("2026-08-26T11:20:30.123456");
+    }
+
+    private JsonNode openApi(String path) throws Exception {
+        String document = mockMvc.perform(get(URI.create(path)))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        return objectMapper.readTree(document);
+    }
+
+    private Set<String> teamRecruitmentOperations(JsonNode openApi) {
+        Set<String> operations = new HashSet<>();
+        Iterator<Map.Entry<String, JsonNode>> paths = openApi.path("paths").fields();
+        while (paths.hasNext()) {
+            Map.Entry<String, JsonNode> path = paths.next();
+            if (!isTeamRecruitmentPath(path.getKey())) {
+                continue;
+            }
+            path.getValue().fieldNames().forEachRemaining(method -> {
+                if (HTTP_METHODS.contains(method)) {
+                    operations.add(method.toUpperCase() + " " + path.getKey());
+                }
+            });
+        }
+        return operations;
+    }
+
+    private boolean isTeamRecruitmentPath(String path) {
+        return path.startsWith("/team-recruitments")
+            || path.startsWith("/team-recruitment-profiles")
+            || path.startsWith("/chatroom/team-recruitment");
+    }
+
+    private JsonNode schema(JsonNode openApi, String name) {
+        JsonNode schema = openApi.path("components").path("schemas").path(name);
+        assertThat(schema.isMissingNode())
+            .as("OpenAPI component schema %s", name)
+            .isFalse();
+        return schema;
+    }
+
+    private JsonNode responseSchema(JsonNode openApi, String path, String method, String status) {
+        JsonNode content = openApi.path("paths")
+            .path(path)
+            .path(method)
+            .path("responses")
+            .path(status)
+            .path("content");
+        JsonNode mediaType = content.path("application/json");
+        if (mediaType.isMissingNode()) {
+            mediaType = content.elements().next();
+        }
+        JsonNode responseSchema = mediaType.path("schema");
+        String reference = responseSchema.path("$ref").asText();
+        assertThat(reference)
+            .as("response schema: %s", responseSchema)
+            .startsWith("#/components/schemas/");
+        return schema(openApi, reference.substring(reference.lastIndexOf('/') + 1));
+    }
+
+    private void assertRequiredNullable(JsonNode schema, String property) {
+        assertRequired(schema, property);
+        assertNullable(schema, property);
+    }
+
+    private void assertRequired(JsonNode schema, String... properties) {
+        assertThat(schema.path("required"))
+            .extracting(JsonNode::asText)
+            .contains(properties);
+    }
+
+    private void assertNullable(JsonNode schema, String property) {
+        JsonNode propertySchema = schema.path("properties").path(property);
+        assertThat(propertySchema.path("nullable").asBoolean())
+            .as("%s must be nullable: %s", property, propertySchema)
+            .isTrue();
+        assertThat(propertySchema.path("type").asText())
+            .as("%s must declare its type next to nullable: %s", property, propertySchema)
+            .isNotBlank();
+        assertThat(propertySchema.has("$ref")).isFalse();
+        assertThat(propertySchema.has("allOf")).isFalse();
+    }
+
+    private void assertInlineObject(JsonNode schema, String property, String... requiredProperties) {
+        JsonNode propertySchema = schema.path("properties").path(property);
+        assertThat(propertySchema.path("type").asText()).isEqualTo("object");
+        assertThat(propertySchema.path("properties").fieldNames())
+            .toIterable()
+            .contains(requiredProperties);
+        assertRequired(propertySchema, requiredProperties);
+    }
+
+    private void assertNonNullableObject(
+        JsonNode openApi,
+        JsonNode schema,
+        String property,
+        String... requiredProperties
+    ) {
+        JsonNode propertySchema = schema.path("properties").path(property);
+        String reference = propertySchema.path("$ref").asText();
+        JsonNode effectiveSchema = reference.isBlank()
+            ? propertySchema
+            : openApi.at(reference.substring(1));
+
+        assertThat(propertySchema.path("nullable").asBoolean()).isFalse();
+        assertThat(effectiveSchema.path("nullable").asBoolean()).isFalse();
+        assertThat(effectiveSchema.path("type").asText()).isEqualTo("object");
+        assertThat(effectiveSchema.path("properties").fieldNames())
+            .toIterable()
+            .contains(requiredProperties);
+        assertRequired(effectiveSchema, requiredProperties);
+    }
+
+    private void assertInlineEnum(JsonNode schema, String property, String... values) {
+        JsonNode propertySchema = schema.path("properties").path(property);
+        assertThat(propertySchema.path("type").asText()).isEqualTo("string");
+        assertThat(propertySchema.path("enum"))
+            .extracting(JsonNode::asText)
+            .containsExactly(values);
+    }
+
+    private void assertQueryParameterNames(JsonNode openApi) {
+        JsonNode parameters = openApi.path("paths")
+            .path("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages")
+            .path("get")
+            .path("parameters");
+        Set<String> queryNames = new HashSet<>();
+        parameters.elements().forEachRemaining(parameter -> {
+            if ("query".equals(parameter.path("in").asText())) {
+                queryNames.add(parameter.path("name").asText());
+            }
+        });
+        assertThat(queryNames).containsExactlyInAnyOrder("afterMessageId", "beforeMessageId", "limit");
+    }
+
+    private void assertDateTime(JsonNode schema, String property, String pattern) {
+        JsonNode dateTime = schema.path("properties").path(property);
+        assertThat(dateTime.path("type").asText()).as("date-time schema: %s", dateTime).isEqualTo("string");
+        assertThat(dateTime.path("format").isMissingNode()).as("date-time schema: %s", dateTime).isTrue();
+        assertThat(dateTime.path("pattern").asText()).as("date-time schema: %s", dateTime).isEqualTo(pattern);
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/global/config/TeamRecruitmentOpenApiCustomizerTest.java
+++ b/src/test/java/in/koreatech/koin/unit/global/config/TeamRecruitmentOpenApiCustomizerTest.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.unit.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.global.config.TeamRecruitmentOpenApiCustomizer;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+
+class TeamRecruitmentOpenApiCustomizerTest {
+
+    @Test
+    void nullablePropertyIsInlinedWithoutMutatingItsSharedComponent() {
+        ObjectSchema component = new ObjectSchema();
+        component.addProperty("id", new IntegerSchema());
+        component.setRequired(List.of("id"));
+        component.setNullable(true);
+        ObjectSchema response = new ObjectSchema();
+        response.addProperty("role", new Schema<>().$ref("#/components/schemas/ApplicationRole"));
+        Components components = new Components()
+            .addSchemas("ApplicationRole", component)
+            .addSchemas("ApplicationCreatedResponse", response);
+
+        new TeamRecruitmentOpenApiCustomizer().customise(new OpenAPI().components(components));
+
+        Schema<?> inline = (Schema<?>)response.getProperties().get("role");
+        assertThat(inline).isNotSameAs(component);
+        assertThat(inline.getType()).isEqualTo("object");
+        assertThat(inline.getProperties()).containsKey("id").isNotSameAs(component.getProperties());
+        assertThat(inline.getRequired()).containsExactly("id").isNotSameAs(component.getRequired());
+        assertThat(inline.getNullable()).isTrue();
+        assertThat(component.getNullable()).isTrue();
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집 Java OpenAPI가 실제 JSON의 required, nullable, 날짜, query 계약을 정확히 표현하도록 정렬합니다.

- Part of #2378

---

### 🚀 주요 변경 내용

* Campus 문서의 팀원 모집 operation 23개를 exact path/method로 고정합니다.
* 채팅·알림 응답 필드와 메시지 요청 필드의 required 계약을 명시합니다.
* TEAM `counterpart`, GENERAL `role`, `apply_block_reason`, 내 지원 정보의 required key와 nullable value를 OpenAPI 3.0 inline schema로 표현합니다.
* nullable `$ref` schema를 복제해 inline하고 공유 component 값을 보존합니다.
* 알림·메시지의 `T` 날짜 형식과 지원·모집의 공백 날짜 형식을 runtime pattern으로 명시합니다.
* `apply_block_reason` 우선순위와 enum 값을 고정합니다.
* 메시지 조회 query 이름을 `afterMessageId`, `beforeMessageId`, `limit`으로 명시합니다.
* 팀원 모집 customizer를 Campus group에 등록합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P1 문서·SDK 계약 오류이며 클라이언트가 nullable·required·날짜 형식을 반영한 타입과 SDK를 생성할 수 있습니다.
  * controller/service 처리와 실제 JSON 값을 유지하며 Java OpenAPI 표현을 정렬합니다.
* **검증**
  * `TeamRecruitmentOpenApiContractTest` 3개와 `TeamRecruitmentOpenApiCustomizerTest` 1개가 통과했습니다.
  * #2404 위 최종 branch에서 팀원 모집 228개와 전역 OpenAPI 3개, 총 231개가 통과했습니다.
  * 직렬화 값 `2026-08-26T11:20:30.123456`과 `2026-08-26 11:20:30`을 확인했습니다.
* **반영 순서**
  * 현재 base는 #2404 branch이며 #2404와 #2390 반영 후 최신 `develop`에 rebase해 최종 OpenAPI 조합을 확인합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)