### PR TITLE
fix: 팀원 모집 지원 마감일의 활동 시작일 제한 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/controller/TeamRecruitmentApi.java
@@ -12,7 +12,6 @@ import static in.koreatech.koin.global.code.ApiResponseCode.OK;
 import static in.koreatech.koin.global.code.ApiResponseCode.REQUEST_TOO_FAST;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
@@ -90,7 +89,6 @@ public interface TeamRecruitmentApi {
 
     @ApiResponseCodes({
         CREATED,
-        TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
         TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
         INVALID_START_DATE_AFTER_END_DATE,
         INVALID_REQUEST_BODY,
@@ -108,7 +106,7 @@ public interface TeamRecruitmentApi {
         - 역할명은 앞뒤 공백을 제거해 저장하며, 대소문자와 악센트만 다른 이름도 중복으로 봅니다.
         - `recruitment_type=GENERAL`은 작성자를 제외한 지원자 모집 정원인 `max_participants`를 보내고
           `roles`는 빈 배열로 보내셔야 합니다.
-        - 지원 마감일은 활동 시작일 이하, 활동 시작일은 활동 종료일 이하여야 합니다.
+        - 활동 시작일은 활동 종료일 이하여야 합니다. 지원 마감일은 활동 기간과의 순서 제한이 없습니다.
         - 모집글과 TEAM 채팅방을 같은 트랜잭션에서 생성하고 작성자를 최초 채팅방 멤버로 추가합니다.
         - 별도의 팀 채팅방 생성 API는 없습니다.
         - 같은 사용자가 동일한 요청을 300ms 안에 반복하면 두 번째 요청은 `409 REQUEST_TOO_FAST`를 반환합니다.
@@ -148,7 +146,6 @@ public interface TeamRecruitmentApi {
         TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED,
         TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED,
         TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED,
-        TEAM_RECRUITMENT_INVALID_DEADLINE_DATE,
         TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION,
         INVALID_START_DATE_AFTER_END_DATE,
         INVALID_REQUEST_BODY,

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/CreateRecruitmentRequest.java
@@ -48,7 +48,7 @@ public record CreateRecruitmentRequest(
     @NotNull
     LocalDate activityEndDate,
 
-    @Schema(description = "지원 마감일. 활동 시작일 이하여야 합니다.", example = "2026-09-03", requiredMode = REQUIRED)
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy-MM-dd")
     @NotNull
     LocalDate deadlineDate,
@@ -82,7 +82,7 @@ public record CreateRecruitmentRequest(
     String qualification
 ) {
     public CreateRecruitmentRequest {
-        RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
+        RecruitmentRequestValidator.validateActivityPeriod(activityStartDate, activityEndDate);
         RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
         if (RecruitmentRequestValidator.isCompleteRoleList(roles, RoleInput::isComplete)) {
             RecruitmentRequestValidator.validateDistinctRoleNames(roles.stream().map(RoleInput::name).toList());

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/RecruitmentRequestValidator.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.team.recruitment.dto;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
 
 import java.text.Normalizer;
@@ -30,15 +29,15 @@ final class RecruitmentRequestValidator {
     private RecruitmentRequestValidator() {
     }
 
-    static void validatePeriod(LocalDate activityStartDate, LocalDate activityEndDate, LocalDate deadlineDate) {
-        if (activityStartDate == null) {
+    /**
+     * 지원 마감일은 활동 기간과 무관하게 받는다. 활동 시작 이후까지 지원을 받는 모집글이 있어 순서를 제한하지 않는다.
+     */
+    static void validateActivityPeriod(LocalDate activityStartDate, LocalDate activityEndDate) {
+        if (activityStartDate == null || activityEndDate == null) {
             return;
         }
-        if (activityEndDate != null && activityEndDate.isBefore(activityStartDate)) {
+        if (activityEndDate.isBefore(activityStartDate)) {
             throw CustomException.of(INVALID_START_DATE_AFTER_END_DATE);
-        }
-        if (deadlineDate != null && deadlineDate.isAfter(activityStartDate)) {
-            throw CustomException.of(TEAM_RECRUITMENT_INVALID_DEADLINE_DATE);
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/UpdateRecruitmentRequest.java
@@ -45,7 +45,7 @@ public record UpdateRecruitmentRequest(
     @NotNull
     LocalDate activityEndDate,
 
-    @Schema(description = "지원 마감일. 활동 시작일 이하여야 합니다.", example = "2026-09-03", requiredMode = REQUIRED)
+    @Schema(description = "지원 마감일", example = "2026-09-03", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy-MM-dd")
     @NotNull
     LocalDate deadlineDate,
@@ -80,7 +80,7 @@ public record UpdateRecruitmentRequest(
     String qualification
 ) {
     public UpdateRecruitmentRequest {
-        RecruitmentRequestValidator.validatePeriod(activityStartDate, activityEndDate, deadlineDate);
+        RecruitmentRequestValidator.validateActivityPeriod(activityStartDate, activityEndDate);
         RecruitmentRequestValidator.validateRoleComposition(recruitmentType, roles, maxParticipants);
         if (RecruitmentRequestValidator.isCompleteRoleList(roles, UpdateRoleInput::isComplete)) {
             RecruitmentRequestValidator.validateDistinctRoleNames(roles.stream().map(UpdateRoleInput::name).toList());

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -95,7 +95,6 @@ public enum ApiResponseCode {
     CALLVAN_REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 콜벤 신고입니다."),
     TEAM_RECRUITMENT_ACTIVITY_END_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "진행 중인 활동이 아닌 경우, 활동 종료일은 필수입니다."),
     TEAM_RECRUITMENT_ACTIVITY_END_DATE_MUST_BE_NULL(HttpStatus.BAD_REQUEST, "진행 중인 활동인 경우, 활동 종료일은 입력하면 안 됩니다."),
-    TEAM_RECRUITMENT_INVALID_DEADLINE_DATE(HttpStatus.BAD_REQUEST, "지원 마감일은 활동 시작일 이하여야 합니다."),
     TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION(HttpStatus.BAD_REQUEST, "모집 유형에 맞지 않는 역할 또는 정원 구성입니다."),
 
     /**

--- a/src/main/resources/db/migration/V7__relax_team_recruitment_deadline_date.sql
+++ b/src/main/resources/db/migration/V7__relax_team_recruitment_deadline_date.sql
@@ -1,0 +1,9 @@
+-- Immutable follow-up migration.
+-- 지원 마감일과 활동 시작일의 순서 제한을 제거한다. 활동 시작 이후까지 지원을 받는 모집글이 있어
+-- 마감일은 활동 기간과 무관하게 받는다. 활동 시작일 <= 활동 종료일 제약은 그대로 유지한다.
+ALTER TABLE `team_recruitment`
+    DROP CHECK `chk_team_recruitment_dates`;
+
+ALTER TABLE `team_recruitment`
+    ADD CONSTRAINT `chk_team_recruitment_dates`
+        CHECK (`activity_start_date` <= `activity_end_date`);

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleContractApiTest.java
@@ -334,12 +334,12 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("지원 마감일이 활동 시작일보다 이후면 400 이다")
+        @DisplayName("지원 마감일이 활동 시작일보다 이후여도 201 이다")
         void deadlineAfterActivityStart() throws Exception {
             String body = """
                 {
                   "category": "STUDY",
-                  "title": "잘못된 기간",
+                  "title": "활동 시작 이후 마감",
                   "meeting_type": "ONLINE",
                   "activity_start_date": "%s",
                   "activity_end_date": "%s",
@@ -360,8 +360,38 @@ class TeamRecruitmentArticleContractApiTest extends AcceptanceTest {
                     .header("Authorization", "Bearer " + authorToken)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(body))
+                .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("활동 종료일이 활동 시작일보다 이전이면 400 이다")
+        void activityEndBeforeActivityStart() throws Exception {
+            String body = """
+                {
+                  "category": "STUDY",
+                  "title": "잘못된 기간",
+                  "meeting_type": "ONLINE",
+                  "activity_start_date": "%s",
+                  "activity_end_date": "%s",
+                  "deadline_date": "%s",
+                  "recruitment_type": "GENERAL",
+                  "max_participants": 3,
+                  "roles": [],
+                  "description": "설명",
+                  "related_url": null,
+                  "qualification": null
+                }
+                """.formatted(
+                LocalDate.now(clock).plusDays(20),
+                LocalDate.now(clock).plusDays(10),
+                LocalDate.now(clock).plusDays(5));
+
+            mockMvc.perform(post("/team-recruitments")
+                    .header("Authorization", "Bearer " + authorToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_INVALID_DEADLINE_DATE"));
+                .andExpect(jsonPath("$.code").value("INVALID_START_DATE_AFTER_END_DATE"));
         }
     }
 

--- a/src/test/java/in/koreatech/koin/acceptance/migration/TeamRecruitmentMigrationTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/migration/TeamRecruitmentMigrationTest.java
@@ -92,6 +92,13 @@ class TeamRecruitmentMigrationTest {
                 .contains("deleted")
                 .contains("deleted_at");
             assertThat(queryString(connection, checkConstraintQuery(
+                "team_recruitment",
+                "chk_team_recruitment_dates"
+            )).toLowerCase(Locale.ROOT))
+                .contains("activity_start_date")
+                .contains("activity_end_date")
+                .doesNotContain("deadline_date");
+            assertThat(queryString(connection, checkConstraintQuery(
                 "team_recruitment_chat_room",
                 "chk_team_recruitment_chat_room_application_scope"
             )).toLowerCase(Locale.ROOT))

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/dto/CreateRecruitmentRequestTest.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.unit.domain.team.recruitment.dto;
 
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static in.koreatech.koin.global.code.ApiResponseCode.INVALID_START_DATE_AFTER_END_DATE;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_DEADLINE_DATE;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_INVALID_ROLE_COMPOSITION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -232,12 +231,19 @@ class CreateRecruitmentRequestTest {
         }
 
         @Test
-        @DisplayName("지원 마감일이 활동 시작일보다 이후이면 예외가 발생한다")
-        void deadlineAfterActivityStartDateFails() {
-            assertThatThrownBy(() -> create(
+        @DisplayName("지원 마감일이 활동 시작일보다 이후여도 된다")
+        void deadlineCanBeAfterActivityStartDate() {
+            assertThatCode(() -> create(
                 TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_END, ACTIVITY_START.plusDays(1)))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", TEAM_RECRUITMENT_INVALID_DEADLINE_DATE);
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("지원 마감일이 활동 종료일보다 이후여도 된다")
+        void deadlineCanBeAfterActivityEndDate() {
+            assertThatCode(() -> create(
+                TeamRecruitmentType.ROLE_BASED, null, ROLES, ACTIVITY_START, ACTIVITY_END, ACTIVITY_END.plusDays(1)))
+                .doesNotThrowAnyException();
         }
 
         @Test


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집글의 지원 마감일이 활동 시작일 이하여야 한다는 제한을 제거합니다. 활동 시작 이후까지 지원을 받는 모집글이 있어, 마감일은 활동 기간과 무관하게 받도록 합니다.
* 제한이 요청 검증과 DB CHECK 양쪽에 걸려 있어 두 곳을 함께 수정했습니다. 검증만 풀면 DB CHECK 위반으로 500 이 발생합니다.

- close #2414

---

### 🚀 주요 변경 내용

* `RecruitmentRequestValidator.validatePeriod(start, end, deadline)` → `validateActivityPeriod(start, end)` 로 변경해 마감일 비교를 제거했습니다. 인자만 남기면 죽은 파라미터가 되므로 시그니처에서 제외하고 호출부 두 곳(작성/수정)을 맞췄습니다. **활동 시작일 <= 활동 종료일 검증은 그대로 유지합니다.**
* `V7__relax_team_recruitment_deadline_date.sql` 추가 — `chk_team_recruitment_dates` 를 `activity_start_date <= activity_end_date` 만 검사하도록 재정의합니다. 기존 행은 모두 완화된 조건을 만족하므로 재생성 시 실패하지 않습니다.
* 도달 불가능해진 `TEAM_RECRUITMENT_INVALID_DEADLINE_DATE` 를 `ApiResponseCode` 와 작성/수정 API 의 `@ApiResponseCodes` 에서 제거했습니다.
* Swagger 문서 정리 — API 설명을 "활동 시작일은 활동 종료일 이하여야 합니다. 지원 마감일은 활동 기간과의 순서 제한이 없습니다." 로 변경하고, 두 요청 DTO 의 마감일 `@Schema` 문구에서 제한 설명을 제거했습니다.

**테스트**

* 기존 400 기대 케이스를 허용 케이스로 전환하고, 빠져 있던 반대 방향 커버리지를 추가했습니다.
  * 단위: 마감일이 활동 시작일 이후 / 활동 종료일 이후 두 경우 모두 통과
  * 인수: 마감일 > 활동 시작일이면 201, 활동 종료일 < 활동 시작일이면 여전히 400 (`INVALID_START_DATE_AFTER_END_DATE`)
* `TeamRecruitmentMigrationTest` 에 `chk_team_recruitment_dates` 가 `deadline_date` 를 더 이상 참조하지 않는다는 단정을 추가했습니다. Testcontainers 로 MySQL 8.0.29 에 V1~V7 을 실제 적용하므로 V7 SQL 자체도 검증됩니다.
* `./gradlew test --tests "*Recruitment*"` 전부 통과했습니다.

---

### 💬 참고 사항

* **배포 시 마이그레이션(ALTER TABLE)이 실행됩니다.** `team_recruitment` 의 CHECK 제약을 DROP 후 재생성합니다.
* 프론트엔드에서 `TEAM_RECRUITMENT_INVALID_DEADLINE_DATE` 로 분기하는 코드가 남아 있어도 해당 응답이 더 이상 발생하지 않으므로 동작에는 문제가 없습니다. (제거 가능 여부는 프론트엔드와 확인 완료)

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Recruitment application deadlines may now fall after the activity start or end date.
  * Activity dates must still be ordered correctly, with the start date on or before the end date.
  * Updated API documentation and validation messages to reflect the revised deadline rules.
  * Existing recruitment posts and requests using later deadlines are now accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->