### PR TITLE
refactor: TeamRecruitmentChatRoom READ_ONLY 상태 완전 제거

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentChatRoomStatus.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/enums/TeamRecruitmentChatRoomStatus.java
@@ -1,6 +1,5 @@
 package in.koreatech.koin.domain.team.recruitment.enums;
 
 public enum TeamRecruitmentChatRoomStatus {
-    ACTIVE,
-    READ_ONLY
+    ACTIVE
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentChatRoom.java
@@ -14,7 +14,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -125,8 +124,4 @@ public class TeamRecruitmentChatRoom extends BaseEntity {
         }
     }
 
-    @Transient
-    public boolean isActive() {
-        return status == TeamRecruitmentChatRoomStatus.ACTIVE;
-    }
 }

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicy.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicy.java
@@ -36,7 +36,6 @@ public final class TeamRecruitmentDirectChatPolicy {
         }
         return recruitment.getStatus() == CLOSED
             && teamChatRoom != null
-            && teamChatRoom.getRoomType() == TEAM
-            && teamChatRoom.isActive();
+            && teamChatRoom.getRoomType() == TEAM;
     }
 }

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/controller/TeamRecruitmentChatApi.java
@@ -9,7 +9,6 @@ import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APP
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_APPLICATION_NOT_FOUND;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_FORBIDDEN;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_NOT_FOUND;
-import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CHAT_READ_ONLY;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_CLOSED;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_FORBIDDEN;
 import static in.koreatech.koin.global.code.ApiResponseCode.TEAM_RECRUITMENT_NOT_FOUND;
@@ -44,7 +43,7 @@ public interface TeamRecruitmentChatApi {
     @Operation(
         summary = "내 팀원 모집 채팅방 목록 조회",
         description = "현재 사용자가 멤버인 TEAM/DIRECT 채팅방을 최근 메시지순으로 반환합니다. "
-            + "메시지가 없는 방과 READ_ONLY 방도 포함합니다."
+            + "메시지가 없는 방도 포함합니다."
     )
     ResponseEntity<List<TeamRecruitmentChatRoomListItemResponse>> getChatRooms(Integer userId);
 
@@ -111,7 +110,6 @@ public interface TeamRecruitmentChatApi {
         INVALID_REQUEST_BODY,
         TEAM_RECRUITMENT_CHAT_NOT_FOUND,
         TEAM_RECRUITMENT_CHAT_FORBIDDEN,
-        TEAM_RECRUITMENT_CHAT_READ_ONLY,
         UNAUTHORIZED_USER,
         FORBIDDEN_USER_TYPE,
     })

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatRoomResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/ChatRoomResponse.java
@@ -19,9 +19,6 @@ public record ChatRoomResponse(
         @Schema(description = "채팅방 타입", example = "TEAM", requiredMode = REQUIRED)
         String roomType,
 
-        @Schema(description = "채팅방 상태", example = "ACTIVE", requiredMode = REQUIRED)
-        String status,
-
         @Schema(
                 description = "현재 채팅방 멤버 수. TEAM은 작성자와 승인된 지원자를 포함하고, DIRECT는 항상 2",
                 example = "3",
@@ -60,7 +57,6 @@ public record ChatRoomResponse(
                 chatRoom.getId(),
                 roomName,
                 chatRoom.getRoomType().name(),
-                chatRoom.getStatus().name(),
                 memberCount,
                 maxMemberCount,
                 counterpart

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/DirectChatRoomResponse.java
@@ -20,9 +20,6 @@ public record DirectChatRoomResponse(
         @Schema(description = "채팅방 타입", example = "DIRECT", requiredMode = REQUIRED)
         String roomType,
 
-        @Schema(description = "채팅방 상태", example = "ACTIVE", requiredMode = REQUIRED)
-        String status,
-
         @Schema(description = "상대방 정보", requiredMode = REQUIRED)
         Counterpart counterpart
 ) {
@@ -39,7 +36,6 @@ public record DirectChatRoomResponse(
                 chatRoom.getId(),
                 counterpartUser.getDisplayNickname(),
                 chatRoom.getRoomType().name(),
-                chatRoom.getStatus().name(),
                 new Counterpart(counterpartUser.getId(), counterpartUser.getDisplayNickname())
         );
     }

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentChatRoomListItemResponse.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/dto/TeamRecruitmentChatRoomListItemResponse.java
@@ -28,9 +28,6 @@ public record TeamRecruitmentChatRoomListItemResponse(
     @Schema(description = "채팅방 타입", example = "TEAM", requiredMode = REQUIRED)
     String roomType,
 
-    @Schema(description = "채팅방 상태", example = "ACTIVE", requiredMode = REQUIRED)
-    String status,
-
     @Schema(description = "DIRECT 상대방 유저 ID. TEAM은 null입니다.", example = "22",
         nullable = true, requiredMode = REQUIRED)
     Integer counterpartId,
@@ -71,7 +68,6 @@ public record TeamRecruitmentChatRoomListItemResponse(
             chatRoom.getId(),
             direct && counterpart != null ? counterpart.getDisplayNickname() : chatRoom.getRecruitment().getTitle(),
             chatRoom.getRoomType().name(),
-            chatRoom.getStatus().name(),
             direct && counterpart != null ? counterpart.getId() : null,
             direct && counterpart != null ? counterpart.getDisplayNickname() : null,
             lastMessage == null ? null : lastMessage.getId(),

--- a/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
+++ b/src/main/java/in/koreatech/koin/domain/teamrecruitment/service/TeamRecruitmentChatService.java
@@ -294,10 +294,6 @@ public class TeamRecruitmentChatService {
         TeamRecruitmentChatMember senderMember = memberRepository.findByChatRoom_IdAndUser_Id(chatRoomId, userId)
                 .orElseThrow(() -> CustomException.of(TEAM_RECRUITMENT_CHAT_FORBIDDEN));
 
-        if (!chatRoom.isActive()) {
-            throw CustomException.of(TEAM_RECRUITMENT_CHAT_READ_ONLY);
-        }
-
         User sender = senderMember.getUser();
 
         TeamRecruitmentChatMessage message = messageRepository.save(

--- a/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
+++ b/src/main/java/in/koreatech/koin/global/code/ApiResponseCode.java
@@ -186,7 +186,6 @@ public enum ApiResponseCode {
     TEAM_RECRUITMENT_ROLE_UPDATE_NOT_ALLOWED(HttpStatus.CONFLICT, "지원자가 있는 역할은 삭제, 이름 변경, 정원 축소를 할 수 없습니다."),
     TEAM_RECRUITMENT_MAX_PARTICIPANTS_BELOW_ACCEPTED(HttpStatus.CONFLICT, "승인된 인원보다 적은 정원으로 수정할 수 없습니다."),
     TEAM_RECRUITMENT_TYPE_CHANGE_NOT_ALLOWED(HttpStatus.CONFLICT, "지원자가 있으면 모집 유형을 변경할 수 없습니다."),
-    TEAM_RECRUITMENT_CHAT_READ_ONLY(HttpStatus.CONFLICT, "읽기 전용 채팅방입니다."),
     TEAM_RECRUITMENT_APPLICATION_NOT_ACCEPTED(HttpStatus.CONFLICT, "승인된 지원서가 아닙니다."),
 
     /**

--- a/src/main/resources/db/migration/V9__migrate_chat_room_status_read_only_to_active.sql
+++ b/src/main/resources/db/migration/V9__migrate_chat_room_status_read_only_to_active.sql
@@ -1,0 +1,3 @@
+UPDATE team_recruitment_chat_room
+SET status = 'ACTIVE'
+WHERE status = 'READ_ONLY';

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentApplicationFlowApiTest.java
@@ -337,8 +337,7 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.chat_room_id").isNumber())
-            .andExpect(jsonPath("$.room_type").value("DIRECT"))
-            .andExpect(jsonPath("$.status").value("ACTIVE"));
+            .andExpect(jsonPath("$.room_type").value("DIRECT"));
     }
 
     @Test
@@ -361,8 +360,7 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.chat_room_id").isNumber())
-            .andExpect(jsonPath("$.room_type").value("DIRECT"))
-            .andExpect(jsonPath("$.status").value("ACTIVE"));
+            .andExpect(jsonPath("$.room_type").value("DIRECT"));
     }
 
     @Test
@@ -452,14 +450,12 @@ class TeamRecruitmentApplicationFlowApiTest extends AcceptanceTest {
                 recruitment.getId(), application.getId())
                 .header("Authorization", "Bearer " + authorToken))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.chat_room_id").value(directRoom.getId()))
-            .andExpect(jsonPath("$.status").value("ACTIVE"));
+            .andExpect(jsonPath("$.chat_room_id").value(directRoom.getId()));
 
         mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}",
                 recruitment.getId(), directRoom.getId())
                 .header("Authorization", "Bearer " + authorToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("ACTIVE"));
+            .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentChatApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentChatApiTest.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.acceptance.domain;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentCategory.PROJECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentMeetingType.ONLINE;
@@ -130,7 +129,6 @@ class TeamRecruitmentChatApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$.chat_room_id").value(room.getId()))
             .andExpect(jsonPath("$.room_name").value(recruitment.getTitle()))
             .andExpect(jsonPath("$.room_type").value("TEAM"))
-            .andExpect(jsonPath("$.status").value("ACTIVE"))
             .andExpect(jsonPath("$.member_count").value(2));
 
         mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}", recruitment.getId(), room.getId()))
@@ -154,7 +152,7 @@ class TeamRecruitmentChatApiTest extends AcceptanceTest {
         TeamRecruitment recruitment = saveRecruitment("목록에서 보이는 팀 모집");
         TeamRecruitmentChatRoom teamRoom = saveTeamRoom(recruitment, ACTIVE);
         TeamRecruitmentApplication application = saveAcceptedApplication(recruitment);
-        TeamRecruitmentChatRoom directRoom = saveDirectRoom(recruitment, application, READ_ONLY);
+        TeamRecruitmentChatRoom directRoom = saveDirectRoom(recruitment, application, ACTIVE);
 
         TeamRecruitmentChatMessage readTeamMessage = saveMessage(teamRoom, author.getUser(), "이미 읽은 팀 메시지", false);
         TeamRecruitmentChatMember applicantTeamMember = chatMemberRepository
@@ -178,7 +176,6 @@ class TeamRecruitmentChatApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$[0].chat_room_id").value(directRoom.getId()))
             .andExpect(jsonPath("$[0].room_name").value(author.getUser().getNickname()))
             .andExpect(jsonPath("$[0].room_type").value("DIRECT"))
-            .andExpect(jsonPath("$[0].status").value("READ_ONLY"))
             .andExpect(jsonPath("$[0].counterpart_id").value(author.getUser().getId()))
             .andExpect(jsonPath("$[0].counterpart_nickname").value(author.getUser().getNickname()))
             .andExpect(jsonPath("$[0].last_message_id").value(latestDirectMessage.getId()))
@@ -380,33 +377,6 @@ class TeamRecruitmentChatApiTest extends AcceptanceTest {
             .andExpect(jsonPath("$[0].message_id").value(fourthMessageId));
         assertThat(chatMemberRepository.findByChatRoom_IdAndUser_Id(room.getId(), applicant.getUser().getId())
             .orElseThrow().getLastReadMessageId()).isEqualTo(fourthMessageId);
-    }
-
-    @Test
-    @DisplayName("READ_ONLY TEAM 채팅방은 메시지 전송만 차단하고 기존 메시지 조회는 허용한다")
-    void readOnlyTeamChatIsReadableButNotWritable() throws Exception {
-        TeamRecruitment recruitment = saveRecruitment("읽기 전용 채팅");
-        TeamRecruitmentChatRoom room = saveTeamRoom(recruitment, READ_ONLY);
-        TeamRecruitmentChatMessage existingMessage = chatMessageRepository.save(TeamRecruitmentChatMessage.builder()
-            .chatRoom(room)
-            .sender(author.getUser())
-            .senderNickname(author.getUser().getNickname())
-            .content("마감 전 메시지")
-            .isImage(false)
-            .build());
-        entityManager.flush();
-
-        sendMessage(room, recruitment, authorToken, "마감 후 메시지")
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.code").value("TEAM_RECRUITMENT_CHAT_READ_ONLY"));
-
-        mockMvc.perform(get("/chatroom/team-recruitment/{recruitmentId}/{chatRoomId}/messages",
-                recruitment.getId(), room.getId())
-                .header("Authorization", "Bearer " + applicantToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(1))
-            .andExpect(jsonPath("$[0].message_id").value(existingMessage.getId()))
-            .andExpect(jsonPath("$[0].content").value("마감 전 메시지"));
     }
 
     private void assertChatNotificationOutbox(

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
@@ -77,13 +77,13 @@ class TeamRecruitmentOpenApiContractTest extends AcceptanceTest {
         );
 
         JsonNode chatRoom = schema(openApi, "ChatRoomResponse");
-        assertRequired(chatRoom, "chat_room_id", "room_name", "room_type", "status", "member_count",
+        assertRequired(chatRoom, "chat_room_id", "room_name", "room_type", "member_count",
             "max_member_count", "counterpart");
         assertNullable(chatRoom, "counterpart");
         assertInlineObject(chatRoom, "counterpart", "id", "nickname");
 
         JsonNode chatRoomListItem = schema(openApi, "TeamRecruitmentChatRoomListItemResponse");
-        assertRequired(chatRoomListItem, "recruitment_id", "chat_room_id", "room_name", "room_type", "status",
+        assertRequired(chatRoomListItem, "recruitment_id", "chat_room_id", "room_name", "room_type",
             "counterpart_id", "counterpart_nickname", "last_message_id", "last_message_content", "last_message_at",
             "last_message_is_image", "unread_message_count");
         assertNullable(chatRoomListItem, "counterpart_id");
@@ -101,7 +101,7 @@ class TeamRecruitmentOpenApiContractTest extends AcceptanceTest {
         assertRequiredNullable(schema(openApi, "MyApplication"), "role");
 
         JsonNode directChatRoom = schema(openApi, "DirectChatRoomResponse");
-        assertRequired(directChatRoom, "chat_room_id", "room_name", "room_type", "status", "counterpart");
+        assertRequired(directChatRoom, "chat_room_id", "room_name", "room_type", "counterpart");
         assertNonNullableObject(openApi, directChatRoom, "counterpart", "id", "nickname");
 
         JsonNode chatMessage = responseSchema(openApi,
@@ -163,9 +163,9 @@ class TeamRecruitmentOpenApiContractTest extends AcceptanceTest {
         JsonNode application = objectMapper.valueToTree(
             new ApplicationCreatedResponse(51, 17, PENDING, null, timestamp));
         JsonNode chatRoom = objectMapper.valueToTree(
-            new ChatRoomResponse(31, "팀 채팅방", "TEAM", "ACTIVE", 1, 2, null));
+            new ChatRoomResponse(31, "팀 채팅방", "TEAM", 1, 2, null));
         JsonNode chatRoomListItem = objectMapper.valueToTree(new TeamRecruitmentChatRoomListItemResponse(
-            17, 31, "팀 채팅방", "TEAM", "ACTIVE", null, null,
+            17, 31, "팀 채팅방", "TEAM", null, null,
             null, null, null, null, 0));
         JsonNode notification = objectMapper.valueToTree(new TeamRecruitmentNotificationResponse(
             101, "NEW_APPLICATION", "APPLICANT_MANAGEMENT", 17, null, null, null,

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/model/TeamRecruitmentDirectChatPolicyTest.java
@@ -3,7 +3,6 @@ package in.koreatech.koin.unit.domain.team.recruitment.model;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.ACCEPTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.RECRUITING;
@@ -44,13 +43,6 @@ class TeamRecruitmentDirectChatPolicyTest {
     }
 
     @Test
-    void READ_ONLY_TEAM_방이면_신규_DIRECT를_열수없다() {
-        TeamRecruitment recruitment = recruitment(CLOSED);
-
-        assertThat(canOpen(ACCEPTED, false, recruitment, teamRoom(recruitment, READ_ONLY))).isFalse();
-    }
-
-    @Test
     void 삭제된_모집글은_ACTIVE_TEAM_방이_남아도_신규_DIRECT를_열수없다() {
         TeamRecruitment deleted = recruitment(CLOSED);
         deleted.markDeleted(LocalDate.of(2026, 8, 28).atStartOfDay());
@@ -62,7 +54,7 @@ class TeamRecruitmentDirectChatPolicyTest {
     void 기존_DIRECT_방은_모집글_상태와_관계없이_열수있다() {
         TeamRecruitment recruitment = recruitment(CLOSED);
 
-        assertThat(canOpen(ACCEPTED, true, recruitment, teamRoom(recruitment, READ_ONLY))).isTrue();
+        assertThat(canOpen(ACCEPTED, true, recruitment, teamRoom(recruitment, ACTIVE))).isTrue();
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/team/recruitment/service/TeamRecruitmentApplicationQueryServiceTest.java
@@ -4,7 +4,6 @@ import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApp
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.PENDING;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus.REJECTED;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.ACTIVE;
-import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus.READ_ONLY;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.DIRECT;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType.TEAM;
 import static in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus.CLOSED;
@@ -531,40 +530,6 @@ class TeamRecruitmentApplicationQueryServiceTest {
     }
 
     @Test
-    void 수동_마감된_모집글의_ACCEPTED_지원자는_기존방이_없으면_DIRECT_CTA가_닫힌다() {
-        TeamRecruitment recruitment = recruitment();
-        recruitment.close();
-        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
-
-        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
-        when(applicationRepository.countByRecruitment_IdAndStatusIn(eq(RECRUITMENT_ID), any()))
-            .thenReturn(1L);
-        when(applicationRepository.findAllByRecruitment_IdAndStatusIn(
-            eq(RECRUITMENT_ID),
-            any(),
-            any(Pageable.class)
-        )).thenReturn(new PageImpl<>(List.of(accepted)));
-        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
-            List.of(RECRUITMENT_ID),
-            "TEAM",
-            TEAM
-        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
-        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
-            .thenReturn(List.of());
-
-        ApplicantListResponse response = queryService.getApplications(
-            RECRUITMENT_ID,
-            List.of(ACCEPTED),
-            1,
-            10,
-            AUTHOR_ID
-        );
-
-        assertThat(response.applications().get(0).canOpenDirectChat()).isFalse();
-    }
-
-    @Test
     void 정원충족으로_자동_마감된_모집글은_ACTIVE_TEAM_방이_있으면_DIRECT_CTA가_열린다() {
         TeamRecruitment recruitment = recruitment(1, 1, CLOSED);
         TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
@@ -641,7 +606,7 @@ class TeamRecruitmentApplicationQueryServiceTest {
             .roomScopeKey("DIRECT-20")
             .roomType(DIRECT)
             .application(accepted)
-            .status(READ_ONLY)
+            .status(ACTIVE)
             .build();
 
         when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
@@ -657,7 +622,7 @@ class TeamRecruitmentApplicationQueryServiceTest {
             List.of(RECRUITMENT_ID),
             "TEAM",
             TEAM
-        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
+        )).thenReturn(List.of(teamRoom(recruitment, ACTIVE)));
         when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
             .thenReturn(List.of(existingDirect));
 
@@ -670,28 +635,6 @@ class TeamRecruitmentApplicationQueryServiceTest {
         );
 
         assertThat(response.applications().get(0).canOpenDirectChat()).isTrue();
-    }
-
-    @Test
-    void 지원서_상세도_마감된_모집글에서_기존방이_없으면_DIRECT_CTA가_닫힌다() {
-        TeamRecruitment recruitment = recruitment();
-        recruitment.close();
-        TeamRecruitmentApplication accepted = applicationWithSnapshot(20, recruitment, ACCEPTED);
-
-        when(studentRepository.getById(AUTHOR_ID)).thenReturn(null);
-        when(recruitmentRepository.findById(RECRUITMENT_ID)).thenReturn(Optional.of(recruitment));
-        when(applicationRepository.findById(20)).thenReturn(Optional.of(accepted));
-        when(chatRoomRepository.findAllByRecruitment_IdInAndRoomScopeKeyAndRoomType(
-            List.of(RECRUITMENT_ID),
-            "TEAM",
-            TEAM
-        )).thenReturn(List.of(teamRoom(recruitment, READ_ONLY)));
-        when(chatRoomRepository.findAllByApplication_IdInAndRoomType(List.of(20), DIRECT))
-            .thenReturn(List.of());
-
-        ApplicantDetail response = queryService.getApplicationDetail(RECRUITMENT_ID, 20, AUTHOR_ID);
-
-        assertThat(response.canOpenDirectChat()).isFalse();
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -172,7 +172,7 @@ class TeamRecruitmentChatServiceTest {
         when(teamRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.TEAM);
         when(directRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
         when(teamRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
-        when(directRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.READ_ONLY);
+        when(directRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
         when(counterpartMember.getChatRoom()).thenReturn(directRoom);
         when(counterpartMember.getUser()).thenReturn(counterpart);
         when(teamMessage.getChatRoom()).thenReturn(teamRoom);
@@ -523,7 +523,6 @@ class TeamRecruitmentChatServiceTest {
         when(chatRoom.getRecruitment()).thenReturn(recruitment);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
         when(memberRepository.findByChatRoom_IdAndUser_Id(CHAT_ROOM_ID, USER_ID)).thenReturn(Optional.of(senderMember));
-        when(chatRoom.isActive()).thenReturn(true);
         when(senderMember.getUser()).thenReturn(anonymousSender);
         when(messageRepository.save(any(TeamRecruitmentChatMessage.class))).thenReturn(savedMessage);
         when(savedMessage.getId()).thenReturn(100);
@@ -539,27 +538,6 @@ class TeamRecruitmentChatServiceTest {
         verify(messageRepository).save(captor.capture());
 
         assertThat(captor.getValue().getSenderNickname()).isEqualTo(anonymousSender.getDisplayNickname());
-    }
-
-    @Test
-    void READ_ONLY_채팅방에_메시지_전송시_409를_반환한다() {
-        TeamRecruitmentChatRoom chatRoom = mock(TeamRecruitmentChatRoom.class);
-        TeamRecruitmentChatMember member = mock(TeamRecruitmentChatMember.class);
-        TeamRecruitment recruitment = mock(TeamRecruitment.class);
-
-        when(chatRoomRepository.findById(CHAT_ROOM_ID)).thenReturn(Optional.of(chatRoom));
-        when(chatRoom.getRecruitment()).thenReturn(recruitment);
-        when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
-        when(memberRepository.findByChatRoom_IdAndUser_Id(CHAT_ROOM_ID, USER_ID))
-                .thenReturn(Optional.of(member));
-        when(chatRoom.isActive()).thenReturn(false);
-
-        assertThatThrownBy(() -> chatService.createMessage(
-                USER_ID, RECRUITMENT_ID, CHAT_ROOM_ID,
-                new CreateChatMessageRequest("안녕", false)))
-                .isInstanceOf(CustomException.class)
-                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
-                        .isEqualTo(ApiResponseCode.TEAM_RECRUITMENT_CHAT_READ_ONLY));
     }
 
     private ChatRoomResponse getChatRoom(

--- a/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
+++ b/src/test/java/in/koreatech/koin/unit/domain/teamrecruitment/service/TeamRecruitmentChatServiceTest.java
@@ -32,7 +32,6 @@ import in.koreatech.koin.global.code.ApiResponseCode;
 import in.koreatech.koin.global.exception.CustomException;
 
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentApplicationStatus;
-import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomStatus;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentChatRoomType;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentStatus;
 import in.koreatech.koin.domain.team.recruitment.enums.TeamRecruitmentType;
@@ -171,8 +170,6 @@ class TeamRecruitmentChatServiceTest {
         when(recruitment.getTitle()).thenReturn("팀원 모집");
         when(teamRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.TEAM);
         when(directRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
-        when(teamRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
-        when(directRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
         when(counterpartMember.getChatRoom()).thenReturn(directRoom);
         when(counterpartMember.getUser()).thenReturn(counterpart);
         when(teamMessage.getChatRoom()).thenReturn(teamRoom);
@@ -242,7 +239,6 @@ class TeamRecruitmentChatServiceTest {
         when(directRoom.getId()).thenReturn(21);
         when(directRoom.getRecruitment()).thenReturn(recruitment);
         when(directRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
-        when(directRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
         when(counterpartMember.getChatRoom()).thenReturn(directRoom);
         when(counterpartMember.getUser()).thenReturn(anonymousCounterpart);
         when(recruitment.getId()).thenReturn(RECRUITMENT_ID);
@@ -399,7 +395,6 @@ class TeamRecruitmentChatServiceTest {
                 .thenReturn(Optional.of(existingRoom));
         when(existingRoom.getId()).thenReturn(CHAT_ROOM_ID);
         when(existingRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
-        when(existingRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
 
         DirectChatRoomCreationResult result = chatService.getOrCreateDirectChatRoom(USER_ID, RECRUITMENT_ID, APPLICATION_ID);
 
@@ -503,7 +498,6 @@ class TeamRecruitmentChatServiceTest {
                 .thenReturn(Optional.of(existingRoom));
         when(existingRoom.getId()).thenReturn(CHAT_ROOM_ID);
         when(existingRoom.getRoomType()).thenReturn(TeamRecruitmentChatRoomType.DIRECT);
-        when(existingRoom.getStatus()).thenReturn(TeamRecruitmentChatRoomStatus.ACTIVE);
 
         DirectChatRoomCreationResult result = chatService.getOrCreateDirectChatRoom(USER_ID, RECRUITMENT_ID, APPLICATION_ID);
 


### PR DESCRIPTION
### 🔍 개요

팀원 모집 채팅방의 `READ_ONLY` 상태를 완전히 제거합니다.

PR #2421에서 팀 모집 마감 시 채팅방을 `READ_ONLY`로 전환하는 로직을 제거했으나, `TeamRecruitmentChatRoomStatus.READ_ONLY` enum 값과 이를 참조하는 모든 코드가 dead code로 남아있었습니다. 프론트엔드(이지현)와 협의 완료 후 완전 제거합니다.

- close #2426

---

### 🚀 주요 변경 내용

* `TeamRecruitmentChatRoomStatus`: `READ_ONLY` enum 값 제거, `ACTIVE`만 유지
* `TeamRecruitmentChatRoom`: `isActive()` transient 메서드 제거
* `TeamRecruitmentChatService`: READ_ONLY 시 메시지 전송 차단 로직(409) 제거
* `TeamRecruitmentDirectChatPolicy`: `canOpenDirectChat()`에서 `isActive()` 체크 제거
* `ChatRoomResponse`, `DirectChatRoomResponse`, `TeamRecruitmentChatRoomListItemResponse`: `status` 필드 제거
* `TeamRecruitmentChatApi`: `TEAM_RECRUITMENT_CHAT_READ_ONLY` 응답 코드 제거
* `ApiResponseCode`: `TEAM_RECRUITMENT_CHAT_READ_ONLY(409)` 제거
* `V9__migrate_chat_room_status_read_only_to_active.sql`: 기존 DB의 `READ_ONLY` 행을 `ACTIVE`로 마이그레이션

---

### 💬 참고 사항

* FE와 `status` 필드 제거 사전 협의 완료
* 프로덕션 DB에 잔존할 수 있는 `READ_ONLY` 행은 V9 마이그레이션으로 일괄 전환
* READ_ONLY 관련 단위/인수 테스트 삭제, 나머지 테스트는 `ACTIVE`로 변경

---

### ✅ Checklist

- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Team recruitment chat rooms no longer expose or support a read-only status.
  * Existing read-only rooms are migrated to active rooms.
  * Messages can be sent in previously read-only rooms.
  * Chat room responses no longer include status information.
  * Direct chats for closed recruitments can remain accessible when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->