### PR TITLE
fix: 채팅방 목록 조회 시 닉네임 미설정 상대방 nickname null 응답 수정

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentChatRoomListItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentChatRoomListItemResponse.java
@@ -69,11 +69,11 @@ public record TeamRecruitmentChatRoomListItemResponse(
         return new TeamRecruitmentChatRoomListItemResponse(
             chatRoom.getRecruitment().getId(),
             chatRoom.getId(),
-            direct && counterpart != null ? counterpart.getNickname() : chatRoom.getRecruitment().getTitle(),
+            direct && counterpart != null ? counterpart.getDisplayNickname() : chatRoom.getRecruitment().getTitle(),
             chatRoom.getRoomType().name(),
             chatRoom.getStatus().name(),
             direct && counterpart != null ? counterpart.getId() : null,
-            direct && counterpart != null ? counterpart.getNickname() : null,
+            direct && counterpart != null ? counterpart.getDisplayNickname() : null,
             lastMessage == null ? null : lastMessage.getId(),
             lastMessage == null ? null : lastMessage.getContent(),
             lastMessage == null ? null : lastMessage.getCreatedAt(),

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -207,7 +207,7 @@ class TeamRecruitmentChatServiceTest {
                 TeamRecruitmentChatRoomListItemResponse::lastMessageId,
                 TeamRecruitmentChatRoomListItemResponse::unreadMessageCount
             )
-            .containsExactly(counterpart.getNickname(), OTHER_USER_ID, counterpart.getNickname(), 101, 0);
+            .containsExactly(counterpart.getDisplayNickname(), OTHER_USER_ID, counterpart.getDisplayNickname(), 101, 0);
         assertThat(responses.get(1))
             .extracting(
                 TeamRecruitmentChatRoomListItemResponse::roomName,
@@ -226,6 +226,39 @@ class TeamRecruitmentChatServiceTest {
         assertThat(chatService.getChatRooms(USER_ID)).isEmpty();
 
         verifyNoInteractions(messageRepository);
+    }
+
+    @Test
+    void 닉네임_미설정_사용자가_상대방인_DIRECT_채팅방_목록_조회시_counterpartNickname이_null이_아니다() {
+        TeamRecruitment recruitment = mock(TeamRecruitment.class);
+        TeamRecruitmentChatRoom directRoom = mock(TeamRecruitmentChatRoom.class);
+        TeamRecruitmentChatMember currentMember = mock(TeamRecruitmentChatMember.class);
+        TeamRecruitmentChatMember counterpartMember = mock(TeamRecruitmentChatMember.class);
+        User currentUser = UserFixture.id_설정_코인_유저(USER_ID);
+        User anonymousCounterpart = UserFixture.닉네임_없는_코인_유저(OTHER_USER_ID);
+
+        when(currentMember.getChatRoom()).thenReturn(directRoom);
+        when(currentMember.getUser()).thenReturn(currentUser);
+        when(directRoom.getId()).thenReturn(21);
+        when(directRoom.getRecruitment()).thenReturn(recruitment);
+        when(directRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
+        when(directRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
+        when(counterpartMember.getChatRoom()).thenReturn(directRoom);
+        when(counterpartMember.getUser()).thenReturn(anonymousCounterpart);
+        when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
+        when(memberRepository.findAllByUserIdWithChatRoomAndRecruitment(USER_ID))
+            .thenReturn(List.of(currentMember));
+        when(memberRepository.findAllWithUsersByChatRoomIds(List.of(21)))
+            .thenReturn(List.of(currentMember, counterpartMember));
+        when(messageRepository.findLatestByChatRoomIds(List.of(21))).thenReturn(List.of());
+        when(messageRepository.countUnreadMessagesByUserId(USER_ID)).thenReturn(List.of());
+
+        List<TeamRecruitmentChatRoomListItemResponse> responses = chatService.getChatRooms(USER_ID);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).roomName()).isEqualTo(anonymousCounterpart.getDisplayNickname());
+        assertThat(responses.get(0).counterpartNickname()).isEqualTo(anonymousCounterpart.getDisplayNickname());
+        assertThat(responses.get(0).counterpartNickname()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
🔍 개요
채팅방 목록 조회 API에서 닉네임 미설정 사용자가 상대방인 경우
counterpartNickname이 null로 응답되는 버그를 수정합니다.

close #2416

🚀 주요 변경 내용
- TeamRecruitmentChatRoomListItemResponse: counterpart.getNickname() → getDisplayNickname()

💬 참고 사항
PR #2413에서 동일 패턴 수정 이력 존재 (getChatRooms에서만 누락된 케이스)

✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct team recruitment chat rooms now consistently display the counterpart’s user-facing nickname in the room name and participant information.
  * Chat rooms involving users without a registered nickname now show an appropriate anonymous display name instead of leaving the information blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->