### PR TITLE
fix: 닉네임 미설정 사용자의 채팅방 조회 및 메시지 전송 버그 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
@@ -36,10 +36,10 @@ public record DirectChatRoomResponse(
     public static DirectChatRoomResponse of(TeamRecruitmentChatRoom chatRoom, User counterpartUser) {
         return new DirectChatRoomResponse(
                 chatRoom.getId(),
-                counterpartUser.getNickname(),
+                counterpartUser.getDisplayNickname(),
                 chatRoom.getRoomType().name(),
                 chatRoom.getStatus().name(),
-                new Counterpart(counterpartUser.getId(), counterpartUser.getNickname())
+                new Counterpart(counterpartUser.getId(), counterpartUser.getDisplayNickname())
         );
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
@@ -77,7 +77,7 @@ public class TeamRecruitmentChatService {
             counterpart = memberRepository.findAllByChatRoom_Id(chatRoomId).stream()
                     .filter(m -> !m.getUser().getId().equals(userId))
                     .findFirst()
-                    .map(m -> new ChatRoomResponse.Counterpart(m.getUser().getId(), m.getUser().getNickname()))
+                    .map(m -> new ChatRoomResponse.Counterpart(m.getUser().getId(), m.getUser().getDisplayNickname()))
                     .orElse(null);
         }
 
@@ -224,7 +224,7 @@ public class TeamRecruitmentChatService {
                 TeamRecruitmentChatMessage.builder()
                         .chatRoom(chatRoom)
                         .sender(sender)
-                        .senderNickname(sender.getNickname())
+                        .senderNickname(sender.getDisplayNickname())
                         .content(request.content())
                         .isImage(request.isImage())
                         .build());

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -2,10 +2,16 @@ package in.koreatech.koin.unit.domain.teamrecruitment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+
+import org.mockito.ArgumentCaptor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +30,7 @@ import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomTy
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitment;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentApplication;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMember;
+import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatMessage;
 import in.koreatech.koin.domain.team.recruitment.model.TeamRecruitmentChatRoom;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentApplicationRepository;
 import in.koreatech.koin.domain.team.recruitment.repository.TeamRecruitmentChatMemberRepository;
@@ -277,6 +284,65 @@ class TeamRecruitmentChatServiceTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
                         .isEqualTo(ApiResponseCode.TEAM_RECRUITMENT_CHAT_NOT_FOUND));
+    }
+
+    @Test
+    void 닉네임_미설정_사용자가_포함된_DIRECT_채팅방_조회시_nickname이_익명_사용자로_응답된다() {
+        User author = UserFixture.id_설정_코인_유저(USER_ID);
+        User anonymousCounterpart = UserFixture.닉네임_없는_코인_유저(OTHER_USER_ID);
+        TeamRecruitmentApplication application = mock(TeamRecruitmentApplication.class);
+        TeamRecruitment recruitment = mock(TeamRecruitment.class);
+        TeamRecruitmentChatRoom existingRoom = mock(TeamRecruitmentChatRoom.class);
+
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
+        when(application.getRecruitment()).thenReturn(recruitment);
+        when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
+        when(application.getStatus()).thenReturn(TeamRecruitmentApplicationStatus.ACCEPTED);
+        when(recruitment.isRecruiting()).thenReturn(true);
+        when(recruitment.getAuthor()).thenReturn(author);
+        when(application.getApplicant()).thenReturn(anonymousCounterpart);
+        when(chatRoomRepository.findByRecruitment_IdAndApplication_IdAndRoomType(
+                RECRUITMENT_ID, APPLICATION_ID, TeamRecruitmentChatRoomType.DIRECT))
+                .thenReturn(Optional.of(existingRoom));
+        when(existingRoom.getId()).thenReturn(CHAT_ROOM_ID);
+        when(existingRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
+        when(existingRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
+
+        DirectChatRoomCreationResult result = chatService.getOrCreateDirectChatRoom(USER_ID, RECRUITMENT_ID, APPLICATION_ID);
+
+        assertThat(result.response().roomName()).isEqualTo(anonymousCounterpart.getDisplayNickname());
+        assertThat(result.response().counterpart().nickname()).isEqualTo(anonymousCounterpart.getDisplayNickname());
+    }
+
+    @Test
+    void 닉네임_미설정_사용자의_메시지_전송시_senderNickname이_익명_사용자로_저장된다() {
+        User anonymousSender = UserFixture.닉네임_없는_코인_유저(USER_ID);
+        TeamRecruitmentChatRoom chatRoom = mock(TeamRecruitmentChatRoom.class);
+        TeamRecruitment recruitment = mock(TeamRecruitment.class);
+        TeamRecruitmentChatMember senderMember = mock(TeamRecruitmentChatMember.class);
+        TeamRecruitmentChatMessage savedMessage = mock(TeamRecruitmentChatMessage.class);
+
+        when(chatRoomRepository.findById(CHAT_ROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(chatRoom.getRecruitment()).thenReturn(recruitment);
+        when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
+        when(memberRepository.findByChatRoom_IdAndUser_Id(CHAT_ROOM_ID, USER_ID)).thenReturn(Optional.of(senderMember));
+        when(chatRoom.isActive()).thenReturn(true);
+        when(senderMember.getUser()).thenReturn(anonymousSender);
+        when(messageRepository.save(any(TeamRecruitmentChatMessage.class))).thenReturn(savedMessage);
+        when(savedMessage.getId()).thenReturn(100);
+        when(memberRepository.findAllByChatRoom_Id(CHAT_ROOM_ID)).thenReturn(List.of());
+        when(savedMessage.getContent()).thenReturn("안녕");
+        when(savedMessage.getSender()).thenReturn(anonymousSender);
+        when(savedMessage.getSenderNickname()).thenReturn(anonymousSender.getDisplayNickname());
+        when(savedMessage.getCreatedAt()).thenReturn(LocalDateTime.now());
+        when(savedMessage.getIsImage()).thenReturn(false);
+
+        ArgumentCaptor<TeamRecruitmentChatMessage> captor = ArgumentCaptor.forClass(TeamRecruitmentChatMessage.class);
+        chatService.createMessage(USER_ID, RECRUITMENT_ID, CHAT_ROOM_ID, new CreateChatMessageRequest("안녕", false));
+        verify(messageRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getSenderNickname()).isEqualTo(anonymousSender.getDisplayNickname());
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/fixture/UserFixture.java
+++ b/src/test/java/in/koreatech/koin/unit/fixture/UserFixture.java
@@ -70,4 +70,19 @@ public final class UserFixture {
             .isDeleted(false)
             .build();
     }
+
+    public static User 닉네임_없는_코인_유저(Integer id) {
+        return User.builder()
+            .id(id)
+            .name("이름")
+            .phoneNumber("01012345678")
+            .email("test2@koreatech.ac.kr")
+            .loginId("test_id2")
+            .loginPw("test_pw2")
+            .gender(MAN)
+            .userType(GENERAL)
+            .isAuthed(true)
+            .isDeleted(false)
+            .build();
+    }
 }


### PR DESCRIPTION
🔍 개요
닉네임이 설정되지 않은 사용자가 포함된 채팅방 조회 시 nickname 필드가 null로 응답되고,
메시지 전송 시 500 에러가 발생하는 문제를 수정합니다.

User.nickname은 nullable 컬럼이지만 getNickname()을 직접 사용하여 null이 그대로 노출되거나
@NotBlank 제약 위반으로 persist 실패하는 버그입니다.

close #2411
close #2412

🚀 주요 변경 내용
- DirectChatRoomResponse: counterpartUser.getNickname() → getDisplayNickname()
- TeamRecruitmentChatService: ChatRoomResponse.Counterpart, senderNickname에 getDisplayNickname() 적용

💬 참고 사항
User.getDisplayNickname()은 nickname → anonymousNickname → "익명 사용자" 순으로 fallback 처리합니다.

✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct chat rooms now consistently display a user’s display nickname, including for users without a custom nickname.
  * Messages sent by users without a custom nickname now retain the correct display nickname for the sender.
* **Tests**
  * Added coverage for nickname display in direct chat rooms and message sender information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->