### PR TITLE
fix: 팀원 모집 마감 시 채팅방 읽기 전용 전환 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
@@ -125,10 +125,6 @@ public class TeamRecruitmentChatRoom extends BaseEntity {
         }
     }
 
-    public void markReadOnly() {
-        this.status = TeamRecruitmentChatRoomStatus.READ_ONLY;
-    }
-
     @Transient
     public boolean isActive() {
         return status == TeamRecruitmentChatRoomStatus.ACTIVE;

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessor.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.team.recruitment.scheduler;
 
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.CHAT_ROOM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
@@ -69,7 +68,6 @@ public class TeamRecruitmentDeadlineCloseProcessor {
         recruitment.close();
         recruitmentRepository.save(recruitment);
         rejectPendingApplications(recruitment, pendingApplications);
-        markRoomsReadOnly(recruitmentId);
         notifyRejectedApplications(recruitment, pendingApplications);
         notifyAcceptedMembers(recruitment, teamRoom, acceptedApplications);
     }
@@ -102,19 +100,6 @@ public class TeamRecruitmentDeadlineCloseProcessor {
         for (TeamRecruitmentApplication application : pendingApplications) {
             application.reject(RECRUITMENT_CLOSED_REASON);
             applicationRepository.save(application);
-        }
-    }
-
-    private void markRoomsReadOnly(Integer recruitmentId) {
-        List<TeamRecruitmentChatRoom> chatRooms = chatRoomRepository.findAllByRecruitment_Id(recruitmentId);
-        if (chatRooms == null) {
-            return;
-        }
-        for (TeamRecruitmentChatRoom chatRoom : chatRooms) {
-            if (chatRoom.getStatus() == ACTIVE) {
-                chatRoom.markReadOnly();
-                chatRoomRepository.save(chatRoom);
-            }
         }
     }
 

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentClosureService.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/service/TeamRecruitmentClosureService.java
@@ -2,7 +2,6 @@ package in.koreatech.koin.domain.team.recruitment.service;
 
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.CHAT_ROOM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationType.APPLICATION_REJECTED;
@@ -55,15 +54,13 @@ public class TeamRecruitmentClosureService {
     private final TeamRecruitmentOutboxEventRepository outboxEventRepository;
 
     /**
-     * 대기 중인 지원서를 거절하고, 모든 채팅방을 읽기 전용으로 바꾸고,
-     * 대기 중이던 지원자와 승인된 팀원에게 알림을 남긴다.
+     * 대기 중인 지원서를 거절하고, 대기 중이던 지원자와 승인된 팀원에게 알림을 남긴다.
      */
     public void onClosed(TeamRecruitment recruitment) {
         List<TeamRecruitmentApplication> pending = findApplications(recruitment.getId(), PENDING);
         List<TeamRecruitmentApplication> accepted = findApplications(recruitment.getId(), ACCEPTED);
 
         rejectAll(pending, RECRUITMENT_CLOSED_REASON);
-        markRoomsReadOnly(recruitment.getId());
         notifyRejected(recruitment, pending, closedRejectedMessage(recruitment));
         notifyAccepted(recruitment, accepted, RECRUITMENT_CLOSED, closedMessage(recruitment));
     }
@@ -76,7 +73,6 @@ public class TeamRecruitmentClosureService {
         List<TeamRecruitmentApplication> accepted = findApplications(recruitment.getId(), ACCEPTED);
 
         rejectAll(pending, RECRUITMENT_DELETED_REASON);
-        markRoomsReadOnly(recruitment.getId());
         notifyRejected(recruitment, pending, deletedRejectedMessage(recruitment));
         notifyAccepted(recruitment, accepted, RECRUITMENT_DELETED, deletedMessage(recruitment));
     }
@@ -104,16 +100,6 @@ public class TeamRecruitmentClosureService {
 
     private void rejectAll(List<TeamRecruitmentApplication> applications, String reason) {
         applications.forEach(application -> application.reject(reason));
-    }
-
-    private void markRoomsReadOnly(Integer recruitmentId) {
-        List<TeamRecruitmentChatRoom> chatRooms = chatRoomRepository.findAllByRecruitment_Id(recruitmentId);
-        if (chatRooms == null) {
-            return;
-        }
-        chatRooms.stream()
-            .filter(chatRoom -> chatRoom.getStatus() == ACTIVE)
-            .forEach(TeamRecruitmentChatRoom::markReadOnly);
     }
 
     private void notifyRejected(

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
@@ -445,20 +444,20 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
             .andExpect(status().isNoContent());
 
         assertThat(chatRoomRepository.findById(directRoom.getId()).orElseThrow().getStatus())
-            .isEqualTo(READ_ONLY);
+            .isEqualTo(ACTIVE);
 
         mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
                 recruitment.getId(), application.getId())
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.chat_room_id").value(directRoom.getId()))
-            .andExpect(jsonPath("$.status").value("READ_ONLY"));
+            .andExpect(jsonPath("$.status").value("ACTIVE"));
 
         mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}",
                 recruitment.getId(), directRoom.getId())
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("READ_ONLY"));
+            .andExpect(jsonPath("$.status").value("ACTIVE"));
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -315,7 +315,7 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
     }
 
     @Test
-    void 수동_마감된_ACCEPTED_지원서는_DIRECT_CTA와_생성_조건이_모두_닫힌다() throws Exception {
+    void 수동_마감된_ACCEPTED_지원서는_ACTIVE_TEAM_방이_있어_DIRECT를_생성할_수_있다() throws Exception {
         TeamRecruitment recruitment = recruitmentContext.recruitment();
         TeamRecruitmentApplication application = savePendingApplication(recruitment);
 
@@ -330,13 +330,15 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.applications[0].status").value("ACCEPTED"))
-            .andExpect(jsonPath("$.applications[0].can_open_direct_chat").value(false));
+            .andExpect(jsonPath("$.applications[0].can_open_direct_chat").value(true));
 
         mockMvc.perform(post("/chatroom/team-recruitment/{recruitmentId}/applications/{applicationId}/direct",
                 recruitment.getId(), application.getId())
                 .header("Authorization", "Bearer " + authorToken))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_CLOSED"));
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.chat_room_id").isNumber())
+            .andExpect(jsonPath("$.room_type").value("DIRECT"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"));
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentArticleFlowApiTest.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentNotificationTargetType.MY_APPLICATIONS;
@@ -124,7 +123,7 @@ class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("수동 마감하면 대기 지원서가 거절되고 채팅방이 READ_ONLY 로 바뀌며 알림이 남는다")
+    @DisplayName("수동 마감하면 대기 지원서가 거절되고 채팅방은 ACTIVE 유지되며 알림이 남는다")
     void 수동_마감_후속_처리() throws Exception {
         TeamRecruitment recruitment = saveGeneralRecruitment("수동 마감", 3, 0);
         TeamRecruitmentChatRoom teamRoom = saveTeamRoom(recruitment);
@@ -139,7 +138,7 @@ class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
         assertThat(applicationRepository.findById(application.getId()).orElseThrow().getStatus())
             .isEqualTo(REJECTED);
         assertThat(chatRoomRepository.findById(teamRoom.getId()).orElseThrow().getStatus())
-            .isEqualTo(READ_ONLY);
+            .isEqualTo(ACTIVE);
         assertThat(notificationRepository.findAllByRecipient_IdAndIsDeletedFalse(applicant.getUser().getId()))
             .extracting(TeamRecruitmentNotification::getType)
             .contains(APPLICATION_REJECTED);
@@ -161,7 +160,7 @@ class TeamRecruitmentArticleFlowApiTest extends AcceptanceTest {
         assertThat(applicationRepository.findById(application.getId()).orElseThrow().getDecisionReason())
             .isEqualTo("RECRUITMENT_DELETED");
         assertThat(chatRoomRepository.findById(teamRoom.getId()).orElseThrow().getStatus())
-            .isEqualTo(READ_ONLY);
+            .isEqualTo(ACTIVE);
         assertThat(notificationRepository.findAllByRecipient_IdAndIsDeletedFalse(applicant.getUser().getId()))
             .extracting(TeamRecruitmentNotification::getMessagePreview)
             .anyMatch(message -> message.contains("삭제되어"));

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDeadlineCloseIntegrationTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentDeadlineCloseIntegrationTest.java
@@ -5,7 +5,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
@@ -188,7 +187,7 @@ class TeamRecruitmentDeadlineCloseIntegrationTest extends AcceptanceTest {
         assertThat(successfulRecruitment.getStatus()).isEqualTo(CLOSED);
         assertThat(successfulPending.getStatus()).isEqualTo(REJECTED);
         assertThat(successfulPending.getDecisionReason()).isEqualTo("RECRUITMENT_CLOSED");
-        assertThat(successfulTeamRoom.getStatus()).isEqualTo(READ_ONLY);
+        assertThat(successfulTeamRoom.getStatus()).isEqualTo(ACTIVE);
         assertThat(notificationRepository.findForOutbox(
             scenario.successfulApplicantId(),
             APPLICATION_REJECTED,

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
@@ -44,7 +44,7 @@ class TeamRecruitmentDirectChatPolicyTest {
     }
 
     @Test
-    void 수동_기한_마감된_ACCEPTED_지원서는_READ_ONLY_TEAM_방이면_DIRECT를_열수없다() {
+    void READ_ONLY_TEAM_방이면_신규_DIRECT를_열수없다() {
         TeamRecruitment recruitment = recruitment(CLOSED);
 
         assertThat(canOpen(ACCEPTED, false, recruitment, teamRoom(recruitment, READ_ONLY))).isFalse();

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
@@ -81,7 +81,6 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             stubApplications(pending, accepted);
             when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
                 .thenReturn(Optional.of(teamRoom));
-            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of(teamRoom, directRoom));
             when(outboxEventRepository.findByEventKey(any())).thenReturn(Optional.empty());
             when(notificationRepository.save(any())).thenAnswer(invocation -> {
                 TeamRecruitmentNotification notification = invocation.getArgument(0);
@@ -150,7 +149,6 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             )).thenReturn(new PageImpl<>(List.of(accepted)));
             when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
                 .thenReturn(Optional.empty());
-            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of());
 
             IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
@@ -178,7 +176,6 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             )).thenReturn(new PageImpl<>(List.of()));
             when(chatRoomRepository.findByRecruitment_IdAndRoomScopeKey(1, "TEAM"))
                 .thenReturn(Optional.empty());
-            when(chatRoomRepository.findAllByRecruitment_Id(1)).thenReturn(List.of());
 
             processor.closeIfExpired(1, TODAY);
 

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
@@ -4,7 +4,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
@@ -100,11 +99,9 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             assertThat(pending.getStatus()).isEqualTo(REJECTED);
             assertThat(pending.getDecisionReason()).isEqualTo("RECRUITMENT_CLOSED");
             assertThat(accepted.getStatus()).isEqualTo(ACCEPTED);
-            assertThat(teamRoom.getStatus()).isEqualTo(READ_ONLY);
-            assertThat(directRoom.getStatus()).isEqualTo(READ_ONLY);
+            assertThat(teamRoom.getStatus()).isEqualTo(ACTIVE);
+            assertThat(directRoom.getStatus()).isEqualTo(ACTIVE);
             verify(applicationRepository).save(pending);
-            verify(chatRoomRepository).save(teamRoom);
-            verify(chatRoomRepository).save(directRoom);
             verify(notificationRepository, org.mockito.Mockito.times(2)).save(any());
             verify(outboxEventRepository, org.mockito.Mockito.times(2)).save(any());
             ArgumentCaptor<TeamRecruitmentOutboxEvent> outboxCaptor =

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/scheduler/TeamRecruitmentDeadlineCloseProcessorTest.java
@@ -102,6 +102,7 @@ class TeamRecruitmentDeadlineCloseProcessorTest {
             assertThat(teamRoom.getStatus()).isEqualTo(ACTIVE);
             assertThat(directRoom.getStatus()).isEqualTo(ACTIVE);
             verify(applicationRepository).save(pending);
+            verify(chatRoomRepository, never()).save(any());
             verify(notificationRepository, org.mockito.Mockito.times(2)).save(any());
             verify(outboxEventRepository, org.mockito.Mockito.times(2)).save(any());
             ArgumentCaptor<TeamRecruitmentOutboxEvent> outboxCaptor =


### PR DESCRIPTION
### 🔍 개요

팀원 모집이 마감(마감일 경과, 수동 마감, 모집글 삭제)될 때 채팅방이 READ_ONLY로 전환되어
메시지 전송 시 409 TEAM_RECRUITMENT_CHAT_READ_ONLY 에러가 발생하는 문제를 수정합니다.
기획에 없던 동작으로, 채팅방은 마감 이후에도 ACTIVE 상태를 유지해야 합니다.

- close #2420

---

### 🚀 주요 변경 내용

* TeamRecruitmentClosureService: onClosed(), onDeleted()에서 markRoomsReadOnly() 호출 제거
* TeamRecruitmentDeadlineCloseProcessor: closeIfExpired()에서 markRoomsReadOnly() 호출 제거
* TeamRecruitmentChatRoom: markReadOnly() Dead Code 제거
* 관련 테스트 4개 파일 어서션 READ_ONLY → ACTIVE로 수정

---

### 💬 참고 사항

* 정원 마감(onCapacityFull) 시에는 기존부터 채팅방 ACTIVE 유지로 설계되어 있었음
* 디자인/PM 확인 완료 — 기획에 없던 동작이었음

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Chat rooms remain active when a recruitment is closed, deleted, or reaches its deadline.
  * Existing direct chat rooms continue to support requests and retrieval after the associated recruitment is deleted.
* **Bug Fixes**
  * Removed automatic transitions of recruitment chat rooms to read-only status during closure workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->