### PR TITLE
fix: 팀원 모집 마감 배치의 모집별 트랜잭션 격리

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseCoordinator.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseCoordinator.java
@@ -1,0 +1,60 @@
+package in.koreatech.koin.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamRecruitmentDeadlineCloseCoordinator {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final int CANDIDATE_BATCH_SIZE = 100;
+    private static final Pageable CANDIDATE_PAGE = PageRequest.of(
+        0,
+        CANDIDATE_BATCH_SIZE,
+        Sort.by(Sort.Direction.ASC, "id")
+    );
+
+    private final TeamRecruitmentRepository recruitmentRepository;
+    private final TeamRecruitmentDeadlineCloseProcessor closeProcessor;
+    private final Clock clock;
+
+    public void closeExpiredRecruitments() {
+        LocalDate today = LocalDate.now(clock.withZone(KST));
+        Page<TeamRecruitment> candidatePage = recruitmentRepository
+            .findAllByStatusAndDeadlineDateBefore(RECRUITING, today, CANDIDATE_PAGE);
+        if (candidatePage == null) {
+            return;
+        }
+
+        List<Integer> candidateIds = candidatePage
+            .getContent()
+            .stream()
+            .map(TeamRecruitment::getId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        for (Integer recruitmentId : candidateIds) {
+            try {
+                closeProcessor.closeIfExpired(recruitmentId, today);
+            } catch (Exception exception) {
+                log.error("팀원 모집글 마감 처리에 실패했습니다. recruitmentId={}", recruitmentId, exception);
+            }
+        }
+    }
+}

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
@@ -24,34 +24,20 @@ import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatR
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TeamRecruitmentDeadlineCloseProcessor {
-
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final int CANDIDATE_BATCH_SIZE = 100;
-    private static final Pageable CANDIDATE_PAGE = PageRequest.of(
-        0,
-        CANDIDATE_BATCH_SIZE,
-        Sort.by(Sort.Direction.ASC, "id")
-    );
 
     private static final String RECRUITMENT_CLOSED_REASON = "RECRUITMENT_CLOSED";
     private static final String OUTBOX_EVENT_TYPE = "TEAM_RECRUITMENT_NOTIFICATION";
@@ -61,30 +47,9 @@ public class TeamRecruitmentDeadlineCloseProcessor {
     private final TeamRecruitmentChatRoomRepository chatRoomRepository;
     private final TeamRecruitmentNotificationRepository notificationRepository;
     private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
-    private final Clock clock;
 
-    @Transactional
-    public void closeExpiredRecruitments() {
-        LocalDate today = LocalDate.now(clock.withZone(KST));
-        Page<TeamRecruitment> candidatePage = recruitmentRepository
-            .findAllByStatusAndDeadlineDateBefore(RECRUITING, today, CANDIDATE_PAGE);
-        if (candidatePage == null) {
-            return;
-        }
-
-        List<Integer> candidateIds = candidatePage
-            .getContent()
-            .stream()
-            .map(TeamRecruitment::getId)
-            .filter(Objects::nonNull)
-            .toList();
-
-        for (Integer recruitmentId : candidateIds) {
-            closeIfExpired(recruitmentId, today);
-        }
-    }
-
-    private void closeIfExpired(Integer recruitmentId, LocalDate today) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void closeIfExpired(Integer recruitmentId, LocalDate today) {
         Optional<TeamRecruitment> lockedRecruitment = recruitmentRepository.findByIdWithLock(recruitmentId);
         if (lockedRecruitment.isEmpty()) {
             return;

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineScheduler.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineScheduler.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TeamRecruitmentDeadlineScheduler {
 
-    private final TeamRecruitmentDeadlineCloseProcessor deadlineCloseProcessor;
+    private final TeamRecruitmentDeadlineCloseCoordinator deadlineCloseCoordinator;
 
     @Scheduled(fixedDelayString = "${team-recruitment.deadline-scheduler.fixed-delay-ms:60000}")
     public void closeExpiredRecruitments() {
         try {
-            deadlineCloseProcessor.closeExpiredRecruitments();
+            deadlineCloseCoordinator.closeExpiredRecruitments();
         } catch (Exception exception) {
             log.error("팀원 모집 마감 스케줄러 처리 중 오류가 발생했습니다.", exception);
         }

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDeadlineCloseIntegrationTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDeadlineCloseIntegrationTest.java
@@ -1,0 +1,282 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType.GENERAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType;
+import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentOutboxEventStatus;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentOutboxEvent;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatRoomRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentNotificationRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutboxEventRepository;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineCloseCoordinator;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineScheduler;
+import in.koreatech.koin.domain.user.model.User;
+import in.koreatech.koin.domain.user.model.UserType;
+import in.koreatech.koin.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+class TeamRecruitmentDeadlineCloseIntegrationTest extends AcceptanceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private TeamRecruitmentDeadlineCloseCoordinator coordinator;
+
+    @Autowired
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private TeamRecruitmentApplicationRepository applicationRepository;
+
+    @Autowired
+    private TeamRecruitmentChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private TeamRecruitmentNotificationRepository notificationRepository;
+
+    @Autowired
+    private TeamRecruitmentOutboxEventRepository outboxEventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private TeamRecruitmentDeadlineScheduler deadlineScheduler;
+
+    @AfterEach
+    void cleanUp() {
+        clear();
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void 손상된_모집의_변경은_전부_롤백되고_다음_정상_모집은_마감된다() {
+        clear();
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        LocalDate today = LocalDate.now(clock.withZone(KST));
+        Scenario scenario = transactionTemplate.execute(status -> seed(today));
+
+        coordinator.closeExpiredRecruitments();
+
+        transactionTemplate.executeWithoutResult(status -> assertResults(scenario));
+    }
+
+    private Scenario seed(LocalDate today) {
+        User author = userRepository.save(user());
+        User failedAcceptedApplicant = userRepository.save(user());
+        User failedPendingApplicant = userRepository.save(user());
+        User successfulPendingApplicant = userRepository.save(user());
+
+        TeamRecruitment failedRecruitment = recruitment(author, today, "손상 모집", 1);
+        TeamRecruitment successfulRecruitment = recruitment(author, today, "정상 모집", 0);
+        recruitmentRepository.save(failedRecruitment);
+        recruitmentRepository.save(successfulRecruitment);
+
+        TeamRecruitmentApplication failedAccepted = application(
+            failedRecruitment,
+            failedAcceptedApplicant,
+            ACCEPTED
+        );
+        TeamRecruitmentApplication failedPending = application(
+            failedRecruitment,
+            failedPendingApplicant,
+            PENDING
+        );
+        TeamRecruitmentApplication successfulPending = application(
+            successfulRecruitment,
+            successfulPendingApplicant,
+            PENDING
+        );
+        applicationRepository.save(failedAccepted);
+        applicationRepository.save(failedPending);
+        applicationRepository.save(successfulPending);
+
+        TeamRecruitmentChatRoom failedDirectRoom = chatRoom(
+            failedRecruitment,
+            failedPending,
+            DIRECT,
+            "APPLICATION:" + failedPending.getId()
+        );
+        TeamRecruitmentChatRoom successfulTeamRoom = chatRoom(
+            successfulRecruitment,
+            null,
+            TEAM,
+            "TEAM"
+        );
+        chatRoomRepository.save(failedDirectRoom);
+        chatRoomRepository.save(successfulTeamRoom);
+
+        return new Scenario(
+            failedRecruitment.getId(),
+            failedAccepted.getId(),
+            failedPending.getId(),
+            failedDirectRoom.getId(),
+            successfulRecruitment.getId(),
+            successfulPending.getId(),
+            successfulPendingApplicant.getId(),
+            successfulTeamRoom.getId()
+        );
+    }
+
+    private void assertResults(Scenario scenario) {
+        TeamRecruitment failedRecruitment = recruitmentRepository.findById(scenario.failedRecruitmentId())
+            .orElseThrow();
+        TeamRecruitmentApplication failedAccepted = applicationRepository.findById(scenario.failedAcceptedId())
+            .orElseThrow();
+        TeamRecruitmentApplication failedPending = applicationRepository.findById(scenario.failedPendingId())
+            .orElseThrow();
+        TeamRecruitmentChatRoom failedDirectRoom = chatRoomRepository.findById(scenario.failedDirectRoomId())
+            .orElseThrow();
+
+        assertThat(failedRecruitment.getStatus()).isEqualTo(RECRUITING);
+        assertThat(failedAccepted.getStatus()).isEqualTo(ACCEPTED);
+        assertThat(failedPending.getStatus()).isEqualTo(PENDING);
+        assertThat(failedPending.getDecisionReason()).isNull();
+        assertThat(failedDirectRoom.getStatus()).isEqualTo(ACTIVE);
+        assertThat(outboxEventRepository.findByEventKey(rejectionEventKey(scenario.failedPendingId())))
+            .isEmpty();
+        assertThat(notificationRepository.findForOutbox(
+            failedPending.getApplicant().getId(),
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            scenario.failedRecruitmentId(),
+            scenario.failedPendingId(),
+            null
+        )).isEmpty();
+
+        TeamRecruitment successfulRecruitment = recruitmentRepository.findById(scenario.successfulRecruitmentId())
+            .orElseThrow();
+        TeamRecruitmentApplication successfulPending = applicationRepository.findById(
+            scenario.successfulPendingId()
+        ).orElseThrow();
+        TeamRecruitmentChatRoom successfulTeamRoom = chatRoomRepository.findById(scenario.successfulTeamRoomId())
+            .orElseThrow();
+
+        assertThat(successfulRecruitment.getStatus()).isEqualTo(CLOSED);
+        assertThat(successfulPending.getStatus()).isEqualTo(REJECTED);
+        assertThat(successfulPending.getDecisionReason()).isEqualTo("RECRUITMENT_CLOSED");
+        assertThat(successfulTeamRoom.getStatus()).isEqualTo(READ_ONLY);
+        assertThat(notificationRepository.findForOutbox(
+            scenario.successfulApplicantId(),
+            APPLICATION_REJECTED,
+            MY_APPLICATIONS,
+            scenario.successfulRecruitmentId(),
+            scenario.successfulPendingId(),
+            null
+        )).hasSize(1);
+        TeamRecruitmentOutboxEvent successfulOutbox = outboxEventRepository
+            .findByEventKey(rejectionEventKey(scenario.successfulPendingId()))
+            .orElseThrow();
+        assertThat(successfulOutbox.getStatus()).isEqualTo(TeamRecruitmentOutboxEventStatus.PENDING);
+    }
+
+    private User user() {
+        return User.builder()
+            .loginPw("password")
+            .userType(UserType.STUDENT)
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+    }
+
+    private TeamRecruitment recruitment(
+        User author,
+        LocalDate today,
+        String title,
+        int currentParticipants
+    ) {
+        return TeamRecruitment.builder()
+            .author(author)
+            .category(PROJECT)
+            .title(title)
+            .meetingType(ONLINE)
+            .activityStartDate(today.plusDays(1))
+            .activityEndDate(today.plusDays(2))
+            .deadlineDate(today.minusDays(1))
+            .recruitmentType(GENERAL)
+            .maxParticipants(5)
+            .currentParticipants(currentParticipants)
+            .description("마감 트랜잭션 격리 테스트")
+            .status(RECRUITING)
+            .build();
+    }
+
+    private TeamRecruitmentApplication application(
+        TeamRecruitment recruitment,
+        User applicant,
+        TeamRecruitmentApplicationStatus status
+    ) {
+        return TeamRecruitmentApplication.builder()
+            .recruitment(recruitment)
+            .applicant(applicant)
+            .motivation("지원 동기")
+            .availability("가능")
+            .status(status)
+            .profileSnapshot("{}")
+            .build();
+    }
+
+    private TeamRecruitmentChatRoom chatRoom(
+        TeamRecruitment recruitment,
+        TeamRecruitmentApplication application,
+        TeamRecruitmentChatRoomType roomType,
+        String roomScopeKey
+    ) {
+        return TeamRecruitmentChatRoom.builder()
+            .recruitment(recruitment)
+            .roomScopeKey(roomScopeKey)
+            .roomType(roomType)
+            .application(application)
+            .status(ACTIVE)
+            .build();
+    }
+
+    private String rejectionEventKey(Integer applicationId) {
+        return "team-recruitment:application:" + applicationId + ":APPLICATION_REJECTED";
+    }
+
+    private record Scenario(
+        Integer failedRecruitmentId,
+        Integer failedAcceptedId,
+        Integer failedPendingId,
+        Integer failedDirectRoomId,
+        Integer successfulRecruitmentId,
+        Integer successfulPendingId,
+        Integer successfulApplicantId,
+        Integer successfulTeamRoomId
+    ) {
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseCoordinatorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseCoordinatorTest.java
@@ -1,0 +1,114 @@
+package in.koreatech.koin.unit.domain.team.recruitment.scheduler;
+
+import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
+import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineCloseCoordinator;
+import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineCloseProcessor;
+import in.koreatech.koin.unit.fixture.UserFixture;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRecruitmentDeadlineCloseCoordinatorTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 28);
+
+    @Mock
+    private TeamRecruitmentRepository recruitmentRepository;
+
+    @Mock
+    private TeamRecruitmentDeadlineCloseProcessor closeProcessor;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TeamRecruitmentDeadlineCloseCoordinator coordinator;
+
+    @BeforeEach
+    void setUpClock() {
+        Clock fixedClock = Clock.fixed(Instant.parse("2026-08-28T03:00:00Z"), KST);
+        when(clock.withZone(KST)).thenReturn(fixedClock);
+    }
+
+    @Test
+    void 한_모집의_마감이_실패해도_다음_모집을_계속_처리한다() {
+        TeamRecruitment first = recruitment(1);
+        TeamRecruitment second = recruitment(2);
+        when(recruitmentRepository.findAllByStatusAndDeadlineDateBefore(
+            eq(RECRUITING),
+            eq(TODAY),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(first, second)));
+        doThrow(new IllegalStateException("마감 실패"))
+            .when(closeProcessor).closeIfExpired(1, TODAY);
+
+        coordinator.closeExpiredRecruitments();
+
+        InOrder processingOrder = inOrder(closeProcessor);
+        processingOrder.verify(closeProcessor).closeIfExpired(1, TODAY);
+        processingOrder.verify(closeProcessor).closeIfExpired(2, TODAY);
+    }
+
+    @Test
+    void 한_번에_ID_오름차순으로_최대_100개를_조회한다() {
+        when(recruitmentRepository.findAllByStatusAndDeadlineDateBefore(
+            eq(RECRUITING),
+            eq(TODAY),
+            any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+
+        coordinator.closeExpiredRecruitments();
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(recruitmentRepository).findAllByStatusAndDeadlineDateBefore(
+            eq(RECRUITING),
+            eq(TODAY),
+            pageableCaptor.capture()
+        );
+        Pageable pageable = pageableCaptor.getValue();
+        assertThat(pageable.getPageNumber()).isZero();
+        assertThat(pageable.getPageSize()).isEqualTo(100);
+        assertThat(pageable.getSort().getOrderFor("id"))
+            .extracting(Sort.Order::getDirection)
+            .isEqualTo(Sort.Direction.ASC);
+    }
+
+    private TeamRecruitment recruitment(Integer id) {
+        return TeamRecruitment.builder()
+            .id(id)
+            .author(UserFixture.id_설정_코인_유저(id))
+            .activityStartDate(TODAY.plusDays(1))
+            .activityEndDate(TODAY.plusDays(10))
+            .deadlineDate(TODAY.minusDays(1))
+            .maxParticipants(5)
+            .currentParticipants(0)
+            .status(RECRUITING)
+            .description("모집 내용")
+            .build();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
@@ -12,7 +12,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentSta
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
@@ -32,13 +31,9 @@ import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentOutbo
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentRepository;
 import in.koreatech.koin.domain.team.recruitment.scheduler.TeamRecruitmentDeadlineCloseProcessor;
 import in.koreatech.koin.unit.fixture.UserFixture;
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +48,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class TeamRecruitmentDeadlineCloseProcessorTest {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final LocalDate TODAY = LocalDate.of(2026, 8, 28);
 
     @Mock
@@ -71,19 +65,8 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
     @Mock
     private TeamRecruitmentOutboxEventRepository outboxEventRepository;
 
-    @Mock
-    private Clock clock;
-
     @InjectMocks
     private TeamRecruitmentDeadlineCloseProcessor processor;
-
-    private Clock fixedClock;
-
-    @BeforeEach
-    void setUpClock() {
-        fixedClock = Clock.fixed(Instant.parse("2026-08-28T03:00:00Z"), KST);
-        when(clock.withZone(KST)).thenReturn(fixedClock);
-    }
 
     @Nested
     class CloseExpiredRecruitments {
@@ -95,7 +78,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             TeamRecruitmentApplication accepted = application(12, recruitment, ACCEPTED);
             TeamRecruitmentChatRoom teamRoom = chatRoom(21, recruitment, TEAM, ACTIVE);
             TeamRecruitmentChatRoom directRoom = chatRoom(22, recruitment, DIRECT, ACTIVE);
-            stubCandidates(recruitment);
+            stubLockedRecruitment(recruitment);
             stubApplications(pending, accepted);
             when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
                 .thenReturn(Optional.of(teamRoom));
@@ -111,7 +94,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
                 return notification;
             });
 
-            processor.closeExpiredRecruitments();
+            processor.closeIfExpired(1, TODAY);
 
             assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
             assertThat(pending.getStatus()).isEqualTo(REJECTED);
@@ -137,13 +120,12 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
         void 이미_마감된_모집은_다시_처리하지_않는다() {
             TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
             TeamRecruitmentApplication pending = application(11, recruitment, PENDING);
-            stubCandidates(recruitment);
-            when(recruitmentRepository.findByIdWithLock(1)).thenReturn(Optional.of(recruitment));
+            stubLockedRecruitment(recruitment);
 
-            processor.closeExpiredRecruitments();
+            processor.closeIfExpired(1, TODAY);
             clearInvocations(applicationRepository, chatRoomRepository, notificationRepository, outboxEventRepository);
 
-            processor.closeExpiredRecruitments();
+            processor.closeIfExpired(1, TODAY);
 
             assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
             assertThat(pending.getStatus()).isEqualTo(PENDING);
@@ -157,7 +139,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
         void 승인된_지원자가_있는데_TEAM_채팅방이_없으면_내부_무결성_예외를_던진다() {
             TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
             TeamRecruitmentApplication accepted = application(12, recruitment, ACCEPTED);
-            stubCandidates(recruitment);
+            stubLockedRecruitment(recruitment);
             when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
                 1,
                 List.of(PENDING),
@@ -174,7 +156,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
 
             IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
-                () -> processor.closeExpiredRecruitments()
+                () -> processor.closeIfExpired(1, TODAY)
             );
 
             assertThat(exception).hasMessageContaining("TEAM 채팅방");
@@ -185,7 +167,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
         @Test
         void 승인된_지원자가_없으면_TEAM_채팅방이_없어도_정상_마감한다() {
             TeamRecruitment recruitment = recruitment(1, TODAY.minusDays(1));
-            stubCandidates(recruitment);
+            stubLockedRecruitment(recruitment);
             when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
                 1,
                 List.of(PENDING),
@@ -200,7 +182,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
                 .thenReturn(Optional.empty());
             when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of());
 
-            processor.closeExpiredRecruitments();
+            processor.closeIfExpired(1, TODAY);
 
             assertThat(recruitment.getStatus()).isEqualTo(CLOSED);
             verify(notificationRepository, never()).save(any());
@@ -214,9 +196,9 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
         @Test
         void 오늘이_마감일이면_모집을_닫지_않는다() {
             TeamRecruitment recruitment = recruitment(1, TODAY);
-            stubCandidates(recruitment);
+            stubLockedRecruitment(recruitment);
 
-            processor.closeExpiredRecruitments();
+            processor.closeIfExpired(1, TODAY);
 
             assertThat(recruitment.getStatus()).isEqualTo(RECRUITING);
             verify(applicationRepository, never()).findAllByRecruitment_IdAndStatusIn(any(), anyList(), any(Pageable.class));
@@ -224,28 +206,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
         }
     }
 
-    @Test
-    void DB에서_마감일_조건을_적용해_앞선_미만료_모집이_많아도_만료_모집을_조회한다() {
-        TeamRecruitment expiredRecruitment = recruitment(101, TODAY.minusDays(1));
-        stubCandidates(expiredRecruitment);
-
-        processor.closeExpiredRecruitments();
-
-        assertThat(expiredRecruitment.getStatus()).isEqualTo(CLOSED);
-        verify(recruitmentRepository).findAllByStatusAndDeadlineDateBefore(
-            eq(RECRUITING),
-            eq(TODAY),
-            any(Pageable.class)
-        );
-    }
-
-    private void stubCandidates(TeamRecruitment recruitment) {
-        when(recruitmentRepository.findAllByStatusAndDeadlineDateBefore(
-            eq(RECRUITING),
-            eq(TODAY),
-            any(Pageable.class)
-        ))
-            .thenReturn(new PageImpl<>(List.of(recruitment)));
+    private void stubLockedRecruitment(TeamRecruitment recruitment) {
         when(recruitmentRepository.findByIdWithLock(recruitment.getId()))
             .thenReturn(Optional.of(recruitment));
     }


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집 마감 배치에서 한 모집의 실패를 해당 모집 transaction으로 격리하고 다음 모집을 계속 처리합니다.

- close #2381

---

### 🚀 주요 변경 내용

* 마감 후보를 ID 오름차순으로 최대 100개 조회합니다.
* 별도 processor Bean이 모집별 `REQUIRES_NEW` transaction으로 처리합니다.
* 실패한 모집은 해당 transaction을 rollback하고 `recruitmentId`를 로그에 기록합니다.
* 다음 모집은 독립 transaction으로 마감 처리를 계속합니다.
* 정상 모집의 `CLOSED`, 대기 지원서 `REJECTED`, 방 `READ_ONLY`, 알림·outbox 결과를 유지합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P3 운영 안정성 보강이며 클라이언트는 기존 API 계약을 그대로 사용합니다.
  * scheduler coordinator와 모집별 transaction processor를 분리합니다.
* **검증**
  * 손상 모집 A의 상태·지원서·채팅방·알림·outbox rollback과 같은 배치의 정상 모집 B commit을 확인했습니다.
  * `./gradlew check --no-daemon --max-workers=1` 결과 총 1,056 tests, failures 0, errors 0, skipped 3입니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired team recruitments are now processed reliably in batches.
  * A failure closing one recruitment no longer prevents other expired recruitments from being closed.
  * Each recruitment is handled independently, preserving successful updates while rolling back failed closures.

* **Tests**
  * Added coverage for batch processing, failure isolation, rollback behavior, notifications, and room status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->