### PR TITLE
fix: 팀원 모집 프로필 활동 설명 글자수 제한을 500자에서 1000자로 확장

### DIFF
--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ProfileActivityInput.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/dto/ProfileActivityInput.java
@@ -42,7 +42,7 @@ public record ProfileActivityInput(
 
     @Schema(description = "활동 설명", example = "기획 담당", requiredMode = REQUIRED)
     @NotBlank
-    @Size(min = 1, max = 500)
+    @Size(min = 1, max = 1000)
     String description
 ) {
     public ProfileActivityInput {

--- a/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentProfileActivity.java
+++ b/src/main/java/in/koreatech/koin/domain/team/recruitment/model/TeamRecruitmentProfileActivity.java
@@ -59,8 +59,8 @@ public class TeamRecruitmentProfileActivity extends BaseEntity {
     private Boolean isOngoing;
 
     @NotNull
-    @Size(max = 500)
-    @Column(name = "description", nullable = false, length = 500)
+    @Size(max = 1000)
+    @Column(name = "description", nullable = false, length = 1000)
     private String description;
 
     @NotNull

--- a/src/main/resources/db/migration/V10__widen_team_recruitment_profile_activity_description.sql
+++ b/src/main/resources/db/migration/V10__widen_team_recruitment_profile_activity_description.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `team_recruitment_profile_activity`
+    MODIFY COLUMN `description` VARCHAR(1000) NOT NULL;

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentOpenApiContractTest.java
@@ -143,6 +143,12 @@ class TeamRecruitmentOpenApiContractTest extends AcceptanceTest {
             "RECRUITMENT_CLOSED", "DEADLINE_PASSED", "ROLE_CLOSED", "PROFILE_REQUIRED");
         assertRequiredNullable(schema(openApi, "RecruitmentDetail"), "application");
         assertInlineObject(schema(openApi, "RecruitmentDetail"), "application", "application_id", "status");
+
+        assertThat(schema(openApi, "ProfileActivityInput")
+            .path("properties")
+            .path("description")
+            .path("maxLength")
+            .asInt()).isEqualTo(1000);
     }
 
     @Test

--- a/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentProfileApiTest.java
+++ b/src/test/java/in/koreatech/koin/acceptance/domain/TeamRecruitmentProfileApiTest.java
@@ -120,6 +120,26 @@ class TeamRecruitmentProfileApiTest extends AcceptanceTest {
             """.formatted(endedAt, isOngoing);
     }
 
+    private static String activityDescriptionBody(String description) {
+        return """
+            {
+              "profile_nickname": "홍길동",
+              "preferred_role": "기획",
+              "skills": [],
+              "activities": [
+                {
+                  "title": "활동",
+                  "started_at": "2025-03-03",
+                  "ended_at": "2025-05-05",
+                  "is_ongoing": false,
+                  "description": "%s"
+                }
+              ],
+              "self_introduction": "소개"
+            }
+            """.formatted(description);
+    }
+
     @Nested
     @DisplayName("GET /team-recruitment-profiles/me")
     class GetProfile {
@@ -273,6 +293,33 @@ class TeamRecruitmentProfileApiTest extends AcceptanceTest {
                     .content(activityBody("\"2025-03-02\"", false)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_START_DATE_AFTER_END_DATE"));
+        }
+
+        @Test
+        @DisplayName("활동 설명이 1000자이면 저장된다")
+        void activityDescriptionAtMaxLengthSucceeds() throws Exception {
+            String description = "가".repeat(1000);
+
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityDescriptionBody(description)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activities[0].description").value(description));
+        }
+
+        @Test
+        @DisplayName("활동 설명이 1000자를 넘으면 400 이다")
+        void activityDescriptionOverMaxLengthFails() throws Exception {
+            String description = "가".repeat(1001);
+
+            mockMvc.perform(put(URL)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(activityDescriptionBody(description)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST_BODY"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("activities[0].description"));
         }
 
         @Test


### PR DESCRIPTION
### 🔍 개요

* 팀원 모집 프로필의 활동(activity) 설명(description) 입력 시, 디자인 UI는 1000자까지 허용하지만 백엔드 검증(`@Size`)과 DB 컬럼은 500자로 고정되어 있어 1000자에 가깝게 입력하면 400 에러가 발생하던 문제를 수정했습니다.

- close #2428

---

### 🚀 주요 변경 내용

* `ProfileActivityInput`, `TeamRecruitmentProfileActivity`의 `description` 검증(`@Size`)을 500 → 1000으로 확장
* `team_recruitment_profile_activity.description` 컬럼을 `VARCHAR(500)` → `VARCHAR(1000)`으로 확장하는 `V10` Flyway 마이그레이션 추가
* 활동 설명 1000자 성공 / 1001자 400 응답을 검증하는 API 회귀 테스트 추가
* 외부(Campus API) Swagger 문서의 `ProfileActivityInput.description` `maxLength`가 1000으로 노출되는지 검증하는 계약 테스트 추가

---

### 💬 참고 사항

* 프론트엔드는 이미 1000자 제한으로 디자인되어 있어 별도 프론트 작업 없이 백엔드만 맞췄습니다.
* Docker(Testcontainers) 기반 `./gradlew clean test` 전체 실행 결과: **1163개 테스트 전부 통과 (실패 0 / 에러 0)**.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Team recruitment profile activity descriptions can now contain up to 1,000 characters, increased from 500.
  * Descriptions at the 1,000-character limit are accepted, while longer descriptions are rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->