### PR TITLE
fix: 어드민 셔틀버스 시간표 API running_days 필드 누락 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/bus/shuttle/controller/AdminShuttleBusTimetableApi.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/shuttle/controller/AdminShuttleBusTimetableApi.java
@@ -44,6 +44,7 @@ public interface AdminShuttleBusTimetableApi {
     @ApiResponseCodes({
         OK,
         INVALID_REQUEST_BODY,
+        REQUIRED_SHUTTLE_RUNNING_DAYS,
     })
     @Operation(summary = "셔틀 버스 시간표를 업데이트한다.")
     @AdminActivityLogging(domain = SHUTTLE_BUS)

--- a/src/main/java/in/koreatech/koin/admin/bus/shuttle/dto/request/AdminShuttleBusUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/shuttle/dto/request/AdminShuttleBusUpdateRequest.java
@@ -10,14 +10,17 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 @JsonNaming(SnakeCaseStrategy.class)
 public record AdminShuttleBusUpdateRequest(
     @Schema(description = "버스 시간표 정보 리스트", requiredMode = REQUIRED)
     @NotEmpty(message = "버스 시간표 정보 리스트가 비어있습니다.")
-    List<InnerAdminShuttleBusUpdateRequest> shuttleBusTimetables
+    List<@NotNull @Valid InnerAdminShuttleBusUpdateRequest> shuttleBusTimetables
 ) {
 
     @JsonNaming(SnakeCaseStrategy.class)
@@ -39,11 +42,11 @@ public record AdminShuttleBusUpdateRequest(
 
         @Schema(description = "정류소 정보 리스트", requiredMode = REQUIRED)
         @NotEmpty(message = "정류소 정보 리스트가 비어있습니다.")
-        List<InnerNodeInfoRequest> nodeInfo,
+        List<@NotNull @Valid InnerNodeInfoRequest> nodeInfo,
 
         @Schema(description = "회차 정보 리스트", requiredMode = REQUIRED)
         @NotEmpty(message = "회차 정보 리스트가 비어있습니다.")
-        List<InnerRouteInfoRequest> routeInfo
+        List<@NotNull @Valid InnerRouteInfoRequest> routeInfo
     ) {
 
         public List<ShuttleBusRoute.NodeInfo> toNodeInfoEntity() {
@@ -59,6 +62,7 @@ public record AdminShuttleBusUpdateRequest(
                     InnerRouteInfoRequest.toEntity(
                         innerRouteInfoRequest.name,
                         innerRouteInfoRequest.detail,
+                        innerRouteInfoRequest.runningDays,
                         innerRouteInfoRequest.arrivalTime
                     )
                 ).toList();
@@ -92,16 +96,29 @@ public record AdminShuttleBusUpdateRequest(
             @Schema(description = "회차 세부 이름", example = "(청주역→본교)", requiredMode = NOT_REQUIRED)
             String detail,
 
+            @Schema(
+                description = "운행 요일 목록 (기존 시간표는 미전달하거나 빈 배열이면 기존 값이 유지되며, 신규 시간표는 필수)",
+                example = "[\"MON\", \"TUE\", \"WED\", \"THU\", \"FRI\"]",
+                requiredMode = NOT_REQUIRED
+            )
+            List<@NotBlank @Pattern(regexp = "MON|TUE|WED|THU|FRI|SAT|SUN") String> runningDays,
+
             @Schema(description = "각 정류소 별 도착 시간", example = "[\"11:10\", null, \"11:35\"]", requiredMode = REQUIRED)
             @NotEmpty(message = "도착 시간 리스트가 비어있습니다.")
             List<String> arrivalTime
         ) {
 
-            public static ShuttleBusRoute.RouteInfo toEntity(String name, String detail, List<String> arrivalTime) {
+            public static ShuttleBusRoute.RouteInfo toEntity(
+                String name,
+                String detail,
+                List<String> runningDays,
+                List<String> arrivalTime
+            ) {
                 return ShuttleBusRoute.RouteInfo
                     .builder()
                     .name(name)
                     .detail(detail)
+                    .runningDays(runningDays)
                     .arrivalTime(arrivalTime)
                     .build();
             }

--- a/src/main/java/in/koreatech/koin/admin/bus/shuttle/dto/response/AdminShuttleBusTimetableResponse.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/shuttle/dto/response/AdminShuttleBusTimetableResponse.java
@@ -52,6 +52,7 @@ public record AdminShuttleBusTimetableResponse(
                 .map(r -> new InnerRouteInfoResponse(
                     r.getName(),
                     r.getDetail(),
+                    r.getRunningDays(),
                     r.getArrivalTime()
                 ))
                 .toList();
@@ -83,6 +84,13 @@ public record AdminShuttleBusTimetableResponse(
 
             @Schema(description = "회차 세부 이름", example = "(청주역→본교)", requiredMode = NOT_REQUIRED)
             String detail,
+
+            @Schema(
+                description = "운행 요일 목록",
+                example = "[\"MON\", \"TUE\", \"WED\", \"THU\", \"FRI\"]",
+                requiredMode = REQUIRED
+            )
+            List<String> runningDays,
 
             @Schema(
                 description = "각 정류소 별 도착 시간 (미정차인 경우 null)",

--- a/src/main/java/in/koreatech/koin/admin/bus/shuttle/service/AdminShuttleBusService.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/shuttle/service/AdminShuttleBusService.java
@@ -1,12 +1,14 @@
 package in.koreatech.koin.admin.bus.shuttle.service;
 
 import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest;
+import static in.koreatech.koin.global.code.ApiResponseCode.REQUIRED_SHUTTLE_RUNNING_DAYS;
 
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import in.koreatech.koin.admin.bus.commuting.enums.SemesterType;
 import in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest;
@@ -16,6 +18,7 @@ import in.koreatech.koin.domain.bus.enums.ShuttleRouteType;
 import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
 import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.NodeInfo;
 import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.RouteInfo;
+import in.koreatech.koin.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -46,8 +49,10 @@ public class AdminShuttleBusService {
                     existing.updateCommutingBusRoute(newNodeInfos, newRouteInfos);
                     return existing;
                 })
-                .orElseGet(
-                    () -> ShuttleBusRoute.builder()
+                .orElseGet(() -> {
+                    validateRunningDaysPresent(newRouteInfos);
+
+                    return ShuttleBusRoute.builder()
                         .semesterType(semesterType.getDescription())
                         .region(region)
                         .routeType(routeType)
@@ -55,10 +60,23 @@ public class AdminShuttleBusService {
                         .subName(subName)
                         .nodeInfo(newNodeInfos)
                         .routeInfo(newRouteInfos)
-                        .build()
-                );
+                        .build();
+                });
 
             adminShuttleBusTimetableRepository.save(timetable);
+        }
+    }
+
+    /**
+     * 운행 요일이 없는 회차는 요일 필터에 걸리지 않아 교통편 조회에서 누락된다.
+     * 기존 시간표는 저장된 운행 요일을 유지할 수 있지만, 신규 시간표는 대체할 값이 없으므로 생성 시점에 검증한다.
+     */
+    private void validateRunningDaysPresent(List<RouteInfo> routeInfos) {
+        boolean hasEmptyRunningDays = routeInfos.stream()
+            .anyMatch(routeInfo -> CollectionUtils.isEmpty(routeInfo.getRunningDays()));
+
+        if (hasEmptyRunningDays) {
+            throw CustomException.of(REQUIRED_SHUTTLE_RUNNING_DAYS);
         }
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/model/ShuttleBusRoute.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/model/ShuttleBusRoute.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.util.CollectionUtils;
 
 import in.koreatech.koin.domain.bus.enums.ShuttleBusRegion;
 import in.koreatech.koin.domain.bus.enums.ShuttleRouteType;
@@ -115,6 +116,9 @@ public class ShuttleBusRoute {
             for (RouteInfo updatedRouteInfo : routeInfos) {
                 if (updatedRouteInfo.getName().equals(routeInfo.getName())) {
                     routeInfo.arrivalTime = updatedRouteInfo.getArrivalTime();
+                    if (!CollectionUtils.isEmpty(updatedRouteInfo.getRunningDays())) {
+                        routeInfo.runningDays = updatedRouteInfo.getRunningDays();
+                    }
                     break;
                 }
             }

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -80,6 +80,7 @@ public enum ApiResponseCode {
     INVALID_EXCEL_ROW(HttpStatus.BAD_REQUEST, "존재하지 않는 엑셀 행이 있습니다."),
     INVALID_EXCEL_COL(HttpStatus.BAD_REQUEST, "존재하지 않는 엑셀 열이 있습니다."),
     INVALID_SHUTTLE_ROUTE_TYPE(HttpStatus.BAD_REQUEST, "등하교 버스 타입이 아닙니다."),
+    REQUIRED_SHUTTLE_RUNNING_DAYS(HttpStatus.BAD_REQUEST, "신규 셔틀버스 시간표에는 운행 요일이 필요합니다."),
     INVALID_NODE_INFO_START_POINT(HttpStatus.BAD_REQUEST, "올바른 정거장 시작 위치가 아닙니다."),
     INVALID_NODE_INFO_END_POINT(HttpStatus.BAD_REQUEST, "올바른 정거장 끝 위치가 아닙니다."),
     INVALID_SEMESTER_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 학기 형식입니다."),

--- a/src/test/java/in/koreatech/koin/unit/admin/bus/AdminShuttleBusServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/admin/bus/AdminShuttleBusServiceTest.java
@@ -1,0 +1,137 @@
+package in.koreatech.koin.unit.admin.bus;
+
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest;
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest.InnerNodeInfoRequest;
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest.InnerRouteInfoRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.admin.bus.commuting.enums.SemesterType;
+import in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest;
+import in.koreatech.koin.admin.bus.shuttle.repository.AdminShuttleBusTimetableRepository;
+import in.koreatech.koin.admin.bus.shuttle.service.AdminShuttleBusService;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.NodeInfo;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.RouteInfo;
+import in.koreatech.koin.global.code.ApiResponseCode;
+import in.koreatech.koin.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class AdminShuttleBusServiceTest {
+
+    @InjectMocks
+    private AdminShuttleBusService adminShuttleBusService;
+
+    @Mock
+    private AdminShuttleBusTimetableRepository adminShuttleBusTimetableRepository;
+
+    private static final List<String> WEEKDAYS = List.of("MON", "TUE", "WED", "THU", "FRI");
+
+    private AdminShuttleBusUpdateRequest createRequest(List<String> runningDays) {
+        return new AdminShuttleBusUpdateRequest(List.of(
+            new InnerAdminShuttleBusUpdateRequest(
+                "천안・아산",
+                "순환",
+                "천안 셔틀",
+                null,
+                List.of(new InnerNodeInfoRequest("한기대", null)),
+                List.of(new InnerRouteInfoRequest("1회", "(천안역→본교)", runningDays, List.of("08:00")))
+            )
+        ));
+    }
+
+    private ShuttleBusRoute createExistingRoute() {
+        return ShuttleBusRoute.builder()
+            .routeName("천안 셔틀")
+            .nodeInfo(List.of(NodeInfo.builder().name("한기대").build()))
+            .routeInfo(List.of(
+                RouteInfo.builder()
+                    .name("1회")
+                    .runningDays(WEEKDAYS)
+                    .arrivalTime(List.of("07:00"))
+                    .build()
+            ))
+            .build();
+    }
+
+    private void givenExistingTimetable(Optional<ShuttleBusRoute> result) {
+        when(adminShuttleBusTimetableRepository
+            .findBySemesterTypeAndRegionAndRouteTypeAndRouteNameAndSubName(
+                anyString(), anyString(), anyString(), anyString(), any()
+            )
+        ).thenReturn(result);
+    }
+
+    @Test
+    @DisplayName("신규 시간표 생성 시 운행 요일이 없으면 예외가 발생한다")
+    void throwExceptionWhenRunningDaysMissingOnCreate() {
+        givenExistingTimetable(Optional.empty());
+
+        assertThatThrownBy(() ->
+            adminShuttleBusService.updateShuttleBusTimetable(createRequest(null), SemesterType.REGULAR)
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.REQUIRED_SHUTTLE_RUNNING_DAYS);
+
+        verify(adminShuttleBusTimetableRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 시간표 생성 시 운행 요일이 빈 배열이면 예외가 발생한다")
+    void throwExceptionWhenRunningDaysEmptyOnCreate() {
+        givenExistingTimetable(Optional.empty());
+
+        assertThatThrownBy(() ->
+            adminShuttleBusService.updateShuttleBusTimetable(createRequest(List.of()), SemesterType.REGULAR)
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.REQUIRED_SHUTTLE_RUNNING_DAYS);
+
+        verify(adminShuttleBusTimetableRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 시간표 생성 시 운행 요일이 저장된다")
+    void saveRunningDaysOnCreate() {
+        givenExistingTimetable(Optional.empty());
+
+        adminShuttleBusService.updateShuttleBusTimetable(createRequest(WEEKDAYS), SemesterType.REGULAR);
+
+        ArgumentCaptor<ShuttleBusRoute> captor = ArgumentCaptor.forClass(ShuttleBusRoute.class);
+        verify(adminShuttleBusTimetableRepository).save(captor.capture());
+        assertThat(captor.getValue().getRouteInfo().get(0).getRunningDays()).isEqualTo(WEEKDAYS);
+    }
+
+    @Test
+    @DisplayName("기존 시간표는 운행 요일을 전달하지 않아도 기존 값을 유지한 채 저장된다")
+    void keepRunningDaysOnUpdate() {
+        givenExistingTimetable(Optional.of(createExistingRoute()));
+
+        adminShuttleBusService.updateShuttleBusTimetable(createRequest(null), SemesterType.REGULAR);
+
+        ArgumentCaptor<ShuttleBusRoute> captor = ArgumentCaptor.forClass(ShuttleBusRoute.class);
+        verify(adminShuttleBusTimetableRepository).save(captor.capture());
+
+        RouteInfo saved = captor.getValue().getRouteInfo().get(0);
+        assertThat(saved.getRunningDays()).isEqualTo(WEEKDAYS);
+        assertThat(saved.getArrivalTime()).containsExactly("08:00");
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/admin/bus/AdminShuttleBusUpdateRequestTest.java
+++ b/src/test/java/in/koreatech/koin/unit/admin/bus/AdminShuttleBusUpdateRequestTest.java
@@ -1,0 +1,47 @@
+package in.koreatech.koin.unit.admin.bus;
+
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest;
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest.InnerNodeInfoRequest;
+import static in.koreatech.koin.admin.bus.shuttle.dto.request.AdminShuttleBusUpdateRequest.InnerAdminShuttleBusUpdateRequest.InnerRouteInfoRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.RouteInfo;
+
+class AdminShuttleBusUpdateRequestTest {
+
+    private static final List<String> WEEKDAYS = List.of("MON", "TUE", "WED", "THU", "FRI");
+
+    private InnerAdminShuttleBusUpdateRequest createRequest(List<String> runningDays) {
+        return new InnerAdminShuttleBusUpdateRequest(
+            "천안・아산",
+            "순환",
+            "천안 셔틀",
+            null,
+            List.of(new InnerNodeInfoRequest("한기대", null)),
+            List.of(new InnerRouteInfoRequest("1회", "(천안역→본교)", runningDays, List.of("08:00")))
+        );
+    }
+
+    @Test
+    @DisplayName("신규 시간표 생성 시 요청의 운행 요일이 엔티티에 반영된다")
+    void mapRunningDaysToEntity() {
+        List<RouteInfo> routeInfos = createRequest(WEEKDAYS).toRouteInfoEntity();
+
+        assertThat(routeInfos).hasSize(1);
+        assertThat(routeInfos.get(0).getRunningDays()).isEqualTo(WEEKDAYS);
+        assertThat(routeInfos.get(0).getArrivalTime()).containsExactly("08:00");
+    }
+
+    @Test
+    @DisplayName("운행 요일을 전달하지 않으면 엔티티의 운행 요일이 비어있다")
+    void mapNullRunningDaysToEntity() {
+        List<RouteInfo> routeInfos = createRequest(null).toRouteInfoEntity();
+
+        assertThat(routeInfos.get(0).getRunningDays()).isNull();
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRouteTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRouteTest.java
@@ -1,0 +1,91 @@
+package in.koreatech.koin.unit.domain.bus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.NodeInfo;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.RouteInfo;
+
+class ShuttleBusRouteTest {
+
+    private static final List<String> WEEKDAYS = List.of("MON", "TUE", "WED", "THU", "FRI");
+    private static final List<String> SATURDAY = List.of("SAT");
+
+    private ShuttleBusRoute createRoute(List<String> runningDays) {
+        return ShuttleBusRoute.builder()
+            .routeName("천안 셔틀")
+            .nodeInfo(List.of(createNodeInfo("한기대")))
+            .routeInfo(List.of(
+                RouteInfo.builder()
+                    .name("1회")
+                    .detail("(천안역→본교)")
+                    .runningDays(runningDays)
+                    .arrivalTime(List.of("08:00", "08:30"))
+                    .build()
+            ))
+            .build();
+    }
+
+    private NodeInfo createNodeInfo(String name) {
+        return NodeInfo.builder()
+            .name(name)
+            .build();
+    }
+
+    private List<RouteInfo> createUpdatedRouteInfos(List<String> runningDays) {
+        return List.of(
+            RouteInfo.builder()
+                .name("1회")
+                .detail("(천안역→본교)")
+                .runningDays(runningDays)
+                .arrivalTime(List.of("09:00", "09:30"))
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("운행 요일을 전달하지 않으면 기존 운행 요일이 유지된다")
+    void keepRunningDaysWhenNotGiven() {
+        ShuttleBusRoute route = createRoute(WEEKDAYS);
+
+        route.updateCommutingBusRoute(
+            List.of(createNodeInfo("한기대")),
+            createUpdatedRouteInfos(null)
+        );
+
+        RouteInfo updated = route.getRouteInfo().get(0);
+        assertThat(updated.getRunningDays()).isEqualTo(WEEKDAYS);
+        assertThat(updated.getArrivalTime()).containsExactly("09:00", "09:30");
+    }
+
+    @Test
+    @DisplayName("운행 요일이 빈 배열이면 기존 운행 요일이 유지된다")
+    void keepRunningDaysWhenEmpty() {
+        ShuttleBusRoute route = createRoute(WEEKDAYS);
+
+        route.updateCommutingBusRoute(
+            List.of(createNodeInfo("한기대")),
+            createUpdatedRouteInfos(List.of())
+        );
+
+        assertThat(route.getRouteInfo().get(0).getRunningDays()).isEqualTo(WEEKDAYS);
+    }
+
+    @Test
+    @DisplayName("운행 요일을 전달하면 기존 운행 요일이 갱신된다")
+    void updateRunningDays() {
+        ShuttleBusRoute route = createRoute(WEEKDAYS);
+
+        route.updateCommutingBusRoute(
+            List.of(createNodeInfo("한기대")),
+            createUpdatedRouteInfos(SATURDAY)
+        );
+
+        assertThat(route.getRouteInfo().get(0).getRunningDays()).isEqualTo(SATURDAY);
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 어드민 셔틀버스 시간표 API에 회차별 운행 요일(`running_days`) 필드가 없어, 업데이트된 시간표가 요일 필터에 걸리지 않아 가장 빠른 교통편 조회에서 셔틀버스가 노출되지 않던 문제를 수정합니다.

- close #2396

---

### 🚀 주요 변경 내용

* `AdminShuttleBusTimetableResponse.InnerRouteInfoResponse` 에 `running_days` 응답 필드 추가 — 엑셀 파서가 이미 계산하던 값을 미리보기 응답으로 내려줍니다.
* `AdminShuttleBusUpdateRequest.InnerRouteInfoRequest` 에 `running_days` 요청 필드 추가 및 `toEntity()` 로 전달.
* **신규 시간표 생성 시 `running_days` 누락을 400 으로 차단** (`REQUIRED_SHUTTLE_RUNNING_DAYS`) — 운행 요일이 없는 문서는 요일 필터에 걸리지 않아 영구히 조회되지 않으므로 생성 시점에 막습니다.
* `running_days` 값에 `MON`~`SUN` 검증(`@Pattern`)을 추가해 오타로 인한 조회 누락을 방지합니다.
* **요청 DTO 에 `@Valid` 캐스케이딩 추가** — 기존에 `@Valid` 가 없어 내부 record 의 `@NotBlank`/`@NotEmpty` 검증이 전혀 동작하지 않던 문제를 함께 수정합니다.
* `ShuttleBusRoute.updateCommutingBusRoute()` 가 `running_days` 가 있으면 갱신, 미전달·빈 배열이면 기존 값을 보존하도록 수정.
* 단위 테스트 9건 추가.

---

### 💬 참고 사항

* **기존 시간표 갱신**은 `running_days` 를 보내지 않아도 동작합니다 — 기존 클라이언트 하위 호환.
* **신규 시간표 생성**은 `running_days` 가 필수입니다. 삐봇 버스 업데이트 로직 반영 필요 (안드로이드팀 협의됨).
* ⚠️ `@Valid` 캐스케이딩 추가로 그동안 무시되던 검증이 활성화됩니다. 빈 `region`·빈 `arrival_time` 등을 보내던 요청이 있었다면 400 이 발생하므로 리뷰 시 확인 부탁드립니다.
* 이미 `running_days` 가 null 로 저장된 기존 문서는 이 PR 로 복구되지 않습니다. 배포 후 어드민에서 엑셀 재업로드가 필요합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)