### PR TITLE
fix: 셔틀 잔여 시간 정렬 중 null 도착 시각 NPE 방지

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/ShuttleBusService.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/ShuttleBusService.java
@@ -68,12 +68,12 @@ public class ShuttleBusService {
     public List<BusRemainTime> getShuttleBusRemainTimes(BusType busType, BusStation depart, BusStation arrival) {
         List<Route> routes = getShuttleRoutesByBusType(busType);
 
+        // 시간 정렬은 BusService에서 계산할 수 없는 항목을 제외한 뒤 수행한다.
         return routes.stream()
             .filter(route -> route.isRunning(clock))
             .filter(route -> route.isCorrectRoute(depart, arrival, clock))
             .map(route -> route.getRemainTime(depart))
             .distinct()
-            .sorted()
             .toList();
     }
 

--- a/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/ShuttleBusService.java
+++ b/src/main/java/in/koreatech/koin/domain/bus/service/shuttle/ShuttleBusService.java
@@ -68,12 +68,13 @@ public class ShuttleBusService {
     public List<BusRemainTime> getShuttleBusRemainTimes(BusType busType, BusStation depart, BusStation arrival) {
         List<Route> routes = getShuttleRoutesByBusType(busType);
 
-        // 시간 정렬은 BusService에서 계산할 수 없는 항목을 제외한 뒤 수행한다.
         return routes.stream()
             .filter(route -> route.isRunning(clock))
             .filter(route -> route.isCorrectRoute(depart, arrival, clock))
             .map(route -> route.getRemainTime(depart))
+            .filter(remainTime -> remainTime.getBusArrivalTime() != null)
             .distinct()
+            .sorted()
             .toList();
     }
 

--- a/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRemainTimeTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRemainTimeTest.java
@@ -1,0 +1,169 @@
+package in.koreatech.koin.unit.domain.bus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import in.koreatech.koin.domain.bus.dto.BusRemainTimeResponse;
+import in.koreatech.koin.domain.bus.dto.BusRemainTimeResponse.InnerBusResponse;
+import in.koreatech.koin.domain.bus.enums.BusStation;
+import in.koreatech.koin.domain.bus.enums.BusType;
+import in.koreatech.koin.domain.bus.enums.ShuttleRouteType;
+import in.koreatech.koin.domain.bus.service.BusNoticeRepository;
+import in.koreatech.koin.domain.bus.service.BusService;
+import in.koreatech.koin.domain.bus.service.city.CityBusService;
+import in.koreatech.koin.domain.bus.service.express.ExpressBusService;
+import in.koreatech.koin.domain.bus.service.shuttle.ShuttleBusRepository;
+import in.koreatech.koin.domain.bus.service.shuttle.ShuttleBusService;
+import in.koreatech.koin.domain.bus.service.shuttle.model.ArrivalNode;
+import in.koreatech.koin.domain.bus.service.shuttle.model.Route;
+import in.koreatech.koin.domain.version.model.Version;
+import in.koreatech.koin.domain.version.model.VersionType;
+import in.koreatech.koin.domain.version.service.VersionService;
+
+@ExtendWith(MockitoExtension.class)
+class ShuttleBusRemainTimeTest {
+
+    private static final String SEMESTER = "정규학기";
+    private static final Clock CLOCK = Clock.fixed(
+        Instant.parse("2026-09-05T02:25:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @Mock
+    private ShuttleBusRepository shuttleBusRepository;
+
+    @Mock
+    private VersionService versionService;
+
+    @Mock
+    private BusNoticeRepository busNoticeRepository;
+
+    @Mock
+    private ExpressBusService expressBusService;
+
+    @Mock
+    private CityBusService cityBusService;
+
+    private BusService busService;
+
+    @BeforeEach
+    void setUp() {
+        when(versionService.getVersionEntity(VersionType.SHUTTLE))
+            .thenReturn(Version.builder().title(SEMESTER).build());
+        ShuttleBusService shuttleBusService = new ShuttleBusService(versionService, shuttleBusRepository, CLOCK);
+        busService = new BusService(
+            CLOCK, busNoticeRepository, versionService, List.of(), expressBusService, cityBusService, shuttleBusService);
+    }
+
+    @Test
+    void 토요일_순환버스와_중복_정류장이_있는_주말버스를_함께_조회한다() {
+        // 공개 시간표의 토요일 오후 순환 노선과 하교 3회 구조를 재현한다.
+        Route cycle = route(ShuttleRouteType.SHUTTLE, null,
+            node("한기대", "14:00"), node("2캠퍼스", null), node("터미널", "14:25"),
+            node("천안역", "14:30"), node("한기대", "15:00"));
+        Route weekend = route(ShuttleRouteType.WEEKEND, "하교",
+            node("한기대", "19:10"), node("천안역B", "19:40"), node("터미널", "19:50"),
+            node("두정역", "하차"), node("터미널", null), node("천안역A", null), node("한기대", null));
+        when(shuttleBusRepository.findAllBySemesterTypeAndRouteType(SEMESTER, ShuttleRouteType.SHUTTLE))
+            .thenReturn(List.of(cycle));
+        when(shuttleBusRepository.findAllBySemesterTypeAndRouteType(SEMESTER, ShuttleRouteType.WEEKEND))
+            .thenReturn(List.of(weekend));
+
+        BusRemainTimeResponse response = getRemainTime(BusType.SHUTTLE);
+
+        assertThat(response).isEqualTo(new BusRemainTimeResponse(
+            "shuttle", new InnerBusResponse(null, 10800L), null));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusType.class, names = {"SHUTTLE", "COMMUTING"})
+    void 무효_시간을_제외하고_중복없는_가까운_두_버스를_반환한다(BusType busType) {
+        ShuttleRouteType type = routeType(busType);
+        givenRoutes(busType, List.of(
+            departure(type, "15:00"),
+            duplicateDeparture(type, null),
+            departure(type, "14:25"),
+            duplicateDeparture(type, "정차"),
+            departure(type, "14:25"),
+            departure(type, "16:00"),
+            departure(type, "10:00")
+        ));
+
+        BusRemainTimeResponse response = getRemainTime(busType);
+
+        assertThat(response).isEqualTo(new BusRemainTimeResponse(
+            busType.getName(), new InnerBusResponse(null, 10800L), new InnerBusResponse(null, 12900L)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusType.class, names = {"SHUTTLE", "COMMUTING"})
+    void 계산할_수_없는_시간과_운행_종료_항목만_있으면_빈_응답을_반환한다(BusType busType) {
+        ShuttleRouteType type = routeType(busType);
+        givenRoutes(busType, List.of(
+            duplicateDeparture(type, null), duplicateDeparture(type, "정차"), departure(type, "10:00")));
+
+        assertThat(getRemainTime(busType)).isEqualTo(new BusRemainTimeResponse(busType.getName(), null, null));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusType.class, names = {"SHUTTLE", "COMMUTING"})
+    void 노선이_없으면_빈_응답을_반환한다(BusType busType) {
+        givenRoutes(busType, List.of());
+
+        assertThat(getRemainTime(busType)).isEqualTo(new BusRemainTimeResponse(busType.getName(), null, null));
+    }
+
+    private BusRemainTimeResponse getRemainTime(BusType busType) {
+        return busService.getBusRemainTime(busType, BusStation.TERMINAL, BusStation.KOREATECH);
+    }
+
+    private void givenRoutes(BusType busType, List<Route> routes) {
+        when(shuttleBusRepository.findAllBySemesterTypeAndRouteType(SEMESTER, routeType(busType)))
+            .thenReturn(routes);
+    }
+
+    private ShuttleRouteType routeType(BusType busType) {
+        return busType == BusType.SHUTTLE ? ShuttleRouteType.SHUTTLE : ShuttleRouteType.WEEKDAYS;
+    }
+
+    private Route departure(ShuttleRouteType type, String time) {
+        return route(type, "등교", node("터미널", time), node("한기대", "도착"));
+    }
+
+    private Route duplicateDeparture(ShuttleRouteType type, String firstTime) {
+        // 노선 판정과 시각 추출의 선택 불일치로 null 시각 객체가 생기는 경계를 재현한다.
+        return route(type, "등교", node("터미널", firstTime), node("터미널", "19:50"), node("한기대", "도착"));
+    }
+
+    private Route route(ShuttleRouteType type, String direction, ArrivalNode... nodes) {
+        Route route = BeanUtils.instantiateClass(Route.class);
+        ReflectionTestUtils.setField(route, "routeName", "테스트 노선");
+        ReflectionTestUtils.setField(route, "routeType", type);
+        ReflectionTestUtils.setField(route, "routeInfo", direction);
+        ReflectionTestUtils.setField(route, "routeDetail", direction);
+        ReflectionTestUtils.setField(route, "runningDays", List.of("SAT"));
+        ReflectionTestUtils.setField(route, "arrivalNodes", new ArrayList<>(List.of(nodes)));
+        return route;
+    }
+
+    private ArrivalNode node(String name, String time) {
+        ArrivalNode node = BeanUtils.instantiateClass(ArrivalNode.class);
+        ReflectionTestUtils.setField(node, "nodeName", name);
+        ReflectionTestUtils.setField(node, "arrivalTime", time);
+        return node;
+    }
+}

--- a/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRemainTimeTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/bus/ShuttleBusRemainTimeTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import in.koreatech.koin.domain.bus.service.BusNoticeRepository;
 import in.koreatech.koin.domain.bus.service.BusService;
 import in.koreatech.koin.domain.bus.service.city.CityBusService;
 import in.koreatech.koin.domain.bus.service.express.ExpressBusService;
+import in.koreatech.koin.domain.bus.service.model.BusRemainTime;
 import in.koreatech.koin.domain.bus.service.shuttle.ShuttleBusRepository;
 import in.koreatech.koin.domain.bus.service.shuttle.ShuttleBusService;
 import in.koreatech.koin.domain.bus.service.shuttle.model.ArrivalNode;
@@ -59,12 +61,13 @@ class ShuttleBusRemainTimeTest {
     private CityBusService cityBusService;
 
     private BusService busService;
+    private ShuttleBusService shuttleBusService;
 
     @BeforeEach
     void setUp() {
         when(versionService.getVersionEntity(VersionType.SHUTTLE))
             .thenReturn(Version.builder().title(SEMESTER).build());
-        ShuttleBusService shuttleBusService = new ShuttleBusService(versionService, shuttleBusRepository, CLOCK);
+        shuttleBusService = new ShuttleBusService(versionService, shuttleBusRepository, CLOCK);
         busService = new BusService(
             CLOCK, busNoticeRepository, versionService, List.of(), expressBusService, cityBusService, shuttleBusService);
     }
@@ -107,6 +110,39 @@ class ShuttleBusRemainTimeTest {
 
         assertThat(response).isEqualTo(new BusRemainTimeResponse(
             busType.getName(), new InnerBusResponse(null, 10800L), new InnerBusResponse(null, 12900L)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusType.class, names = {"SHUTTLE", "COMMUTING"})
+    void 셔틀_서비스는_null_시각을_제외하고_중복없는_시간순_목록을_반환한다(BusType busType) {
+        ShuttleRouteType type = routeType(busType);
+        givenRoutes(busType, List.of(
+            departure(type, "15:00"),
+            duplicateDeparture(type, null),
+            departure(type, "14:25"),
+            duplicateDeparture(type, "정차"),
+            departure(type, "14:25"),
+            departure(type, "16:00")
+        ));
+
+        List<BusRemainTime> remainTimes = shuttleBusService.getShuttleBusRemainTimes(
+            busType, BusStation.TERMINAL, BusStation.KOREATECH);
+
+        assertThat(remainTimes)
+            .extracting(BusRemainTime::getBusArrivalTime)
+            .containsExactly(LocalTime.of(14, 25), LocalTime.of(15, 0), LocalTime.of(16, 0));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusType.class, names = {"SHUTTLE", "COMMUTING"})
+    void 셔틀_서비스는_null_시각만_있으면_빈_목록을_반환한다(BusType busType) {
+        ShuttleRouteType type = routeType(busType);
+        givenRoutes(busType, List.of(duplicateDeparture(type, null), duplicateDeparture(type, "정차")));
+
+        List<BusRemainTime> remainTimes = shuttleBusService.getShuttleBusRemainTimes(
+            busType, BusStation.TERMINAL, BusStation.KOREATECH);
+
+        assertThat(remainTimes).isEmpty();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### 🔍 개요

* `GET /bus`에서 정상 도착 시각과 null 시각이 함께 선택되면 셔틀 서비스의 선행 정렬이 `BusRemainTime.compareTo():85`에서 NPE를 발생시킵니다. 셔틀 서비스에서 도착 시각이 null인 항목을 정렬 전에 제외하여 이번 NPE를 차단합니다.

- close #2409

---

### 🚀 주요 변경 내용

* `ShuttleBusService.getShuttleBusRemainTimes()`에서 `.map()` 이후 도착 시각이 null인 항목을 제외하고, `.distinct()`와 `.sorted()`를 유지합니다. 호출하는 서비스에 의존하지 않고 이 메서드 자체에서 중복 없는 시간순 목록을 반환합니다. `BusService`에 정렬을 맡긴다는 기존 주석은 제거했습니다.
* 실제 `Route`와 `ShuttleBusService`를 사용하는 회귀 테스트 11개를 추가합니다. `BusService`를 통한 응답과 셔틀 서비스 직접 호출을 검증하며, 저장소와 외부 서비스 의존성만 mock 처리합니다.
  - 토요일 11:25, 순환 노선의 `14:25`와 중복 터미널이 있는 주말 하교 노선의 null 시각이 함께 선택되는 조건
  - 셔틀/통학 각각의 정상·null·문자열 시간 혼합, 시간순 정렬, 중복 제거, 운행 종료 항목 제외 및 빈 응답
  - `ShuttleBusService` 직접 호출 시 정상·null·문자열 시간 혼합 목록의 정렬/중복 제거와 null 시각만 있는 목록의 빈 결과


---

### 💬 참고 사항

* 최초 수정 전 회귀 테스트 7개 중 3개가 서버와 동일한 NPE 및 `BusRemainTime.java:85`로 실패했습니다. 리뷰 반영을 위해 추가한 직접 호출 테스트 4개도 이전 구현에서는 실패했고, null 필터와 정렬을 이 메서드에서 수행하도록 수정한 후 통과했습니다.
* 로컬 검증: `./gradlew test --tests 'in.koreatech.koin.unit.domain.bus.*' bootJar --console=plain` 성공. 버스 테스트 29개, 실패/오류/건너뜀 0개이며 애플리케이션 JAR 생성도 성공했습니다. `git diff --check`도 통과했습니다. 로컬 JDK는 20.0.2이며 GitHub CI는 저장소 설정대로 JDK 17에서 전체 build를 실행합니다.
* 공개 시간표를 기반으로 토요일 운행 fixture를 구성한 서비스 단위 재현입니다. 원 요청의 파라미터와 당시 DB 스냅샷을 특정하거나 운영 HTTP E2E를 수행한 것은 아닙니다.
* 이번 변경은 NPE 차단 핫픽스입니다. `Route`의 방향/운행 구간 판정 및 중복 정류장 선택 불일치는 남습니다. 계산할 수 없는 항목을 제외하는 기존 동작을 유지하며, 누락될 수 있는 버스의 정확한 경로와 출발 시각까지 교정하지는 않습니다. 실제 하교 시간표의 방향 반전으로 시간 순서가 거꾸로인 경로가 통과하는 문제도 #2409에 후속 과제로 기록했습니다.
* DB·시간표·응답 스키마 변경은 없습니다. 이 커밋을 revert하면 변경을 되돌릴 수 있습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Excluded shuttle bus entries without valid arrival times.
  - Removed duplicate results and consistently sorted available buses by arrival time.
  - Improved handling for weekend, circular, shuttle, and commuting bus routes.
  - Empty results are returned when no valid route or usable bus information is available.

- **Tests**
  - Added coverage for invalid and duplicate departures, result ordering, supported bus types, missing routes, and routes with unusable arrival times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
