### PR TITLE
fix: 어드민 등하교 버스 시간표에 running_days 저장

### DIFF
--- a/src/main/java/in/koreatech/koin/admin/bus/commuting/dto/AdminCommutingBusUpdateRequest.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/commuting/dto/AdminCommutingBusUpdateRequest.java
@@ -75,10 +75,16 @@ public record AdminCommutingBusUpdateRequest(
             @NotEmpty(message = "도착 시간 목록은 필수 입력값입니다.")
             List<String> arrivalTime
         ) {
-            public static ShuttleBusRoute.RouteInfo toEntity(String name, String detail, List<String> arrivalTime) {
+            public static ShuttleBusRoute.RouteInfo toEntity(
+                String name,
+                String detail,
+                List<String> runningDays,
+                List<String> arrivalTime
+            ) {
                 return ShuttleBusRoute.RouteInfo.builder()
                     .name(name)
                     .detail(detail)
+                    .runningDays(runningDays)
                     .arrivalTime(arrivalTime)
                     .build();
             }
@@ -91,11 +97,11 @@ public record AdminCommutingBusUpdateRequest(
                 .toList();
         }
 
-        public List<ShuttleBusRoute.RouteInfo> toRouteInfoEntity() {
+        public List<ShuttleBusRoute.RouteInfo> toRouteInfoEntity(List<String> runningDays) {
             return routeInfo.stream()
                 .map(innerRouteInfoRequest ->
                     InnerRouteInfo.toEntity(innerRouteInfoRequest.name, innerRouteInfoRequest.detail,
-                        innerRouteInfoRequest.arrivalTime)
+                        runningDays, innerRouteInfoRequest.arrivalTime)
                 )
                 .toList();
         }

--- a/src/main/java/in/koreatech/koin/admin/bus/commuting/service/AdminCommutingBusService.java
+++ b/src/main/java/in/koreatech/koin/admin/bus/commuting/service/AdminCommutingBusService.java
@@ -2,6 +2,7 @@ package in.koreatech.koin.admin.bus.commuting.service;
 
 import static in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest.InnerAdminCommutingBusUpdateRequest;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest;
 import in.koreatech.koin.admin.bus.commuting.enums.SemesterType;
 import in.koreatech.koin.admin.bus.commuting.repository.AdminCommutingBusRepository;
+import in.koreatech.koin.admin.bus.shuttle.enums.RunningDays;
 import in.koreatech.koin.domain.bus.enums.ShuttleBusRegion;
 import in.koreatech.koin.domain.bus.enums.ShuttleRouteType;
 import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
@@ -31,6 +33,9 @@ public class AdminCommutingBusService {
             ShuttleRouteType routeType = ShuttleRouteType.convertFrom(commutingBusUpdateRequest.routeType());
             routeType.validateCommuting();
 
+            // 등하교 버스는 validateCommuting() 으로 주중 노선만 허용되므로 운행 요일이 주중으로 결정된다.
+            List<String> runningDays = RunningDays.WEEKDAYS.getDays();
+
             Optional<ShuttleBusRoute> shuttleBusRoute = adminCommutingBusRepository
                 .findBySemesterTypeAndRegionAndRouteTypeAndRouteNameAndSubName(
                     semesterType.getDescription(),
@@ -44,7 +49,7 @@ public class AdminCommutingBusService {
                 ShuttleBusRoute route = shuttleBusRoute.get();
                 route.updateCommutingBusRoute(
                     commutingBusUpdateRequest.toNodeInfoEntity(),
-                    commutingBusUpdateRequest.toRouteInfoEntity()
+                    commutingBusUpdateRequest.toRouteInfoEntity(runningDays)
                 );
                 adminCommutingBusRepository.save(route);
             } else {
@@ -55,7 +60,7 @@ public class AdminCommutingBusService {
                     .routeName(commutingBusUpdateRequest.routeName())
                     .subName(commutingBusUpdateRequest.subName())
                     .nodeInfo(commutingBusUpdateRequest.toNodeInfoEntity())
-                    .routeInfo(commutingBusUpdateRequest.toRouteInfoEntity())
+                    .routeInfo(commutingBusUpdateRequest.toRouteInfoEntity(runningDays))
                     .build());
             }
         }

--- a/src/test/java/in/koreatech/koin/unit/admin/bus/AdminCommutingBusServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/admin/bus/AdminCommutingBusServiceTest.java
@@ -1,0 +1,100 @@
+package in.koreatech.koin.unit.admin.bus;
+
+import static in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest.InnerAdminCommutingBusUpdateRequest;
+import static in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest.InnerAdminCommutingBusUpdateRequest.InnerNodeInfo;
+import static in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest.InnerAdminCommutingBusUpdateRequest.InnerRouteInfo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import in.koreatech.koin.admin.bus.commuting.dto.AdminCommutingBusUpdateRequest;
+import in.koreatech.koin.admin.bus.commuting.enums.SemesterType;
+import in.koreatech.koin.admin.bus.commuting.repository.AdminCommutingBusRepository;
+import in.koreatech.koin.admin.bus.commuting.service.AdminCommutingBusService;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.NodeInfo;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ShuttleBusRoute.RouteInfo;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCommutingBusServiceTest {
+
+    @InjectMocks
+    private AdminCommutingBusService adminCommutingBusService;
+
+    @Mock
+    private AdminCommutingBusRepository adminCommutingBusRepository;
+
+    private static final List<String> WEEKDAYS = List.of("MON", "TUE", "WED", "THU", "FRI");
+
+    private AdminCommutingBusUpdateRequest createRequest() {
+        return new AdminCommutingBusUpdateRequest(List.of(
+            new InnerAdminCommutingBusUpdateRequest(
+                "천안・아산",
+                "주중",
+                "천안 등하교",
+                null,
+                List.of(new InnerNodeInfo("한기대", null)),
+                List.of(new InnerRouteInfo("등교", null, List.of("08:00")))
+            )
+        ));
+    }
+
+    private void givenExistingTimetable(Optional<ShuttleBusRoute> result) {
+        when(adminCommutingBusRepository
+            .findBySemesterTypeAndRegionAndRouteTypeAndRouteNameAndSubName(
+                anyString(), any(), any(), anyString(), any()
+            )
+        ).thenReturn(result);
+    }
+
+    private ShuttleBusRoute captureSavedRoute() {
+        ArgumentCaptor<ShuttleBusRoute> captor = ArgumentCaptor.forClass(ShuttleBusRoute.class);
+        verify(adminCommutingBusRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("신규 등하교 시간표 생성 시 운행 요일이 주중으로 저장된다")
+    void saveWeekdaysOnCreate() {
+        givenExistingTimetable(Optional.empty());
+
+        adminCommutingBusService.updateCommutingBusTimetable(SemesterType.REGULAR, createRequest());
+
+        assertThat(captureSavedRoute().getRouteInfo().get(0).getRunningDays()).isEqualTo(WEEKDAYS);
+    }
+
+    @Test
+    @DisplayName("운행 요일이 비어있던 기존 등하교 시간표는 갱신 시 주중으로 채워진다")
+    void backfillWeekdaysOnUpdate() {
+        ShuttleBusRoute existing = ShuttleBusRoute.builder()
+            .routeName("천안 등하교")
+            .nodeInfo(List.of(NodeInfo.builder().name("한기대").build()))
+            .routeInfo(List.of(
+                RouteInfo.builder()
+                    .name("등교")
+                    .arrivalTime(List.of("07:00"))
+                    .build()
+            ))
+            .build();
+        givenExistingTimetable(Optional.of(existing));
+
+        adminCommutingBusService.updateCommutingBusTimetable(SemesterType.REGULAR, createRequest());
+
+        RouteInfo saved = captureSavedRoute().getRouteInfo().get(0);
+        assertThat(saved.getRunningDays()).isEqualTo(WEEKDAYS);
+        assertThat(saved.getArrivalTime()).containsExactly("08:00");
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 등하교 버스 시간표를 저장할 때 회차별 운행 요일(`running_days`)이 채워지지 않아, 요일 필터에 걸리지 않아 교통편 조회에서 누락되던 문제를 수정합니다.
* #2397 에서 셔틀버스만 수정했고, 등하교는 같은 증상이 남아 있었습니다.

- close #2398

---

### 🚀 주요 변경 내용

* `AdminCommutingBusService` 가 `RunningDays.WEEKDAYS` 를 `toRouteInfoEntity()` 로 넘겨 신규·기존 시간표 모두 `running_days` 를 채웁니다.
* `AdminCommutingBusUpdateRequest.InnerRouteInfo.toEntity()` 에 `runningDays` 파라미터 추가.
* 단위 테스트 2건 추가 (신규 생성 시 주중 저장 / 기존 문서 갱신 시 주중 백필).

---

### 💬 참고 사항

* **클라이언트 변경이 필요 없습니다.** #2396(셔틀)과 달리 요청 필드를 추가하지 않고 서버가 값을 도출합니다.
  * `AdminCommutingBusService` 가 `routeType.validateCommuting()` 으로 `SHUTTLE`·`WEEKEND` 를 거부하므로 주중 노선만 통과합니다. 운행 요일이 `MON`~`FRI` 로 결정돼 있습니다.
  * 통학 엑셀 추출기는 셔틀과 달리 운행 요일을 계산하지 않아, 클라이언트가 왕복시킬 값 자체가 없습니다.
* **기존 데이터가 자동 복구됩니다.** 이미 `running_days` 가 null 인 등하교 문서는 다음 시간표 업데이트 때 채워집니다. (셔틀은 회차별 요일이 달라 자가 복구가 불가능하며 엑셀 재업로드가 필요합니다)
* `RunningDays` 는 `admin.bus.shuttle.enums` 에 있어 commuting 패키지에서 참조합니다. 같은 `admin.bus` 하위라 그대로 재사용했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commuting shuttle bus timetables now correctly record weekday operation (Monday–Friday).
  * Existing timetables with missing operating days are automatically updated with weekday information while preserving arrival times.

* **Tests**
  * Added coverage for creating and updating commuting bus timetables, including operating-day data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->