### PR TITLE
fix: OpenAPI dialect와 component schema 참조 정합성 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/global/config/SwaggerConfig.java
+++ b/src/main/java/in/koreatech/koin/global/config/SwaggerConfig.java
@@ -2,10 +2,14 @@ package in.koreatech.koin.global.config;
 
 import java.time.LocalDate;
 
+import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import in.koreatech.koin.global.exception.ErrorResponse;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -38,11 +42,26 @@ public class SwaggerConfig {
         Server server = new Server();
         server.setUrl(serverUrl);
         return new OpenAPI()
-            .openapi("3.1.0")
+            .openapi("3.0.3")
             .info(apiInfo())
             .addSecurityItem(securityRequirement)
             .components(components)
             .addServersItem(server);
+    }
+
+    @Bean
+    public GlobalOpenApiCustomizer errorResponseSchemaCustomizer() {
+        ResolvedSchema errorResponseSchema = ModelConverters.getInstance()
+            .readAllAsResolvedSchema(ErrorResponse.class);
+        return openApi -> {
+            Components components = openApi.getComponents();
+            if (components == null) {
+                components = new Components();
+                openApi.setComponents(components);
+            }
+            components.addSchemas(ErrorResponse.class.getSimpleName(), errorResponseSchema.schema);
+            errorResponseSchema.referencedSchemas.forEach(components::addSchemas);
+        };
     }
 
     private Info apiInfo() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,6 +104,8 @@ cors:
 
 springdoc:
   use-fqn: true
+  api-docs:
+    version: OPENAPI_3_0
 
 cloudfront:
   distribution-id: ${CLOUDFRONT_DISTRIBUTION_ID}

--- a/src/test/java/in/koreatech/koin/acceptance/domain/CampusOpenApiSchemaContractTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/CampusOpenApiSchemaContractTest.java
@@ -1,0 +1,71 @@
+package in.koreatech.koin.acceptance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import in.koreatech.koin.acceptance.AcceptanceTest;
+import in.koreatech.koin.acceptance.support.JsonAssertions;
+
+class CampusOpenApiSchemaContractTest extends AcceptanceTest {
+
+    private static final String CAMPUS_GROUP = "3. Campus API";
+
+    @Test
+    void openapi_document_uses_the_declared_3_0_dialect() throws Exception {
+        JsonNode openApi = campusOpenApi();
+
+        assertThat(openApi.path("openapi").asText()).isEqualTo("3.0.3");
+    }
+
+    @Test
+    void every_local_schema_reference_is_resolved() throws Exception {
+        JsonNode openApi = campusOpenApi();
+        List<String> references = new ArrayList<>();
+        collectReferences(openApi, references);
+
+        List<String> unresolved = references.stream()
+            .filter(reference -> reference.startsWith("#/components/schemas/"))
+            .filter(reference -> openApi.at(reference.substring(1)).isMissingNode())
+            .distinct()
+            .toList();
+
+        assertThat(unresolved).isEmpty();
+    }
+
+    @Test
+    void error_response_models_are_registered_as_components() throws Exception {
+        JsonNode schemas = campusOpenApi().path("components").path("schemas");
+
+        assertThat(schemas.fieldNames()).toIterable()
+            .contains("ErrorResponse", "FieldError");
+    }
+
+    private JsonNode campusOpenApi() throws Exception {
+        MvcResult result = mockMvc.perform(get("/v3/api-docs/{group}", CAMPUS_GROUP))
+            .andExpect(status().isOk())
+            .andReturn();
+        return JsonAssertions.convertJsonNode(result);
+    }
+
+    private void collectReferences(JsonNode node, List<String> references) {
+        if (node.isObject()) {
+            if (node.has("$ref")) {
+                references.add(node.path("$ref").asText());
+            }
+            node.elements().forEachRemaining(child -> collectReferences(child, references));
+            return;
+        }
+        if (node.isArray()) {
+            node.elements().forEachRemaining(child -> collectReferences(child, references));
+        }
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* 런타임 OpenAPI의 dialect와 Springdoc schema 표현을 3.0.3으로 정렬하고 전역 error schema 참조를 해소합니다.

- close #2403

---

### 🚀 주요 변경 내용

* `springdoc.api-docs.version=OPENAPI_3_0`을 설정합니다.
* 생성 문서 header를 `openapi: 3.0.3`으로 정렬합니다.
* `ErrorResponse`, `FieldError`, ModelConverters referenced schema를 Components에 등록합니다.
* Campus `/v3/api-docs`의 모든 local `$ref`를 해소합니다.

---

### 💬 참고 사항

* **영향**
  * 심각도는 P1 OpenAPI·SDK 계약 오류이며 클라이언트 validator와 SDK 생성기가 유효한 3.0.3 문서를 소비합니다.
  * 기존 controller/service 동작을 유지하며 OpenAPI 생성 설정을 정렬합니다.
* **검증**
  * `CampusOpenApiSchemaContractTest` 3개로 dialect 3.0.3, `ErrorResponse`·`FieldError` component 등록, 전체 local `$ref` 해소를 확인했습니다.
* **반영 순서**
  * OpenAPI 정리 체인의 첫 PR이며 다음 순서는 #2390 → #2391입니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)